### PR TITLE
Fix NeighborLoader bug with PyTorch-Lightning

### DIFF
--- a/test/loader/test_loader_utils.py
+++ b/test/loader/test_loader_utils.py
@@ -1,0 +1,16 @@
+# This file cannot be named `test_utils` as there exists already such file
+# in `test/profile/test_utils.py` which would yield a name conflict.
+
+from torch_geometric.loader.utils import edge_type_to_str
+
+
+def test_edge_type_to_str_for_tuple():
+    edge_type = ("SrcNode", "EdgeType", "DstNode")
+
+    assert edge_type_to_str(edge_type) == "SrcNode__EdgeType__DstNode"
+
+
+def test_edge_type_to_str_for_str():
+    edge_type = "SrcNode__EdgeType__DstNode"
+
+    assert edge_type_to_str(edge_type) == edge_type

--- a/torch_geometric/loader/utils.py
+++ b/torch_geometric/loader/utils.py
@@ -11,9 +11,13 @@ from torch_geometric.data import Data, HeteroData
 from torch_geometric.data.storage import NodeStorage, EdgeStorage
 
 
-def edge_type_to_str(edge_type: EdgeType) -> str:
+def edge_type_to_str(edge_type: Union[EdgeType, str]) -> str:
     # Since C++ cannot take dictionaries with tuples as key as input, edge type
     # triplets need to be converted into single strings.
+
+    if isinstance(edge_type, str):
+        return edge_type
+
     return '__'.join(edge_type)
 
 


### PR DESCRIPTION
When using PyTorch-Lightning's DDP on heterogeneous graphs, the NeighborLoader
implementation fails due to re-creation of the loader object. While Lightning
replaces the sampler to a distributed version, the `num_neighbors` parameter
is extracted from the current object and passed to the new one. At this point
it is already in the desired format, so we must not convert the dict keys again
using `edge_type_to_str()` function. This bug fix checks whether the `edge_type`
is already a string and does not apply the conversion in such case.

Resolves issue: https://github.com/pyg-team/pytorch_geometric/issues/3601