### PR TITLE
Point Transformer examples

### DIFF
--- a/examples/point_transformer_classification.py
+++ b/examples/point_transformer_classification.py
@@ -190,15 +190,16 @@ def test(loader):
 
 
 if __name__ == '__main__':
-    
+
     device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
     model = Net(train_dataset.num_classes, 1, dim_model=[
                 32, 64, 128, 256, 512], k=16).to(device)
     # NB : learning parameters are different from the paper
     optimizer = torch.optim.Adam(model.parameters(), lr=0.001)
-    scheduler = torch.optim.lr_scheduler.StepLR(optimizer, step_size=20, gamma=0.5)
-    
-    
+    scheduler = torch.optim.lr_scheduler.StepLR(optimizer,
+                                                step_size=20,
+                                                gamma=0.5)
+
     for epoch in range(1, 201):
         loss = train()
         test_acc = test(test_loader)

--- a/examples/point_transformer_classification.py
+++ b/examples/point_transformer_classification.py
@@ -95,6 +95,11 @@ class TransitionDown(torch.nn.Module):
         sub_pos, out = pos[id_clusters], x_out
         return out, sub_pos, sub_batch
 
+def MLP(channels):
+    return Seq(*[
+        Seq(Lin(channels[i - 1], channels[i]), BN(channels[i]), ReLU())
+        for i in range(1, len(channels))
+    ])
 
 class Net(torch.nn.Module):
     def __init__(self, in_channels, out_channels, dim_model, k=16):
@@ -105,11 +110,7 @@ class Net(torch.nn.Module):
         in_channels = max(in_channels, 1)
 
         # first block
-        self.mlp_input = Seq(
-            Lin(in_channels, dim_model[0]),
-            BN(dim_model[0]),
-            ReLU()
-        )
+        self.mlp_input = MLP([in_channels, dim_model[0]])
 
         self.transformer_input = TransformerBlock(in_channels=dim_model[0],
                                                   out_channels=dim_model[0])

--- a/examples/point_transformer_classification.py
+++ b/examples/point_transformer_classification.py
@@ -16,8 +16,6 @@ from torch_cluster import fps
 from torch_scatter import scatter_max
 
 path = osp.join(osp.dirname(osp.realpath(__file__)), '..', 'data/ModelNet10')
-# In its current state, PointTransformerConv does not support the absence of
-# features, so we create dummy nodes features with the 'Constant' Transform
 pre_transform, transform = T.NormalizeScale(), T.Compose(
     [T.SamplePoints(1024)])
 train_dataset = ModelNet(path, '10', True, transform, pre_transform)
@@ -27,9 +25,9 @@ test_loader = DataLoader(test_dataset, batch_size=32, shuffle=False)
 
 
 class TransformerBlock(torch.nn.Module):
-    def __init__(self, in_channels, out_channels, hidden_channels):
+    def __init__(self, in_channels, out_channels):
         super(TransformerBlock, self).__init__()
-        self.lin_in = Lin(in_channels, hidden_channels)
+        self.lin_in = Lin(in_channels, in_channels)
         self.lin_out = Lin(out_channels, out_channels)
 
         self.pos_nn = Seq(
@@ -45,7 +43,7 @@ class TransformerBlock(torch.nn.Module):
         )
 
         self.transformer = PointTransformerConv(
-            hidden_channels,
+            in_channels,
             out_channels,
             pos_nn=self.pos_nn,
             attn_nn=self.attn_nn
@@ -56,37 +54,49 @@ class TransformerBlock(torch.nn.Module):
         x = self.lin_in(x).relu()
         x = self.transformer(x, pos, edge_index)
         x = self.lin_out(x).relu()
-        # x = x + x_skip
+        # x = x + x_skip # negatively impacts training
         return x
 
 
-def transition_down(x, pos, mlp, batch=None, k=16):
+class TransitionDown(torch.nn.Module):
     '''
         Samples the input point cloud by a ratio percentage to reduce
         cardinality and uses an mlp to augment features dimensionnality
     '''
 
-    # FPS sampling
-    id_clusters = fps(pos, ratio=0.25, batch=batch)
+    def __init__(self, in_channels, out_channels, ratio=0.25, k=16):
+        super(TransitionDown, self).__init__()
+        self.k = k
+        self.ratio = ratio
+        self.mlp = Seq(
+            Lin(in_channels, out_channels),
+            BN(out_channels),
+            ReLU()
+        )
 
-    # compute for each cluster the k nearest points
-    sub_batch = batch[id_clusters] if batch is not None else None
-    # beware of self loop
-    id_k_neighbor = knn(pos, pos[id_clusters], k=k,
-                        batch_x=batch, batch_y=sub_batch)
+    def forward(self, x, pos, batch):
+        # FPS sampling
+        id_clusters = fps(pos, ratio=self.ratio, batch=batch)
 
-    # transformation of features through a simple MLP
-    x = mlp(x)
+        # compute for each cluster the k nearest points
+        sub_batch = batch[id_clusters] if batch is not None else None
 
-    # Max pool onto each cluster the features from knn in points
-    x_out, _ = scatter_max(x[id_k_neighbor[1]],
-                           id_k_neighbor[0],
-                           dim_size=id_clusters.size(0),
-                           dim=0)
+        # beware of self loop
+        id_k_neighbor = knn(pos, pos[id_clusters], k=self.k,
+                            batch_x=batch, batch_y=sub_batch)
 
-    # keep only the clusters and their max-pooled features
-    new_pos, new_x = pos[id_clusters], x_out
-    return new_x, new_pos, sub_batch
+        # transformation of features through a simple MLP
+        x = self.mlp(x)
+
+        # Max pool onto each cluster the features from knn in points
+        x_out, _ = scatter_max(x[id_k_neighbor[1]],
+                               id_k_neighbor[0],
+                               dim_size=id_clusters.size(0),
+                               dim=0)
+
+        # keep only the clusters and their max-pooled features
+        new_pos, new_x = pos[id_clusters], x_out
+        return new_x, new_pos, sub_batch
 
 
 class Net(torch.nn.Module):
@@ -105,25 +115,22 @@ class Net(torch.nn.Module):
         )
 
         self.transformer_input = TransformerBlock(in_channels=dim_model[0],
-                                                  out_channels=dim_model[0],
-                                                  hidden_channels=dim_model[0])
-
+                                                  out_channels=dim_model[0])
         # backbone layers
         self.transformers_down = torch.nn.ModuleList()
