### PR TITLE
Make batch argument optionnal in voxel_grid / update GridSampling documentation 

### DIFF
--- a/test/nn/pool/test_voxel_grid.py
+++ b/test/nn/pool/test_voxel_grid.py
@@ -7,10 +7,14 @@ def test_voxel_grid():
     pos = torch.Tensor([[0, 0], [11, 9], [2, 8], [2, 2], [8, 3]])
     batch = torch.tensor([0, 0, 0, 1, 1])
 
-    assert voxel_grid(pos, batch, size=5).tolist() == [0, 5, 3, 6, 7]
+    assert voxel_grid(pos, size=5, batch=batch).tolist() == [0, 5, 3, 6, 7]
+    assert voxel_grid(pos, size=5).tolist() == [0, 5, 3, 0, 1]
 
-    cluster = voxel_grid(pos, batch, size=5, start=-1, end=[18, 14])
+    cluster = voxel_grid(pos, size=5, batch=batch, start=-1, end=[18, 14])
     assert cluster.tolist() == [0, 10, 4, 16, 17]
+
+    cluster_no_batch = voxel_grid(pos, size=5, start=-1, end=[18, 14])
+    assert cluster_no_batch.tolist() == [0, 10, 4, 0, 1]
 
 
 def test_single_voxel_grid():
@@ -19,8 +23,14 @@ def test_single_voxel_grid():
     batch = torch.tensor([0, 0, 0, 1, 1])
     x = torch.randn(5, 16)
 
-    cluster = voxel_grid(pos, batch, size=5)
+    cluster = voxel_grid(pos, size=5, batch=batch)
     assert cluster.tolist() == [0, 0, 0, 1, 1]
 
     data = Batch(x=x, edge_index=edge_index, pos=pos, batch=batch)
     data = avg_pool(cluster, data)
+
+    cluster_no_batch = voxel_grid(pos, size=5)
+    assert cluster_no_batch.tolist() == [0, 0, 0, 0, 0]
+
+    data_no_batch = Batch(x=x, edge_index=edge_index, pos=pos)
+    data_no_batch = avg_pool(cluster_no_batch, data_no_batch)

--- a/torch_geometric/nn/pool/voxel_grid.py
+++ b/torch_geometric/nn/pool/voxel_grid.py
@@ -1,4 +1,8 @@
+from typing import Union, List, Optional
+
 import torch
+from torch import Tensor
+
 from torch_geometric.utils.repeat import repeat
 
 try:
@@ -7,7 +11,13 @@ except ImportError:
     grid_cluster = None
 
 
-def voxel_grid(pos, size, batch=None, start=None, end=None):
+def voxel_grid(
+    pos: Tensor,
+    size: Union[float, List[float], Tensor],
+    batch: Optional[Tensor] = None,
+    start: Optional[Union[float, List[float], Tensor]] = None,
+    end: Optional[Union[float, List[float], Tensor]] = None,
+) -> Tensor:
     r"""Voxel grid pooling from the, *e.g.*, `Dynamic Edge-Conditioned Filters
     in Convolutional Networks on Graphs <https://arxiv.org/abs/1704.02901>`_
     paper, which overlays a regular grid of user-defined size over a point

--- a/torch_geometric/nn/pool/voxel_grid.py
+++ b/torch_geometric/nn/pool/voxel_grid.py
@@ -18,8 +18,8 @@ def voxel_grid(pos, size, batch=None, start=None, end=None):
             :math:`\mathbf{X} \in \mathbb{R}^{(N_1 + \ldots + N_B) \times D}`.
         size (float or [float] or Tensor): Size of a voxel (in each dimension).
         batch (LongTensor, optional): Batch vector :math:`\mathbf{b} \in {\{ 0,
-            \ldots,B-1\}}^N`, which assigns each node to a specific example.
-             (default: :obj:`None`)
+            \ldots,B-1\}}^N`, which assigns each node to a specific example. 
+            (default: :obj:`None`)
         start (float or [float] or Tensor, optional): Start coordinates of the
             grid (in each dimension). If set to :obj:`None`, will be set to the
             minimum coordinates found in :attr:`pos`. (default: :obj:`None`)

--- a/torch_geometric/nn/pool/voxel_grid.py
+++ b/torch_geometric/nn/pool/voxel_grid.py
@@ -7,7 +7,7 @@ except ImportError:
     grid_cluster = None
 
 
-def voxel_grid(pos, batch, size, start=None, end=None):
+def voxel_grid(pos, size, batch=None, start=None, end=None):
     r"""Voxel grid pooling from the, *e.g.*, `Dynamic Edge-Conditioned Filters
     in Convolutional Networks on Graphs <https://arxiv.org/abs/1704.02901>`_
     paper, which overlays a regular grid of user-defined size over a point
