### PR TITLE
Updates to dimenet model

### DIFF
--- a/torch_geometric/nn/models/dimenet.py
+++ b/torch_geometric/nn/models/dimenet.py
@@ -59,7 +59,9 @@ class BesselBasisLayer(torch.nn.Module):
         self.reset_parameters()
 
     def reset_parameters(self):
-        torch.arange(1, self.freq.numel() + 1, out=self.freq).mul_(PI)
+        with torch.no_grad():
+            torch.arange(1, self.freq.numel() + 1, out=self.freq).mul_(PI)
+        self.freq.requires_grad_()
 
     def forward(self, dist):
         dist = dist.unsqueeze(-1) / self.cutoff
@@ -293,6 +295,9 @@ class DimeNet(torch.nn.Module):
                  num_after_skip: int = 2, num_output_layers: int = 3,
                  act: Callable = swish):
         super().__init__()
+
+        if num_spherical < 2:
+            raise ValueError("num_spherical should be greater than 1")
 
         self.cutoff = cutoff
         self.max_num_neighbors = max_num_neighbors


### PR DESCRIPTION
Two minor fixes to dimenet model:
1. When initializing `model = DimeNet(hidden_channels = 5, out_channels=19, num_blocks=1, num_bilinear=1, num_spherical=1, num_radial=1)`, it throws a `RuntimeError: a leaf Variable that requires grad is being used in an in-place operation.`. It occurs in the `reset_parameters` method of `BesselBasisLayer`.  The cause is that we are performing an in-place operation in the leaf variable when resetting parameters.
2. The model requires `num_spherical` to be at least 2. I am not sure why it is, but it fixes. Sorry about it.