-        self.mlp_down = torch.nn.ModuleList()
+        self.transition_down = torch.nn.ModuleList()
 
         for i in range(len(dim_model) - 1):
             # Add Transition Down block followed by a Transformer block
-            self.mlp_down.append(Seq(
-                Lin(dim_model[i], dim_model[i + 1]),
-                BN(dim_model[i + 1]),
-                ReLU())
+            self.transition_down.append(
+                TransitionDown(in_channels=dim_model[i],
+                               out_channels=dim_model[i + 1],
+                               k=self.k)
             )
 
             self.transformers_down.append(
                 TransformerBlock(in_channels=dim_model[i + 1],
-                                 out_channels=dim_model[i + 1],
-                                 hidden_channels=dim_model[i + 1])
+                                 out_channels=dim_model[i + 1])
             )
 
         # class score computation
@@ -147,8 +154,7 @@ class Net(torch.nn.Module):
 
         # backbone
         for i in range(len(self.transformers_down)):
-            x, pos, batch = transition_down(
-                x, pos, self.mlp_down[i], batch=batch, k=self.k)
+            x, pos, batch = self.transition_down[i](x, pos, batch=batch)
 
             edge_index = knn_graph(pos, k=self.k, batch=batch)
             x = self.transformers_down[i](x, pos, edge_index)
@@ -194,7 +200,6 @@ if __name__ == '__main__':
     device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
     model = Net(train_dataset.num_classes, 1, dim_model=[
                 32, 64, 128, 256, 512], k=16).to(device)
