### PR TITLE
Minor Fix to CGConv.

### DIFF
--- a/test/nn/conv/test_cg_conv.py
+++ b/test/nn/conv/test_cg_conv.py
@@ -43,6 +43,20 @@ def test_cg_conv():
     jit = torch.jit.script(conv.jittable(t))
     assert jit((x1, x2), adj.t()).tolist() == out.tolist()
 
+    # Test batch_norm true:
+    adj = SparseTensor(row=row, col=col, sparse_sizes=(4, 4))
+    conv = CGConv(8, batch_norm=True)
+    assert conv.__repr__() == 'CGConv(8, dim=0)'
+    out = conv(x1, edge_index)
+    assert out.size() == (4, 8)
+    assert conv(x1, edge_index, size=(4, 4)).tolist() == out.tolist()
+    assert conv(x1, adj.t()).tolist() == out.tolist()
+
+    t = '(Tensor, Tensor, OptTensor, Size) -> Tensor'
+    jit = torch.jit.script(conv.jittable(t))
+    assert jit(x1, edge_index).tolist() == out.tolist()
+    assert jit(x1, edge_index, size=(4, 4)).tolist() == out.tolist()
+
 
 def test_cg_conv_with_edge_features():
     x1 = torch.randn(4, 8)

--- a/torch_geometric/nn/conv/cg_conv.py
+++ b/torch_geometric/nn/conv/cg_conv.py
@@ -56,7 +56,7 @@ class CGConv(MessagePassing):
         if batch_norm:
             self.bn = BatchNorm1d(channels[1])
         else:
-            self.register_parameter('bn', None)
+            self.bn = None
 
         self.reset_parameters()
 


### PR DESCRIPTION
 #3147
The `self.bn` parameter was created even if `batch_norm` was false, this PR fixes that.