### PR TITLE
Bug Fix: Order of transforms in label_prop example

### DIFF
--- a/examples/label_prop.py
+++ b/examples/label_prop.py
@@ -7,8 +7,8 @@ from torch_geometric.nn import LabelPropagation
 root = osp.join(osp.dirname(osp.realpath(__file__)), '..', 'data', 'OGB')
 dataset = PygNodePropPredDataset(
     'ogbn-arxiv', root, transform=T.Compose([
-        T.ToSparseTensor(),
         T.ToUndirected(),
+        T.ToSparseTensor(),
     ]))
 split_idx = dataset.get_idx_split()
 evaluator = Evaluator(name='ogbn-arxiv')


### PR DESCRIPTION
This example doesn't work properly as currently written. The correct way is to reverse the order of transformations, such that we first convert the graph to undirected, then get the sparse representation.

Empirically, try running this file with the transformations listed both ways for 50 iterations, and it becomes clear from the results that the original implementation is incorrect. 

Submitted for extra credit in CS224W 