### PR TITLE
Fix issue with GeneralConv when skip_linear=False and in_channels == out_channels

### DIFF
--- a/torch_geometric/nn/conv/general_conv.py
+++ b/torch_geometric/nn/conv/general_conv.py
@@ -116,7 +116,7 @@ class GeneralConv(MessagePassing):
     def reset_parameters(self):
         self.lin_msg.reset_parameters()
         if hasattr(self.lin_self, 'reset_parameters'):
-            self.lin_self.reset_parameters() 
+            self.lin_self.reset_parameters()
         if self.in_edge_channels is not None:
             self.lin_edge.reset_parameters()
         if self.attention and self.attention_type == 'additive':

--- a/torch_geometric/nn/conv/general_conv.py
+++ b/torch_geometric/nn/conv/general_conv.py
@@ -115,7 +115,8 @@ class GeneralConv(MessagePassing):
 
     def reset_parameters(self):
         self.lin_msg.reset_parameters()
-        self.lin_self.reset_parameters()
+        if hasattr(self.lin_self, 'reset_parameters'):
+            self.lin_self.reset_parameters() 
         if self.in_edge_channels is not None:
             self.lin_edge.reset_parameters()
         if self.attention and self.attention_type == 'additive':


### PR DESCRIPTION
Hi, 

when creating a GeneralConv layer with the same number of input and output channels, the following crash happens:

```python
In [1]: from torch_geometric.nn import GeneralConv

In [2]: l = GeneralConv(10, 10)
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
<ipython-input-4-f35b230802e7> in <module>
----> 1 l = GeneralConv(10, 10)

~/dev/tf2/lib/python3.9/site-packages/torch_geometric/nn/conv/general_conv.py in __init__(self, in_channels, out_channels, in_edge_channels, aggr, skip_linear, directed_msg, heads, attention, attention_type, l2_normalize, bias, **kwargs)
    105                     self.attention_type))
    106 
--> 107         self.reset_parameters()
    108 
    109     def reset_parameters(self):

~/dev/tf2/lib/python3.9/site-packages/torch_geometric/nn/conv/general_conv.py in reset_parameters(self)
    109     def reset_parameters(self):
    110         self.lin_msg.reset_parameters()
--> 111         self.lin_self.reset_parameters()
    112         if self.in_edge_channels is not None:
    113             self.lin_edge.reset_parameters()

~/dev/tf2/lib/python3.9/site-packages/torch/nn/modules/module.py in __getattr__(self, name)
   1175             if name in modules:
   1176                 return modules[name]
-> 1177         raise AttributeError("'{}' object has no attribute '{}'".format(
   1178             type(self).__name__, name))
   1179 

AttributeError: 'Identity' object has no attribute 'reset_parameters'
```

The reason for the crash is that, when `skip_linear=False` and `in_channels == out_channels`, the `lin_self` layer is a `nn.Identity` and it has no parameters to reset.
This PR fixes the issue by checking that the `lin_self` layer actually has parameters to reset. 

Feel free to change the condition check if you prefer a different style :)

Cheers