### PR TITLE
Refactor: `MLP` initialization

### DIFF
--- a/test/nn/models/test_mlp.py
+++ b/test/nn/models/test_mlp.py
@@ -11,10 +11,16 @@ from torch_geometric.nn import MLP
 def test_mlp(batch_norm, relu_first):
     x = torch.randn(4, 16)
 
+    torch.manual_seed(12345)
     mlp = MLP([16, 32, 32, 64], batch_norm=batch_norm, relu_first=relu_first)
-    assert mlp.__repr__() == 'MLP(16, 32, 32, 64)'
+    assert str(mlp) == 'MLP(16, 32, 32, 64)'
     out = mlp(x)
     assert out.size() == (4, 64)
 
     jit = torch.jit.script(mlp)
     assert torch.allclose(jit(x), out)
+
+    torch.manual_seed(12345)
+    mlp = MLP(16, hidden_channels=32, out_channels=64, num_layers=3,
+              batch_norm=batch_norm, relu_first=relu_first)
+    assert torch.allclose(mlp(x), out)

--- a/torch_geometric/nn/models/linkx.py
+++ b/torch_geometric/nn/models/linkx.py
@@ -106,7 +106,7 @@ class LINKX(torch.nn.Module):
         self.cat_lin2 = torch.nn.Linear(hidden_channels, hidden_channels)
 
         channels = [hidden_channels] * num_layers + [out_channels]
-        self.final_mlp = MLP(channels, dropout, relu_first=True)
+        self.final_mlp = MLP(channels, dropout=dropout, relu_first=True)
 
         self.reset_parameters()
 

--- a/torch_geometric/nn/models/mlp.py
+++ b/torch_geometric/nn/models/mlp.py
@@ -34,11 +34,11 @@ class MLP(torch.nn.Module):
         channel_list (List[int] or int, optional): List of input, intermediate
             and output channels. :obj:`len(channel_list) - 1` denotes the
             number of layers of the MLP (default: :obj:`None`)
-        in_channels (int): Size of each input sample.
+        in_channels (int, optional): Size of each input sample.
             Will override :attr:`channel_list`. (default: :obj:`None`)
-        hidden_channels (int): Size of each hidden sample.
+        hidden_channels (int, optional): Size of each hidden sample.
             Will override :attr:`channel_list`. (default: :obj:`None`)
-        out_channels (int): Size of each output sample.
+        out_channels (int, optional): Size of each output sample.
             Will override :attr:`channel_list`. (default: :obj:`None`)
         num_layers (int, optional): The number of layers.
             Will override :attr:`channel_list`. (default: :obj:`None`)

