### PR TITLE
Initialise self._alpha in TransformerConv for torch.jit.script Compatibility

### DIFF
--- a/torch_geometric/nn/conv/transformer_conv.py
+++ b/torch_geometric/nn/conv/transformer_conv.py
@@ -110,6 +110,7 @@ class TransformerConv(MessagePassing):
         self.concat = concat
         self.dropout = dropout
         self.edge_dim = edge_dim
+        self._alpha = None
 
         if isinstance(in_channels, int):
             in_channels = (in_channels, in_channels)


### PR DESCRIPTION
Currently the attribute `self._alpha` is not initialised in the layer causing `torch.script.jit` to crash when trying to jit a model using one of these layers. The fix is simple: Initialise all attributes in layer for torch.jit.script compatibility.