### PR TITLE
Graph Relational Attention

### DIFF
--- a/examples/rgat_conv.py
+++ b/examples/rgat_conv.py
@@ -2,11 +2,11 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 import torch.optim as optim
-from torch_geometric.nn import RGATConv
 from torch.nn import Linear
 from torch.nn.utils import clip_grad_value_
 
 from torch_geometric.datasets import Entities
+from torch_geometric.nn import RGATConv
 
 
 class RGAT(nn.Module):

--- a/examples/rgat_conv.py
+++ b/examples/rgat_conv.py
@@ -1,0 +1,88 @@
+import torch.nn as nn
+import torch
+import torch.nn.functional as F
+from torch.nn.utils import clip_grad_value_
+from torch.nn import Linear
+
+import torch.optim as optim
+from torch_geometric.datasets import Entities
+from rgat_conv import RGATConv
+
+
+class Net(nn.Module):
+    def __init__(self, d=2):
+        super(Net, self).__init__()
+
+        self.nclass = 4
+        self.readout = "add"
+        self.in_channels = 16
+        self.out_channels = 25
+        self.d = d
+
+        self.conv_layers = nn.ModuleList([
+            RGATConv(16, 20, num_relations=90, num_bases=35, mod="additive",
+                     attention_mechanism="within-relation",
+                     attention_mode="multiplicative-self-attention",
+                     heads=2, d=2),
+            RGATConv(80, 25, num_relations=90, num_blocks=2, mod=None,
+                     attention_mechanism="across-relation",
+                     attention_mode="additive-self-attention",
+                     heads=2, d=1, dropout=0.6, edge_dim=16, bias=False),
+                     ])
+
+        self.fc = Linear(16, self.in_channels, bias=False)
+
+        self.linear = Linear(self.d * self.out_channels, self.nclass)
+
+    def forward(self, x, edge_index, edge_type, edge_attr):
+        if x.dim() == 1:
+            x = x.unsqueeze(-1)
+
+        hid_x = self.fc(x)
+
+        for yt, conv in enumerate(self.conv_layers):
+            if yt == 0:
+                hid_x = conv(hid_x, edge_index, edge_type, edge_attr=None)
+            else:
+                hid_x = conv(hid_x, edge_index, edge_type, edge_attr)
+
+        x = self.linear(hid_x)
+        return F.log_softmax(x, dim=-1)
+
+
+if __name__ == '__main__':
+    dataset = Entities(root='/tmp/AIFB', name='AIFB')
+
+    edge_index, edge_type, train_labels, test_labels, train_mask, test_mask, \
+        num_nodes = dataset[0].edge_index, dataset[0].edge_type, \
+        dataset[0].train_y, dataset[0].test_y, dataset[0].train_idx, \
+        dataset[0].test_idx, dataset[0].num_nodes
+
+    x = torch.randn(num_nodes, 16)
+    edge_attr = torch.randn(58086, 2, 3, 7, 16)
+
+    model = Net()
+    optimizer = optim.Adam(model.parameters(), lr=1e-2, weight_decay=1e-3,
+                           msgrad=False)
+
+    model.train()
+    for epoch in range(100):
+        optimizer.zero_grad()
+        output = model(x, edge_index, edge_type, edge_attr, torch.tensor([0]))
+        loss = F.nll_loss(output[train_mask], train_labels)
+        loss.backward()
+        clip_grad_value_(model.parameters(), 2.0)
+        optimizer.step()
+
+        model.eval()
+        train_acc = torch.sum(output[train_mask].argmax(dim=1) == train_labels)
+        train_acc = train_acc / len(train_mask)
+        test_acc = torch.sum(output[test_mask].argmax(dim=1) == test_labels)
+        test_acc = test_acc.item() / len(test_mask)
+
+        print('Epoch {:03d}'.format(epoch+1),
+              'train_loss: {:.4f}'.format(loss),
+              'train_acc: {:.4f}'.format(train_acc),
+              'test_acc: {:.4f}'.format(test_acc))
+
+    print("Optimization Finished!")

--- a/examples/rgat_conv.py
+++ b/examples/rgat_conv.py
@@ -2,7 +2,7 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 import torch.optim as optim
-from rgat_conv import RGATConv
+from torch_geometric.nn import RGATConv
 from torch.nn import Linear
 from torch.nn.utils import clip_grad_value_
 

--- a/examples/rgat_conv.py
+++ b/examples/rgat_conv.py
@@ -1,74 +1,86 @@
-import torch.nn as nn
 import torch
+import torch.nn as nn
 import torch.nn.functional as F
-from torch.nn.utils import clip_grad_value_
-from torch.nn import Linear
-
 import torch.optim as optim
-from torch_geometric.datasets import Entities
 from rgat_conv import RGATConv
+from torch.nn import Linear
+from torch.nn.utils import clip_grad_value_
+
+from torch_geometric.datasets import Entities
 
 
-class Net(nn.Module):
-    def __init__(self, d=2):
-        super(Net, self).__init__()
+class RGAT(nn.Module):
+    def __init__(self, in_channels, hidden_channels, out_channels, nclass=4):
+        super().__init__()
 
-        self.nclass = 4
-        self.readout = "add"
-        self.in_channels = 16
-        self.out_channels = 25
-        self.d = d
+        self.nclass = nclass
+        self.in_channels = in_channels
+        self.hidden_channels = hidden_channels
+        self.out_channels = out_channels
 
-        self.conv_layers = nn.ModuleList([
-            RGATConv(16, 20, num_relations=90, num_bases=35, mod="additive",
-                     attention_mechanism="within-relation",
-                     attention_mode="multiplicative-self-attention",
-                     heads=2, d=2),
-            RGATConv(80, 25, num_relations=90, num_blocks=2, mod=None,
-                     attention_mechanism="across-relation",
-                     attention_mode="additive-self-attention",
-                     heads=2, d=1, dropout=0.6, edge_dim=16, bias=False),
-                     ])
+        self.convs = nn.ModuleList([
+            RGATConv(self.hidden_channels, 20, num_relations=90, num_bases=35,
+                     mod="additive", attention_mechanism="within-relation",
+                     attention_mode="multiplicative-self-attention", heads=2,
+                     d=2),
+            # The "in_channels" for every single layer after the first layer
+            # must be equal to the product of three arguments:
+            # "heads * d * out_channels" being used in the previous layer
+            # because each RGATConv layer outputs "heads * d * out_channels"
+            # features for each node
+            RGATConv(80, self.out_channels, num_relations=90, num_blocks=2,
+                     mod=None, attention_mechanism="across-relation",
+                     attention_mode="additive-self-attention", heads=2, d=1,
+                     dropout=0.6, edge_dim=16, bias=False),
+        ])
 