--- a/torch_geometric/nn/models/mlp.py
+++ b/torch_geometric/nn/models/mlp.py
@@ -10,10 +10,9 @@ from torch_geometric.nn.dense.linear import Linear
 
 class MLP(torch.nn.Module):
     r"""A Multi-Layer Perception (MLP) model.
-
     There exists two ways to create an :class:`MLP`:
 
-    1. By specifying explit channel sizes, *e.g.*,
+    1. By specifying explicit channel sizes, *e.g.*,
 
        .. code-block:: python
 
@@ -21,8 +20,8 @@ class MLP(torch.nn.Module):
 
        creates a three-layer MLP with **differently** sized hidden layers.
 
-    1. By specifying a fixed hidden channel size over a certain number of
-       layers, *e.g.*,
+    1. By specifying fixed hidden channel sizes over a number of layers,
+       *e.g.*,
 
        .. code-block:: python
 
@@ -32,17 +31,17 @@ class MLP(torch.nn.Module):
        creates a three-layer MLP with **equally** sized hidden layers.
 
     Args:
-        channel_list (List[int] or int): List of input, intermediate and output
-            channels. :obj:`len(channel_list) - 1` denotes the number of layers
-            of the MLP.
+        channel_list (List[int] or int, optional): List of input, intermediate
+            and output channels. :obj:`len(channel_list) - 1` denotes the
+            number of layers of the MLP (default: :obj:`None`)
         in_channels (int): Size of each input sample.
-            Overrides :attr:`channel_list`. (default: :obj:`None`)
+            Will override :attr:`channel_list`. (default: :obj:`None`)
         hidden_channels (int): Size of each hidden sample.
-            Overrides :attr:`channel_list`. (default: :obj:`None`)
+            Will override :attr:`channel_list`. (default: :obj:`None`)
         out_channels (int): Size of each output sample.
-            Overrides :attr:`channel_list`. (default: :obj:`None`)
+            Will override :attr:`channel_list`. (default: :obj:`None`)
         num_layers (int, optional): The number of layers.
-            Overrides :attr:`channel_list`. (default: :obj:`None`)
+            Will override :attr:`channel_list`. (default: :obj:`None`)
         dropout (float, optional): Dropout probability of each hidden
             embedding. (default: :obj:`0.`)
         batch_norm (bool, optional): If set to :obj:`False`, will not make use
@@ -72,6 +71,7 @@ class MLP(torch.nn.Module):
             channel_list = [hidden_channels] * (num_layers - 1)
             channel_list = [in_channels] + channel_list + [out_channels]
 
+        assert isinstance(channel_list, (tuple, list))
         assert len(channel_list) >= 2
         self.channel_list = channel_list
         self.dropout = dropout

--- a/torch_geometric/nn/models/mlp.py
+++ b/torch_geometric/nn/models/mlp.py
@@ -10,7 +10,7 @@ from torch_geometric.nn.dense.linear import Linear
 
 class MLP(torch.nn.Module):
     r"""A Multi-Layer Perception (MLP) model.
-    There exists two ways to create an :class:`MLP`:
+    There exists two ways to instantiate an :class:`MLP`:
 
     1. By specifying explicit channel sizes, *e.g.*,
 

--- a/torch_geometric/nn/models/mlp.py
+++ b/torch_geometric/nn/models/mlp.py
@@ -9,26 +9,27 @@ from torch_geometric.nn.dense.linear import Linear
 
 
 class MLP(torch.nn.Module):
-    r"""A multi-layer perception (MLP) model.
+    r"""A Multi-Layer Perception (MLP) model.
 
     There exists two ways to create an :class:`MLP`:
 
-    1. Via :attr:`channel_list`
+    1. By specifying explit channel sizes, *e.g.*,
 
-      .. code-block:: python
+       .. code-block:: python
 
-        mlp = MLP([16, 32, 64, 128])
+          mlp = MLP([16, 32, 64, 128])
 
-      which creates a three-layer MLP with **differently sized hidden layers**.
+       creates a three-layer MLP with **differently** sized hidden layers.
 
-    1. Via :attr:`num_layers`
+    1. By specifying a fixed hidden channel size over a certain number of
+       layers, *e.g.*,
 
-      .. code-block:: python
+       .. code-block:: python
 
-        mlp = MLP(in_channels=16, hidden_channels=32,
-                  out_channels=128, num_layers=3)
+          mlp = MLP(in_channels=16, hidden_channels=32,
+                    out_channels=128, num_layers=3)
 
-      which creates a three-layer MLP with **equally sized hidden layers**.
+       creates a three-layer MLP with **equally** sized hidden layers.
 
     Args:
         channel_list (List[int] or int): List of input, intermediate and output
@@ -88,14 +89,17 @@ class MLP(torch.nn.Module):
 
     @property
     def in_channels(self) -> int:
+        r"""Size of each input sample."""
         return self.channel_list[0]
 
     @property
     def out_channels(self) -> int:
+        r"""Size of each output sample."""
         return self.channel_list[-1]
 
     @property
     def num_layers(self) -> int:
+        r"""The number of layers."""
         return len(self.channel_list) - 1
 
     def reset_parameters(self):


### PR DESCRIPTION
1. via `channel_list`:
   ```python
   mlp = MLP([16, 32, 64, 128])
   ```
2. via `num_layers`:
   ```python
   mlp = MLP(in_channels=16, hidden_channels=32,
             out_channels=128, num_layers=3)
   ```
