### PR TITLE
Add PyTorch dataset and dataloader classes for TemporalData

### DIFF
--- a/examples/tgn.py
+++ b/examples/tgn.py
@@ -17,6 +17,7 @@ import torch
 from torch.nn import Linear
 from sklearn.metrics import average_precision_score, roc_auc_score
 
+from torch_geometric.data import TemporalDataset, TemporalDataLoader
 from torch_geometric.datasets import JODIEDataset
 from torch_geometric.nn import TGNMemory, TransformerConv
 from torch_geometric.nn.models.tgn import (LastNeighborLoader, IdentityMessage,
@@ -26,13 +27,23 @@ device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
 
 path = osp.join(osp.dirname(osp.realpath(__file__)), '..', 'data', 'JODIE')
 dataset = JODIEDataset(path, name='wikipedia')
-data = dataset[0].to(device)
+data = dataset[0]
 
 # Ensure to only sample actual destination nodes as negatives.
 min_dst_idx, max_dst_idx = int(data.dst.min()), int(data.dst.max())
 
 train_data, val_data, test_data = data.train_val_test_split(
     val_ratio=0.15, test_ratio=0.15)
+
+train_dataset = TemporalDataset(train_data)
+val_dataset = TemporalDataset(val_data)
+test_dataset = TemporalDataset(test_data)
+
+train_loader = TemporalDataLoader(train_dataset, batch_size=200, shuffle=False)
+val_loader = TemporalDataLoader(val_dataset, batch_size=200, shuffle=False)
+test_loader = TemporalDataLoader(test_dataset, batch_size=200, shuffle=False)
+
+data = data.to(device)
 
 neighbor_loader = LastNeighborLoader(data.num_nodes, size=10, device=device)
 
@@ -103,7 +114,8 @@ def train():
     neighbor_loader.reset_state()  # Start with an empty graph.
 
     total_loss = 0
-    for batch in train_data.seq_batches(batch_size=200):
+    for batch in train_loader:
+        batch = batch.to(device)
         optimizer.zero_grad()
 
         src, pos_dst, t, msg = batch.src, batch.dst, batch.t, batch.msg
@@ -139,7 +151,7 @@ def train():
 
 
 @torch.no_grad()
-def test(inference_data):
+def test(inference_loader):
     memory.eval()
     gnn.eval()
     link_pred.eval()
@@ -147,7 +159,8 @@ def test(inference_data):
     torch.manual_seed(12345)  # Ensure deterministic sampling across epochs.
 
     aps, aucs = [], []
-    for batch in inference_data.seq_batches(batch_size=200):
+    for batch in inference_loader:
+        batch = batch.to(device)
         src, pos_dst, t, msg = batch.src, batch.dst, batch.t, batch.msg
 
         neg_dst = torch.randint(min_dst_idx, max_dst_idx + 1, (src.size(0), ),
@@ -180,7 +193,7 @@ def test(inference_data):
 for epoch in range(1, 51):
     loss = train()
     print(f'  Epoch: {epoch:02d}, Loss: {loss:.4f}')
-    val_ap, val_auc = test(val_data)
-    test_ap, test_auc = test(test_data)
+    val_ap, val_auc = test(val_loader)
+    test_ap, test_auc = test(test_loader)
     print(f' Val AP: {val_ap:.4f},  Val AUC: {val_auc:.4f}')
     print(f'Test AP: {test_ap:.4f}, Test AUC: {test_auc:.4f}')

--- a/test/data/test_temporal_dataloader.py
+++ b/test/data/test_temporal_dataloader.py
@@ -1,18 +1,19 @@
 import torch
-from torch_geometric.data import TemporalData, TemporalDataset, TemporalDataLoader
+from torch_geometric.data import TemporalData, TemporalDataset, \
+    TemporalDataLoader
 
 
 def test_temporal_dataloader():
     src = torch.tensor([1, 2, 0])
     dst = torch.tensor([3, 1, 2])
     t = torch.Tensor([0., 5., 29.])
-    msg = torch.Tensor([[564., 8997., 22., 5.],
-                        [8965., 53., 5., 892.],
+    msg = torch.Tensor([[564., 8997., 22., 5.], [8965., 53., 5., 892.],
                         [879., 23., 564., 88.]])
     y = torch.tensor([0, 1, 0])
     data = TemporalData(src=src, dst=dst, t=t, msg=msg, y=y)
 
-    assert data.__repr__() == ('TemporalData(dst=[3], msg=[3, 4], src=[3], t=[3], y=[3])')
+    assert data.__repr__() == (
+        'TemporalData(dst=[3], msg=[3, 4], src=[3], t=[3], y=[3])')
 
     dataset = TemporalDataset(data)
 
@@ -24,6 +25,6 @@ def test_temporal_dataloader():
         assert batch.dst.tolist() == [3, 1]
         assert batch.t.tolist() == [0., 5.]
         assert batch.msg.tolist() == [[564., 8997., 22., 5.],
-                                     [8965., 53., 5., 892.]]
+                                      [8965., 53., 5., 892.]]
         assert batch.y.tolist() == [0, 1]
         break

--- a/test/data/test_temporal_dataloader.py
+++ b/test/data/test_temporal_dataloader.py
@@ -1,0 +1,29 @@
+import torch
+from torch_geometric.data import TemporalData, TemporalDataset, TemporalDataLoader
+
+
+def test_temporal_dataloader():
+    src = torch.tensor([1, 2, 0])
+    dst = torch.tensor([3, 1, 2])
+    t = torch.Tensor([0., 5., 29.])
+    msg = torch.Tensor([[564., 8997., 22., 5.],
+                        [8965., 53., 5., 892.],
+                        [879., 23., 564., 88.]])
+    y = torch.tensor([0, 1, 0])
+    data = TemporalData(src=src, dst=dst, t=t, msg=msg, y=y)
+
+    assert data.__repr__() == ('TemporalData(dst=[3], msg=[3, 4], src=[3], t=[3], y=[3])')
+
+    dataset = TemporalDataset(data)
+
+    loader = TemporalDataLoader(dataset, batch_size=2, shuffle=False)
+
+    for batch in loader:
+        assert len(batch) == len(batch.keys)
+        assert batch.src.tolist() == [1, 2]
+        assert batch.dst.tolist() == [3, 1]
+        assert batch.t.tolist() == [0., 5.]
+        assert batch.msg.tolist() == [[564., 8997., 22., 5.],
+                                     [8965., 53., 5., 892.]]
+        assert batch.y.tolist() == [0, 1]
+        break

--- a/torch_geometric/data/__init__.py
+++ b/torch_geometric/data/__init__.py
@@ -4,6 +4,7 @@ from .batch import Batch
 from .dataset import Dataset
 from .in_memory_dataset import InMemoryDataset
 from .dataloader import DataLoader, DataListLoader, DenseDataLoader
+from .temporal_dataloader import TemporalDataset, TemporalDataLoader
 from .sampler import NeighborSampler, RandomNodeSampler
 from .cluster import ClusterData, ClusterLoader
 from .graph_saint import (GraphSAINTSampler, GraphSAINTNodeSampler,
@@ -18,9 +19,11 @@ __all__ = [
     'Batch',
     'Dataset',
     'InMemoryDataset',
+    'TemporalDataset',
     'DataLoader',
     'DataListLoader',
     'DenseDataLoader',
+    'TemporalDataLoader',
     'NeighborSampler',
     'RandomNodeSampler',
     'ClusterData',

--- a/torch_geometric/data/temporal_dataloader.py
+++ b/torch_geometric/data/temporal_dataloader.py
@@ -4,24 +4,29 @@ from torch_geometric.data import TemporalData
 
 
 class TemporalDataset(torch.utils.data.Dataset):
-    """
-    Converts a TemporalData object to a PyTorch Dataset
+    r"""Converts a :class:`torch_geometric.data.TemporalDataset`
+    object to a PyTorch Dataset.
+
+    Args:
+        temporal_data (TemporalData): TemporalData object that contains all
+            data in the dynamic graph dataset
     """
 
     def __init__(self, temporal_data: TemporalData):
         self.temporal_data = temporal_data
 
     def __len__(self):
+        r"""Gets the number of samples in the dataset."""
         return len(self.temporal_data.src)
 
     def __getitem__(self, idx):
+        r"""Gets the data object at index :obj:`idx`."""
         return self.temporal_data[idx]
 
 
 class TemporalDataCollater(object):
-    """
-    Collates TemporalData objects for batching
-    """
+    r"""Collates :class:`torch_geometric.data.TemporalDataset` objects
+    for batching."""
 
     def collate(self, temporal_data_list):
         batch = TemporalData()
@@ -35,8 +40,15 @@ class TemporalDataCollater(object):
 
 
 class TemporalDataLoader(torch.utils.data.DataLoader):
-    """
-    PyTorch DataLoader for TemporalData objects
+    r"""Data loader which merges data objects from a
+    :class:`torch_geometric.data.TemporalDataset` to a mini-batch.
+
+    Args:
+        dataset (TemporalDataset): The dataset from which to load the data.
+        batch_size (int, optional): How many samples per batch to load.
+            (default: :obj:`1`)
+        shuffle (bool, optional): If set to :obj:`True`, the data will be
+            reshuffled at every epoch (default: :obj:`False`)
     """
 
     def __init__(self, dataset: TemporalDataset, batch_size=1, shuffle=False,

--- a/torch_geometric/data/temporal_dataloader.py
+++ b/torch_geometric/data/temporal_dataloader.py
@@ -1,0 +1,53 @@
+import torch
+from torch.utils.data.dataloader import default_collate
+from torch_geometric.data import TemporalData
+
+
+class TemporalDataset(torch.utils.data.Dataset):
+    """
+    Converts a TemporalData object to a PyTorch Dataset
+    """
+    def __init__(self, temporal_data: TemporalData):
+        self.temporal_data = temporal_data
+
+    def __len__(self):
+        return len(self.temporal_data.src)
+
+    def __getitem__(self, idx):
+        return self.temporal_data[idx]
+
+
+class TemporalDataCollater(object):
+    """
+    Collates TemporalData objects for batching
+    """
+    def collate(self, temporal_data_list):
+        batch = TemporalData()
+        for key in temporal_data_list[0].keys:
+            batch[key] = default_collate([d[key] for d in temporal_data_list
+                                          ]).squeeze(1)
+        return batch
+
+    def __call__(self, batch):
+        return self.collate(batch)
+
+
+class TemporalDataLoader(torch.utils.data.DataLoader):
+    """
+    PyTorch DataLoader for TemporalData objects
+    """
+    def __init__(self,
+                 dataset: TemporalDataset,
+                 batch_size=1,
+                 shuffle=False,
+                 **kwargs):
+
+        if "collate_fn" in kwargs:
+            del kwargs["collate_fn"]
+
+        super(TemporalDataLoader,
+              self).__init__(dataset,
+                             batch_size,
+                             shuffle,
+                             collate_fn=TemporalDataCollater(),
+                             **kwargs)

--- a/torch_geometric/data/temporal_dataloader.py
+++ b/torch_geometric/data/temporal_dataloader.py
@@ -7,6 +7,7 @@ class TemporalDataset(torch.utils.data.Dataset):
     """
     Converts a TemporalData object to a PyTorch Dataset
     """
+
     def __init__(self, temporal_data: TemporalData):
         self.temporal_data = temporal_data
 
@@ -21,11 +22,12 @@ class TemporalDataCollater(object):
     """
     Collates TemporalData objects for batching
     """
+
     def collate(self, temporal_data_list):
         batch = TemporalData()
         for key in temporal_data_list[0].keys:
-            batch[key] = default_collate([d[key] for d in temporal_data_list
-                                          ]).squeeze(1)
+            batch[key] = default_collate(
+                [d[key] for d in temporal_data_list]).squeeze(1)
         return batch
 
     def __call__(self, batch):
@@ -36,18 +38,13 @@ class TemporalDataLoader(torch.utils.data.DataLoader):
     """
     PyTorch DataLoader for TemporalData objects
     """
-    def __init__(self,
-                 dataset: TemporalDataset,
-                 batch_size=1,
-                 shuffle=False,
+
+    def __init__(self, dataset: TemporalDataset, batch_size=1, shuffle=False,
                  **kwargs):
 
         if "collate_fn" in kwargs:
             del kwargs["collate_fn"]
 
         super(TemporalDataLoader,
-              self).__init__(dataset,
-                             batch_size,
-                             shuffle,
-                             collate_fn=TemporalDataCollater(),
-                             **kwargs)
+              self).__init__(dataset, batch_size, shuffle,
+                             collate_fn=TemporalDataCollater(), **kwargs)


### PR DESCRIPTION
## What
This adds native PyTorch `DataLoader` support for `TemporalData`, which is used for dynamic graph datasets. This is based on the idea mentioned here: #2567 

## Why
By allowing dynamic graph events in `TemporalData` format to be loaded via the new `TemporalDataLoader`, we can inherit the functionality of PyTorch `DataLoader`. For example, this is useful for:
- Interfacing with other libraries such as PyTorch Lightning, where a PyTorch `DataLoader` is expected
- Shuffling data loading using the `shuffle` argument when defining static baselines where time information is not important
- Parallelising data loading using the `num_workers` argument, in particular when there is preprocessing

Note: Currently, `TemporalData` has a `seq_batches()` method that generates slices of a tensor, batch by batch. In the case where we have a small dataset that we just need to load sequentially without preprocessing and don't need a `DataLoader`-like API, `seq_batches()` is faster. This is because using PyTorch `DataLoader` means splitting the data into individual training samples before collating them, but `seq_batches` skips the splitting and collating steps. This is similar to PyTorch and PyTorch Geometric `DataLoader` classes.

## How
A `TemporalDataset` is created that wraps around `TemporalData` to create a PyTorch `Dataset` object. Individual samples are collated by the `TemporalDataLoader` using a special collater for `TemporalData` objects.  

## Testing
Tests were implemented to check for the shapes and values of inputs and outputs to `TemporalDataLoader`. The TGN-attn implementation in `examples/` was modified by replacing the `seq_batches()` method with `TemporalDataLoader` and it produced similar results.
