### PR TITLE
fix neighbor_loader device

### DIFF
--- a/torch_geometric/loader/neighbor_loader.py
+++ b/torch_geometric/loader/neighbor_loader.py
@@ -200,7 +200,7 @@ class NeighborLoader(torch.utils.data.DataLoader):
             self.directed,
         )
 
-        data = filter_data(self.data, node, row, col, edge, self.perm)
+        data = filter_data(self.data, node, row, col, edge, self.perm).to(self.data.x.device)
         data.batch_size = len(indices)
         data = data if self.transform is None else self.transform(data)
 


### PR DESCRIPTION
Fix neighbor_loader device, make sure features and edges are on the same device. In some cases, the sampled edges/adj_t are on CPU while data.x is on GPU.