### PR TITLE
Make gravnet_conv.py compatible with torch.jit.script

### DIFF
--- a/test/nn/conv/test_gravnet_conv.py
+++ b/test/nn/conv/test_gravnet_conv.py
@@ -32,3 +32,5 @@ def test_gravnet_conv():
     jit = torch.jit.script(conv.jittable(t))
     assert jit((x1, x2)).tolist() == out21.tolist()
     assert jit((x1, x2), (batch1, batch2)).tolist() == out22.tolist()
+
+    torch.jit.script(conv.jittable())  # Test without explicit typing.

--- a/torch_geometric/nn/conv/gravnet_conv.py
+++ b/torch_geometric/nn/conv/gravnet_conv.py
@@ -80,8 +80,11 @@ class GravNetConv(MessagePassing):
         self.lin_out1.reset_parameters()
         self.lin_out2.reset_parameters()
 
-    def forward(self, x: Union[Tensor, PairTensor],
-                batch: Union[OptTensor, Optional[PairTensor]]) -> Tensor:
+    def forward(
+            self, x: Union[Tensor, PairTensor],
+            batch: Union[OptTensor, Optional[PairTensor]] = None) -> Tensor:
+        # type: (Tensor, OptTensor) -> Tensor  # noqa
+        # type: (PairTensor, Optional[PairTensor]) -> Tensor  # noqa
         """"""
 
         is_bipartite: bool = True

--- a/torch_geometric/nn/conv/gravnet_conv.py
+++ b/torch_geometric/nn/conv/gravnet_conv.py
@@ -80,9 +80,8 @@ class GravNetConv(MessagePassing):
         self.lin_out1.reset_parameters()
         self.lin_out2.reset_parameters()
 
-    def forward(
-            self, x: Union[Tensor, PairTensor],
-            batch: Union[OptTensor, Optional[PairTensor]]) -> Tensor:
+    def forward(self, x: Union[Tensor, PairTensor],
+                batch: Union[OptTensor, Optional[PairTensor]]) -> Tensor:
         """"""
 
         is_bipartite: bool = True

--- a/torch_geometric/nn/conv/gravnet_conv.py
+++ b/torch_geometric/nn/conv/gravnet_conv.py
@@ -82,7 +82,7 @@ class GravNetConv(MessagePassing):
 
     def forward(
             self, x: Union[Tensor, PairTensor],
-            batch: Union[OptTensor, Optional[PairTensor]] = None) -> Tensor:
+            batch: Union[OptTensor, Optional[PairTensor]]) -> Tensor:
         """"""
 
         is_bipartite: bool = True


### PR DESCRIPTION
Removes unnecessary default value in order to make the layer compatible with torch.jit.script. See [the corresponding issue](https://github.com/pyg-team/pytorch_geometric/issues/3884).