-    # NB : learning parameters are different from the paper
     optimizer = torch.optim.Adam(model.parameters(), lr=0.001)
     scheduler = torch.optim.lr_scheduler.StepLR(optimizer,
                                                 step_size=20,

--- a/examples/point_transformer_classification.py
+++ b/examples/point_transformer_classification.py
@@ -1,0 +1,193 @@
+import os.path as osp
+
+import torch
+import torch.nn.functional as F
+from torch.nn import Sequential as Seq, Linear as Lin, BatchNorm1d as BN, ReLU
+
+import torch_geometric.transforms as T
+from torch_geometric.datasets import ModelNet
+from torch_geometric.data import DataLoader, Data
+from torch_geometric.nn.pool import max_pool_neighbor_x, knn
+from torch_geometric.nn.conv import PointTransformerConv
+from torch_geometric.graphgym.models import global_mean_pool
+
+from torch_cluster import knn_graph
+from torch_cluster import fps
+
+path = osp.join(osp.dirname(osp.realpath(__file__)), '..', 'data/ModelNet10')
+#In its current state, PointTransformerConv does not support the absence of features, so we create dummy nodes features with the 'Constant' Transform
+pre_transform, transform = T.NormalizeScale(), T.Compose([T.SamplePoints(1024), T.Constant(1)])
+train_dataset = ModelNet(path, '10', True, transform, pre_transform)
+test_dataset = ModelNet(path, '10', False, transform, pre_transform)
+train_loader = DataLoader(train_dataset, batch_size=32, shuffle=True)
+test_loader = DataLoader(test_dataset, batch_size=32, shuffle=False)
+
+class TransformerBlock(torch.nn.Module):
+    def __init__(self, in_channels, out_channels, hidden_channels):
+        super(TransformerBlock, self).__init__()
+        self.lin_in = Seq( Lin(in_channels, hidden_channels), ReLU())
+        self.lin_out = Seq( Lin(out_channels, out_channels), ReLU())
+        
+        self.pos_nn = Seq(
+                Lin(3, 64),
+                ReLU(),
+                Lin(64, out_channels)
+            )
+        
+        self.attn_nn = Seq(
+                Lin(out_channels, 64),
+                ReLU(),
+                Lin(64, out_channels)
+            )
+
+        self.transformer = PointTransformerConv(in_channels, out_channels, pos_nn=self.pos_nn, attn_nn=self.attn_nn)
+        
+    def forward(self, x, pos, edge_index):
+        x = self.lin_in(x)
+        x = self.transformer(x, pos, edge_index)
+        x = self.lin_out(x)
+        
+        return x
+
+
+
+
+def transition_down(x, pos, mlp, batch=None, k=16):
+    '''
+        Samples the input point cloud by a ratio percentage to reduce 
+        cardinality and uses an mlp to augment features dimensionnality
+    '''
+    
+    #FPS sampling
+    id_clusters = fps(pos, ratio = 0.25, batch=batch)
+    
+    #compute for each cluster the k nearest points
+    sub_batch = batch[id_clusters] if batch is not None else None
+    id_k_neighbor = knn(pos, pos[id_clusters], k=k, batch_x=batch, batch_y = sub_batch) #beware of self loop
+    
+    #transformation of features through a simple MLP
+    x = mlp(x)
+    
+    #Max pool onto each cluster the features from knn in points
+    data = Data(pos = pos, x=x, edge_index= id_k_neighbor, batch=batch)
+    max_pool_neighbor_x(data)
+    
+    #keep only the clusters and their max-pooled features
+    new_pos, new_x = data.pos[id_clusters], data.x[id_clusters]
+    return new_x, new_pos, sub_batch
+
+    
+def MLP(channels, batch_norm=True):
+    return Seq(*[
+        Seq(Lin(channels[i - 1], channels[i]), ReLU(), BN(channels[i]))
+        for i in range(1, len(channels))
+    ])
+
+
+class Net(torch.nn.Module):    
+    def __init__(self, NUM_CLASSES, NUM_FEATURES, dim_model= [32,64,128,256,512], k=16):
+        super(Net, self).__init__()
+        self.k = k
+        
+        #first block
+        self.mlp_input = Seq(
+            Lin(NUM_FEATURES, 32),
+            BN(32), 
+            ReLU()
+        )        
+        
+        #backbone layers
+        self.transformers_down = torch.nn.ModuleList()
+        self.mlp_down = torch.nn.ModuleList()
+        
+        for i in range(len(dim_model)-1):
+            
+            #Add Point Transformer block followed by a Transition Down block
+            self.transformers_down.append(
+                TransformerBlock(in_channels = dim_model[i], 
+                                 out_channels = dim_model[i + 1], 
+                                 hidden_channels= dim_model[i])
+                )
+            self.mlp_down.append(Seq( 
+                                Lin(dim_model[i+1], dim_model[i+1]), 
+                                BN(dim_model[i+1]), 
+                                ReLU()) 
+                )
+            
+        #end block
+        self.transformer = TransformerBlock(in_channels = dim_model[-1], out_channels = dim_model[-1], hidden_channels= dim_model[-1])
+        
+    
+        #class score computation
+        self.lin = Seq(Lin(dim_model[-1],64),
+                              ReLU(),
+                              Lin(64,64),
+                              ReLU(),
+                              Lin(64,NUM_CLASSES))
+                    
+        
+
+
+    def forward(self, data):
+        x, pos, batch = data.x, data.pos, data.batch
+
+        #first block
+        x = self.mlp_input(x)
+        
+        #backbone
+        for i in range(len(self.transformers_down)):
+            edge_index = knn_graph(pos, k=self.k, batch = batch)
+            x = self.transformers_down[i](x, pos, edge_index)
+            x, pos, batch = transition_down(x, pos, self.mlp_down[i], batch = batch, k=self.k)
+        
+        #end block
+        edge_index = knn_graph(pos, k=self.k, batch = batch)
+        x = self.transformer(x, pos, edge_index)
+        
+        #GlobalAveragePooling
+        x = global_mean_pool(x, batch)
+            
+        #Class score
+        out = self.lin(x)
+        
+        return F.log_softmax(out, dim=-1)
+
+device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
+model = Net(train_dataset.num_classes, 1, k=16).to(device)
+optimizer = torch.optim.SGD(model.parameters(), lr=0.05, momentum=0.9, weight_decay=0.0001)
+scheduler = torch.optim.lr_scheduler.MultiStepLR(optimizer, milestones=[120,160], gamma=0.1)
+
+
+def train():
+    model.train()
+
+    total_loss = 0
+    for data in train_loader:
+        data = data.to(device)
+        optimizer.zero_grad()
+        out = model(data)
+        loss = F.nll_loss(out, data.y)
+        loss.backward()
+        total_loss += loss.item() * data.num_graphs
+        optimizer.step()
+    return total_loss / len(train_dataset)
+
+
+def test(loader):
+    model.eval()
+
+    correct = 0
+    for data in loader:
+        data = data.to(device)
+        with torch.no_grad():
+            pred = model(data).max(dim=1)[1]
+        correct += pred.eq(data.y).sum().item()
+    return correct / len(loader.dataset)
+
+
+for epoch in range(1, 201):
+    loss = train()
+    test_acc = test(test_loader)
+    print('Epoch {:03d}, Loss: {:.4f}, Test: {:.4f}'.format(
+        epoch, loss, test_acc))
+    scheduler.step()

--- a/examples/point_transformer_classification.py
+++ b/examples/point_transformer_classification.py
@@ -52,11 +52,11 @@ class TransformerBlock(torch.nn.Module):
         )
 
     def forward(self, x, pos, edge_index):
-        x_skip = x.clone()
+        #x_skip = x.clone()
         x = self.lin_in(x).relu()
         x = self.transformer(x, pos, edge_index)
         x = self.lin_out(x).relu()
-        x = x + x_skip
+        #x = x + x_skip
         return x
 
 

--- a/examples/point_transformer_classification.py
+++ b/examples/point_transformer_classification.py
@@ -95,8 +95,8 @@ class Net(torch.nn.Module):
 
         # first block
         self.mlp_input = Seq(
-            Lin(NUM_FEATURES, 32),
-            BN(32),
+            Lin(NUM_FEATURES, dim_model[0]),
+            BN(dim_model[0]),
             ReLU()
         )
 

--- a/examples/point_transformer_classification.py
+++ b/examples/point_transformer_classification.py
@@ -10,7 +10,7 @@ from torch_geometric.data import Data
 from torch_geometric.loader import DataLoader
 from torch_geometric.nn.pool import max_pool_neighbor_x, knn
 from torch_geometric.nn.conv import PointTransformerConv
-from torch_geometric.graphgym.models import global_mean_pool
+from torch_geometric.nn import global_mean_pool
 
 from torch_cluster import knn_graph
 from torch_cluster import fps

--- a/examples/point_transformer_classification.py
+++ b/examples/point_transformer_classification.py
@@ -29,14 +29,8 @@ test_loader = DataLoader(test_dataset, batch_size=32, shuffle=False)
 class TransformerBlock(torch.nn.Module):
     def __init__(self, in_channels, out_channels, hidden_channels):
         super(TransformerBlock, self).__init__()
-        self.lin_in = Seq(
-            Lin(in_channels, hidden_channels),
-            ReLU()
-        )
-        self.lin_out = Seq(
-            Lin(out_channels, out_channels),
-            ReLU()
-        )
+        self.lin_in  = Lin(in_channels, hidden_channels)
+        self.lin_out = Lin(out_channels, out_channels)
 
         self.pos_nn = Seq(
             Lin(3, 64),
@@ -58,9 +52,9 @@ class TransformerBlock(torch.nn.Module):
         )
 
     def forward(self, x, pos, edge_index):
