### PR TITLE
Make EPS adjustable to the precision (e.g., fp16)

### DIFF
--- a/torch_geometric/nn/conv/gmm_conv.py
+++ b/torch_geometric/nn/conv/gmm_conv.py
@@ -7,6 +7,9 @@ from torch.nn import Parameter
 from torch_geometric.nn.conv import MessagePassing
 
 from ..inits import zeros, glorot
+from ..epsilon import EPSILON
+
+EPS = EPSILON()
 
 
 class GMMConv(MessagePassing):
@@ -122,7 +125,6 @@ class GMMConv(MessagePassing):
         return out
 
     def message(self, x_j: Tensor, edge_attr: Tensor):
-        EPS = 1e-15
         F, M = self.rel_in_channels, self.out_channels
         (E, D), K = edge_attr.size(), self.kernel_size
 

--- a/torch_geometric/nn/dense/diff_pool.py
+++ b/torch_geometric/nn/dense/diff_pool.py
@@ -1,6 +1,7 @@
 import torch
+from ..epsilon import EPSILON
 
-EPS = 1e-15
+EPS = EPSILON()
 
 
 def dense_diff_pool(x, adj, s, mask=None):

--- a/torch_geometric/nn/dense/mincut_pool.py
+++ b/torch_geometric/nn/dense/mincut_pool.py
@@ -1,6 +1,7 @@
 import torch
+from ..epsilon import EPSILON
 
-EPS = 1e-15
+EPS = EPSILON()
 
 
 def dense_mincut_pool(x, adj, s, mask=None):

--- a/torch_geometric/nn/epsilon.py
+++ b/torch_geometric/nn/epsilon.py
@@ -1,0 +1,18 @@
+import torch
+from torch import Tensor
+
+
+class EPSILON(object):
+    r"""A small value adjustable to the precision"""
+
+    def __init__(self):
+        super().__init__()
+
+    def __add__(self, other: Tensor) -> Tensor:
+        if other.dtype == torch.float16:
+            return other + 1e-7
+        else:
+            return other + 1e-15
+
+    def __radd__(self, other: Tensor) -> Tensor:
+        return self.__add__(other)

--- a/torch_geometric/nn/models/autoencoder.py
+++ b/torch_geometric/nn/models/autoencoder.py
@@ -4,8 +4,9 @@ from torch_geometric.utils import (negative_sampling, remove_self_loops,
                                    add_self_loops)
 
 from ..inits import reset
+from ..epsilon import EPSILON
 
-EPS = 1e-15
+EPS = EPSILON()
 MAX_LOGSTD = 10
 
 

--- a/torch_geometric/nn/models/deep_graph_infomax.py
+++ b/torch_geometric/nn/models/deep_graph_infomax.py
@@ -3,8 +3,9 @@ from torch.nn import Parameter
 from sklearn.linear_model import LogisticRegression
 
 from ..inits import reset, uniform
+from ..epsilon import EPSILON
 
-EPS = 1e-15
+EPS = EPSILON()
 
 
 class DeepGraphInfomax(torch.nn.Module):

--- a/torch_geometric/nn/models/gnn_explainer.py
+++ b/torch_geometric/nn/models/gnn_explainer.py
@@ -10,7 +10,9 @@ from torch_geometric.nn import MessagePassing
 from torch_geometric.data import Data
 from torch_geometric.utils import k_hop_subgraph, to_networkx
 
-EPS = 1e-15
+from ..epsilon import EPSILON
+
+EPS = EPSILON()
 
 
 class GNNExplainer(torch.nn.Module):

--- a/torch_geometric/nn/models/metapath2vec.py
+++ b/torch_geometric/nn/models/metapath2vec.py
@@ -4,7 +4,9 @@ from torch.utils.data import DataLoader
 from torch_sparse import SparseTensor
 from sklearn.linear_model import LogisticRegression
 
-EPS = 1e-15
+from ..epsilon import EPSILON
+
+EPS = EPSILON()
 
 
 class MetaPath2Vec(torch.nn.Module):

--- a/torch_geometric/nn/models/node2vec.py
+++ b/torch_geometric/nn/models/node2vec.py
@@ -6,13 +6,15 @@ from sklearn.linear_model import LogisticRegression
 
 from torch_geometric.utils.num_nodes import maybe_num_nodes
 
+from ..epsilon import EPSILON
+
 try:
     import torch_cluster  # noqa
     random_walk = torch.ops.torch_cluster.random_walk
 except ImportError:
     random_walk = None
 
-EPS = 1e-15
+EPS = EPSILON()
 
 
 class Node2Vec(torch.nn.Module):


### PR DESCRIPTION
This PR fixes a bug of `inf` or `nan` value when using `EPS = 1e-15` with half-precision models.