### PR TITLE
Minor clarification in instructions to install from master

### DIFF
--- a/README.md
+++ b/README.md
@@ -397,14 +397,7 @@ pip install torch-spline-conv -f https://data.pyg.org/whl/torch-1.8.0+${CUDA}.ht
 
 ### From master
 
-In case you want to experiment with the latest PyG features which are not fully released yet, ensure that `torch-scatter` and `torch-sparse` are installed by [following the [steps mentioned above](#pip-wheels)
-
-```
-pip install torch-scatter -f https://data.pyg.org/whl/torch-${TORCH}+${CUDA}.html
-pip install torch-sparse -f https://data.pyg.org/whl/torch-${TORCH}+${CUDA}.html
-```
-
-and install PyG from master via
+In case you want to experiment with the latest PyG features which are not fully released yet, ensure that `torch-scatter` and `torch-sparse` are installed by [following the steps mentioned above](#pip-wheels), and install PyG from master via:
 
 ```
 pip install git+https://github.com/pyg-team/pytorch_geometric.git


### PR DESCRIPTION
I tried to install from master to check out some of the exciting new PyG features and it complained about `torch_sparse` missing when just using `pip install git+https://github.com/pyg-team/pytorch_geometric.git`. 
I also needed to install the wheels for `torch_scatter` and `torch_sparse`, so I added the instructions to the README.md