-        x = self.lin_in(x)
+        x = self.lin_in(x).relu()
         x = self.transformer(x, pos, edge_index)
-        x = self.lin_out(x)
+        x = self.lin_out(x).relu()
 
         return x
 

--- a/examples/point_transformer_classification.py
+++ b/examples/point_transformer_classification.py
@@ -15,68 +15,82 @@ from torch_cluster import knn_graph
 from torch_cluster import fps
 
 path = osp.join(osp.dirname(osp.realpath(__file__)), '..', 'data/ModelNet10')
-#In its current state, PointTransformerConv does not support the absence of features, so we create dummy nodes features with the 'Constant' Transform
-pre_transform, transform = T.NormalizeScale(), T.Compose([T.SamplePoints(1024), T.Constant(1)])
+# In its current state, PointTransformerConv does not support the absence of
+# features, so we create dummy nodes features with the 'Constant' Transform
+pre_transform, transform = T.NormalizeScale(), T.Compose(
+    [T.SamplePoints(1024), T.Constant(1)])
 train_dataset = ModelNet(path, '10', True, transform, pre_transform)
 test_dataset = ModelNet(path, '10', False, transform, pre_transform)
 train_loader = DataLoader(train_dataset, batch_size=32, shuffle=True)
 test_loader = DataLoader(test_dataset, batch_size=32, shuffle=False)
 
+
 class TransformerBlock(torch.nn.Module):
     def __init__(self, in_channels, out_channels, hidden_channels):
         super(TransformerBlock, self).__init__()
-        self.lin_in = Seq( Lin(in_channels, hidden_channels), ReLU())
-        self.lin_out = Seq( Lin(out_channels, out_channels), ReLU())
-        
-        self.pos_nn = Seq(
-                Lin(3, 64),
-                ReLU(),
-                Lin(64, out_channels)
-            )
-        
-        self.attn_nn = Seq(
-                Lin(out_channels, 64),
-                ReLU(),
-                Lin(64, out_channels)
-            )
+        self.lin_in = Seq(
+            Lin(in_channels, hidden_channels),
+            ReLU()
+        )
+        self.lin_out = Seq(
+            Lin(out_channels, out_channels),
+            ReLU()
+        )
 
-        self.transformer = PointTransformerConv(in_channels, out_channels, pos_nn=self.pos_nn, attn_nn=self.attn_nn)
-        
+        self.pos_nn = Seq(
+            Lin(3, 64),
+            ReLU(),
+            Lin(64, out_channels)
+        )
+
+        self.attn_nn = Seq(
+            Lin(out_channels, 64),
+            ReLU(),
+            Lin(64, out_channels)
+        )
+
+        self.transformer = PointTransformerConv(
+            in_channels,
+            out_channels,
+            pos_nn=self.pos_nn,
+            attn_nn=self.attn_nn
+        )
+
     def forward(self, x, pos, edge_index):
         x = self.lin_in(x)
         x = self.transformer(x, pos, edge_index)
         x = self.lin_out(x)
-        
+
         return x
-
-
 
 
 def transition_down(x, pos, mlp, batch=None, k=16):
     '''
-        Samples the input point cloud by a ratio percentage to reduce 
+        Samples the input point cloud by a ratio percentage to reduce
         cardinality and uses an mlp to augment features dimensionnality
     '''
-    
-    #FPS sampling
-    id_clusters = fps(pos, ratio = 0.25, batch=batch)
-    
-    #compute for each cluster the k nearest points
+
+    # FPS sampling
+    id_clusters = fps(pos, ratio=0.25, batch=batch)
+
+    # compute for each cluster the k nearest points
     sub_batch = batch[id_clusters] if batch is not None else None
-    id_k_neighbor = knn(pos, pos[id_clusters], k=k, batch_x=batch, batch_y = sub_batch) #beware of self loop
-    
-    #transformation of features through a simple MLP
+    # beware of self loop
+    id_k_neighbor = knn(pos, pos[id_clusters], k=k,
+                        batch_x=batch, batch_y=sub_batch)
+
+    # transformation of features through a simple MLP
     x = mlp(x)
-    
-    #Max pool onto each cluster the features from knn in points
-    data = Data(pos = pos, x=x, edge_index= id_k_neighbor, batch=batch)
+
+    # Max pool onto each cluster the features from knn in points
+    data = Data(pos=pos, x=x, edge_index=id_k_neighbor, batch=batch)
     max_pool_neighbor_x(data)
-    
-    #keep only the clusters and their max-pooled features
+
+    # keep only the clusters and their max-pooled features
     new_pos, new_x = data.pos[id_clusters], data.x[id_clusters]
     return new_x, new_pos, sub_batch
 
-    
+
 def MLP(channels, batch_norm=True):
     return Seq(*[
         Seq(Lin(channels[i - 1], channels[i]), ReLU(), BN(channels[i]))
@@ -84,78 +98,83 @@ def MLP(channels, batch_norm=True):
     ])
 
 
-class Net(torch.nn.Module):    
-    def __init__(self, NUM_CLASSES, NUM_FEATURES, dim_model= [32,64,128,256,512], k=16):
+class Net(torch.nn.Module):
+    def __init__(self, NUM_CLASSES, NUM_FEATURES, dim_model, k=16):
         super(Net, self).__init__()
         self.k = k
-        
-        #first block
+
+        # first block
         self.mlp_input = Seq(
             Lin(NUM_FEATURES, 32),
-            BN(32), 
+            BN(32),
             ReLU()
-        )        
-        
-        #backbone layers
+        )
+
+        # backbone layers
         self.transformers_down = torch.nn.ModuleList()
         self.mlp_down = torch.nn.ModuleList()
