### PR TITLE
Fix graphgym multilabel loss/logger

### DIFF
--- a/torch_geometric/graphgym/loss.py
+++ b/torch_geometric/graphgym/loss.py
@@ -22,11 +22,8 @@ def compute_loss(pred, true):
 
     # default manipulation for pred and true
     # can be skipped if special loss computation is needed
-    # if multi task binary classification, treat as flatten binary
     pred = pred.squeeze(-1) if pred.ndim > 1 else pred
     true = true.squeeze(-1) if true.ndim > 1 else true
-    if true.ndim > 1 and cfg.dataset.task_type == 'classification':
-        pred, true = torch.flatten(pred), torch.flatten(true)
 
     # Try to load customized loss
     for func in register.loss_dict.values():
@@ -36,10 +33,10 @@ def compute_loss(pred, true):
 
     if cfg.model.loss_fun == 'cross_entropy':
         # multiclass
-        if pred.ndim > 1:
+        if pred.ndim > 1 and true.ndim == 1:
             pred = F.log_softmax(pred, dim=-1)
             return F.nll_loss(pred, true), pred
-        # binary
+        # binary or multilabel
         else:
             true = true.float()
             return bce_loss(pred, true), torch.sigmoid(pred)


### PR DESCRIPTION
This PR proposes a minor modification to the loss function regarding the handling of the binary and multilabel classification settings.
1. The flattening seems unnecessary since the [``BCEWithLogitsLoss``](https://pytorch.org/docs/stable/generated/torch.nn.BCEWithLogitsLoss.html) should work just fine so long as the shapes between ``y_true`` and ``y_pred`` are consistent.
2. In Line36, I added an extra condition of ``true.ndim == 1`` so that the multiclass setting is correctly distinguished from the multilabel setting.

This is should also fix the issue I posted as a comment in another issue https://github.com/pyg-team/pytorch_geometric/issues/890#issuecomment-945037351

The error I encountered previously in the multilabel setting is due to mismatching dimensions between ``y_pred`` and ``y_true`` when calling ``logger.update_stats`` in ``train_epoch`` (see below). In particular, ``pred_score`` is flattened by ``compute_loss``, but ``true`` is not, causing the mismatching dimension error as required by [``logger.update_stats``](https://github.com/pyg-team/pytorch_geometric/blob/4557254c849eda62ce1860a56370eb4a54aa76dd/torch_geometric/graphgym/logger.py#L144).

https://github.com/pyg-team/pytorch_geometric/blob/4557254c849eda62ce1860a56370eb4a54aa76dd/torch_geometric/graphgym/train.py#L21-L26