### PR TITLE
Proposed scatter algorithm for dataparallel

### DIFF
--- a/torch_geometric/nn/data_parallel.py
+++ b/torch_geometric/nn/data_parallel.py
@@ -101,9 +101,9 @@ class DataParallel(torch.nn.DataParallel):
         list_of_batches = []
         for ii in range(num_devices):
             tmp_data_list = []
-            for gpu_id in new_device_id:
+            for jj, gpu_id in enumerate(new_device_id):
                 if gpu_id == ii:
-                    tmp_data_list.append(data_list[gpu_id])
+                    tmp_data_list.append(data_list[jj])
 
             list_of_batches.append(Batch.from_data_list(tmp_data_list).to(torch.device('cuda:{}'.format(ii))))
 

--- a/torch_geometric/nn/data_parallel.py
+++ b/torch_geometric/nn/data_parallel.py
@@ -2,6 +2,7 @@ import warnings
 from itertools import chain
 
 import torch
+
 from torch_geometric.data import Batch
 
 
@@ -34,9 +35,15 @@ class DataParallel(torch.nn.DataParallel):
             (default: :obj:`device_ids[0]`)
     """
 
-    def __init__(self, module, device_ids=None, output_device=None):
+    def __init__(self, module, device_ids=None, output_device=None, use_original=True):
         super(DataParallel, self).__init__(module, device_ids, output_device)
         self.src_device = torch.device("cuda:{}".format(self.device_ids[0]))
+
+        # To store the mapping back to the input order
+        self.id_map = []
+
+        # Use the original algorithm
+        self.use_original = use_original
 
     def forward(self, data_list):
         """"""
@@ -54,7 +61,7 @@ class DataParallel(torch.nn.DataParallel):
                 raise RuntimeError(
                     ('Module must have its parameters and buffers on device '
                      '{} but found one of them on device {}.').format(
-                         self.src_device, t.device))
+                        self.src_device, t.device))
 
         inputs = self.scatter(data_list, self.device_ids)
         replicas = self.replicate(self.module, self.device_ids[:len(inputs)])
@@ -62,49 +69,96 @@ class DataParallel(torch.nn.DataParallel):
         return self.gather(outputs, self.output_device)
 
     def scatter(self, data_list, device_ids):
-        """
-        This function distributes the data in the data_list into batches 
+        r"""
+        This function distributes the data in the data_list into batches
         to be sent to the gpus in device_ids
-         - This first spreads the largest graphs to the gpus in order 
+         - This first spreads the largest graphs to the gpus in order
          - Then it add the next largest graph to the gpu with the lowest number of nodes
          - Finally it add the smallest graphs to gpus to ensure each gpu has at least 2 graphs
         """
+        # Gets the number of GPUs being used
         num_devices = min(len(device_ids), len(data_list))
+        
+        # Gets the number of nodes in each data object in the input data list
+        num_nodes = torch.tensor([data.num_nodes for data in data_list])
 
-        count = torch.tensor([data.num_nodes for data in data_list])
+        if self.use_original:
+            # The original implementation
+            cumsum = num_nodes.cumsum(0)
+            cumsum = torch.cat([cumsum.new_zeros(1), cumsum], dim=0)
+            device_id = num_devices * cumsum.to(torch.float) / cumsum[-1].item()
+            device_id = (device_id[:-1] + device_id[1:]) / 2.0
+            device_id = device_id.to(torch.long)  # round.
+            split = device_id.bincount().cumsum(0)
+            split = torch.cat([split.new_zeros(1), split], dim=0)
+            split = torch.unique(split, sorted=True)
+            split = split.tolist()
 
-        sorted_indices = torch.argsort(count, dim=0, descending=True)
+            return [
+                Batch.from_data_list(data_list[split[i]:split[i + 1]]).to(
+                    torch.device('cuda:{}'.format(device_ids[i])))
+                for i in range(len(split) - 1)
+            ]
+        
+        else:
+            # The proposed implementation
+            sorted_indices = torch.argsort(num_nodes, dim=0, descending=True)
 
