### PR TITLE
Fix key output of networkx edge getter:

### DIFF
--- a/torch_geometric/utils/convert.py
+++ b/torch_geometric/utils/convert.py
@@ -133,11 +133,12 @@ def from_networkx(G, group_node_attrs: Optional[Union[List[str], all]] = None,
     G = nx.convert_node_labels_to_integers(G)
     G = G.to_directed() if not nx.is_directed(G) else G
 
-    if type(G) is nx.MultiGraph or type(G) is nx.MultiDiGraph:
-        edge_index = torch.LongTensor(
-            list(G.edges(keys=False))).t().contiguous()
+    if isinstance(G, (nx.MultiGraph, nx.MultiDiGraph)):
+        edges = list(G.edges(keys=False))
     else:
-        edge_index = torch.LongTensor(list(G.edges)).t().contiguous()
+        edges = list(G.edges)
+
+    edge_index = torch.tensor(edges, dtype=torch.long).t().contiguous()
 
     data = defaultdict(list)
 

--- a/torch_geometric/utils/convert.py
+++ b/torch_geometric/utils/convert.py
@@ -132,7 +132,7 @@ def from_networkx(G, group_node_attrs: Optional[Union[List[str], all]] = None,
 
     G = nx.convert_node_labels_to_integers(G)
     G = G.to_directed() if not nx.is_directed(G) else G
-    
+
     if type(G) is nx.MultiGraph or type(G) is nx.MultiDiGraph:
         edge_index = torch.LongTensor(
             list(G.edges(keys=False))).t().contiguous()

--- a/torch_geometric/utils/convert.py
+++ b/torch_geometric/utils/convert.py
@@ -132,7 +132,7 @@ def from_networkx(G, group_node_attrs: Optional[Union[List[str], all]] = None,
 
     G = nx.convert_node_labels_to_integers(G)
     G = G.to_directed() if not nx.is_directed(G) else G
-    edge_index = torch.LongTensor(list(G.edges)).t().contiguous()
+    edge_index = torch.LongTensor(list(G.edges(keys=False))).t().contiguous()
 
     data = defaultdict(list)
 

--- a/torch_geometric/utils/convert.py
+++ b/torch_geometric/utils/convert.py
@@ -134,7 +134,8 @@ def from_networkx(G, group_node_attrs: Optional[Union[List[str], all]] = None,
     G = G.to_directed() if not nx.is_directed(G) else G
     
     if type(G) is nx.MultiGraph or type(G) is nx.MultiDiGraph:
-        edge_index = torch.LongTensor(list(G.edges(keys=False))).t().contiguous()
+        edge_index = torch.LongTensor(
+            list(G.edges(keys=False))).t().contiguous()
     else:
         edge_index = torch.LongTensor(list(G.edges)).t().contiguous()
 

--- a/torch_geometric/utils/convert.py
+++ b/torch_geometric/utils/convert.py
@@ -132,7 +132,11 @@ def from_networkx(G, group_node_attrs: Optional[Union[List[str], all]] = None,
 
     G = nx.convert_node_labels_to_integers(G)
     G = G.to_directed() if not nx.is_directed(G) else G
-    edge_index = torch.LongTensor(list(G.edges(keys=False))).t().contiguous()
+    
+    if type(G) is nx.MultiGraph or type(G) is nx.MultiDiGraph:
+        edge_index = torch.LongTensor(list(G.edges(keys=False))).t().contiguous()
+    else:
+        edge_index = torch.LongTensor(list(G.edges)).t().contiguous()
 
     data = defaultdict(list)
 


### PR DESCRIPTION
Removed the key output, which resulted in a three-dimensional tensor, when using MultiDiGraphs.
Three-dimensional edge tuples could not be converted into the required [2,-1] COO format.

Example:
Right:
` print(list(G.edges(keys=False)))`
 [(2, 1), (5, 4), (5, 4), (5, 4), (6, 1), (7, 1)]

Wrong:
`print(list(G.edges))`
[(2, 1, 0), (5, 4, 0), (5, 4, 1), (5, 4, 2), (6, 1, 0), (7, 1, 0)]

Wrong:
`print(torch.LongTensor(list(G.edges)))`
 tensor([[2, 1, 0],
        [5, 4, 0],
        [5, 4, 1],
        [5, 4, 2],
        [6, 1, 0],
        [7, 1, 0]])
Right:
`print(torch.LongTensor(list(G.edges(keys=False))).t().contiguous())`
 tensor([[2, 5, 5, 5, 6, 7],
        [1, 4, 4, 4, 1, 1]])`