### PR TITLE
Zip fix

### DIFF
--- a/test/data/test_data.py
+++ b/test/data/test_data.py
@@ -127,6 +127,7 @@ def test_copy_data():
     out = copy.copy(data)
     assert id(data) != id(out)
     assert id(data._store) != id(out._store)
+    assert len(data.stores) == len(out.stores)
     for store1, store2 in zip(data.stores, out.stores):
         assert id(store1) != id(store2)
         assert id(data) == id(store1._parent())
@@ -136,6 +137,7 @@ def test_copy_data():
     out = copy.deepcopy(data)
     assert id(data) != id(out)
     assert id(data._store) != id(out._store)
+    assert len(data.stores) == len(out.stores)
     for store1, store2 in zip(data.stores, out.stores):
         assert id(store1) != id(store2)
         assert id(data) == id(store1._parent())

--- a/test/data/test_hetero_data.py
+++ b/test/data/test_hetero_data.py
@@ -108,6 +108,7 @@ def test_copy_hetero_data():
 
     out = copy.copy(data)
     assert id(data) != id(out)
+    assert len(data.stores) == len(out.stores)
     for store1, store2 in zip(data.stores, out.stores):
         assert id(store1) != id(store2)
         assert id(data) == id(store1._parent())
@@ -119,6 +120,7 @@ def test_copy_hetero_data():
 
     out = copy.deepcopy(data)
     assert id(data) != id(out)
+    assert len(data.stores) == len(out.stores)
     for store1, store2 in zip(data.stores, out.stores):
         assert id(store1) != id(store2)
     assert id(out) == id(out['paper']._parent())

--- a/test/nn/conv/test_hgt_conv.py
+++ b/test/nn/conv/test_hgt_conv.py
@@ -34,8 +34,10 @@ def test_hgt_conv_same_dimensions():
     assert out_dict1['author'].size() == (4, 16)
     assert out_dict1['paper'].size() == (6, 16)
     out_dict2 = conv(x_dict, adj_t_dict)
-    for out1, out2 in zip(out_dict1.values(), out_dict2.values()):
-        assert torch.allclose(out1, out2, atol=1e-6)
+    assert len(out_dict1) == len(out_dict2)
+    for node_type in out_dict1.keys():
+        assert torch.allclose(out_dict1[node_type], out_dict2[node_type],
+                              atol=1e-6)
 
     # TODO: Test JIT functionality. We need to wait on this one until PyTorch
     # allows indexing `ParameterDict` mappings :(
@@ -75,8 +77,10 @@ def test_hgt_conv_different_dimensions():
     assert out_dict1['author'].size() == (4, 32)
     assert out_dict1['paper'].size() == (6, 32)
     out_dict2 = conv(x_dict, adj_t_dict)
-    for out1, out2 in zip(out_dict1.values(), out_dict2.values()):
-        assert torch.allclose(out1, out2, atol=1e-6)
+    assert len(out_dict1) == len(out_dict2)
+    for node_type in out_dict1.keys():
+        assert torch.allclose(out_dict1[node_type], out_dict2[node_type],
+                              atol=1e-6)
 
 
 def test_hgt_conv_lazy():
@@ -110,5 +114,8 @@ def test_hgt_conv_lazy():
     assert out_dict1['author'].size() == (4, 32)
     assert out_dict1['paper'].size() == (6, 32)
     out_dict2 = conv(x_dict, adj_t_dict)
-    for out1, out2 in zip(out_dict1.values(), out_dict2.values()):
-        assert torch.allclose(out1, out2, atol=1e-6)
+
+    assert len(out_dict1) == len(out_dict2)
+    for node_type in out_dict1.keys():
+        assert torch.allclose(out_dict1[node_type], out_dict2[node_type],
+                              atol=1e-6)


### PR DESCRIPTION
This PR makes the following updates to tests.

1. removed the usage of zip form test_hgt_conv.
2. in test_data and test_hetero_data, check if the lenght of stores match before comparing them.