### PR TITLE
Improve `dropout_adj` efficiency

### DIFF
--- a/test/utils/test_dropout.py
+++ b/test/utils/test_dropout.py
@@ -4,7 +4,10 @@ from torch_geometric.utils import dropout_adj
 
 
 def test_dropout_adj():
-    edge_index = torch.tensor([[0, 1, 1, 2, 2, 3], [1, 0, 2, 1, 3, 2]])
+    edge_index = torch.tensor([
+        [0, 1, 1, 2, 2, 3],
+        [1, 0, 2, 1, 3, 2],
+    ])
     edge_attr = torch.Tensor([1, 2, 3, 4, 5, 6])
 
     out = dropout_adj(edge_index, edge_attr, training=False)
@@ -13,10 +16,10 @@ def test_dropout_adj():
 
     torch.manual_seed(5)
     out = dropout_adj(edge_index, edge_attr)
-    assert out[0].tolist() == [[1, 3], [0, 2]]
-    assert out[1].tolist() == [2, 6]
+    assert out[0].tolist() == [[0, 1, 2, 2], [1, 2, 1, 3]]
+    assert out[1].tolist() == [1, 3, 4, 5]
 
-    torch.manual_seed(5)
+    torch.manual_seed(6)
     out = dropout_adj(edge_index, edge_attr, force_undirected=True)
-    assert out[0].tolist() == [[1, 2], [2, 1]]
-    assert out[1].tolist() == [3, 3]
+    assert out[0].tolist() == [[0, 1, 1, 2], [1, 2, 0, 1]]
+    assert out[1].tolist() == [1, 3, 1, 3]

--- a/torch_geometric/utils/dropout.py
+++ b/torch_geometric/utils/dropout.py
@@ -46,10 +46,10 @@ def dropout_adj(
 
     row, col = edge_index
 
-    mask = torch.rand(row.size(0), device=edge_index.device) < p
+    mask = torch.rand(row.size(0), device=edge_index.device) >= p
 
     if force_undirected:
-        mask &= row < col
+        mask[row > col] = False
 
     row, col, edge_attr = filter_adj(row, col, edge_attr, mask)
 

--- a/torch_geometric/utils/dropout.py
+++ b/torch_geometric/utils/dropout.py
@@ -1,15 +1,24 @@
+from typing import Optional, Tuple
+
 import torch
-from torch_sparse import coalesce
+from torch import Tensor
 
-from .num_nodes import maybe_num_nodes
+from torch_geometric.typing import OptTensor
 
 
-def filter_adj(row, col, edge_attr, mask):
+def filter_adj(row: Tensor, col: Tensor, edge_attr: OptTensor,
+               mask: Tensor) -> Tuple[Tensor, Tensor, OptTensor]:
     return row[mask], col[mask], None if edge_attr is None else edge_attr[mask]
 
 
-def dropout_adj(edge_index, edge_attr=None, p=0.5, force_undirected=False,
-                num_nodes=None, training=True):
+def dropout_adj(
+    edge_index: Tensor,
+    edge_attr: OptTensor = None,
+    p: float = 0.5,
+    force_undirected: bool = False,
+    num_nodes: Optional[int] = None,
+    training: bool = True,
+) -> Tuple[Tensor, OptTensor]:
     r"""Randomly drops edges from the adjacency matrix
     :obj:`(edge_index, edge_attr)` with probability :obj:`p` using samples from
     a Bernoulli distribution.


### PR DESCRIPTION
Closes https://github.com/pyg-team/pytorch_geometric/discussions/4054

- [x] Mask tensors are now initialized on GPU
- [x] Removed duplicated call of `filter_adj` in case `force_undirected=True`
- [x] Removed `coalesce` call  