### PR TITLE
`LightGCN`: Initialize embeddings via `xavier_uniform`

### DIFF
--- a/torch_geometric/nn/models/lightgcn.py
+++ b/torch_geometric/nn/models/lightgcn.py
@@ -79,7 +79,7 @@ class LightGCN(torch.nn.Module):
 
         self.embedding = Embedding(num_nodes, embedding_dim)
         torch.nn.init.xavier_uniform_(self.embedding.weight)
-        
+
         self.convs = ModuleList([LGConv(**kwargs) for _ in range(num_layers)])
 
         self.reset_parameters()

--- a/torch_geometric/nn/models/lightgcn.py
+++ b/torch_geometric/nn/models/lightgcn.py
@@ -78,14 +78,12 @@ class LightGCN(torch.nn.Module):
         self.register_buffer('alpha', alpha)
 
         self.embedding = Embedding(num_nodes, embedding_dim)
-        torch.nn.init.xavier_uniform_(self.embedding.weight)
-
         self.convs = ModuleList([LGConv(**kwargs) for _ in range(num_layers)])
 
         self.reset_parameters()
 
     def reset_parameters(self):
-        self.embedding.reset_parameters()
+        torch.nn.init.xavier_uniform_(self.embedding.weight)
         for conv in self.convs:
             conv.reset_parameters()
 

--- a/torch_geometric/nn/models/lightgcn.py
+++ b/torch_geometric/nn/models/lightgcn.py
@@ -78,6 +78,8 @@ class LightGCN(torch.nn.Module):
         self.register_buffer('alpha', alpha)
 
         self.embedding = Embedding(num_nodes, embedding_dim)
+        torch.nn.init.xavier_uniform_(self.embedding.weight)
+        
         self.convs = ModuleList([LGConv(**kwargs) for _ in range(num_layers)])
 
         self.reset_parameters()


### PR DESCRIPTION
I observed that when we use Xavier method that mentioned in Original LightGCN paper the performance increases than the current model.