### PR TITLE
GNNExplainer support for multiple mask types, regression

### DIFF
--- a/test/nn/models/test_gnn_explainer.py
+++ b/test/nn/models/test_gnn_explainer.py
@@ -92,7 +92,7 @@ def test_gnn_explainer_explain_node(model, return_type, allow_edge_mask,
 
 
 @pytest.mark.parametrize('allow_edge_mask', [True, False])
-@pytest.mark.parametrize('return_type', ['log_prob', 'regression'])
+@pytest.mark.parametrize('return_type', return_types)
 @pytest.mark.parametrize('feat_mask_type', feat_mask_types)
 @pytest.mark.parametrize('model', [GNN()])
 def test_gnn_explainer_explain_graph(model, return_type, allow_edge_mask,

--- a/test/nn/models/test_gnn_explainer.py
+++ b/test/nn/models/test_gnn_explainer.py
@@ -73,21 +73,22 @@ def test_gnn_explainer_explain_node(model, return_type, allow_edge_mask,
                                             threshold=0.8,
                                             node_alpha=node_feat_mask)
     else:
-        edge_y = torch.randint(low=0, high=30, size=(edge_index.size(1),))
-        _, _ = explainer.visualize_subgraph(2, edge_index, edge_mask,
-                                            y=y, edge_y=edge_y, threshold=0.8)
+        edge_y = torch.randint(low=0, high=30, size=(edge_index.size(1), ))
+        _, _ = explainer.visualize_subgraph(2, edge_index, edge_mask, y=y,
+                                            edge_y=edge_y, threshold=0.8)
     if feat_mask_type == 'individual_feature':
         assert node_feat_mask.size() == x.size()
     elif feat_mask_type == 'scalar':
-        assert node_feat_mask.size() == (x.size(0),)
+        assert node_feat_mask.size() == (x.size(0), )
     else:
         assert node_feat_mask.size() == (x.size(1), )
     assert node_feat_mask.min() >= 0 and node_feat_mask.max() <= 1
     assert edge_mask.size() == (edge_index.size(1), )
     assert edge_mask.min() >= 0 and edge_mask.max() <= 1
     if not allow_edge_mask:
-        assert list(edge_mask) == [1., 1., 1., 1.,
-                                   1., 1., 1., 1., 0., 0., 0., 0., 0., 0.]
+        assert list(edge_mask) == [
+            1., 1., 1., 1., 1., 1., 1., 1., 0., 0., 0., 0., 0., 0.
+        ]
 
 
 @pytest.mark.parametrize('allow_edge_mask', [True, False])
@@ -106,22 +107,19 @@ def test_gnn_explainer_explain_graph(model, return_type, allow_edge_mask,
 
     node_feat_mask, edge_mask = explainer.explain_graph(x, edge_index)
     if feat_mask_type == 'scalar':
-        _, _ = explainer.visualize_subgraph(-1, edge_index,
-                                            edge_mask,
-                                            y=torch.tensor(2),
-                                            threshold=0.8,
+        pass
+        _, _ = explainer.visualize_subgraph(-1, edge_index, edge_mask,
+                                            y=torch.tensor(2), threshold=0.8,
                                             node_alpha=node_feat_mask)
     else:
-        edge_y = torch.randint(low=0, high=30, size=(edge_index.size(1),))
-        _, _ = explainer.visualize_subgraph(-1, edge_index,
-                                            edge_mask,
-                                            edge_y=edge_y,
-                                            y=torch.tensor(2),
+        edge_y = torch.randint(low=0, high=30, size=(edge_index.size(1), ))
+        _, _ = explainer.visualize_subgraph(-1, edge_index, edge_mask,
+                                            edge_y=edge_y, y=torch.tensor(2),
                                             threshold=0.8)
     if feat_mask_type == 'individual_feature':
         assert node_feat_mask.size() == x.size()
     elif feat_mask_type == 'scalar':
-        assert node_feat_mask.size() == (x.size(0),)
+        assert node_feat_mask.size() == (x.size(0), )
     else:
         assert node_feat_mask.size() == (x.size(1), )
     assert node_feat_mask.min() >= 0 and node_feat_mask.max() <= 1

--- a/test/nn/models/test_gnn_explainer.py
+++ b/test/nn/models/test_gnn_explainer.py
@@ -48,11 +48,12 @@ class GNN(torch.nn.Module):
         return x.log_softmax(dim=1)
 
 
+return_types = ['log_prob', 'regression']
 feat_mask_types = ['individual_feature', 'scalar', 'feature']
 
 
 @pytest.mark.parametrize('allow_edge_mask', [True, False])
-@pytest.mark.parametrize('return_type', ['log_prob', 'regression'])
+@pytest.mark.parametrize('return_type', return_types)
 @pytest.mark.parametrize('feat_mask_type', feat_mask_types)
 @pytest.mark.parametrize('model', [GCN(), GAT()])
 def test_gnn_explainer_explain_node(model, return_type, allow_edge_mask,
@@ -86,9 +87,8 @@ def test_gnn_explainer_explain_node(model, return_type, allow_edge_mask,
     assert edge_mask.size() == (edge_index.size(1), )
     assert edge_mask.min() >= 0 and edge_mask.max() <= 1
     if not allow_edge_mask:
-        assert list(edge_mask) == [
-            1., 1., 1., 1., 1., 1., 1., 1., 0., 0., 0., 0., 0., 0.
-        ]
+        assert edge_mask[:8].tolist() == [1.] * 8
+        assert edge_mask[8:].tolist() == [0.] * 6
 
 
 @pytest.mark.parametrize('allow_edge_mask', [True, False])
@@ -141,7 +141,7 @@ def test_gnn_explainer_to_log_prob(model):
     assert torch.allclose(prob_to_log(prob), log_to_log(log_prob))
 
 
-@pytest.mark.parametrize('return_type', ['log_prob', 'regression'])
+@pytest.mark.parametrize('return_type', return_types)
 @pytest.mark.parametrize('model', [GAT()])
 def test_gnn_explainer_with_existing_self_loops(model, return_type):
     explainer = GNNExplainer(model, log=False, return_type=return_type)

--- a/test/nn/models/test_gnn_explainer.py
+++ b/test/nn/models/test_gnn_explainer.py
@@ -48,9 +48,13 @@ class GNN(torch.nn.Module):
         return x.log_softmax(dim=1)
 
 
+@pytest.mark.parametrize('allow_edge_mask', [True, False])
+@pytest.mark.parametrize('return_type', ['log_prob', 'regression'])
+@pytest.mark.parametrize('feat_mask_type', ['individual_feature', 'scalar', 'feature'])
 @pytest.mark.parametrize('model', [GCN(), GAT()])
-def test_gnn_explainer_explain_node(model):
-    explainer = GNNExplainer(model, log=False)
+def test_gnn_explainer_explain_node(model, return_type, allow_edge_mask, feat_mask_type):
+    explainer = GNNExplainer(model, log=False, return_type=return_type,
+                             allow_edge_mask=allow_edge_mask, feat_mask_type=feat_mask_type)
     assert explainer.__repr__() == 'GNNExplainer()'
 
     x = torch.randn(8, 3)
@@ -59,26 +63,53 @@ def test_gnn_explainer_explain_node(model):
                                [1, 0, 2, 1, 3, 2, 4, 3, 5, 4, 6, 5, 7, 6]])
 
     node_feat_mask, edge_mask = explainer.explain_node(2, x, edge_index)
-    _, _ = explainer.visualize_subgraph(2, edge_index, edge_mask, y=y,
-                                        threshold=0.8)
-    assert node_feat_mask.size() == (x.size(1), )
+    if feat_mask_type == 'scalar':
+        _, _ = explainer.visualize_subgraph(2, edge_index, edge_mask, y=y,
+                                            threshold=0.8, node_alpha=node_feat_mask)
+    else:
+        edge_y = torch.randint(low=0, high=30, size=(edge_index.size(1),))
+        _, _ = explainer.visualize_subgraph(2, edge_index, edge_mask, y=y, edge_y=edge_y,
+                                            threshold=0.8)
+    if feat_mask_type == 'individual_feature':
+        assert node_feat_mask.size() == x.size()
+    elif feat_mask_type == 'scalar':
+        assert node_feat_mask.size() == (x.size(0),)
+    else:
+        assert node_feat_mask.size() == (x.size(1), )
     assert node_feat_mask.min() >= 0 and node_feat_mask.max() <= 1
     assert edge_mask.size() == (edge_index.size(1), )
     assert edge_mask.min() >= 0 and edge_mask.max() <= 1
+    if not allow_edge_mask:
+        assert list(edge_mask) == [1., 1., 1., 1.,
+                                   1., 1., 1., 1., 0., 0., 0., 0., 0., 0.]
 
 
+@pytest.mark.parametrize('allow_edge_mask', [True, False])
+@pytest.mark.parametrize('return_type', ['log_prob', 'regression'])
+@pytest.mark.parametrize('feat_mask_type', ['individual_feature', 'scalar', 'feature'])
 @pytest.mark.parametrize('model', [GNN()])
-def test_gnn_explainer_explain_graph(model):
-    explainer = GNNExplainer(model, log=False)
+def test_gnn_explainer_explain_graph(model, return_type, allow_edge_mask, feat_mask_type):
+    explainer = GNNExplainer(model, log=False, return_type=return_type,
+                             allow_edge_mask=allow_edge_mask, feat_mask_type=feat_mask_type)
 
     x = torch.randn(8, 3)
     edge_index = torch.tensor([[0, 1, 1, 2, 2, 3, 4, 5, 5, 6, 6, 7],
                                [1, 0, 2, 1, 3, 2, 5, 4, 6, 5, 7, 6]])
 
     node_feat_mask, edge_mask = explainer.explain_graph(x, edge_index)
-    _, _ = explainer.visualize_subgraph(-1, edge_index, edge_mask,
-                                        y=torch.tensor(2), threshold=0.8)
-    assert node_feat_mask.size() == (x.size(1), )
+    if feat_mask_type == 'scalar':
+        _, _ = explainer.visualize_subgraph(-1, edge_index, edge_mask, y=torch.tensor(2),
+                                            threshold=0.8, node_alpha=node_feat_mask)
+    else:
+        edge_y = torch.randint(low=0, high=30, size=(edge_index.size(1),))
+        _, _ = explainer.visualize_subgraph(-1, edge_index, edge_mask, edge_y=edge_y,
+                                            y=torch.tensor(2), threshold=0.8)
+    if feat_mask_type == 'individual_feature':
+        assert node_feat_mask.size() == x.size()
+    elif feat_mask_type == 'scalar':
+        assert node_feat_mask.size() == (x.size(0),)
+    else:
+        assert node_feat_mask.size() == (x.size(1), )
     assert node_feat_mask.min() >= 0 and node_feat_mask.max() <= 1
     assert edge_mask.size() == (edge_index.size(1), )
     assert edge_mask.max() <= 1 and edge_mask.min() >= 0
@@ -98,9 +129,10 @@ def test_gnn_explainer_to_log_prob(model):
     assert torch.allclose(prob_to_log(prob), log_to_log(log_prob))
 
 
-@pytest.mark.parametrize('model', [GAT()])
-def test_gnn_explainer_with_existing_self_loops(model):
-    explainer = GNNExplainer(model, log=False)
+@pytest.mark.parametrize('return_type', ['log_prob', 'regression'])
+@pytest.mark.parametrize('model', [GAT(), GCN()])
+def test_gnn_explainer_with_existing_self_loops(model, return_type):
+    explainer = GNNExplainer(model, log=False, return_type=return_type)
 
     x = torch.randn(8, 3)
     edge_index = torch.tensor([[0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7],

--- a/test/nn/models/test_gnn_explainer.py
+++ b/test/nn/models/test_gnn_explainer.py
@@ -48,13 +48,18 @@ class GNN(torch.nn.Module):
         return x.log_softmax(dim=1)
 
 
+feat_mask_types = ['individual_feature', 'scalar', 'feature']
+
+
 @pytest.mark.parametrize('allow_edge_mask', [True, False])
 @pytest.mark.parametrize('return_type', ['log_prob', 'regression'])
-@pytest.mark.parametrize('feat_mask_type', ['individual_feature', 'scalar', 'feature'])
+@pytest.mark.parametrize('feat_mask_type', feat_mask_types)
 @pytest.mark.parametrize('model', [GCN(), GAT()])
-def test_gnn_explainer_explain_node(model, return_type, allow_edge_mask, feat_mask_type):
+def test_gnn_explainer_explain_node(model, return_type, allow_edge_mask,
+                                    feat_mask_type):
     explainer = GNNExplainer(model, log=False, return_type=return_type,
-                             allow_edge_mask=allow_edge_mask, feat_mask_type=feat_mask_type)
+                             allow_edge_mask=allow_edge_mask,
+                             feat_mask_type=feat_mask_type)
     assert explainer.__repr__() == 'GNNExplainer()'
 
     x = torch.randn(8, 3)
@@ -65,11 +70,12 @@ def test_gnn_explainer_explain_node(model, return_type, allow_edge_mask, feat_ma
     node_feat_mask, edge_mask = explainer.explain_node(2, x, edge_index)
     if feat_mask_type == 'scalar':
         _, _ = explainer.visualize_subgraph(2, edge_index, edge_mask, y=y,
-                                            threshold=0.8, node_alpha=node_feat_mask)
+                                            threshold=0.8,
+                                            node_alpha=node_feat_mask)
     else:
         edge_y = torch.randint(low=0, high=30, size=(edge_index.size(1),))
-        _, _ = explainer.visualize_subgraph(2, edge_index, edge_mask, y=y, edge_y=edge_y,
-                                            threshold=0.8)
+        _, _ = explainer.visualize_subgraph(2, edge_index, edge_mask,
+                                            y=y, edge_y=edge_y, threshold=0.8)
     if feat_mask_type == 'individual_feature':
         assert node_feat_mask.size() == x.size()
     elif feat_mask_type == 'scalar':
@@ -86,11 +92,13 @@ def test_gnn_explainer_explain_node(model, return_type, allow_edge_mask, feat_ma
 
 @pytest.mark.parametrize('allow_edge_mask', [True, False])
 @pytest.mark.parametrize('return_type', ['log_prob', 'regression'])
-@pytest.mark.parametrize('feat_mask_type', ['individual_feature', 'scalar', 'feature'])
+@pytest.mark.parametrize('feat_mask_type', feat_mask_types)
 @pytest.mark.parametrize('model', [GNN()])
-def test_gnn_explainer_explain_graph(model, return_type, allow_edge_mask, feat_mask_type):
+def test_gnn_explainer_explain_graph(model, return_type, allow_edge_mask,
+                                     feat_mask_type):
     explainer = GNNExplainer(model, log=False, return_type=return_type,
-                             allow_edge_mask=allow_edge_mask, feat_mask_type=feat_mask_type)
+                             allow_edge_mask=allow_edge_mask,
+                             feat_mask_type=feat_mask_type)
 
     x = torch.randn(8, 3)
     edge_index = torch.tensor([[0, 1, 1, 2, 2, 3, 4, 5, 5, 6, 6, 7],
@@ -98,12 +106,18 @@ def test_gnn_explainer_explain_graph(model, return_type, allow_edge_mask, feat_m
 
     node_feat_mask, edge_mask = explainer.explain_graph(x, edge_index)
     if feat_mask_type == 'scalar':
-        _, _ = explainer.visualize_subgraph(-1, edge_index, edge_mask, y=torch.tensor(2),
-                                            threshold=0.8, node_alpha=node_feat_mask)
+        _, _ = explainer.visualize_subgraph(-1, edge_index,
+                                            edge_mask,
+                                            y=torch.tensor(2),
+                                            threshold=0.8,
+                                            node_alpha=node_feat_mask)
     else:
         edge_y = torch.randint(low=0, high=30, size=(edge_index.size(1),))
-        _, _ = explainer.visualize_subgraph(-1, edge_index, edge_mask, edge_y=edge_y,
-                                            y=torch.tensor(2), threshold=0.8)
+        _, _ = explainer.visualize_subgraph(-1, edge_index,
+                                            edge_mask,
+                                            edge_y=edge_y,
+                                            y=torch.tensor(2),
+                                            threshold=0.8)
     if feat_mask_type == 'individual_feature':
         assert node_feat_mask.size() == x.size()
     elif feat_mask_type == 'scalar':
@@ -130,7 +144,7 @@ def test_gnn_explainer_to_log_prob(model):
 
 
 @pytest.mark.parametrize('return_type', ['log_prob', 'regression'])
-@pytest.mark.parametrize('model', [GAT(), GCN()])
+@pytest.mark.parametrize('model', [GAT()])
 def test_gnn_explainer_with_existing_self_loops(model, return_type):
     explainer = GNNExplainer(model, log=False, return_type=return_type)
 

--- a/torch_geometric/nn/models/gnn_explainer.py
+++ b/torch_geometric/nn/models/gnn_explainer.py
@@ -51,13 +51,13 @@ class GNNExplainer(torch.nn.Module):
             to use individual feature-level mask for each node, and
             :obj:`'scalar'` to use a scalar (node-level) mask for each
             individual node. (default: :obj:`'feature'`)
-        allow_edge_mask (boolean, optional): if False, edge mask will not
+        allow_edge_mask (boolean, optional): if set to :obj:`False`, edge mask will not
             be optimized.
             (default: :obj:`True`)
-        coeffs (dict, optional): Dictionary of hyperparameters with which
-            to update the coefficients dictionary
         log (bool, optional): If set to :obj:`False`, will not log any learning
             progress. (default: :obj:`True`)
+        **kwargs (dict, optional): Additional hyperparameters with which
+            to update the coefficients dictionary
     """
 
     coeffs = {
@@ -72,7 +72,7 @@ class GNNExplainer(torch.nn.Module):
     def __init__(self, model, epochs: int = 100, lr: float = 0.01,
                  num_hops: Optional[int] = None, return_type: str = 'log_prob',
                  feat_mask_type: str = 'feature', allow_edge_mask: bool = True,
-                 coeffs: Union[dict, None] = None, log: bool = True):
+                 log: bool = True, **kwargs):
         super(GNNExplainer, self).__init__()
         assert return_type in ['log_prob', 'prob', 'raw', 'regression']
         assert feat_mask_type in ['feature', 'individual_feature', 'scalar']
@@ -84,8 +84,7 @@ class GNNExplainer(torch.nn.Module):
         self.log = log
         self.allow_edge_mask = allow_edge_mask
         self.feat_mask_type = feat_mask_type
-        if coeffs is not None:
-            self.coeffs.update(coeffs)
+        self.coeffs.update(kwargs)
 
     def __set_masks__(self, x, edge_index, init="normal"):
         (N, F), E = x.size(), edge_index.size(1)

--- a/torch_geometric/nn/models/gnn_explainer.py
+++ b/torch_geometric/nn/models/gnn_explainer.py
@@ -1,4 +1,4 @@
-from typing import Optional, Union
+from typing import Optional
 
 from math import sqrt
 from inspect import signature

--- a/torch_geometric/nn/models/gnn_explainer.py
+++ b/torch_geometric/nn/models/gnn_explainer.py
@@ -97,7 +97,7 @@ class GNNExplainer(torch.nn.Module):
         self.edge_mask = torch.nn.Parameter(torch.randn(E) * std)
         if not self.allow_edge_mask:
             self.edge_mask.requires_grad_(False)
-            self.edge_mask.fill_(float('inf'))  # Sigmoid returns `1`.
+            self.edge_mask.fill_(float('inf'))  # `sigmoid()` returns `1`.
         self.loop_mask = edge_index[0] != edge_index[1]
 
         for module in self.model.modules():

--- a/torch_geometric/nn/models/gnn_explainer.py
+++ b/torch_geometric/nn/models/gnn_explainer.py
@@ -51,9 +51,8 @@ class GNNExplainer(torch.nn.Module):
             to use individual feature-level mask for each node, and
             :obj:`'scalar'` to use a scalar (node-level) mask for each
             individual node. (default: :obj:`'feature'`)
-        allow_edge_mask (boolean, optional): if set to :obj:`False`, edge mask will not
-            be optimized.
-            (default: :obj:`True`)
+        allow_edge_mask (boolean, optional): if set to :obj:`False`, edge mask
+            will not be optimized. (default: :obj:`True`)
         log (bool, optional): If set to :obj:`False`, will not log any learning
             progress. (default: :obj:`True`)
         **kwargs (dict, optional): Additional hyperparameters with which


### PR DESCRIPTION
This updates the `GNNExplainer` model with the following:
* Support for  `return_type='regression'`. The error term of loss is then calculated as Euclidean distance between the original and current prediction.
* Support for different types of node mask (node-level, feature-level and feature-level for each individual node)
* Some subgraph visualization parameters (`node_alpha`, `edge_y` and `plot_random_state` for reproducible node placement)
