### PR TITLE
updated the __call__ of the NeighborSampler

### DIFF
--- a/torch_geometric/loader/neighbor_loader.py
+++ b/torch_geometric/loader/neighbor_loader.py
@@ -57,10 +57,9 @@ class NeighborSampler:
         else:
             raise TypeError(f'NeighborLoader found invalid type: {type(data)}')
 
-    def __call__(self, indices: List[int]):
-        if not isinstance(indices, Tensor):
-            index = torch.tensor(indices)
-        assert index.dtype == torch.int64
+    def __call__(self, index: Union[List[int], Tensor]):
+        if not isinstance(index, torch.LongTensor):
+            index = torch.LongTensor(index)
 
         if issubclass(self.data_cls, Data):
             sample_fn = torch.ops.torch_sparse.neighbor_sample


### PR DESCRIPTION
The call to the NeighborSampler in the torch_geometric/loader/neighbor_loader.py (line #63 on the master branch) has a bug at the beginning. The input argument "indices" is set to the new variable "index" if the "indices" is not a list. Then the assertion is triggered if the type does not match. The bug is for the case the input argument is indeed a torch.Tensor, hence the new variable "index" is undefined and the assert triggers an "Unknown Variable" error.

```python
def __call__(self, indices: List[int]):
    if not isinstance(indices, Tensor):
        index = torch.tensor(indices)
    assert index.dtype == torch.int64
```

The fix is simply just to change the the variable name "indices" to "index" at the beginning. Furthermore, the assertion can be also addressed properly as shown below:

```python
def __call__(self, index: Union[List[int], Tensor]):
    if not isinstance(index, torch.LongTensor):
        index = torch.LongTensor(index)
```

To even make things clean and concise, the if statement not only checks for a tensor type but a long one, hence it convert the index as needed.