-        new_device_id = list(range(num_devices))
+            # This will contain the GPU the data object has been assigned. 
+            # It is initialised with the num_device largest node counts 
+            new_device_id = list(range(num_devices))
+            
+            # These tensors track how many nodes and how many graphs are on each GPU respectively
+            num_nodes_per_device = torch.tensor([0] * num_devices)
+            num_graphs_per_device = torch.tensor([0] * num_devices)
+            
+            # This is the main loop that does the assignment of the data objects to the devices 
+            for ii, nodes in enumerate(num_nodes):
+                if ii < len(new_device_id):
+                    # Fill the tracker with the new_device_id initialised values
+                    num_nodes_per_device[new_device_id[ii]] += num_nodes[sorted_indices[ii]]
+                    num_graphs_per_device[new_device_id[ii]] += 1
 
-        totals = torch.tensor([0] * num_devices)
-        n_graphs = torch.tensor([0] * num_devices)
-        for ii, c in enumerate(count):
-            if ii < len(new_device_id):
-                totals[new_device_id[ii]] += count[sorted_indices[ii]]
-                n_graphs[new_device_id[ii]] += 1
-
-            elif ii >= len(count) - num_devices:
-                if n_graphs[torch.argmin(n_graphs).item()] == 1:
-                    new_device_id.append(torch.argmin(n_graphs).item())
-                    n_graphs[new_device_id[ii]] += 1
-                    totals[new_device_id[ii]] += count[sorted_indices[ii]]
+                elif ii >= num_nodes.size()[0] - num_devices:
+                    # This checks the last num_device data objects in the list (smallest ones)
+                    # and part ensures that there are at least 2 graphs per device
+                    if num_graphs_per_device[torch.argmin(num_graphs_per_device).item()] == 1:
+                        new_device_id.append(torch.argmin(num_graphs_per_device).item())
+                        num_graphs_per_device[new_device_id[ii]] += 1
+                        num_nodes_per_device[new_device_id[ii]] += num_nodes[sorted_indices[ii]]
+                    else:
+                        # If they all have 2 or more graphs it assigns the it to the device with the least nodes 
+                        new_device_id.append(torch.argmin(num_nodes_per_device).item())
+                        num_graphs_per_device[new_device_id[ii]] += 1
+                        num_nodes_per_device[new_device_id[ii]] += num_nodes[sorted_indices[ii]]
                 else:
-                    new_device_id.append(torch.argmin(totals).item())
-                    n_graphs[new_device_id[ii]] += 1
-                    totals[new_device_id[ii]] += count[sorted_indices[ii]]
-            else:
-                new_device_id.append(torch.argmin(totals).item())
-                n_graphs[new_device_id[ii]] += 1
-                totals[new_device_id[ii]] += count[sorted_indices[ii]]
+                    # This assigns the data object to the device with the least nodes
+                    new_device_id.append(torch.argmin(num_nodes_per_device).item())
+                    num_graphs_per_device[new_device_id[ii]] += 1
+                    num_nodes_per_device[new_device_id[ii]] += num_nodes[sorted_indices[ii]]
 
-        list_of_batches = []
-        for ii in range(num_devices):
-            tmp_data_list = []
-            for jj, gpu_id in enumerate(new_device_id):
-                if gpu_id == ii:
-                    tmp_data_list.append(data_list[jj])
+            # Now the assigned data objects are converted in to batches for each device
+            # The id_map is filled in at this point. It must be emptied at each call of scatter
+            list_of_batches = []
+            self.id_map = []
+            for gpu in range(num_devices):
+                tmp_data_list = []
+                for jj, gpu_id in enumerate(new_device_id):
+                    if gpu_id == gpu:
+                        tmp_data_list.append(data_list[sorted_indices[jj]])
+                        self.id_map.append(sorted_indices[jj].item())
 
-            list_of_batches.append(Batch.from_data_list(tmp_data_list).to(torch.device('cuda:{}'.format(ii))))
+                list_of_batches.append(Batch.from_data_list(tmp_data_list).to(torch.device('cuda:{}'.format(gpu))))
 
