### PR TITLE
Fix graphgym config storage directory

### DIFF
--- a/graphgym/main.py
+++ b/graphgym/main.py
@@ -10,7 +10,6 @@ from torch_geometric.graphgym.config import (
     cfg,
     dump_cfg,
     load_cfg,
-    set_agg_dir,
     set_out_dir,
     set_run_dir,
 )
@@ -59,7 +58,7 @@ if __name__ == '__main__':
             train_dict[cfg.train.mode](loggers, loaders, model, optimizer,
                                        scheduler)
     # Aggregate results from different seeds
-    agg_runs(set_agg_dir(cfg.out_dir, args.cfg_file), cfg.metric_best)
+    agg_runs(cfg.out_dir, cfg.metric_best)
     # When being launched in batch mode, mark a yaml as done
     if args.mark_done:
         os.rename(args.cfg_file, f'{args.cfg_file}_done')

--- a/graphgym/main.py
+++ b/graphgym/main.py
@@ -11,6 +11,7 @@ from torch_geometric.graphgym.config import (
     dump_cfg,
     load_cfg,
     set_agg_dir,
+    set_out_dir,
     set_run_dir,
 )
 from torch_geometric.graphgym.loader import create_loader
@@ -28,12 +29,13 @@ if __name__ == '__main__':
     args = parse_args()
     # Load config file
     load_cfg(cfg, args)
+    set_out_dir(cfg.out_dir, args.cfg_file)
     # Set Pytorch environment
     torch.set_num_threads(cfg.num_threads)
     dump_cfg(cfg)
     # Repeat for different random seeds
     for i in range(args.repeat):
-        set_run_dir(cfg.out_dir, args.cfg_file)
+        set_run_dir(cfg.out_dir)
         set_printing()
         # Set configurations for each run
         cfg.seed = cfg.seed + 1

--- a/test/graphgym/test_graphgym.py
+++ b/test/graphgym/test_graphgym.py
@@ -14,7 +14,7 @@ from torch_geometric.graphgym.config import (
     cfg,
     dump_cfg,
     load_cfg,
-    set_agg_dir,
+    set_out_dir,
     set_run_dir,
 )
 from torch_geometric.graphgym.loader import create_loader
@@ -51,12 +51,13 @@ def test_run_single_graphgym(skip_train_eval, use_trivial_metric):
     cfg.run_dir = osp.join('/', 'tmp', str(random.randrange(sys.maxsize)))
     cfg.dataset.dir = osp.join('/', 'tmp', 'pyg_test_datasets', 'Planetoid')
 
+    set_out_dir(cfg.out_dir, args.cfg_file)
     dump_cfg(cfg)
     set_printing()
 
     seed_everything(cfg.seed)
     auto_select_device()
-    set_run_dir(cfg.out_dir, args.cfg_file)
+    set_run_dir(cfg.out_dir)
 
     cfg.train.skip_train_eval = skip_train_eval
     cfg.train.enable_ckpt = use_trivial_metric and skip_train_eval
@@ -101,6 +102,6 @@ def test_run_single_graphgym(skip_train_eval, use_trivial_metric):
 
     assert osp.isdir(get_ckpt_dir()) is cfg.train.enable_ckpt
 
-    agg_runs(set_agg_dir(cfg.out_dir, args.cfg_file), cfg.metric_best)
+    agg_runs(cfg.out_dir, cfg.metric_best)
 
     shutil.rmtree(cfg.out_dir)

--- a/test/graphgym/test_graphgym.py
+++ b/test/graphgym/test_graphgym.py
@@ -42,7 +42,7 @@ def trivial_metric(true, pred, task_type):
 @pytest.mark.parametrize('auto_resume', [True, False])
 @pytest.mark.parametrize('skip_train_eval', [True, False])
 @pytest.mark.parametrize('use_trivial_metric', [True, False])
-def test_run_single_graphgym(skip_train_eval, use_trivial_metric):
+def test_run_single_graphgym(auto_resume, skip_train_eval, use_trivial_metric):
     Args = namedtuple('Args', ['cfg_file', 'opts'])
     root = osp.join(osp.dirname(osp.realpath(__file__)))
     args = Args(osp.join(root, 'example_node.yml'), [])

--- a/test/graphgym/test_graphgym.py
+++ b/test/graphgym/test_graphgym.py
@@ -39,6 +39,7 @@ def trivial_metric(true, pred, task_type):
     return 1
 
 
+@pytest.mark.parametrize('auto_resume', [True, False])
 @pytest.mark.parametrize('skip_train_eval', [True, False])
 @pytest.mark.parametrize('use_trivial_metric', [True, False])
 def test_run_single_graphgym(skip_train_eval, use_trivial_metric):