-        
-        for i in range(len(dim_model)-1):
-            
-            #Add Point Transformer block followed by a Transition Down block
-            self.transformers_down.append(
-                TransformerBlock(in_channels = dim_model[i], 
-                                 out_channels = dim_model[i + 1], 
-                                 hidden_channels= dim_model[i])
-                )
-            self.mlp_down.append(Seq( 
-                                Lin(dim_model[i+1], dim_model[i+1]), 
-                                BN(dim_model[i+1]), 
-                                ReLU()) 
-                )
-            
-        #end block
-        self.transformer = TransformerBlock(in_channels = dim_model[-1], out_channels = dim_model[-1], hidden_channels= dim_model[-1])
-        
-    
-        #class score computation
-        self.lin = Seq(Lin(dim_model[-1],64),
-                              ReLU(),
-                              Lin(64,64),
-                              ReLU(),
-                              Lin(64,NUM_CLASSES))
-                    
-        
 
+        for i in range(len(dim_model) - 1):
+
+            # Add Point Transformer block followed by a Transition Down block
+            self.transformers_down.append(
+                TransformerBlock(in_channels=dim_model[i],
+                                 out_channels=dim_model[i + 1],
+                                 hidden_channels=dim_model[i])
+            )
+            self.mlp_down.append(Seq(
+                Lin(dim_model[i + 1], dim_model[i + 1]),
+                BN(dim_model[i + 1]),
+                ReLU())
+            )
+
+        # end block
+        self.transformer = TransformerBlock(
+            in_channels=dim_model[-1],
+            out_channels=dim_model[-1],
+            hidden_channels=dim_model[-1]
+        )
+
+        # class score computation
+        self.lin = Seq(Lin(dim_model[-1], 64),
+                       ReLU(),
+                       Lin(64, 64),
+                       ReLU(),
+                       Lin(64, NUM_CLASSES))
 
     def forward(self, data):
         x, pos, batch = data.x, data.pos, data.batch
 
-        #first block
+        # first block
         x = self.mlp_input(x)
-        
-        #backbone
+
+        # backbone
         for i in range(len(self.transformers_down)):
-            edge_index = knn_graph(pos, k=self.k, batch = batch)
+            edge_index = knn_graph(pos, k=self.k, batch=batch)
             x = self.transformers_down[i](x, pos, edge_index)
-            x, pos, batch = transition_down(x, pos, self.mlp_down[i], batch = batch, k=self.k)
-        
-        #end block
-        edge_index = knn_graph(pos, k=self.k, batch = batch)
+            x, pos, batch = transition_down(
+                x, pos, self.mlp_down[i], batch=batch, k=self.k)
+
+        # end block
+        edge_index = knn_graph(pos, k=self.k, batch=batch)
         x = self.transformer(x, pos, edge_index)
-        
-        #GlobalAveragePooling
+
+        # GlobalAveragePooling
         x = global_mean_pool(x, batch)
-            
-        #Class score
+
+        # Class score
         out = self.lin(x)
-        
+
         return F.log_softmax(out, dim=-1)
 
+
 device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
-model = Net(train_dataset.num_classes, 1, k=16).to(device)
-optimizer = torch.optim.SGD(model.parameters(), lr=0.05, momentum=0.9, weight_decay=0.0001)
-scheduler = torch.optim.lr_scheduler.MultiStepLR(optimizer, milestones=[120,160], gamma=0.1)
+model = Net(train_dataset.num_classes, 1, dim_model=[
+            32, 64, 128, 256, 512], k=16).to(device)
+optimizer = torch.optim.SGD(
+    model.parameters(), lr=0.05, momentum=0.9, weight_decay=0.0001)
+scheduler = torch.optim.lr_scheduler.MultiStepLR(
+    optimizer, milestones=[120, 160], gamma=0.1)
 
 
 def train():

--- a/examples/point_transformer_classification.py
+++ b/examples/point_transformer_classification.py
@@ -26,7 +26,7 @@ test_loader = DataLoader(test_dataset, batch_size=32, shuffle=False)
 
 class TransformerBlock(torch.nn.Module):
     def __init__(self, in_channels, out_channels):
-        super(TransformerBlock, self).__init__()
+        super().__init__()
         self.lin_in = Lin(in_channels, in_channels)
         self.lin_out = Lin(out_channels, out_channels)
 
