### PR TITLE
Fix Wiki-CS to be undirected by default

### DIFF
--- a/torch_geometric/datasets/fake.py
+++ b/torch_geometric/datasets/fake.py
@@ -31,8 +31,8 @@ class FakeDataset(InMemoryDataset):
             If set to :obj:`"auto"`, will return graph-level labels if
             :obj:`num_graphs > 1`, and node-level labels other-wise.
             (default: :obj:`"auto"`)
-        is_undirected (bool): Whether the graphs to generate are undirected.
-            (default: :obj:`True`)
+        is_undirected (bool, optional): Whether the graphs to generate are
+            undirected. (default: :obj:`True`)
         transform (callable, optional): A function/transform that takes in
             an :obj:`torch_geometric.data.Data` object and returns a
             transformed version. The data object will be transformed before

--- a/torch_geometric/datasets/sbm_dataset.py
+++ b/torch_geometric/datasets/sbm_dataset.py
@@ -25,8 +25,8 @@ class StochasticBlockModelDataset(InMemoryDataset):
         num_channels (int, optional): The number of node features. If given
             as :obj:`None`, node features are not generated.
             (default: :obj:`None`)
-        is_undirected (bool): Whether the graph to generate is undirected.
-            (default: :obj:`True`)
+        is_undirected (bool, optional): Whether the graph to generate is
+            undirected. (default: :obj:`True`)
         transform (callable, optional): A function/transform that takes in
             an :obj:`torch_geometric.data.Data` object and returns a
             transformed version. The data object will be transformed before
@@ -132,8 +132,8 @@ class RandomPartitionGraphDataset(StochasticBlockModelDataset):
         num_channels (int, optional): The number of node features. If given
             as :obj:`None`, node features are not generated.
             (default: :obj:`None`)
-        is_undirected (bool): Whether the graph to generate is undirected.
-            (default: :obj:`True`)
+        is_undirected (bool, optional): Whether the graph to generate is
+            undirected. (default: :obj:`True`)
         transform (callable, optional): A function/transform that takes in
             an :obj:`torch_geometric.data.Data` object and returns a
             transformed version. The data object will be transformed before

--- a/torch_geometric/datasets/wikics.py
+++ b/torch_geometric/datasets/wikics.py
@@ -51,7 +51,8 @@ class WikiCS(InMemoryDataset):
         y = torch.tensor(data['labels'], dtype=torch.long)
 
         if self.directed:
-            edges = [[(i, j) for j in js] for i, js in enumerate(data['links'])]
+            edges = [[(i, j) for j in js]
+                     for i, js in enumerate(data['links'])]
             edges = list(chain(*edges))
         else:
             edges = [[(i, j) for j in js] + [(j, i) for j in js]

--- a/torch_geometric/datasets/wikics.py
+++ b/torch_geometric/datasets/wikics.py
@@ -1,7 +1,12 @@
+from typing import Optional, Callable
+
 import json
+import warnings
 from itertools import chain
 
 import torch
+
+from torch_geometric.utils import to_undirected
 from torch_geometric.data import InMemoryDataset, Data, download_url
 
 
@@ -21,22 +26,31 @@ class WikiCS(InMemoryDataset):
             an :obj:`torch_geometric.data.Data` object and returns a
             transformed version. The data object will be transformed before
             being saved to disk. (default: :obj:`None`)
+        is_undirected (bool, optional): Whether the graph is undirected.
+            (default: :obj:`True`)
     """
 
     url = 'https://github.com/pmernyei/wiki-cs-dataset/raw/master/dataset'
 
-    def __init__(self, root, transform=None, pre_transform=None,
-                 directed=False):
+    def __init__(self, root: str, transform: Optional[Callable] = None,
+                 pre_transform: Optional[Callable] = None,
+                 is_undirected: Optional[bool] = None):
+        if is_undirected is None:
+            warnings.warn(
+                f"The {self.__class__.__name__} dataset now returns an "
+                f"undirected graph by default. Please explicitly specify "
+                f"'is_undirected=False' to restore the old behaviour.")
+            is_undirected = True
+        self.is_undirected = is_undirected
         super().__init__(root, transform, pre_transform)
         self.data, self.slices = torch.load(self.processed_paths[0])
-        self.directed = directed
 
     @property
-    def raw_file_names(self):
-        return ['data.json']
+    def raw_file_names(self) -> str:
+        return 'data.json'
 
     @property
-    def processed_file_names(self):
+    def processed_file_names(self) -> str:
         return 'data.pt'
 
     def download(self):
@@ -50,15 +64,11 @@ class WikiCS(InMemoryDataset):
         x = torch.tensor(data['features'], dtype=torch.float)
         y = torch.tensor(data['labels'], dtype=torch.long)
 
-        if self.directed:
-            edges = [[(i, j) for j in js]
-                     for i, js in enumerate(data['links'])]
-            edges = list(chain(*edges))
-        else:
-            edges = [[(i, j) for j in js] + [(j, i) for j in js]
-                     for i, js in enumerate(data['links'])]
-            edges = list(set(chain(*edges)))
+        edges = [[(i, j) for j in js] for i, js in enumerate(data['links'])]
+        edges = list(chain(*edges))
         edge_index = torch.tensor(edges, dtype=torch.long).t().contiguous()
+        if self.is_undirected:
+            edge_index = to_undirected(edge_index, num_nodes=x.size(0))
 
         train_mask = torch.tensor(data['train_masks'], dtype=torch.bool)
         train_mask = train_mask.t().contiguous()


### PR DESCRIPTION
I discovered a mistake I made when assembling the [Wiki-CS dataset](https://github.com/pmernyei/wiki-cs-dataset): I intended to make it an undirected graph and [presented it as such](https://arxiv.org/pdf/2007.02901.pdf), but when making the dataloader for PyG, I forgot the process it accordingly. See also [the relevant issue on my repo](https://github.com/pmernyei/wiki-cs-dataset/issues/3).
 
This PR is updates the dataset to actually be undirected by default, while leaving an optional flag for loading it as a directed dataset for anyone who prefers to use it that way.

I also thought it might be worth adding a warning when loading the dataset for reproducability, since of course this makes new results non-comparble with existing reported results on the default settings. I'm not sure if/how that would be appropriate, though (do we just add a print statement, or is there some more sophisticated logging management in PyG?), so I'll leave that to the maintainers.

Thank you!