@@ -50,6 +51,7 @@ def test_run_single_graphgym(skip_train_eval, use_trivial_metric):
     cfg.out_dir = osp.join('/', 'tmp', str(random.randrange(sys.maxsize)))
     cfg.run_dir = osp.join('/', 'tmp', str(random.randrange(sys.maxsize)))
     cfg.dataset.dir = osp.join('/', 'tmp', 'pyg_test_datasets', 'Planetoid')
+    cfg.train.auto_resume = auto_resume
 
     set_out_dir(cfg.out_dir, args.cfg_file)
     dump_cfg(cfg)

--- a/torch_geometric/graphgym/__init__.py
+++ b/torch_geometric/graphgym/__init__.py
@@ -4,7 +4,7 @@ from .utils import *  # noqa
 from .checkpoint import load_ckpt, save_ckpt, remove_ckpt, clean_ckpt
 from .cmd_args import parse_args
 from .config import (cfg, set_cfg, load_cfg, dump_cfg, set_run_dir,
-                     set_agg_dir, get_fname)
+                     set_agg_dir, set_out_dir, get_fname)
 from .init import init_weights
 from .loader import create_loader
 from .logger import set_printing, create_logger
@@ -30,6 +30,7 @@ __all__ = classes = [
     'load_cfg',
     'dump_cfg',
     'set_run_dir',
+    'set_out_dir',
     'set_agg_dir',
     'get_fname',
     'init_weights',

--- a/torch_geometric/graphgym/__init__.py
+++ b/torch_geometric/graphgym/__init__.py
@@ -4,7 +4,7 @@ from .utils import *  # noqa
 from .checkpoint import load_ckpt, save_ckpt, remove_ckpt, clean_ckpt
 from .cmd_args import parse_args
 from .config import (cfg, set_cfg, load_cfg, dump_cfg, set_run_dir,
-                     set_agg_dir, set_out_dir, get_fname)
+                     set_out_dir, get_fname)
 from .init import init_weights
 from .loader import create_loader
 from .logger import set_printing, create_logger
@@ -31,7 +31,6 @@ __all__ = classes = [
     'dump_cfg',
     'set_run_dir',
     'set_out_dir',
-    'set_agg_dir',
     'get_fname',
     'init_weights',
     'create_loader',

--- a/torch_geometric/graphgym/config.py
+++ b/torch_geometric/graphgym/config.py
@@ -561,20 +561,6 @@ def set_run_dir(out_dir, fname):
         makedirs_rm_exist(cfg.run_dir)
 
 
-def set_agg_dir(out_dir, fname):
-    r"""
-    Create the directory for aggregated results over
-    all the random seeds
-
-    Args:
-        out_dir (string): Directory for output, specified in :obj:`cfg.out_dir`
-        fname (string): Filename for the yaml format configuration file
-
-    """
-    fname = get_fname(fname)
-    return os.path.join(out_dir, fname)
-
-
 set_cfg(cfg)
 
 

--- a/torch_geometric/graphgym/config.py
+++ b/torch_geometric/graphgym/config.py
@@ -543,7 +543,7 @@ def set_out_dir(out_dir, fname):
         makedirs_rm_exist(cfg.out_dir)
 
 
-def set_run_dir(out_dir, fname):
+def set_run_dir(out_dir):
     r"""
     Create the directory for each random seed experiment run
 
@@ -552,7 +552,6 @@ def set_run_dir(out_dir, fname):
         fname (string): Filename for the yaml format configuration file
 
     """
-    fname = get_fname(fname)
     cfg.run_dir = os.path.join(out_dir, str(cfg.seed))
     # Make output directory
     if cfg.train.auto_resume:

--- a/torch_geometric/graphgym/config.py
+++ b/torch_geometric/graphgym/config.py
@@ -525,6 +525,24 @@ def get_fname(fname):
     return fname
 
 
+def set_out_dir(out_dir, fname):
+    r"""
+    Create the directory for full experiment run
+
+    Args:
+        out_dir (string): Directory for output, specified in :obj:`cfg.out_dir`
+        fname (string): Filename for the yaml format configuration file
+
+    """
+    fname = get_fname(fname)
+    cfg.out_dir = os.path.join(out_dir, fname)
+    # Make output directory
+    if cfg.train.auto_resume:
+        os.makedirs(cfg.out_dir, exist_ok=True)
+    else:
+        makedirs_rm_exist(cfg.out_dir)
+
+
 def set_run_dir(out_dir, fname):
     r"""
     Create the directory for each random seed experiment run
@@ -535,7 +553,7 @@ def set_run_dir(out_dir, fname):
 
     """
     fname = get_fname(fname)
-    cfg.run_dir = os.path.join(out_dir, fname, str(cfg.seed))
+    cfg.run_dir = os.path.join(out_dir, str(cfg.seed))
     # Make output directory
     if cfg.train.auto_resume:
         os.makedirs(cfg.run_dir, exist_ok=True)


### PR DESCRIPTION
Previously, GraphGym config YAML was stored in the root directory of the experiments, which was not desirable. Now, the config will be correctly stored in each specific experiment directory.