@@ -65,7 +65,7 @@ class TransitionDown(torch.nn.Module):
     '''
 
     def __init__(self, in_channels, out_channels, ratio=0.25, k=16):
-        super(TransitionDown, self).__init__()
+        super().__init__()
         self.k = k
         self.ratio = ratio
         self.mlp = Seq(
@@ -101,7 +101,7 @@ class TransitionDown(torch.nn.Module):
 
 class Net(torch.nn.Module):
     def __init__(self, NUM_CLASSES, NUM_FEATURES, dim_model, k=16):
-        super(Net, self).__init__()
+        super().__init__()
         self.k = k
 
         # dummy feature is created if there is none given
@@ -145,7 +145,7 @@ class Net(torch.nn.Module):
 
         # add dummy features in case there is none
         if x is None:
-            x = torch.ones((pos.shape[0], 1)).to(pos.get_device())
+            x = torch.ones((pos.shape[0], 1), device=pos.get_device())
 
         # first block
         x = self.mlp_input(x)
@@ -198,7 +198,7 @@ def test(loader):
 if __name__ == '__main__':
 
     device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
-    model = Net(train_dataset.num_classes, 1, dim_model=[
+    model = Net(train_dataset.num_classes, 0, dim_model=[
                 32, 64, 128, 256, 512], k=16).to(device)
     optimizer = torch.optim.Adam(model.parameters(), lr=0.001)
     scheduler = torch.optim.lr_scheduler.StepLR(optimizer,
@@ -208,6 +208,6 @@ if __name__ == '__main__':
     for epoch in range(1, 201):
         loss = train()
         test_acc = test(test_loader)
-        print('Epoch {:03d}, Loss: {:.4f}, Test: {:.4f}'.format(
+        print(f'Epoch {epoch:03d}, Loss: {loss:.4f}, Test: {test_acc:.4f}')
             epoch, loss, test_acc))
         scheduler.step()

--- a/examples/point_transformer_classification.py
+++ b/examples/point_transformer_classification.py
@@ -140,8 +140,7 @@ class Net(torch.nn.Module):
                        ReLU(),
                        Lin(64, out_channels))
 
-    def forward(self, data):
-        x, pos, batch = data.x, data.pos, data.batch
+    def forward(self, x, pos, batch=None):
 
         # add dummy features in case there is none
         if x is None:
@@ -175,7 +174,7 @@ def train():
     for data in train_loader:
         data = data.to(device)
         optimizer.zero_grad()
-        out = model(data)
+        out = model(data.x, data.pos, data.batch)
         loss = F.nll_loss(out, data.y)
         loss.backward()
         total_loss += loss.item() * data.num_graphs
@@ -190,7 +189,7 @@ def test(loader):
     correct = 0
     for data in loader:
         data = data.to(device)
-        pred = model(data).max(dim=1)[1]
+        pred = model(data.x, data.pos, data.batch).max(dim=1)[1]
         correct += pred.eq(data.y).sum().item()
     return correct / len(loader.dataset)
 

--- a/examples/point_transformer_classification.py
+++ b/examples/point_transformer_classification.py
@@ -95,11 +95,13 @@ class TransitionDown(torch.nn.Module):
         sub_pos, out = pos[id_clusters], x_out
         return out, sub_pos, sub_batch
 
+
 def MLP(channels):
     return Seq(*[
         Seq(Lin(channels[i - 1], channels[i]), BN(channels[i]), ReLU())
         for i in range(1, len(channels))
     ])
+
 
 class Net(torch.nn.Module):
     def __init__(self, in_channels, out_channels, dim_model, k=16):

--- a/examples/point_transformer_segmentation.py
+++ b/examples/point_transformer_segmentation.py
@@ -31,7 +31,8 @@ train_loader = DataLoader(train_dataset, batch_size=10, shuffle=True)
 test_loader = DataLoader(test_dataset, batch_size=10, shuffle=False)
 
 
-def transition_up(x_sub, pos_sub, mlp_sub, x, pos, mlp, batch_sub=None, batch=None):
+def transition_up(x_sub, pos_sub, mlp_sub, x, pos, mlp, batch_sub=None,
+                  batch=None):
     '''
         Reduce features dimensionnality and interpolate back to higher
         resolution and cardinality

--- a/examples/point_transformer_segmentation.py
+++ b/examples/point_transformer_segmentation.py
@@ -130,8 +130,7 @@ class Net(torch.nn.Module):
                        ReLU(),
                        Lin(64, out_channels))
 
-    def forward(self, data):
-        x, pos, batch = data.x, data.pos, data.batch
+    def forward(self, x, pos, batch=None):
 
         # add dummy features in case there is none
         if x is None:
@@ -203,7 +202,7 @@ def train():
     for i, data in enumerate(train_loader):
         data = data.to(device)
         optimizer.zero_grad()
-        out = model(data)
+        out = model(data.x, data.pos, data.batch)
         loss = F.nll_loss(out, data.y)
         loss.backward()
         optimizer.step()
@@ -225,7 +224,7 @@ def test(loader):
 
     for data in loader:
         data = data.to(device)
-        pred = model(data).argmax(dim=1)
+        pred = model(data.x, data.pos, data.batch).argmax(dim=1)
 
         i, u = i_and_u(pred, data.y, loader.dataset.num_classes, data.batch)
         iou = i.cpu().to(torch.float) / u.cpu().to(torch.float)

--- a/examples/point_transformer_segmentation.py
+++ b/examples/point_transformer_segmentation.py
@@ -65,7 +65,7 @@ class TransitionUp(torch.nn.Module):
 
 
 class Net(torch.nn.Module):
-    def __init__(self, out_channels, in_channels, dim_model, k=16):
+    def __init__(self, in_channels, out_channels, dim_model, k=16):
         super().__init__()
         self.k = k
 
@@ -177,13 +177,14 @@ class Net(torch.nn.Module):
                 x=out_x[- i - 2],
                 x_sub=x,
                 pos=out_pos[- i - 2],
-                pos_sub=pos,
+                pos_sub=out_pos[- i - 1],
                 batch_sub=out_batch[- i - 1],
                 batch=out_batch[- i - 2]
             )
 
-            edge_index = knn_graph(pos, k=self.k, batch=out_batch[- i - 2])
-            x = self.transformers_up[- i - 1](x, pos, edge_index)
+            edge_index = knn_graph(out_pos[- i - 2], k=self.k,
+                                   batch=out_batch[- i - 2])
+            x = self.transformers_up[- i - 1](x, out_pos[- i - 2], edge_index)
 
         # Class score
         out = self.lin(x)