-        self.fc = Linear(16, self.in_channels, bias=False)
+        self.lin1 = Linear(self.in_channels, self.hidden_channels, bias=False)
 
-        self.linear = Linear(self.d * self.out_channels, self.nclass)
+        # The following layer is being used so that the final returned output
+        # will consist of "nclass" features for each node
+        self.lin2 = Linear(2 * self.out_channels, self.nclass)
 
     def forward(self, x, edge_index, edge_type, edge_attr):
-        if x.dim() == 1:
-            x = x.unsqueeze(-1)
 
-        hid_x = self.fc(x)
+        hid_x = self.lin1(x)
 
-        for yt, conv in enumerate(self.conv_layers):
+        # "edge_attr" is being put to some use only for the second layer
+        # just to check if arbitrary ordering of "edge_attr" among layers
+        # of a GNN module can be achieved. Nevertheless, "edge_attr" can
+        # be passed to any "RGAT" layer.
+        for yt, conv in enumerate(self.convs):
             if yt == 0:
                 hid_x = conv(hid_x, edge_index, edge_type, edge_attr=None)
+                hid_x = F.relu(hid_x)
             else:
                 hid_x = conv(hid_x, edge_index, edge_type, edge_attr)
 
-        x = self.linear(hid_x)
+        x = self.lin2(hid_x)
         return F.log_softmax(x, dim=-1)
 
 
 if __name__ == '__main__':
+    device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
     dataset = Entities(root='/tmp/AIFB', name='AIFB')
+    data = dataset[0]
+    data = data.to(device)
 
     edge_index, edge_type, train_labels, test_labels, train_mask, test_mask, \
-        num_nodes = dataset[0].edge_index, dataset[0].edge_type, \
-        dataset[0].train_y, dataset[0].test_y, dataset[0].train_idx, \
-        dataset[0].test_idx, dataset[0].num_nodes
+        num_nodes = data.edge_index, data.edge_type, \
+        data.train_y, data.test_y, data.train_idx, \
+        data.test_idx, data.num_nodes
 
     x = torch.randn(num_nodes, 16)
     edge_attr = torch.randn(58086, 2, 3, 7, 16)
 
-    model = Net()
+    model = RGAT(16, 16, 25).to(device)
     optimizer = optim.Adam(model.parameters(), lr=1e-2, weight_decay=1e-3,
-                           msgrad=False)
+                           amsgrad=False)
 
-    model.train()
     for epoch in range(100):
+        model.train()
         optimizer.zero_grad()
-        output = model(x, edge_index, edge_type, edge_attr, torch.tensor([0]))
+        output = model(x, edge_index, edge_type, edge_attr)
         loss = F.nll_loss(output[train_mask], train_labels)
         loss.backward()
         clip_grad_value_(model.parameters(), 2.0)
@@ -80,7 +92,7 @@ if __name__ == '__main__':
         test_acc = torch.sum(output[test_mask].argmax(dim=1) == test_labels)
         test_acc = test_acc.item() / len(test_mask)
 