-        return list_of_batches
+            return list_of_batches
+
+    def gather(self, outputs, output_device):
+        """
+        Gathers the results from the GPUs and returns the answer in the correct order
+        """
+        if self.use_original:
+            return super().gather(outputs, output_device)
+        else:
+            return torch.index_select(super().gather(outputs, output_device),
+                                      0,
+                                      torch.argsort(torch.LongTensor(self.id_map).to(output_device), dim=0))


### PR DESCRIPTION
I have been trying to run a network with batch normalisation from torch.nn after the graph convolutions and global pooling. When running on multiple GPUs it crashes as some batches are of a single graph.

Proposed scatter algorithm to ensure each device has 2 graphs present to avoid batch norm from crashing. It also improves the balance.

I have tested this with 4 GPUs with the following batch sizes 2 (removed batch norm for this test), 4, 6, 8 and 32.

An example of the improvement for a batch size of 32, showing the first 3 data lists.
**Batch 0**
Original device allocation: [0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 3, 3, 3]
Original graphs per device: [ 5, 11, 13,  3]
Original total nodes per device: [114166,  59242,  99157,  62128]
Proposed device allocation: [0, 1, 2, 3, 3, 2, 1, 3, 2, 1, 3, 0, 2, 1, 3, 2, 0, 1, 3, 1, 0, 2, 3, 0, 1, 2, 3, 0, 1, 3, 2, 1]
Proposed graphs per new_device: [6, 9, 8, 9]
Proposed total nodes per device: [83457, 83759, 83747, 83730]

Standard deviations
Original Nodes per device: 27268.0
Proposed Nodes per device: 144.7
Original Graphs per device: 4.8
Proposed Graphs per device: 1.4

**Batch 1**
Original device allocation: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 2, 3, 3, 3]
Original graphs per device: [16,  6,  7,  3]
Original total nodes per device: [143070, 110554, 147301, 172038]
Proposed device allocation: [0, 1, 2, 3, 3, 2, 1, 2, 1, 3, 1, 2, 3, 3, 1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 2, 0, 1, 3, 2]
Proposed graphs per new_device: [ 2, 10, 10, 10]
Proposed total nodes per device: [169202, 134669, 134480, 134612]

Standard deviations
Original Nodes per device: 25260.1
Proposed Nodes per device: 17307.7
Original Graphs per device: 5.6
Proposed Graphs per device: 4.0

**Batch 2**
Original device allocation: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 2, 2, 3, 3, 3, 3, 3, 3, 3])
Original graphs per device: [11,  6,  8,  7]
Original total nodes per device: [61676, 27303, 87470, 55921]
Proposed device allocation: [0, 1, 2, 3, 3, 2, 1, 2, 3, 1, 1, 3, 2, 2, 3, 1, 2, 1, 3, 2, 3, 1, 2, 3, 1, 2, 1, 3, 0, 3, 2, 1]
Proposed graphs per new_device: [ 2, 10, 10, 10]
Proposed total nodes per device: [59041, 57805, 57788, 57736]

Standard deviations
Original Nodes per device: 24688.6
Proposed Nodes per device: 633.0
Original Graphs per device: 2.2
Proposed Graphs per device: 4.0

**Batch 3**
Original device allocation: [0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3]
Original graphs per device: [ 3,  8, 11, 10]
Original total nodes per device: [41879, 34950, 24246, 32947]
Proposed device allocation: [0, 1, 2, 3, 3, 2, 3, 2, 3, 2, 3, 1, 2, 3, 2, 1, 3, 2, 1, 3, 2, 1, 3, 1, 2, 3, 1, 2, 0, 2, 1, 3]
Proposed graphs per new_device: [ 2,  8, 11, 11]
Proposed total nodes per device: [36336, 32729, 32580, 32377]

Standard deviations
Original Nodes per device: 7263.0
Proposed Nodes per device: 1892.5
Original Graphs per device: 3.6
Proposed Graphs per device: 4.2

As you can see the balance in the above cases. 

Best Regards

Adam