### PR TITLE
doc fix for TransformerConv's beta coefficient

### DIFF
--- a/torch_geometric/nn/conv/transformer_conv.py
+++ b/torch_geometric/nn/conv/transformer_conv.py
@@ -49,8 +49,8 @@ class TransformerConv(MessagePassing):
                 \alpha_{i,j} \mathbf{W}_2 \vec{x}_j \right)}_{=\mathbf{m}_i}
 
             with :math:`\beta_i = \textrm{sigmoid}(\mathbf{w}_5^{\top}
-            [ \mathbf{W}_1 \mathbf{x}_i, \mathbf{m}_i, \mathbf{W}_1 \mathbf{x}_i -
-            \mathbf{m}_i ])` (default: :obj:`False`)
+            [ \mathbf{W}_1 \mathbf{x}_i, \mathbf{m}_i, \mathbf{W}_1
+            \mathbf{x}_i - \mathbf{m}_i ])` (default: :obj:`False`)
         dropout (float, optional): Dropout probability of the normalized
             attention coefficients which exposes each node to a stochastically
             sampled neighborhood during training. (default: :obj:`0`)

--- a/torch_geometric/nn/conv/transformer_conv.py
+++ b/torch_geometric/nn/conv/transformer_conv.py
@@ -49,8 +49,8 @@ class TransformerConv(MessagePassing):
                 \alpha_{i,j} \mathbf{W}_2 \vec{x}_j \right)}_{=\mathbf{m}_i}
 
             with :math:`\beta_i = \textrm{sigmoid}(\mathbf{w}_5^{\top}
-            [ \mathbf{x}_i, \mathbf{m}_i, \mathbf{x}_i - \mathbf{m}_i ])`
-            (default: :obj:`False`)
+            [ \mathbf{W}_1 \mathbf{x}_i, \mathbf{m}_i, \mathbf{W}_1 \mathbf{x}_i -
+            \mathbf{m}_i ])` (default: :obj:`False`)
         dropout (float, optional): Dropout probability of the normalized
             attention coefficients which exposes each node to a stochastically
             sampled neighborhood during training. (default: :obj:`0`)


### PR DESCRIPTION
Both [code](https://github.com/pyg-team/pytorch_geometric/blob/27e3e26ce73676f6d99377b4ea98cf62b2ac63aa/torch_geometric/nn/conv/transformer_conv.py#L187) and paper use `W_1 x_i` instead of `x_i`.

![Inked2021-11-09_194117_LI](https://user-images.githubusercontent.com/41546976/140918022-3f91a2ea-3126-4d77-8f00-914c7b1527df.jpg)