--- a/examples/point_transformer_segmentation.py
+++ b/examples/point_transformer_segmentation.py
@@ -105,7 +105,7 @@ class Net(torch.nn.Module):
 
             # Add Transition Up block followed by Point Transformer block
             self.transition_up.append(
-                TransitionUp(in_channels=dim_model[i+1],
+                TransitionUp(in_channels=dim_model[i + 1],
                              out_channels=dim_model[i])
             )
 

--- a/examples/point_transformer_segmentation.py
+++ b/examples/point_transformer_segmentation.py
@@ -1,4 +1,5 @@
-from point_transformer_classification import TransitionDown, TransformerBlock, MLP
+from point_transformer_classification import TransitionDown, TransformerBlock
+from point_transformer_classification import MLP
 
 import os.path as osp
 

--- a/examples/point_transformer_segmentation.py
+++ b/examples/point_transformer_segmentation.py
@@ -1,4 +1,4 @@
-from point_transformer_classification import TransitionDown, TransformerBlock
+from point_transformer_classification import TransitionDown, TransformerBlock, MLP
 
 import os.path as osp
 
@@ -73,11 +73,7 @@ class Net(torch.nn.Module):
         in_channels = max(in_channels, 1)
 
         # first block
-        self.mlp_input = Seq(
-            Lin(in_channels, dim_model[0]),
-            BN(dim_model[0]),
-            ReLU()
-        )
+        self.mlp_input = MLP([in_channels, dim_model[0]])
 
         self.transformer_input = TransformerBlock(in_channels=dim_model[0],
                                                   out_channels=dim_model[0],

--- a/examples/point_transformer_segmentation.py
+++ b/examples/point_transformer_segmentation.py
@@ -38,7 +38,7 @@ class TransitionUp(torch.nn.Module):
     '''
 
     def __init__(self, in_channels, out_channels):
-        super(TransitionUp, self).__init__()
+        super().__init__()
         self.mlp_sub = Seq(
             Lin(in_channels, out_channels),
             BN(out_channels),
@@ -66,7 +66,7 @@ class TransitionUp(torch.nn.Module):
 
 class Net(torch.nn.Module):
     def __init__(self, NUM_CLASSES, NUM_FEATURES, dim_model, k=16):
-        super(Net, self).__init__()
+        super().__init__()
         self.k = k
 
         # dummy feature is created if there is none given

--- a/examples/point_transformer_segmentation.py
+++ b/examples/point_transformer_segmentation.py
@@ -57,8 +57,8 @@ class Net(torch.nn.Module):
 
         # first block
         self.mlp_input = Seq(
-            Lin(NUM_FEATURES, 32),
-            BN(32),
+            Lin(NUM_FEATURES, dim_model[0]),
+            BN(dim_model[0]),
             ReLU()
         )
 

--- a/examples/point_transformer_segmentation.py
+++ b/examples/point_transformer_segmentation.py
@@ -1,0 +1,237 @@
+from point_transformer_classification import transition_down, TransformerBlock
+
+import os.path as osp
+
+import torch
+import torch.nn.functional as F
+from torch.nn import Sequential as Seq, Linear as Lin, BatchNorm1d as BN, ReLU
+
+import torch_geometric.transforms as T
+from torch_geometric.datasets import ShapeNet
+from torch_geometric.loader import DataLoader
+from torch_geometric.utils import intersection_and_union as i_and_u
+from torch_geometric.nn.unpool import knn_interpolate
+
+from torch_cluster import knn_graph
+
+category = 'Airplane'  # Pass in `None` to train on all categories.
+path = osp.join(osp.dirname(osp.realpath(__file__)), '..', 'data', 'ShapeNet')
+transform = T.Compose([
+    T.RandomTranslate(0.01),
+    T.RandomRotate(15, axis=0),
+    T.RandomRotate(15, axis=1),
+    T.RandomRotate(15, axis=2),
+])
+pre_transform = T.NormalizeScale()
+train_dataset = ShapeNet(path, category, split='trainval', transform=transform,
+                         pre_transform=pre_transform)
+test_dataset = ShapeNet(path, category, split='test',
+                        pre_transform=pre_transform)
+train_loader = DataLoader(train_dataset, batch_size=10, shuffle=True)
+test_loader = DataLoader(test_dataset, batch_size=10, shuffle=False)
+
+
+def transition_up(x_sub, pos_sub, mlp_sub, x, pos, mlp, batch_sub=None, batch=None):
+    '''
+        Reduce features dimensionnality and interpolate back to higher
+        resolution and cardinality
+    '''
+
+    # transform low-res features
+    x_sub = mlp_sub(x_sub)
+
+    # interpolate low-res feats to high-res points
+    x_interpolated = knn_interpolate(
+        x_sub, pos_sub, pos, k=3, batch_x=batch_sub, batch_y=batch)
+
+    x = mlp(x) + x_interpolated
+
+    return x, pos
+
+
+class Net(torch.nn.Module):
+    def __init__(self, NUM_CLASSES, NUM_FEATURES, dim_model, k=16):
+        super(Net, self).__init__()
+        self.k = k
+
+        # first block
+        self.mlp_input = Seq(
+            Lin(NUM_FEATURES, 32),
+            BN(32),
+            ReLU()
+        )
+
+        # backbone layers
+        self.transformers_up = torch.nn.ModuleList()
+        self.transformers_down = torch.nn.ModuleList()
+        self.mlp_down = torch.nn.ModuleList()
+        self.mlp_up_sub = torch.nn.ModuleList()
+        self.mlp_up = torch.nn.ModuleList()
+
+        for i in range(len(dim_model) - 1):
+
+            # Add Point Transformer block followed by a Transition Down block
+            self.transformers_down.append(
+                TransformerBlock(in_channels=dim_model[i],
+                                 out_channels=dim_model[i + 1],
+                                 hidden_channels=dim_model[i])
+            )
+            self.mlp_down.append(Seq(
+                Lin(dim_model[i + 1], dim_model[i + 1]),
+                BN(dim_model[i + 1]),
+                ReLU())
+            )
+
+            # Add Transition Up block followed by Point Transformer block
+            self.mlp_up_sub.append(Seq(
+                Lin(dim_model[i], dim_model[i]),
+                BN(dim_model[i]),
+                ReLU())
+            )
+
+            self.mlp_up.append(Seq(
+                Lin(dim_model[i], dim_model[i]),
+                BN(dim_model[i]),
+                ReLU())
+            )
+
+            self.transformers_up.append(TransformerBlock(
+                in_channels=dim_model[i + 1],
+                out_channels=dim_model[i],
+                hidden_channels=dim_model[i + 1]))
+
+        # summit layers
+        self.transformer = TransformerBlock(
+            in_channels=dim_model[-1],
+            out_channels=dim_model[-1],
+            hidden_channels=dim_model[-1]
+        )
+
+        self.mlp_summit = Seq(
+            Lin(dim_model[-1], dim_model[-1]),
+            BN(dim_model[-1]),
+            ReLU()
+        )
+
+        # end block
+        self.transformer = TransformerBlock(
+            in_channels=dim_model[-1],
+            out_channels=dim_model[-1],
+            hidden_channels=dim_model[-1]
+        )
+
+        # class score computation
+        self.lin = Seq(Lin(dim_model[0], 64),
+                       ReLU(),
+                       Lin(64, 64),
+                       ReLU(),
+                       Lin(64, NUM_CLASSES))
+
+    def forward(self, data):
+        x, pos, batch = data.x, data.pos, data.batch
+
+        out_x = []
+        out_pos = []
+        out_batch = []
+
+        # first block
+        x = self.mlp_input(x)
+
+        # save outputs for skipping connections
+        out_x.append(x)
+        out_pos.append(pos)
+        out_batch.append(batch)
+
+        # backbone down : #reduce cardinality and augment dimensionnality
+        for i in range(len(self.transformers_down)):
+            edge_index = knn_graph(pos, k=self.k, batch=batch)
+            x = self.transformers_down[i](x, pos, edge_index)
+            x, pos, batch = transition_down(
+                x, pos, self.mlp_down[i], batch=batch, k=self.k)
+
+            out_x.append(x)
+            out_pos.append(pos)
+            out_batch.append(batch)
+
+        # summit
+        edge_index = knn_graph(pos, k=self.k, batch=batch)
+        x = self.transformer(x, pos, edge_index)
+        x = self.mlp_summit(x)
+
+        # backbone up : augment cardinality and reduce dimensionnality
+        n = len(self.transformers_down)
+        for i in range(n):
+            edge_index = knn_graph(pos, k=16, batch=out_batch[- i - 1])
+            x = self.transformers_up[- i - 1](x, pos, edge_index)
+            x, pos = transition_up(x,
+                                   pos,
+                                   self.mlp_up_sub[- i - 1],
+                                   out_x[- i - 2],
+                                   out_pos[- i - 2],
+                                   self.mlp_up[- i - 1],
+                                   batch_sub=out_batch[- i - 1],
+                                   batch=out_batch[- i - 2])
+
+        # Class score
+        out = self.lin(x)
+
+        return F.log_softmax(out, dim=-1)
+
+
+device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
+model = Net(train_dataset.num_classes, 3, dim_model=[
+                32, 64, 128, 256, 512], k=16).to(device)
+optimizer = torch.optim.Adam(model.parameters(), lr=0.001)
+scheduler = torch.optim.lr_scheduler.StepLR(optimizer, step_size=20, gamma=0.5)
+
+
+def train():
+    model.train()
+
+    total_loss = correct_nodes = total_nodes = 0
+    for i, data in enumerate(train_loader):
+        data = data.to(device)
+        optimizer.zero_grad()
+        out = model(data)
+        loss = F.nll_loss(out, data.y)
+        loss.backward()
+        optimizer.step()
+        total_loss += loss.item()
+        correct_nodes += out.argmax(dim=1).eq(data.y).sum().item()
+        total_nodes += data.num_nodes
+
+        if (i + 1) % 10 == 0:
+            print(f'[{i+1}/{len(train_loader)}] Loss: {total_loss / 10:.4f} '
+                  f'Train Acc: {correct_nodes / total_nodes:.4f}')
+            total_loss = correct_nodes = total_nodes = 0
+
+
+@torch.no_grad()
+def test(loader):
+    model.eval()
+
+    y_mask = loader.dataset.y_mask
+    ious = [[] for _ in range(len(loader.dataset.categories))]
+
+    for data in loader:
+        data = data.to(device)
+        pred = model(data).argmax(dim=1)
+
+        i, u = i_and_u(pred, data.y, loader.dataset.num_classes, data.batch)
+        iou = i.cpu().to(torch.float) / u.cpu().to(torch.float)
+        iou[torch.isnan(iou)] = 1
+
+        # Find and filter the relevant classes for each category.
+        for iou, category in zip(iou.unbind(), data.category.unbind()):
+            ious[category.item()].append(iou[y_mask[category]])
+
+    # Compute mean IoU.
+    ious = [torch.stack(iou).mean(0).mean(0) for iou in ious]
+    return torch.tensor(ious).mean().item()
+
+
+for epoch in range(1, 100):
+    train()
+    iou = test(test_loader)
+    print('Epoch: {:02d}, Test IoU: {:.4f}'.format(epoch, iou))
+    scheduler.step()


### PR DESCRIPTION
Hello

This PR is an implementation of 2 examples using Point Transformer Conv for classification and part segmentation

I tried to follow the architecture described in the paper although some details are not provided. The author released an appendix a month ago, and affirmed the full details and implementations will be disclosed to the community soon, so the architecture may have to be updated later.
https://arxiv.org/abs/2012.09164

It performs roughly around 0.84 for classification (without normals) and 0.80 for part segmentation (against 0.93% with normals and 0.84 instance IoU in paper). The learning rates parameters are different as the results seemed worse when using the one from the paper but if you have any advice/remark, I would be glad to test.

I am unsure about the "elegance" of some parts of the code, especially the transition down and up block parts, with the mlps in argument and all. Same for the outputs in x, pos and batch that are saved in a list for skipping connections in segmentation


![schema](https://user-images.githubusercontent.com/58271711/137641349-0c0d450e-dfef-4139-8858-f6e28b3987a7.png)

edit : I just realized I am pushing from master, I can't change it now, so tell me if I need to open a new PR or if we go on with this branch

