### PR TITLE
Fixed an issue with parent state changing upon pickling

### DIFF
--- a/test/data/test_batch.py
+++ b/test/data/test_batch.py
@@ -193,10 +193,17 @@ def test_batching_with_new_dimension():
 def test_pickling():
     data = Data(x=torch.randn(5, 16))
     batch = Batch.from_data_list([data, data, data, data])
+    assert id(batch._store._parent()) == id(batch)
+    assert batch.num_nodes == 20
 
     path = f'{random.randrange(sys.maxsize)}.pt'
     torch.save(batch, path)
+    assert id(batch._store._parent()) == id(batch)
+    assert batch.num_nodes == 20
+
     batch = torch.load(path)
+    assert id(batch._store._parent()) == id(batch)
+    assert batch.num_nodes == 20
 
     assert batch.__class__.__name__ == 'DataBatch'
     assert len(batch) == 3

--- a/torch_geometric/data/storage.py
+++ b/torch_geometric/data/storage.py
@@ -95,7 +95,7 @@ class BaseStorage(MutableMapping):
         return out
 
     def __getstate__(self) -> Dict[str, Any]:
-        out = self.__dict__
+        out = self.__dict__.copy()
 
         _parent = out.get('_parent', None)
         if _parent is not None:


### PR DESCRIPTION
There's currently an issue with `BaseStorage` pickling `parent` objects.

The state of `BaseStorage` is modified upon pickling resulting the properties reliant on `self._parent` throwing errors.
For example, the property `num_nodes` and `num_edges` which relies on the call `self._parent()` will return unexpected result before and after pickling.
- Before Pickling: `num_nodes` and `num_edges` will return values accordingly when `x`, `pos` or `batch` is given.
- After Pickling: `num_nodes` and `num_edges` will throw an Exception because `self._parent` is now `self._parent()` and not a `weakref`.

This PR attempts to resolve this issue by returning a copy of `self.__dict__` instead of modifying it directly.