### PR TITLE
fix args.linear option in autoencoder example

### DIFF
--- a/examples/autoencoder.py
+++ b/examples/autoencoder.py
@@ -75,9 +75,9 @@ if not args.variational and not args.linear:
 elif not args.variational and args.linear:
     model = GAE(LinearEncoder(in_channels, out_channels))
 elif args.variational and not args.linear:
-    model = VGAE(VariationalLinearEncoder(in_channels, out_channels))
-elif args.variational and args.linear:
     model = VGAE(VariationalGCNEncoder(in_channels, out_channels))
+elif args.variational and args.linear:
+    model = VGAE(VariationalLinearEncoder(in_channels, out_channels))
 
 model = model.to(device)
 optimizer = torch.optim.Adam(model.parameters(), lr=0.01)


### PR DESCRIPTION
swap options for VariationalGCNEncoder and VariationalLinearEncoder for args.linear option