### PR TITLE
bug fix reading MalNet Tiny

### DIFF
--- a/torch_geometric/datasets/malnet_tiny.py
+++ b/torch_geometric/datasets/malnet_tiny.py
@@ -67,6 +67,8 @@ class MalNetTiny(InMemoryDataset):
                     edges = f.read().split('\n')[5:-1]
                 edge_index = [[int(s) for s in edge.split()] for edge in edges]
                 edge_index = torch.tensor(edge_index).t().contiguous()
+                # Remove isolated nodes, including those with only a self-loop
+                edge_index = remove_isolated_nodes(edge_index)[0]
                 num_nodes = int(edge_index.max()) + 1
                 data = Data(edge_index=edge_index, y=y, num_nodes=num_nodes)
                 data_list.append(data)

--- a/torch_geometric/datasets/malnet_tiny.py
+++ b/torch_geometric/datasets/malnet_tiny.py
@@ -7,6 +7,7 @@ import os.path as osp
 import torch
 from torch_geometric.data import (InMemoryDataset, Data, download_url,
                                   extract_tar)
+from torch_geometric.utils import remove_isolated_nodes
 
 
 class MalNetTiny(InMemoryDataset):
@@ -14,7 +15,7 @@ class MalNetTiny(InMemoryDataset):
     `"A Large-Scale Database for Graph Representation Learning"
     <https://openreview.net/pdf?id=1xDTDk3XPW>`_ paper.
     :class:`MalNetTiny` contains 5,000 malicious and benign software function
-    call graphs across 5 different types.
+    call graphs across 5 different types. Each graph contains at most 5k nodes.
 
     Args:
         root (string): Root directory where the dataset should be saved.
@@ -64,7 +65,7 @@ class MalNetTiny(InMemoryDataset):
             for filename in filenames:
                 with open(filename, 'r') as f:
                     edges = f.read().split('\n')[5:-1]
-                edge_index = [[int(edge[0]), int(edge[-1])] for edge in edges]
+                edge_index = [[int(s) for s in edge.split()] for edge in edges]
                 edge_index = torch.tensor(edge_index).t().contiguous()
                 num_nodes = int(edge_index.max()) + 1
                 data = Data(edge_index=edge_index, y=y, num_nodes=num_nodes)


### PR DESCRIPTION
1. The PyG's MalNetTiny class was wrongly reading `*.edgelist` files, when only first digit from source node and last digit from the destination node numbers were parsed. 
2. In MalNet `*.edgelist` files some nodes are not used at all, i.e. they are isolated if we consider the graph to have `edge_index.max().item() + 1` nodes. I used [remove_isolated_nodes](https://pytorch-geometric.readthedocs.io/en/latest/_modules/torch_geometric/utils/isolated.html#remove_isolated_nodes) to remove these isolated nodes as well as those that only have a self-loop.