@@ -16,9 +16,10 @@ def voxel_grid(pos, batch, size, start=None, end=None):
     Args:
         pos (Tensor): Node position matrix
             :math:`\mathbf{X} \in \mathbb{R}^{(N_1 + \ldots + N_B) \times D}`.
-        batch (LongTensor): Batch vector :math:`\mathbf{b} \in {\{ 0, \ldots,
-            B-1\}}^N`, which assigns each node to a specific example.
         size (float or [float] or Tensor): Size of a voxel (in each dimension).
+        batch (LongTensor, optional): Batch vector :math:`\mathbf{b} \in {\{ 0,
+            \ldots,B-1\}}^N`, which assigns each node to a specific example.
+             (default: :obj:`None`)
         start (float or [float] or Tensor, optional): Start coordinates of the
             grid (in each dimension). If set to :obj:`None`, will be set to the
             minimum coordinates found in :attr:`pos`. (default: :obj:`None`)
@@ -40,6 +41,9 @@ def voxel_grid(pos, batch, size, start=None, end=None):
     end = end.tolist() if torch.is_tensor(end) else end
 
     size, start, end = repeat(size, dim), repeat(start, dim), repeat(end, dim)
+
+    if batch is None:
+        batch = torch.zeros(pos.shape[0], dtype=torch.long)
 
     pos = torch.cat([pos, batch.unsqueeze(-1).type_as(pos)], dim=-1)
     size = size + [1]

--- a/torch_geometric/nn/pool/voxel_grid.py
+++ b/torch_geometric/nn/pool/voxel_grid.py
@@ -18,7 +18,7 @@ def voxel_grid(pos, size, batch=None, start=None, end=None):
             :math:`\mathbf{X} \in \mathbb{R}^{(N_1 + \ldots + N_B) \times D}`.
         size (float or [float] or Tensor): Size of a voxel (in each dimension).
         batch (LongTensor, optional): Batch vector :math:`\mathbf{b} \in {\{ 0,
-            \ldots,B-1\}}^N`, which assigns each node to a specific example. 
+            \ldots,B-1\}}^N`, which assigns each node to a specific example.
             (default: :obj:`None`)
         start (float or [float] or Tensor, optional): Start coordinates of the
             grid (in each dimension). If set to :obj:`None`, will be set to the

--- a/torch_geometric/transforms/grid_sampling.py
+++ b/torch_geometric/transforms/grid_sampling.py
@@ -37,7 +37,7 @@ class GridSampling(BaseTransform):
         else:
             batch = data.batch
 
-        c = torch_geometric.nn.voxel_grid(data.pos, batch, self.size,
+        c = torch_geometric.nn.voxel_grid(data.pos, self.size, batch,
                                           self.start, self.end)
         c, perm = torch_geometric.nn.pool.consecutive.consecutive_cluster(c)
 

--- a/torch_geometric/transforms/grid_sampling.py
+++ b/torch_geometric/transforms/grid_sampling.py
@@ -1,10 +1,14 @@
+from typing import Union, List, Optional
+
 import re
 
 import torch
+from torch import Tensor
 import torch.nn.functional as F
 from torch_scatter import scatter_add, scatter_mean
 
 import torch_geometric
+from torch_geometric.data import Data
 from torch_geometric.transforms import BaseTransform
 
 
@@ -24,18 +28,17 @@ class GridSampling(BaseTransform):
             maximum coordinates found in :obj:`data.pos`.
             (default: :obj:`None`)
     """
-    def __init__(self, size, start=None, end=None):
+    def __init__(self, size: Union[float, List[float], Tensor],
+                 start: Optional[Union[float, List[float], Tensor]] = None,
+                 end: Optional[Union[float, List[float], Tensor]] = None):
         self.size = size
         self.start = start
         self.end = end
 
-    def __call__(self, data):
+    def __call__(self, data: Data) -> Data:
         num_nodes = data.num_nodes
 
-        if 'batch' not in data:
-            batch = data.pos.new_zeros(num_nodes, dtype=torch.long)
-        else:
-            batch = data.batch
+        batch = data.get('batch', None)
 
         c = torch_geometric.nn.voxel_grid(data.pos, self.size, batch,
                                           self.start, self.end)
@@ -58,5 +61,5 @@ class GridSampling(BaseTransform):
 
         return data
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return '{}(size={})'.format(self.__class__.__name__, self.size)

--- a/torch_geometric/transforms/grid_sampling.py
+++ b/torch_geometric/transforms/grid_sampling.py
@@ -10,6 +10,8 @@ from torch_geometric.transforms import BaseTransform
 
 class GridSampling(BaseTransform):
     r"""Clusters points into voxels with size :attr:`size`.
+    Each cluster returned is a new point based on the mean of all points
+    inside the given cluster.
 
     Args:
         size (float or [float] or Tensor): Size of a voxel (in each dimension).


### PR DESCRIPTION
This PR does the following :

- adds documentation on return nature of GridSampling
- removes the mandatory argument 'batch' for voxel_grid, defaulting it to None