-        print('Epoch {:03d}'.format(epoch+1),
+        print('Epoch {:03d}'.format(epoch + 1),
               'train_loss: {:.4f}'.format(loss),
               'train_acc: {:.4f}'.format(train_acc),
               'test_acc: {:.4f}'.format(test_acc))

--- a/test/nn/conv/test_rgat_conv.py
+++ b/test/nn/conv/test_rgat_conv.py
@@ -1,7 +1,6 @@
 import torch
-from torch_sparse import SparseTensor
-
 from rgat_conv import RGATConv
+from torch_sparse import SparseTensor
 
 
 def test_rgat_conv():
@@ -12,31 +11,30 @@ def test_rgat_conv():
     adj = SparseTensor(row=row, col=col, value=edge_attr, sparse_sizes=(4, 4))
     edge_type = torch.tensor([0, 2, 1, 2])
 
-    conv = RGATConv(8, 20, num_relations=4, num_bases=4,
-                    mod="additive", attention_mechanism="across-relation",
-                    attention_mode="additive-self-attention",
-                    heads=2, d=1, edge_dim=8, bias=False)
+    conv = RGATConv(8, 20, num_relations=4, num_bases=4, mod="additive",
+                    attention_mechanism="across-relation",
+                    attention_mode="additive-self-attention", heads=2, d=1,
+                    edge_dim=8, bias=False)
     assert str(conv) == 'RGATConv(8, 20, heads=2)'
     out = conv(x, edge_index, edge_type, edge_attr)
     assert out.size() == (4, 40)
-    assert torch.allclose(conv(x, edge_index, edge_type, edge_attr,
-                               size=(4, 4)), out)
+    assert torch.allclose(
+        conv(x, edge_index, edge_type, edge_attr, size=(4, 4)), out)
     assert torch.allclose(conv(x, adj.t(), edge_type), out)
 
     t = '(Tensor, Tensor, OptTensor, OptTensor, Size, NoneType) -> Tensor'
     jit = torch.jit.script(conv.jittable(t))
-    assert torch.allclose(jit(x, edge_index, edge_type, edge_attr),
-                          out)
+    assert torch.allclose(jit(x, edge_index, edge_type, edge_attr), out)
 
-    conv = RGATConv(8, 20, num_relations=4, num_blocks=2,
-                    mod="additive", attention_mechanism="across-relation",
-                    attention_mode="additive-self-attention",
-                    heads=2, d=1, edge_dim=8, bias=False)
+    conv = RGATConv(8, 20, num_relations=4, num_blocks=2, mod="additive",
+                    attention_mechanism="across-relation",
+                    attention_mode="additive-self-attention", heads=2, d=1,
+                    edge_dim=8, bias=False)
     assert str(conv) == 'RGATConv(8, 20, heads=2)'
     out = conv(x, edge_index, edge_type, edge_attr)
     assert out.size() == (4, 40)
-    assert torch.allclose(conv(x, edge_index, edge_type, edge_attr,
-                               size=(4, 4)), out)
+    assert torch.allclose(
+        conv(x, edge_index, edge_type, edge_attr, size=(4, 4)), out)
     assert torch.allclose(conv(x, adj.t(), edge_type), out)
 
     t = ('(Tensor, SparseTensor, OptTensor, OptTensor, '

--- a/test/nn/conv/test_rgat_conv.py
+++ b/test/nn/conv/test_rgat_conv.py
@@ -12,15 +12,15 @@ def test_rgat_conv():
     adj = SparseTensor(row=row, col=col, value=edge_attr, sparse_sizes=(4, 4))
     edge_type = torch.tensor([0, 2, 1, 2])
 
-    conv = RGATConv(8, 20, num_relations=4, num_bases=4,
-                    mod="additive", attention_mechanism="across-relation",
-                    attention_mode="additive-self-attention",
-                    heads=2, d=1, edge_dim=8, bias=False)
+    conv = RGATConv(8, 20, num_relations=4, num_bases=4, mod="additive",
+                    attention_mechanism="across-relation",
+                    attention_mode="additive-self-attention", heads=2, d=1,
+                    edge_dim=8, bias=False)
     assert str(conv) == 'RGATConv(8, 20, heads=2)'
     out = conv(x, edge_index, edge_type, edge_attr)
     assert out.size() == (4, 40)
-    assert torch.allclose(conv(x, edge_index, edge_type, edge_attr,
-                               size=(4, 4)), out)
+    assert torch.allclose(
+        conv(x, edge_index, edge_type, edge_attr, size=(4, 4)), out)
     assert torch.allclose(conv(x, adj.t(), edge_type), out)
 
     t = '(Tensor, Tensor, OptTensor, OptTensor, Size, NoneType) -> Tensor'
@@ -28,13 +28,13 @@ def test_rgat_conv():
     assert torch.allclose(jit(x, edge_index, edge_type),
                           conv(x, edge_index, edge_type))
 
-    conv = RGATConv(8, 20, num_relations=4, num_blocks=2,
-                    mod="additive", attention_mechanism="across-relation",
-                    attention_mode="additive-self-attention",
-                    heads=2, d=1, edge_dim=8, bias=False)
+    conv = RGATConv(8, 20, num_relations=4, num_blocks=2, mod="additive",
+                    attention_mechanism="across-relation",
+                    attention_mode="additive-self-attention", heads=2, d=1,
+                    edge_dim=8, bias=False)
     assert str(conv) == 'RGATConv(8, 20, heads=2)'
     out = conv(x, edge_index, edge_type, edge_attr)
     assert out.size() == (4, 40)
-    assert torch.allclose(conv(x, edge_index, edge_type, edge_attr,
-                               size=(4, 4)), out)
+    assert torch.allclose(
+        conv(x, edge_index, edge_type, edge_attr, size=(4, 4)), out)
     assert torch.allclose(conv(x, adj.t(), edge_type), out)

--- a/test/nn/conv/test_rgat_conv.py
+++ b/test/nn/conv/test_rgat_conv.py
@@ -1,6 +1,7 @@
 import torch
-from torch_geometric.nn import RGATConv
 from torch_sparse import SparseTensor
+
+from torch_geometric.nn import RGATConv
 
 
 def test_rgat_conv():

--- a/test/nn/conv/test_rgat_conv.py
+++ b/test/nn/conv/test_rgat_conv.py
@@ -1,5 +1,5 @@
 import torch
-from rgat_conv import RGATConv
+from torch_geometric.nn import RGATConv
 from torch_sparse import SparseTensor
 
 

--- a/test/nn/conv/test_rgat_conv.py
+++ b/test/nn/conv/test_rgat_conv.py
@@ -12,33 +12,29 @@ def test_rgat_conv():
     adj = SparseTensor(row=row, col=col, value=edge_attr, sparse_sizes=(4, 4))
     edge_type = torch.tensor([0, 2, 1, 2])
 
-    conv = RGATConv(8, 20, num_relations=4, num_bases=4, mod="additive",
-                    attention_mechanism="across-relation",
-                    attention_mode="additive-self-attention", heads=2, d=1,
-                    edge_dim=8, bias=False)
+    conv = RGATConv(8, 20, num_relations=4, num_bases=4,
+                    mod="additive", attention_mechanism="across-relation",
+                    attention_mode="additive-self-attention",
+                    heads=2, d=1, edge_dim=8, bias=False)
     assert str(conv) == 'RGATConv(8, 20, heads=2)'
     out = conv(x, edge_index, edge_type, edge_attr)
     assert out.size() == (4, 40)
-    assert torch.allclose(
-        conv(x, edge_index, edge_type, edge_attr, size=(4, 4)), out)
+    assert torch.allclose(conv(x, edge_index, edge_type, edge_attr,
+                               size=(4, 4)), out)
     assert torch.allclose(conv(x, adj.t(), edge_type), out)
 
     t = '(Tensor, Tensor, OptTensor, OptTensor, Size, NoneType) -> Tensor'
     jit = torch.jit.script(conv.jittable(t))
-    assert torch.allclose(jit(x, edge_index, edge_type, edge_attr), out)
+    assert torch.allclose(jit(x, edge_index, edge_type),
+                          conv(x, edge_index, edge_type))
 
-    conv = RGATConv(8, 20, num_relations=4, num_blocks=2, mod="additive",
-                    attention_mechanism="across-relation",
-                    attention_mode="additive-self-attention", heads=2, d=1,
-                    edge_dim=8, bias=False)
+    conv = RGATConv(8, 20, num_relations=4, num_blocks=2,
+                    mod="additive", attention_mechanism="across-relation",
+                    attention_mode="additive-self-attention",
+                    heads=2, d=1, edge_dim=8, bias=False)
     assert str(conv) == 'RGATConv(8, 20, heads=2)'
     out = conv(x, edge_index, edge_type, edge_attr)
     assert out.size() == (4, 40)
-    assert torch.allclose(
-        conv(x, edge_index, edge_type, edge_attr, size=(4, 4)), out)
+    assert torch.allclose(conv(x, edge_index, edge_type, edge_attr,
+                               size=(4, 4)), out)
     assert torch.allclose(conv(x, adj.t(), edge_type), out)
-
-    t = ('(Tensor, SparseTensor, OptTensor, OptTensor, '
-         'Size, NoneType) -> Tensor')
-    jit = torch.jit.script(conv.jittable(t))
-    assert torch.allclose(jit(x, adj.t(), edge_type), out)

--- a/test/nn/conv/test_rgat_conv.py
+++ b/test/nn/conv/test_rgat_conv.py
@@ -1,0 +1,45 @@
+import torch
+from torch_sparse import SparseTensor
+
+from rgat_conv import RGATConv
+
+
+def test_rgat_conv():
+    x = torch.randn(4, 8)
+    edge_index = torch.tensor([[0, 1, 2, 3], [0, 0, 1, 1]])
+    row, col = edge_index
+    edge_attr = torch.randn((4, 8))
+    adj = SparseTensor(row=row, col=col, value=edge_attr, sparse_sizes=(4, 4))
+    edge_type = torch.tensor([0, 2, 1, 2])
+
+    conv = RGATConv(8, 20, num_relations=4, num_bases=4,
+                    mod="additive", attention_mechanism="across-relation",
+                    attention_mode="additive-self-attention",
+                    heads=2, d=1, edge_dim=8, bias=False)
+    assert str(conv) == 'RGATConv(8, 20, heads=2)'
+    out = conv(x, edge_index, edge_type, edge_attr)
+    assert out.size() == (4, 40)
+    assert torch.allclose(conv(x, edge_index, edge_type, edge_attr,
+                               size=(4, 4)), out)
+    assert torch.allclose(conv(x, adj.t(), edge_type), out)
+
+    t = '(Tensor, Tensor, OptTensor, OptTensor, Size, NoneType) -> Tensor'
+    jit = torch.jit.script(conv.jittable(t))
+    assert torch.allclose(jit(x, edge_index, edge_type, edge_attr),
+                          out)
+
+    conv = RGATConv(8, 20, num_relations=4, num_blocks=2,
+                    mod="additive", attention_mechanism="across-relation",
+                    attention_mode="additive-self-attention",
+                    heads=2, d=1, edge_dim=8, bias=False)
+    assert str(conv) == 'RGATConv(8, 20, heads=2)'
+    out = conv(x, edge_index, edge_type, edge_attr)
+    assert out.size() == (4, 40)
+    assert torch.allclose(conv(x, edge_index, edge_type, edge_attr,
+                               size=(4, 4)), out)
+    assert torch.allclose(conv(x, adj.t(), edge_type), out)
+
+    t = ('(Tensor, SparseTensor, OptTensor, OptTensor, '
+         'Size, NoneType) -> Tensor')
+    jit = torch.jit.script(conv.jittable(t))
+    assert torch.allclose(jit(x, adj.t(), edge_type), out)

--- a/torch_geometric/nn/conv/__init__.py
+++ b/torch_geometric/nn/conv/__init__.py
@@ -1,5 +1,6 @@
 from .message_passing import MessagePassing
 from .gcn_conv import GCNConv
+from .rgat_conv import RGATConv
 from .cheb_conv import ChebConv
 from .sage_conv import SAGEConv
 from .graph_conv import GraphConv
@@ -52,6 +53,7 @@ from .lg_conv import LGConv
 __all__ = [
     'MessagePassing',
     'GCNConv',
+    'RGATConv',
     'ChebConv',
     'SAGEConv',
     'GraphConv',

--- a/torch_geometric/nn/conv/rgat_conv.py
+++ b/torch_geometric/nn/conv/rgat_conv.py
@@ -1,0 +1,558 @@
+from typing import Optional
+from torch_geometric.typing import (Adj, Size, OptTensor)
+
+import torch
+from torch import Tensor
+import torch.nn.functional as F
+from torch_geometric.nn.conv import MessagePassing
+from torch_sparse import SparseTensor, set_diag
+from torch.nn import Parameter, ReLU
+from torch_geometric.nn.dense.linear import Linear
+from torch_geometric.utils import remove_self_loops, add_self_loops, softmax
+from torch_geometric.nn.inits import zeros, ones, glorot
+from torch_scatter import scatter_add
+
+
+class RGATConv(MessagePassing):
+    r"""The relational graph attentional operator from the `"Relational Graph
+    Attention Networks" <https://arxiv.org/abs/1904.05811>`_ paper where the
+    attention logits :math:`\mathbf{E}^{(r)}_{i,j}` for each relation type
+    (:math:`\mathbf{r}`) are computed with the help of both query and key
+    kernels,
+    *i.e.*
+
+    .. math::
+        \mathbf{q}^{(r)}_i = \mathbf{\Theta}^{(r)}\mathbf{x}_{i} \ \cdot
+        \ \mathbf{Q}^{(r)}
+
+    and
+
+    .. math::
+        \mathbf{k}^{(r)}_i = \mathbf{\Theta}^{(r)}\mathbf{x}_{i} \ \cdot
+        \ \mathbf{K}^{(r)},
+
+    where the query (:math:`\mathbf{Q}^{(r)}`) and key kernels
+    (:math:`\mathbf{K}^{(r)}`) are combined to form the attention kernels
+    :math:`\mathbf{A}^{(r)}`. Now, two schemes have been proposed to compute
+    attention logits :math:`\mathbf{E}^{(r)}_{i,j}` for each relation type
+    (:math:`\mathbf{r}`)
+
+    .. math:: \mathbf{E}^{(r)}_{i,j} = \mathrm{LeakyReLU}(\mathbf{q}^{(r)}_i +
+        \mathbf{k}^{(r)}_j) \ \ \ \ (Additive \ attention \ logits)
+
+    and
+
+    .. math:: \mathbf{E}^{(r)}_{i,j} = \mathbf{q}^{(r)}_i \ \cdot
+        \ \mathbf{k}^{(r)}_j \ \ \ \ (Multiplicative \ attention \ logits)
+
+    If the graph has multi-dimensional edge features
+    :math:`\mathbf{e}^{(r)}_{i,j}`, the attention logits
+    :math:`\mathbf{E}^{(r)}_{i,j}` for each relation type (:math:`\mathbf{r}`)
+    are computed as
+
+    .. math:: \mathbf{E}^{(r)}_{i,j} = \mathrm{LeakyReLU}(\mathbf{q}^{(r)}_i +
+        \mathbf{k}^{(r)}_j + (\mathbf{\Theta}^{(r)}_e\mathbf{e}^{(r)}_{i,j}
+        \ \cdot \ \mathbf{E}^{(r)})) \ \ \ \ (Additive \ attention \ logits)
+
+    and
+
+    .. math:: \mathbf{E}^{(r)}_{i,j} = (\mathbf{q}^{(r)}_i \ \cdot
+        \ \mathbf{k}^{(r)}_j) \ \cdot \ (\mathbf{\Theta}^{(r)}_e
+        \ \mathbf{e}^{(r)}_{i,j} \ \cdot \ \mathbf{E}^{(r)})
+        \ \ \ \ (Multiplicative \ attention \ logits),
+
+    where the edge kernel (:math:`\mathbf{E}^{(r)}`) when combine with the
+    query and key kernels form the final attention kernel
+    (:math:`\mathbf{A}^{(r)}`). The attention coefficients
+    :math:`\alpha^{(r)}_{i,j}` calculation for each relation type
+    (:math:`\mathbf{r}`) is done via two different attention mechanisms
+
+    .. math::
+        \alpha^{(r)}_{i,j} =
+        \frac{
+        \exp\left(\mathbf{E}^{(r)}_{i,j}\right)}
+        {\sum_{k \in \mathcal{N}(i)^{(r)}}
+        \exp\left(\mathbf{E}^{(r)}_{i,k}\right)}
+        \ \ \ (within-relation \ attention \ mechanism)
+
+    and
+
+    .. math::
+        \alpha^{(r)}_{i,j} =
+        \frac{
+        \exp\left(\mathbf{E}^{(r)}_{i,j}\right)}
+        {\sum_{r^{\prime} \in \mathcal{R}}\sum_{k \in
+        \mathcal{N}(i)^{(r^{\prime})}}
+        \exp\left(\mathbf{E}^{(r^{\prime})}_{i,k}\right)}
+        \ \ \ (across-relation \ attention \ mechanism)
+
+    where :math:`\mathcal{R}` denotes the set of relations, *i.e.* edge types.
+    Edge type needs to be a one-dimensional :obj:`torch.long` tensor which
+    stores a relation identifier :math:`\in \{ 0, \ldots, |\mathcal{R}| - 1\}`
+    for each edge. To enhance the discriminative power of attention-based GNNs,
+    this layer implements four different cardinality preservation options (for
+    each relation type (:math:`\mathbf{r}`)) proposed in the `"Improving
+    Attention Mechanism in Graph Neural Networks via Cardinality Preservation"
+    <https://arxiv.org/abs/1907.02204>`_ paper
+
+    .. math::
+        \mathbf{x}^{{\prime}(r)}_i = \sum_{j \in \mathcal{N}(i)^{(r)}}
+        \alpha^{(r)}_{i,j} \mathbf{x}^{(r)}_j + \mathcal{W} \ \odot
+        \ \sum_{j \in \mathcal{N}(i)^{(r)}} \mathbf{x}^{(r)}_j \ \ \ (additive)
+
+    .. math::
+        \mathbf{x}^{{\prime}(r)}_i = \psi(|\mathcal{N}^{(r)}_i|) \ \odot
+        \ \sum_{j \in \mathcal{N}(i)^{(r)}} \alpha^{(r)}_{i,j}
+        \mathbf{x}^{(r)}_j \ \ \ (scaled)
+
+    .. math::
+        \mathbf{x}^{{\prime}(r)}_i = \sum_{j \in \mathcal{N}(i)^{(r)}}
+        (\alpha^{(r)}_{i,j} + 1) \mathbf{x}^{(r)}_j \ \ \ (f-additive)
+
+    .. math::
+        \mathbf{x}^{{\prime}(r)}_i = |\mathcal{N}^{(r)}_i| \ \odot \ \sum_{j
+        \in \mathcal{N}(i)^{(r)}} \alpha^{(r)}_{i,j} \mathbf{x}^{(r)}_j
+        \ \ \ (f-scaled)
+
+    .. note::
+        When :obj:`attention_mode=additive-self-attention` and
+        :obj:`concat=True`, the layer outputs :obj:`heads * out_channels`
+        features for each node, and when
+        :obj:`attention_mode=multiplicative-self-attention` and
+        :obj:`concat=True`, the layer outputs :obj:`heads * d * out_channels`
+        features for each node. Besides, if
+        :obj:`attention_mode=additive-self-attention` and
+        :obj:`concat=False/None`, the layer outputs :obj:`out_channels`
+        features for each node and if
+        :obj:`attention_mode=multiplicative-self-attention` and
+        :obj:`concat=False/None`, the layer outputs :obj:`d * out_channels`
+        features for each node. Make sure to set the :obj:`in_channels`
+        argument of this layer accordingly, if more than one instance of
+        this layer is used. Furthermore, to stochastically sample the attention
+        coefficients, please use :obj:`dropout` value between 0 and 1, and
+        set :obj:`mod=None`.
+
+
+    Args:
+        in_channels (int): Size of each input sample, or :obj:`-1` to derive
+        the size from the first input(s) to the forward method.
+        out_channels (int): Size of each output sample.
+        num_relations (int): Number of relations.
+        num_bases (int, optional): If set to not :obj:`None`, this layer will
+            use the basis-decomposition regularization scheme where
+            :obj:`num_bases` denotes the number of bases to use.
+            (default: :obj:`None`)
+        num_blocks (int, optional): If set to not :obj:`None`, this layer will
+            use the block-diagonal-decomposition regularization scheme where
+            :obj:`num_blocks` denotes the number of blocks to use.
+            (default: :obj:`None`)
+        aggr (string, optional): The aggregation scheme to use.
+            (:obj:`"add"`, :obj:`"mean"`, :obj:`"max"`)
+        mod (string, optional): The cardinality preservation option to use.
+            (:obj:`"additive"`, :obj:`"scaled"`, :obj:`"f-additive"`,
+            :obj:`"f-scaled"`, default: :obj:`None`)
+        attention_mechanism (string): The attention mechanism to use.
+            (:obj:`"within-relation"`, :obj:`"across-relation"`)
+        attention_mode (string): The mode to calculate attention logits.
+            (:obj:`"additive-self-attention"`,
+            :obj:`"multiplicative-self-attention"`)
+        heads (int, optional): Number of multi-head-attentions.
+            (default: :obj:`1`)
+        d (int): Number of dimensions for query and key kernels.
+            (default: :obj:`1`)
+        concat (bool, optional): If set to :obj:`False`, the multi-head
+            attentions are averaged instead of concatenated.
+            (default: :obj:`True`)
+        negative_slope (float, optional): LeakyReLU angle of the negative
+            slope. (default: :obj:`0.2`)
+        dropout (float, optional): Dropout probability of the normalized
+            attention coefficients which exposes each node to a stochastically
+            sampled neighborhood during training. (default: :obj:`0`)
+        add_self_loops (bool, optional): If set to :obj:`False`, will not add
+            self-loops to the input graph. (default: :obj:`False`)
+        edge_dim (int, optional): Edge feature dimensionality (in case
+            there are any). (default: :obj:`None`)
+        fill_value (float, optional): The way to generate
+            edge features of self-loops (in case :obj:`edge_dim != None`).
+            If given as :obj:`float`, edge features of
+            self-loops will be directly given by :obj:`fill_value`.
+            (default: :obj:`1.`)
+        bias (bool, optional): If set to :obj:`False`, the layer will not
+            learn an additive bias. (default: :obj:`True`)
+        **kwargs (optional): Additional arguments of
+            :class:`torch_geometric.nn.conv.MessagePassing`.
+    """
+
+    _alpha: OptTensor
+
+    def __init__(
+            self,
+            in_channels: int,
+            out_channels: int,
+            num_relations: int,
+            num_bases: Optional[int] = None,
+            num_blocks: Optional[int] = None,
+            aggr: str = 'add',
+            mod: Optional[str] = None,
+            attention_mechanism: str = "within-relation",
+            attention_mode: str = "additive-self-attention",
+            heads: int = 1,
+            d: int = 1,
+            concat: bool = True,
+            negative_slope: float = 0.2,
+            dropout: float = 0.0,
+            add_self_loops: bool = False,
+            edge_dim: Optional[int] = None,
+            fill_value: float = 1.,
+            bias: bool = True,
+            **kwargs,
+    ):
+
+        super(RGATConv, self).__init__(aggr=aggr, node_dim=0, **kwargs)
+
+        self.heads = heads
+        self.negative_slope = negative_slope
+        self.dropout = dropout
+        self.mod = mod
+        self.activation = ReLU()
+        self.concat = concat
+        self.attention_mode = attention_mode
+        self.attention_mechanism = attention_mechanism
+        self.d = d
+        self.add_self_loops = add_self_loops
+        self.edge_dim = edge_dim
+        self.fill_value = fill_value
+
+        self.in_channels = in_channels
+        self.out_channels = out_channels
+        self.num_relations = num_relations
+        self.num_bases = num_bases
+        self.num_blocks = num_blocks
+
+        mod_types = ['additive', 'scaled', 'f-additive', 'f-scaled']
+
+        if self.attention_mechanism != "within-relation" and \
+                self.attention_mechanism != "across-relation":
+            raise ValueError('attention mechanism must either be '
+                             '"within-relation" or "across-relation"')
+
+        if self.attention_mode != "additive-self-attention" and \
+                self.attention_mode != "multiplicative-self-attention":
+            raise ValueError('attention mode must either be '
+                             '"additive-self-attention" or '
+                             '"multiplicative-self-attention"')
+
+        if self.attention_mode == "additive-self-attention" and self.d > 1:
+            raise ValueError('"additive-self-attention" mode cannot be '
+                             'applied when value of d is greater than 1. '
+                             'Use "multiplicative-self-attention" instead.')
+
+        if self.edge_dim is not None and self.edge_dim != 1 and \
+                self.add_self_loops:
+            raise ValueError('"edge_dim" with value greater than 1 is '
+                             'currently not yet supported for '
+                             '"edge_attr" while adding self loops to the '
+                             'input graph')
+
+        if self.dropout > 0.0 and self.mod in mod_types:
+            raise ValueError('mod must be None with dropout value greater '
+                             'than 0 in order to sample attention '
+                             'coefficients stochastically')
+
+        if num_bases is not None and num_blocks is not None:
+            raise ValueError('Can not apply both basis-decomposition and '
+                             'block-diagonal-decomposition at the same time.')
+
+        # The learnable parameters to compute both attention logits and
+        # attention coefficients:
+        self.q = Parameter(torch.Tensor(self.heads * self.out_channels,
+                                        self.heads * self.d))
+        self.k = Parameter(torch.Tensor(self.heads * self.out_channels,
+                                        self.heads * self.d))
+
+        if bias and concat:
+            self.bias = Parameter(torch.Tensor(self.heads * self.d *
+                                               self.out_channels))
+        elif bias and not concat:
+            self.bias = Parameter(torch.Tensor(self.d * self.out_channels))
+        else:
+            self.register_parameter('bias', None)
+
+        if edge_dim is not None:
+            self.lin_edge = Linear(self.edge_dim, self.heads *
+                                   self.out_channels, bias=False,
+                                   weight_initializer='glorot')
+            self.e = Parameter(torch.Tensor(self.heads * self.out_channels,
+                                            self.heads * self.d))
+        else:
+            self.lin_edge = None
+            self.register_parameter('e', None)
+
+        if num_bases is not None:
+            self.att = Parameter(torch.Tensor(self.num_relations,
+                                              self.num_bases))
+            self.basis = Parameter(torch.Tensor(self.num_bases,
+                                                self.in_channels,
+                                                self.heads *
+                                                self.out_channels))
+        elif num_blocks is not None:
+            assert (self.in_channels % self.num_blocks == 0
+                    and (self.heads * self.out_channels) %
+                    self.num_blocks == 0), \
+                "both 'in_channels' and 'heads * out_channels' must be " \
+                "multiple of 'num_blocks' used"
+            self.weight = Parameter(
+                torch.Tensor(self.num_relations, self.num_blocks,
+                             self.in_channels // self.num_blocks,
+                             (self.heads * self.out_channels) //
+                             self.num_blocks))
+        else:
+            self.weight = Parameter(torch.Tensor(self.num_relations,
+                                                 self.in_channels,
+                                                 self.heads *
+                                                 self.out_channels))
+
+        self.w = Parameter(torch.ones(self.out_channels))
+        self.l1 = Parameter(torch.FloatTensor(1, self.out_channels))
+        self.b1 = Parameter(torch.FloatTensor(1, self.out_channels))
+        self.l2 = Parameter(torch.FloatTensor(self.out_channels,
+                                              self.out_channels))
+        self.b2 = Parameter(torch.FloatTensor(1, self.out_channels))
+
+        self._alpha = None
+
+        self.reset_parameters()
+
+    def reset_parameters(self):
+        if self.num_bases is not None:
+            glorot(self.basis)
+            glorot(self.att)
+        else:
+            glorot(self.weight)
+        glorot(self.q)
+        glorot(self.k)
+        zeros(self.bias)
+        ones(self.l1)
+        zeros(self.b1)
+        torch.full(self.l2.size(), 1 / self.out_channels)
+        zeros(self.b2)
+        if self.lin_edge is not None:
+            glorot(self.lin_edge)
+            glorot(self.e)
+
+    def forward(self, x: Tensor, edge_index: Adj, edge_type: OptTensor = None,
+                edge_attr: OptTensor = None, size: Size = None,
+                return_attention_weights=None):
+
+        r"""
+        Args:
+            x: The input node features. Can be either a :obj:`[num_nodes,
+                in_channels]` node feature matrix, or an optional
+                one-dimensional node index tensor (in which case input features
+                are treated as trainable node embeddings).
+            edge_type: The one-dimensional relation type/index for each edge in
+                :obj:`edge_index`.
+                Should be only :obj:`None` in case :obj:`edge_index` is of type
+                :class:`torch_sparse.tensor.SparseTensor`.
+                (default: :obj:`None`)
+            return_attention_weights (bool, optional): If set to :obj:`True`,
+                will additionally return the tuple
+                :obj:`(edge_index, attention_weights)`, holding the computed
+                attention weights for each edge. (default: :obj:`None`)
+        """
+
+        if self.add_self_loops:
+            if isinstance(edge_index, Tensor):
+                num_nodes = x.size(0)
+                num_nodes = min(size) if size is not None else num_nodes
+                edge_index, edge_attr = remove_self_loops(
+                    edge_index, edge_attr)
+                edge_index, edge_attr = add_self_loops(
+                    edge_index, edge_attr, fill_value=self.fill_value,
+                    num_nodes=num_nodes)
+            elif isinstance(edge_index, SparseTensor):
+                if self.edge_dim is None:
+                    edge_index = set_diag(edge_index)
+                else:
+                    raise NotImplementedError(
+                        "The usage of 'edge_attr' and 'add_self_loops' "
+                        "simultaneously is currently not yet supported for "
+                        "'edge_index' in a 'SparseTensor' form")
+
+        out = self.propagate(edge_index=edge_index, edge_type=edge_type, x=x,
+                             size=size, edge_attr=edge_attr)
+
+        alpha = self._alpha
+        assert alpha is not None, "attention coefficients don't have any value"
+        self._alpha = None
+
+        if isinstance(return_attention_weights, bool):
+            if isinstance(edge_index, Tensor):
+                return out, (edge_index, alpha)
+            elif isinstance(edge_index, SparseTensor):
+                return out, edge_index.set_value(alpha, layout='coo')
+        else:
+            return out
+
+    def message(self, x_i: Tensor, x_j: Tensor, edge_type: Tensor,
+                edge_attr: OptTensor, index: Tensor, ptr: OptTensor,
+                size_i: Optional[int]) -> Tensor:
+
+        if self.num_bases is not None:  # Basis-decomposition =================
+            w = torch.matmul(self.att, self.basis.view(self.num_bases, -1))
+            w = w.view(self.num_relations, self.in_channels, self.heads *
+                       self.out_channels)
+        if self.num_blocks is not None:  # Block-diagonal-decomposition =======
+            if x_i.dtype == torch.long and x_j.dtype == torch.long and \
+                    self.num_blocks is not None:
+                raise ValueError('Block-diagonal decomposition not supported '
+                                 'for non-continuous input features.')
+            w = self.weight
+            x_i, x_j = x_i.view(-1, 1, w.size(1), w.size(2)), x_j.\
+                view(-1, 1, w.size(1), w.size(2))
+            w = torch.index_select(w, 0, edge_type)
+            outi = torch.einsum('abcd,acde->ace', x_i, w).contiguous().\
+                view(-1, self.heads * self.out_channels)
+            outj = torch.einsum('abcd,acde->ace', x_j, w).contiguous().\
+                view(-1, self.heads * self.out_channels)
+        else:  # No regularization/Basis-decomposition ========================
+            if self.num_bases is None:
+                w = self.weight
+            w = torch.index_select(w, 0, edge_type)
+            outi = torch.bmm(x_i.unsqueeze(1), w).squeeze(-2)
+            outj = torch.bmm(x_j.unsqueeze(1), w).squeeze(-2)
+
+        qi = torch.matmul(outi, self.q)
+        kj = torch.matmul(outj, self.k)
+
+        if edge_attr is not None:
+            if edge_attr.dim() == 1:
+                edge_attr = edge_attr.view(-1, 1)
+            assert self.lin_edge is not None, "Please set 'edge_dim = " \
+                                              "edge_attr.size(-1)' while " \
+                                              "calling the RGATConv layer"
+            edge_attributes = self.lin_edge(edge_attr).view(-1, self.heads *
+                                                            self.out_channels)
+            if edge_attributes.size(0) != edge_attr.size(0):
+                edge_attributes = torch.index_select(edge_attributes, 0,
+                                                     edge_type)
+            alpha_edge = torch.matmul(edge_attributes, self.e)
+
+        if self.attention_mode == "additive-self-attention":
+            if edge_attr is not None:
+                alpha = torch.add(qi, kj) + alpha_edge
+            else:
+                alpha = torch.add(qi, kj)
+            alpha = F.leaky_relu(alpha, self.negative_slope)
+        elif self.attention_mode == "multiplicative-self-attention":
+            if edge_attr is not None:
+                alpha = (qi * kj) * alpha_edge
+            else:
+                alpha = qi * kj
+
+        if self.attention_mechanism == "within-relation":
+            across_out = torch.zeros_like(alpha)
+
+            for r in range(index.size(0)):
+                g = softmax(alpha[r], index[r], ptr)
+                across_out[r] += g.view(self.heads * self.d)
+            alpha = across_out
+        elif self.attention_mechanism == "across-relation":
+            alpha = softmax(alpha, index, ptr, size_i)
+
+        self._alpha = alpha
+
+        if self.mod == "additive":
+            if self.attention_mode == "additive-self-attention":
+                ones = torch.ones_like(alpha)
+                h = outj.view(-1, self.heads, self.out_channels) * \
+                    ones.view(-1, self.heads, 1)
+                h = torch.mul(self.w, h)
+
+                return outj.view(-1, self.heads, self.out_channels) * alpha.\
+                    view(-1, self.heads, 1) + h
+            elif self.attention_mode == "multiplicative-self-attention":
+                ones = torch.ones_like(alpha)
+                h = outj.view(-1, self.heads, 1, self.out_channels) * \
+                    ones.view(-1, self.heads, self.d, 1)
+                h = torch.mul(self.w, h)
+
+                return outj.view(-1, self.heads, 1,
+                                 self.out_channels) * alpha.\
+                    view(-1, self.heads, self.d, 1) + h
+
+        elif self.mod == "scaled":
+            if self.attention_mode == "additive-self-attention":
+                ones = alpha.new_ones(index.size())
+                degree = scatter_add(ones, index,
+                                     dim_size=size_i)[index].unsqueeze(-1)
+                degree = torch.matmul(degree, self.l1) + self.b1
+                degree = self.activation(degree)
+                degree = torch.matmul(degree, self.l2) + self.b2
+
+                return torch.mul(outj.view(-1, self.heads, self.out_channels) *
+                                 alpha.view(-1, self.heads, 1),
+                                 degree.view(-1, 1, self.out_channels))
+            elif self.attention_mode == "multiplicative-self-attention":
+                ones = alpha.new_ones(index.size())
+                degree = scatter_add(ones, index,
+                                     dim_size=size_i)[index].unsqueeze(-1)
+                degree = torch.matmul(degree, self.l1) + self.b1
+                degree = self.activation(degree)
+                degree = torch.matmul(degree, self.l2) + self.b2
+
+                return torch.mul(outj.view(-1, self.heads, 1,
+                                           self.out_channels) *
+                                 alpha.view(-1, self.heads, self.d, 1),
+                                 degree.view(-1, 1, 1, self.out_channels))
+
+        elif self.mod == "f-additive":
+            alpha = torch.where(alpha > 0, alpha + 1, alpha)
+
+        elif self.mod == "f-scaled":
+            ones = alpha.new_ones(index.size())
+            degree = scatter_add(ones, index,
+                                 dim_size=size_i)[index].unsqueeze(-1)
+            alpha = alpha * degree
+
+        elif self.training and self.dropout > 0:
+            alpha = F.dropout(alpha, p=self.dropout, training=True)
+
+        else:
+            alpha = alpha  # original
+
+        if self.attention_mode == "additive-self-attention":
+            return alpha.view(-1, self.heads, 1) * outj.view(-1, self.heads,
+                                                             self.out_channels)
+        elif self.attention_mode == "multiplicative-self-attention":
+            return (alpha.view(-1, self.heads, self.d, 1) *
+                    outj.view(-1, self.heads, 1, self.out_channels))
+
+    def update(self, aggr_out: Tensor):
+        if self.attention_mode == "additive-self-attention":
+            if self.concat is True:
+                aggr_out = aggr_out.view(-1, self.heads * self.out_channels)
+            else:
+                aggr_out = aggr_out.mean(dim=1)
+
+            if self.bias is not None:
+                aggr_out = aggr_out + self.bias
+
+            return aggr_out
+        elif self.attention_mode == "multiplicative-self-attention":
+            if self.concat is True:
+                aggr_out = aggr_out.view(-1, self.heads * self.d *
+                                         self.out_channels)
+            else:
+                aggr_out = aggr_out.mean(dim=1)
+                aggr_out = aggr_out.view(-1, self.d * self.out_channels)
+
+            if self.bias is not None:
+                aggr_out = aggr_out + self.bias
+
+            return aggr_out
+
+    def __repr__(self):
+        return '{}({}, {}, heads={})'.format(self.__class__.__name__,
+                                             self.in_channels,
+                                             self.out_channels, self.heads)


### PR DESCRIPTION
Added Relational Graph Attention Networks, which computes attention coefficients for relational graphs for each relation type for any number of relations and attention heads. Moreover, also provides functionality for edge attributes to handle.