### PR TITLE
Automatically sort imports with `isort`

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -25,12 +25,12 @@ jobs:
 
       - name: Install dependencies
         run: |
-          pip install flake8
+          pip install tox
           pip install pyroma
 
       - name: Run linting
         run: |
-          flake8 .
+          tox -e flake8
 
       - name: Check package metadata
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ coverage.xml
 
 !torch_geometric/data/
 !test/data/
+.tox

--- a/torch_geometric/data/collate.py
+++ b/torch_geometric/data/collate.py
@@ -1,7 +1,6 @@
-from typing import List, Tuple, Optional, Union, Any
-
 from collections import defaultdict
 from collections.abc import Mapping, Sequence
+from typing import Any, List, Optional, Tuple, Union
 
 import torch
 from torch import Tensor

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,16 @@
+# Tox (http://tox.testrun.org/) is a tool for running tests
+# in multiple virtualenvs. This configuration file will run the
+# test suite on all supported python versions. To use it, "pip install tox"
+# and then run "tox" from this directory.
+
+[tox]
+envlist =
+    lint
+
+[testenv:lint]
+deps =
+    isort
+skip_install = true
+commands =
+    isort torch_geometric/data/collate.py
+description = Run linters.

--- a/tox.ini
+++ b/tox.ini
@@ -6,6 +6,7 @@
 [tox]
 envlist =
     lint
+    flake8
 
 [testenv:lint]
 deps =
@@ -14,3 +15,11 @@ skip_install = true
 commands =
     isort torch_geometric/data/collate.py
 description = Run linters.
+
+[testenv:flake8]
+skip_install = true
+commands =
+    flake8 .
+deps =
+    flake8
+    flake8-isort


### PR DESCRIPTION
This PR does the following:

1. Introduces a `tox.ini` configuration file for use with `tox`. This can be installed with `pip install tox` and run from the shell with `tox`. It is similar to `make`, but more oriented towards Python. Configurations can be added with `[testenv:<your name]` then run with `tox -e <your name>`. If `tox` is run by itself, everything in the `envlist` gets run.
2. Ports the commands to install and run `flake8` into the `tox.ini` and update the GitHub actions to use this
3. Adds a configuration for running `isort` in the `tox.ini` file. This automatically sorts imports in Python files to ensure consistency, especially from a wide variety of contributors. Right now the configuration is only demonstrated on `collate.py` but should be updated to read `isort torch_geometric/ test/ setup.py` to run on all source files before accepting this PR
4. Add the `flake8-isort` plugin to the flake8 dependencies to have CI check that isort was run properly. Note, this means that CI will indeed fail until running isort on the rest. I just didn't do this yet since it would make a _massive_ diff. 

TL;DR: streamlined linting config/installation, demonstrated sorting imports with `isort`