### PR TITLE
Fixed `avg_deg` calculation

### DIFF
--- a/torch_geometric/nn/conv/pna_conv.py
+++ b/torch_geometric/nn/conv/pna_conv.py
@@ -109,8 +109,10 @@ class PNAConv(MessagePassing):
         bin_degrees = torch.arange(len(deg))
         self.avg_deg: Dict[str, float] = {
             'lin': ((bin_degrees * deg).sum() / total_no_vertices).item(),
-            'log': (((bin_degrees + 1).log() * deg).sum() / total_no_vertices).item(),
-            'exp': ((bin_degrees.exp() * deg).sum() / total_no_vertices).item(),
+            'log':
+            (((bin_degrees + 1).log() * deg).sum() / total_no_vertices).item(),
+            'exp':
+            ((bin_degrees.exp() * deg).sum() / total_no_vertices).item(),
         }
 
         if self.edge_dim is not None:

--- a/torch_geometric/nn/conv/pna_conv.py
+++ b/torch_geometric/nn/conv/pna_conv.py
@@ -105,14 +105,12 @@ class PNAConv(MessagePassing):
         self.F_out = self.out_channels // towers
 
         deg = deg.to(torch.float)
-        total_no_vertices = deg.sum()
-        bin_degrees = torch.arange(len(deg))
+        num_nodes = int(deg.sum())
+        bin_degrees = torch.arange(deg.numel())
         self.avg_deg: Dict[str, float] = {
-            'lin': ((bin_degrees * deg).sum() / total_no_vertices).item(),
-            'log':
-            (((bin_degrees + 1).log() * deg).sum() / total_no_vertices).item(),
-            'exp':
-            ((bin_degrees.exp() * deg).sum() / total_no_vertices).item(),
+            'lin': float((bin_degrees * deg).sum()) / num_nodes,
+            'log': float(((bin_degrees + 1).log() * deg).sum()) / num_nodes,
+            'exp': float((bin_degrees.exp() * deg).sum()) / num_nodes,
         }
 
         if self.edge_dim is not None:

--- a/torch_geometric/nn/conv/pna_conv.py
+++ b/torch_geometric/nn/conv/pna_conv.py
@@ -105,10 +105,12 @@ class PNAConv(MessagePassing):
         self.F_out = self.out_channels // towers
 
         deg = deg.to(torch.float)
+        total_no_vertices = deg.sum()
+        bin_degrees = torch.arange(len(deg))
         self.avg_deg: Dict[str, float] = {
-            'lin': deg.mean().item(),
-            'log': (deg + 1).log().mean().item(),
-            'exp': deg.exp().mean().item(),
+            'lin': ((bin_degrees * deg).sum() / total_no_vertices).item(),
+            'log': (((bin_degrees + 1).log() * deg).sum() / total_no_vertices).item(),
+            'exp': ((bin_degrees.exp() * deg).sum() / total_no_vertices).item(),
         }
 
         if self.edge_dim is not None:


### PR DESCRIPTION
Fixed calculation of `self.avg_deg` in `pna_conv.py` to correctly calculate averages (the change is consistent with original code at https://github.com/lukecavabarrett/pna).

The variable `deg` is a histogram of in-degrees of nodes in the training set. In the original implementation, the average degree is calculated by taking the mean of the elements of `deg` (the log and exp averages are calculated similarly). This actually takes an average of the frequencies, which is not the desired behaviour.

This change ensures that `self.avg_deg` is indeed finding the average (and log and exp averages) of the vertex in-degrees by calculating the sum-product of the degrees and their associated frequencies.