### PR TITLE
Imporve negative sampling

### DIFF
--- a/test/utils/test_negative_sampling.py
+++ b/test/utils/test_negative_sampling.py
@@ -1,7 +1,9 @@
 import torch
-from torch_geometric.utils import to_undirected, is_undirected
+from torch_geometric.utils import (to_undirected, is_undirected,
+                                   contains_self_loops)
 from torch_geometric.utils.negative_sampling import edge_index_to_vector
 from torch_geometric.utils.negative_sampling import vector_to_edge_index
+from torch_geometric.utils.negative_sampling import is_neg_samp_feasible
 from torch_geometric.utils import (negative_sampling,
                                    structured_negative_sampling,
                                    batched_negative_sampling)
@@ -28,14 +30,16 @@ def test_edge_index_to_vector_and_vice_versa():
     col = torch.arange(N).view(1, -1).repeat(N, 1).view(-1)
     edge_index = torch.stack([row, col], dim=0)
 
-    idx, population = edge_index_to_vector(edge_index, (N, N), bipartite=True)
+    idx, population = edge_index_to_vector(edge_index, (N, N),
+                                           bipartite=True)
     assert population == N * N
     assert idx.tolist() == list(range(population))
     edge_index2 = vector_to_edge_index(idx, (N, N), bipartite=True)
     assert is_undirected(edge_index2)
     assert edge_index.tolist() == edge_index2.tolist()
 
-    idx, population = edge_index_to_vector(edge_index, (N, N), bipartite=False)
+    idx, population = edge_index_to_vector(edge_index, (N, N),
+                                           bipartite=False)
     assert population == N * N - N
     assert idx.tolist() == list(range(population))
     mask = edge_index[0] != edge_index[1]  # Remove self-loops.
@@ -43,7 +47,8 @@ def test_edge_index_to_vector_and_vice_versa():
     assert is_undirected(edge_index2)
     assert edge_index[:, mask].tolist() == edge_index2.tolist()
 
-    idx, population = edge_index_to_vector(edge_index, (N, N), bipartite=False,
+    idx, population = edge_index_to_vector(edge_index, (N, N),
+                                           bipartite=False,
                                            force_undirected=True)
     assert population == (N * (N + 1)) / 2 - N
     assert idx.tolist() == list(range(population))
@@ -99,6 +104,38 @@ def test_structured_negative_sampling():
     neg_adj = torch.zeros(4, 4, dtype=torch.bool)
     neg_adj[i, k] = 1
     assert (adj & neg_adj).sum() == 0
+
+
+def test_structured_negative_sampling_without_self_loops():
+    edge_index = torch.LongTensor([[0, 0, 1, 1, 2], [1, 2, 0, 2, 1]])
+    i, j, k = structured_negative_sampling(edge_index, num_nodes=4,
+                                           contains_neg_self_loops=False)
+    neg_edge_index = torch.vstack([i, k])
+    assert not contains_self_loops(neg_edge_index)
+
+
+def test_check_feasibility_of_negative_sampling():
+    edge_index = torch.LongTensor(
+        [[0, 0, 1, 1, 2, 2, 2], [1, 2, 0, 2, 0, 1, 1]])
+    assert not is_neg_samp_feasible(edge_index, 'structure', 3, False, False)
+    assert is_neg_samp_feasible(edge_index, 'structure', 3, False, True)
+    assert is_neg_samp_feasible(edge_index, 'structure', 4, False, False)
+    assert not is_neg_samp_feasible(edge_index, 'common', 3, False)
+    assert is_neg_samp_feasible(edge_index, 'common', 4, False)
+    edge_index = torch.LongTensor([[0, 0, 1, 1, 2], [1, 2, 0, 2, 0]])
+    assert is_neg_samp_feasible(edge_index, 'common', 3, False)
+
+    # undirected
+    edge_index = torch.as_tensor([[0, 0, 1], [1, 2, 2]])
+    assert not is_neg_samp_feasible(edge_index, 'common', 3, False, False,
+                                    True)
+    assert is_neg_samp_feasible(edge_index, 'common', 3, False, False, False)
+
+    # bipartite
+    edge_index = torch.as_tensor([[0, 0, 1, 1, 2, 2], [0, 1, 0, 1, 0, 1]])
+    assert not is_neg_samp_feasible(edge_index, 'common', (3, 2), True)
+    edge_index = torch.as_tensor([[0, 0, 1, 1, 2], [0, 1, 0, 1, 0]])
+    assert is_neg_samp_feasible(edge_index, 'common', (3, 2), True)
 
 
 def test_batched_negative_sampling():

--- a/torch_geometric/utils/__init__.py
+++ b/torch_geometric/utils/__init__.py
@@ -26,7 +26,8 @@ from .random import (erdos_renyi_graph, stochastic_blockmodel_graph,
                      barabasi_albert_graph)
 from .negative_sampling import (negative_sampling,
                                 structured_negative_sampling,
-                                batched_negative_sampling)
+                                batched_negative_sampling,
+                                is_neg_samp_feasible)
 from .train_test_split_edges import train_test_split_edges
 from .metric import (accuracy, true_positive, true_negative, false_positive,
                      false_negative, precision, recall, f1_score,
@@ -71,6 +72,7 @@ __all__ = [
     'negative_sampling',
     'structured_negative_sampling',
     'batched_negative_sampling',
+    'is_neg_samp_feasible',
     'train_test_split_edges',
     'accuracy',
     'true_positive',


### PR DESCRIPTION
This PR does three things:
1. Allow `structured_negative_sampling` not to sample negative self-loops. 
2. As reject sampling will loop forever or raise an error if there are no possible negative edges. We add a function `is_neg_samp_feasible` for judging the feasibility of sampling. Its application utilizes `assert` which will only work in `debug` mode. We also make this function suitable for bipartite graphs and `force_undirected = True`.
3. Add related test unit cases.