### PR TITLE
graphgym: fix clash of run_dir naming, better save location for config and log files

### DIFF
--- a/graphgym/main.py
+++ b/graphgym/main.py
@@ -40,14 +40,15 @@ if __name__ == '__main__':
     load_cfg(cfg, args)
     # Set Pytorch environment
     torch.set_num_threads(cfg.num_threads)
-    dump_cfg(cfg)
-    set_printing()
+    dump_cfg(cfg, args.cfg_file)
     # Repeat for different random seeds
     for i in range(args.repeat):
         # Set configurations for each run
-        seed_everything(cfg.seed + i)
+        cfg.seed += 1
+        seed_everything(cfg.seed)
         auto_select_device()
         set_run_dir(cfg.out_dir, args.cfg_file)
+        set_printing()
         # Set machine learning pipeline
         loaders = create_loader()
         loggers = create_logger()

--- a/torch_geometric/graphgym/config.py
+++ b/torch_geometric/graphgym/config.py
@@ -37,7 +37,7 @@ def set_cfg(cfg):
     cfg.cfg_dest = 'config.yaml'
 
     # Random seed
-    cfg.seed = 1
+    cfg.seed = 0
 
     # Print rounding
     cfg.round = 4
@@ -473,16 +473,21 @@ def assert_cfg(cfg):
     cfg.run_dir = cfg.out_dir
 
 
-def dump_cfg(cfg):
+def dump_cfg(cfg, fname):
     r"""
-    Dumps the config to the output directory specified in
-    :obj:`cfg.out_dir`
+    Dumps the config to the output directory in
+    :obj:`cfg.out_dir/fname`
 
     Args:
         cfg (CfgNode): Configuration node
 
     """
-    cfg_file = os.path.join(cfg.out_dir, cfg.cfg_dest)
+    fname = fname.split('/')[-1]
+    if fname.endswith('.yaml'):
+        fname = fname[:-5]
+    cfg_dir = os.path.join(cfg.out_dir, fname)
+    os.makedirs(cfg_dir, exist_ok=True)
+    cfg_file = os.path.join(cfg_dir, cfg.cfg_dest)
     with open(cfg_file, 'w') as f:
         cfg.dump(stream=f)
 


### PR DESCRIPTION
When running `graphgym/main.py` with multiple repetitions, the results of every run were overriding the previous run. The reason is that the `run_dir` name (where the results are written) depends on `cfg.seed`, which is not updated in between runs.

This PR fixes this by updating `cfg.seed` for every new repetition.

Furthermore, the config file was always dumped to `out_dir`. Running another experiment with another config file, but the same `out_dir` would cause the previous (different) config file to be overwritten. The same holds for the log file. Especially in the case of running over a grid, the dumped config for each grid configuration was overwritten by the next configuration tested. Instead, each directory that saves the results for a specific configuration should also contain the corresponding config and log files.

This PR fixes this by dumping both config and log file into `out_dir/fname` where `fname` is the config file name. The single runs are also contained in this directory, under `out_dir/fname/1`, `out_dir/fname/2`, etc. IMHO it makes sense to keep the config file there.

Test suite, `pycodestyle` and `flake8` were run. Tests pass. No new style issues in the files that are touched by this PR.