### PR TITLE
add mnist superpixel visualization

### DIFF
--- a/examples/mnist_visualization.py
+++ b/examples/mnist_visualization.py
@@ -1,0 +1,60 @@
+import os.path as osp
+
+import numpy as np
+import pandas as pd
+from PIL import ImageColor
+import seaborn as sns
+import networkx as nx
+from matplotlib import pyplot as plt
+
+from torchvision.datasets import MNIST
+from torch_geometric.datasets import MNISTSuperpixels
+
+def visualize(image, data):
+    plt.figure(figsize=(17, 8))
+    
+    # plot the mnist image
+    plt.subplot(1, 2, 1)
+    plt.title("MNIST")
+    np_image = np.array(image)
+    plt.imshow(np_image)
+    
+    # plot the super-pixel graph
+    plt.subplot(1, 2, 2)
+    x, edge_index = data.x, data.edge_index
+    
+    # construct networkx graph
+    df = pd.DataFrame({'from': edge_index[0], 'to': edge_index[1]})
+    G = nx.from_pandas_edgelist(df, 'from', 'to')    
+    
+    # flip over the axis of pos, this is because the default axis direction of networkx is different
+    pos = {i: np.array([data.pos[i][0], 27 - data.pos[i][1]]) for i in range(data.num_nodes)}
+    
+    # get the current node index of G
+    idx = list(G.nodes())
+
+    # set the node sizes using node features
+    size = x[idx] * 500 + 200
+    
+    # set the node colors using node features
+    color = []
+    for i in idx:
+        grey = x[i]
+        if grey == 0:
+            color.append('skyblue')
+        else:
+            color.append('red')
+    
+    nx.draw(G, with_labels=True, node_size=size, node_color=color, pos=pos)
+    plt.title("MNIST Superpixel")
+
+if __name__ == '__main__':
+    path = osp.join(osp.dirname(osp.realpath(__file__)), '..', 'data', 'MNIST')
+    image_dataset = MNIST(root=path, download=True)
+    graph_dataset = MNISTSuperpixels(root=path)
+
+    example = 25
+    image, label = image_dataset[example]
+    data = graph_dataset[example]
+    print("Image Label:", label)
+    visualize(image, data)


### PR DESCRIPTION
Dear Matthias,

I believe this is what everybody wants when they are trying to visualize the mnist_superpixel dataset. 

![image](https://user-images.githubusercontent.com/22238123/116395057-37197080-a856-11eb-9faf-f7eac2174861.png)

Actually it took me quite some time to make it looks perfect since I found the default axis direction of networkx.draw() is wried, the y-axis of data.pos needs to be flipped over,  also the index of networkx graph is not in order, so it requires some re-indexing operations.

As mentioned in https://github.com/rusty1s/pytorch_geometric/issues/320, your old script [here](https://github.com/rusty1s/pytorch_geometric/blob/da78a9bc6074913713e0fffd908a4365dfe20ef9/torch_geometric/visualization/mnist_graph.py) is no longer working with latest torch_geometric. And I think my solution is very easy to read and not hacky at all : ), so I'd love to share it with everybody.