### PR TITLE
Fix to_undirected option in to_networkx, fix test

### DIFF
--- a/test/utils/test_convert.py
+++ b/test/utils/test_convert.py
@@ -78,9 +78,12 @@ def test_to_networkx_undirected():
         assert G.nodes[1]['pos'] == [1, 1]
 
         if remove_self_loops:
-            assert nx.to_numpy_matrix(G).tolist() == [[0, 2], [2, 0]]
+            assert nx.to_numpy_matrix(G).tolist() == [[0, 1], [1, 0]]
         else:
-            assert nx.to_numpy_matrix(G).tolist() == [[3, 2], [2, 0]]
+            assert nx.to_numpy_matrix(G).tolist() == [[3, 1], [1, 0]]
+
+    G = to_networkx(data, edge_attrs=['weight'], to_undirected=False)
+    assert nx.to_numpy_matrix(G).tolist() == [[3, 1], [2, 0]]
 
 
 def test_from_networkx():

--- a/torch_geometric/utils/convert.py
+++ b/torch_geometric/utils/convert.py
@@ -92,7 +92,7 @@ def to_networkx(data, node_attrs=None, edge_attrs=None, to_undirected=False,
 
     for i, (u, v) in enumerate(data.edge_index.t().tolist()):
 
-        if to_undirected and v > u:
+        if to_undirected and u > v:
             continue
 
         if remove_self_loops and u == v:


### PR DESCRIPTION
This PR aims to fix a minor bug for ``to_networkx`` function with ``to_undirected=True`` (https://github.com/pyg-team/pytorch_geometric/issues/3873).

The corresponding unit test is updated to match the expected behavior of preserving the upper triangle rather than the lower triangle of the adjacency matrix.