### PR TITLE
added dropout argument to han_conv.

### DIFF
--- a/test/nn/conv/test_han_conv.py
+++ b/test/nn/conv/test_han_conv.py
@@ -46,6 +46,14 @@ def test_han_conv():
         assert torch.allclose(out_dict1[node_type], out_dict2[node_type],
                               atol=1e-6)
 
+    # non zero dropout
+    conv = HANConv(in_channels, 16, metadata, heads=2, dropout=0.1)
+    assert str(conv) == 'HANConv(16, heads=2)'
+    out_dict1 = conv(x_dict, edge_index_dict)
+    assert len(out_dict1) == 2
+    assert out_dict1['author'].size() == (6, 16)
+    assert out_dict1['paper'].size() == (5, 16)
+
 
 def test_han_conv_lazy():
 


### PR DESCRIPTION
In the HAN paper, dropout is applied on attention while training on various datasets. 
This PR adds the dropout argument to HanConv.