### PR TITLE
Update message_passing.py

### DIFF
--- a/torch_geometric/nn/conv/message_passing.py
+++ b/torch_geometric/nn/conv/message_passing.py
@@ -241,8 +241,8 @@ class MessagePassing(torch.nn.Module):
 
         out['index'] = out['edge_index_i']
         out['size'] = size
-        out['size_i'] = size[1] if size[1] is not None else size[0]
-        out['size_j'] = size[0] if size[0] is not None else size[1]
+        out['size_i'] = size[i] if size[i] is not None else size[j]
+        out['size_j'] = size[j] if size[j] is not None else size[i]
         out['dim_size'] = out['size_i']
 
         return out


### PR DESCRIPTION
When using a bipartite graph for reverse message passing(set flow = 'target_to_source'), the message aggregation fails or  returns a tensor of the wrong dimension due to incorrect dim_size, although it doesn't really matter and different edge_index can be used to achieve the same effect.
ps:I'm new to pyg, so please forgive me if it's not correct.