### PR TITLE
Fix memory updater in tgn.py.

### DIFF
--- a/torch_geometric/nn/models/tgn.py
+++ b/torch_geometric/nn/models/tgn.py
@@ -137,9 +137,8 @@ class TGNMemory(torch.nn.Module):
         memory = self.gru(aggr, self.memory[n_id])
 
         # Get local copy of updated `last_update`.
-        last_update = scatter_max(t, idx, dim=0, dim_size=self.last_update.shape[0])[0][
-             n_id
-         ]
+        last_update = scatter_max(
+            t, idx, dim=0, dim_size=self.last_update.shape[0])[0][n_id]
 
         return memory, last_update
 

--- a/torch_geometric/nn/models/tgn.py
+++ b/torch_geometric/nn/models/tgn.py
@@ -137,8 +137,8 @@ class TGNMemory(torch.nn.Module):
         memory = self.gru(aggr, self.memory[n_id])
 
         # Get local copy of updated `last_update`.
-        last_update = scatter_max(
-            t, idx, dim=0, dim_size=self.last_update.shape[0])[0][n_id]
+        dim_size = self.last_update.size(0)
+        last_update = scatter_max(t, idx, dim=0, dim_size=dim_size)[0][n_id]
 
         return memory, last_update
 

--- a/torch_geometric/nn/models/tgn.py
+++ b/torch_geometric/nn/models/tgn.py
@@ -137,7 +137,9 @@ class TGNMemory(torch.nn.Module):
         memory = self.gru(aggr, self.memory[n_id])
 
         # Get local copy of updated `last_update`.
-        last_update = self.last_update.scatter(0, idx, t)[n_id]
+        last_update = scatter_max(t, idx, dim=0, dim_size=self.last_update.shape[0])[0][
+             n_id
+         ]
 
         return memory, last_update
 


### PR DESCRIPTION
The behavior of `scatter` is non-deterministic when indices are not unique ([docs](https://pytorch.org/docs/stable/generated/torch.Tensor.scatter_.html)), resulting in `last_update` to be replaced with random timestamp. Modified `scatter` to `scatter_max` in torch_scatter.