### PR TITLE
Fix `edge_insensitive` homophily measure

### DIFF
--- a/test/utils/test_homophily.py
+++ b/test/utils/test_homophily.py
@@ -23,6 +23,6 @@ def test_homophily():
     assert homophily(edge_index, y, batch, method).tolist() == [1., 0.]
 
     method = 'edge_insensitive'
-    assert pytest.approx(homophily(edge_index, y, method=method)) == 0.0999999
-    assert pytest.approx(homophily(adj, y, method=method)) == 0.0999999
+    assert pytest.approx(homophily(edge_index, y, method=method)) == 0.1999999
+    assert pytest.approx(homophily(adj, y, method=method)) == 0.1999999
     assert homophily(edge_index, y, batch, method).tolist() == [0., 0.]

--- a/torch_geometric/utils/homophily.py
+++ b/torch_geometric/utils/homophily.py
@@ -98,7 +98,11 @@ def homophily(edge_index: Adj, y: Tensor, batch: OptTensor = None,
         num_graphs = num_nodes.numel()
         batch = num_classes * batch + y
 
-        h = homophily(edge_index, y, batch, method='edge')
+        out = torch.zeros(row.size(0), device=row.device)
+        out[y[row] == y[col]] = 1.
+        dim_size = int(batch.max()) + 1
+        h = scatter_mean(torch.cat((out, out)), batch[torch.cat((row, col))],
+                         dim=0, dim_size=dim_size)
         h = h.view(num_graphs, num_classes)
 
         counts = batch.bincount(minlength=num_classes * num_graphs)

--- a/torch_geometric/utils/homophily.py
+++ b/torch_geometric/utils/homophily.py
@@ -2,7 +2,7 @@ from typing import Union
 
 import torch
 from torch import Tensor
-from torch_scatter import scatter_max, scatter_mean
+from torch_scatter import scatter_mean
 from torch_sparse import SparseTensor
 
 from torch_geometric.typing import Adj, OptTensor
@@ -92,27 +92,22 @@ def homophily(edge_index: Adj, y: Tensor, batch: OptTensor = None,
 
     elif method == 'edge_insensitive':
         assert y.dim() == 1
+        num_classes = int(y.max()) + 1
+        assert num_classes >= 2
         batch = torch.zeros_like(y) if batch is None else batch
         num_nodes = degree(batch, dtype=torch.int64)
         num_graphs = num_nodes.numel()
-        num_classes, _ = scatter_max(y, batch)
-        num_classes += 1
-        max_num_classes = int(y.max()) + 1
-        batch = max_num_classes * batch + y
+        batch = num_classes * batch + y
 
-        out = torch.zeros(row.size(0), device=row.device)
-        out[y[row] == y[col]] = 1.
-        dim_size = int(batch.max()) + 1
+        h = homophily(edge_index, y, batch, method='edge')
+        h = h.view(num_graphs, num_classes)
 
-        h = scatter_mean(torch.cat((out, out)), batch[torch.cat((row, col))],
-                         dim=0, dim_size=dim_size)
-        h = h.view(num_graphs, max_num_classes)
-
-        counts = batch.bincount(minlength=max_num_classes * num_graphs)
-        counts = counts.view(num_graphs, max_num_classes)
+        counts = batch.bincount(minlength=num_classes * num_graphs)
+        counts = counts.view(num_graphs, num_classes)
         proportions = counts / num_nodes.view(-1, 1)
 
-        out = (h - proportions).clamp_(min=0).sum(dim=-1) / (num_classes - 1)
+        out = (h - proportions).clamp_(min=0).sum(dim=-1)
+        out /= num_classes - 1
         return out if out.numel() > 1 else float(out)
 
     else:

--- a/torch_geometric/utils/homophily.py
+++ b/torch_geometric/utils/homophily.py
@@ -43,7 +43,7 @@ def homophily(edge_index: Adj, y: Tensor, batch: OptTensor = None,
       and size of each class:
 
       .. math::
-        \frac{1}{C} \sum_{k=1}^{C} \max \left(0, h_k - \frac{|\mathcal{C}_k|}
+        \frac{1}{C-1} \sum_{k=1}^{C} \max \left(0, h_k - \frac{|\mathcal{C}_k|}
         {|\mathcal{V}|} \right),
 
       where :math:`C` denotes the number of classes, :math:`|\mathcal{C}_k|`
@@ -105,7 +105,7 @@ def homophily(edge_index: Adj, y: Tensor, batch: OptTensor = None,
         counts = counts.view(num_graphs, num_classes)
         proportions = counts / num_nodes.view(-1, 1)
 
-        out = (h - proportions).clamp_(min=0).mean(dim=-1)
+        out = (h - proportions).clamp_(min=0).sum(dim=-1).div(num_classes - 1)
         return out if out.numel() > 1 else float(out)
 
     else:


### PR DESCRIPTION
Regarding #3977

I found some gaps between the definition of the feat homophily measure in the [paper](https://arxiv.org/pdf/2110.14446.pdf) and the implementation of it in #3977, so I suggest to fix them.

1. The paper suggested the measure as 'summation over _C_ classes (0 to C-1) and division by _C-1_'.
However, the code has used the mean operator, which leads to wrong calculation.

2. To compute h_k value, the code has used edge homophily function, but I think the definition of h_k is different from it.
We have to consider the degrees of each node, instead of the number of edges.

I think the answers of the test cases need to be corrected too.