### PR TITLE
`DimeNet++` implementation

### DIFF
--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -32,7 +32,6 @@ jobs:
         run: |
           pip install torch-scatter -f https://data.pyg.org/whl/torch-${{ matrix.torch-version }}+cpu.html
           pip install torch-sparse -f https://data.pyg.org/whl/torch-${{ matrix.torch-version }}+cpu.html
-          pip install torch-cluster -f https://data.pyg.org/whl/torch-${{ matrix.torch-version }}+cpu.html
 
       - name: Install main package
         run: |

--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -32,6 +32,7 @@ jobs:
         run: |
           pip install torch-scatter -f https://data.pyg.org/whl/torch-${{ matrix.torch-version }}+cpu.html
           pip install torch-sparse -f https://data.pyg.org/whl/torch-${{ matrix.torch-version }}+cpu.html
+          pip install torch-cluster -f https://data.pyg.org/whl/torch-${{ matrix.torch-version }}+cpu.html
 
       - name: Install main package
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ## [2.0.5] - 2022-MM-DD
 ### Added
-- DimeNet++ Model ([#4432](https://github.com/pyg-team/pytorch_geometric/pull/4432))
+- Added the `DimeNet++` model ([#4432](https://github.com/pyg-team/pytorch_geometric/pull/4432))
 - Added benchmarks via [`wandb`](https://wandb.ai/site) ([#4656](https://github.com/pyg-team/pytorch_geometric/pull/4656), [#4672](https://github.com/pyg-team/pytorch_geometric/pull/4672), [#4676](https://github.com/pyg-team/pytorch_geometric/pull/4676))
 - Added `unbatch` functionality ([#4628](https://github.com/pyg-team/pytorch_geometric/pull/4628))
 - Confirm that `to_hetero()` works with custom functions, *e.g.*, `dropout_adj` ([4653](https://github.com/pyg-team/pytorch_geometric/pull/4653))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ## [2.0.5] - 2022-MM-DD
 ### Added
+- DimeNet++ Model ([#4432](https://github.com/pyg-team/pytorch_geometric/pull/4432))
 - Added benchmarks via [`wandb`](https://wandb.ai/site) ([#4656](https://github.com/pyg-team/pytorch_geometric/pull/4656), [#4672](https://github.com/pyg-team/pytorch_geometric/pull/4672), [#4676](https://github.com/pyg-team/pytorch_geometric/pull/4676))
 - Added `unbatch` functionality ([#4628](https://github.com/pyg-team/pytorch_geometric/pull/4628))
 - Confirm that `to_hetero()` works with custom functions, *e.g.*, `dropout_adj` ([4653](https://github.com/pyg-team/pytorch_geometric/pull/4653))

--- a/examples/qm9_pretrained_dimenet.py
+++ b/examples/qm9_pretrained_dimenet.py
@@ -1,15 +1,23 @@
+import argparse
 import os.path as osp
 
 import torch
 
 from torch_geometric.datasets import QM9
 from torch_geometric.loader import DataLoader
-from torch_geometric.nn import DimeNet
+from torch_geometric.nn import DimeNet, DimeNetPlusPlus
+
+parser = argparse.ArgumentParser()
+parser.add_argument('--use_dimenet_plus_plus', action='store_true')
+args = parser.parse_args()
+
+Model = DimeNetPlusPlus if args.use_dimenet_plus_plus else DimeNet
 
 path = osp.join(osp.dirname(osp.realpath(__file__)), '..', 'data', 'QM9')
 dataset = QM9(path)
 
-# DimeNet uses the atomization energy for targets U0, U, H, and G.
+# DimeNet uses the atomization energy for targets U0, U, H, and G, i.e.:
+# 7 -> 12, 8 -> 13, 9 -> 14, 10 -> 15
 idx = torch.tensor([0, 1, 2, 3, 4, 5, 6, 12, 13, 14, 15, 11])
 dataset.data.y = dataset.data.y[:, idx]
 
@@ -17,11 +25,11 @@ device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
 
 for target in range(12):
     # Skip target \delta\epsilon, since it can be computed via
-    # \epsilon_{LUMO} - \epsilon_{HOMO}.
+    # \epsilon_{LUMO} - \epsilon_{HOMO}:
     if target == 4:
         continue
 
-    model, datasets = DimeNet.from_qm9_pretrained(path, dataset, target)
+    model, datasets = Model.from_qm9_pretrained(path, dataset, target)
     train_dataset, val_dataset, test_dataset = datasets
 
     model = model.to(device)
@@ -37,7 +45,7 @@ for target in range(12):
 
     mae = torch.cat(maes, dim=0)
 
-    # Report meV instead of eV.
+    # Report meV instead of eV:
     mae = 1000 * mae if target in [2, 3, 4, 6, 7, 8, 9, 10] else mae
 
     print(f'Target: {target:02d}, MAE: {mae.mean():.5f} ± {mae.std():.5f}')

--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,7 @@ graphgym_requires = [
 full_requires = graphgym_requires + [
     'h5py',
     'numba',
+    'sympy',
     'pandas',
     'captum',
     'rdflib',

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,6 @@ install_requires = [
     'tqdm',
     'numpy',
     'scipy',
-    'sympy',
     'jinja2',
     'requests',
     'pyparsing',
@@ -43,7 +42,6 @@ benchmark_requires = [
 test_requires = [
     'pytest',
     'pytest-cov',
-    'sympy',
 ]
 
 dev_requires = test_requires + [

--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,7 @@ install_requires = [
     'tqdm',
     'numpy',
     'scipy',
+    'sympy',
     'jinja2',
     'requests',
     'pyparsing',
@@ -42,6 +43,7 @@ benchmark_requires = [
 test_requires = [
     'pytest',
     'pytest-cov',
+    'sympy',
 ]
 
 dev_requires = test_requires + [

--- a/test/nn/models/test_dimenet.py
+++ b/test/nn/models/test_dimenet.py
@@ -1,40 +1,41 @@
 import torch
-import torch.nn as nn
+import torch.nn.functional as F
 
 from torch_geometric.data import Data
-from torch_geometric.nn.models.dimenet import DimeNetPlusPlus
+from torch_geometric.nn import DimeNetPlusPlus
+from torch_geometric.testing import onlyFullTest
 
 
-class TestDimeNetPlusPlus:
-    def setup(self):
-        n_atoms = 20
-        z = torch.randint(1, 10, size=(n_atoms, ))
-        pos = torch.randn(n_atoms, 3)
-        self.data = Data(
-            z=z,
-            pos=pos)  # A molecule's atomic numbers and positional coordinates
-        self.model = DimeNetPlusPlus(hidden_channels=5, out_channels=1,
-                                     num_blocks=5, out_emb_channels=3,
-                                     int_emb_size=5, basis_emb_size=5,
-                                     num_spherical=5, num_radial=5,
-                                     num_before_skip=2, num_after_skip=2)
+@onlyFullTest
+def test_dimenet_plus_plus():
+    data = Data(
+        z=torch.randint(1, 10, (20, )),
+        pos=torch.randn(20, 3),
+        y=torch.tensor([1.]),
+    )
 
-    def test_output(self):
-        with torch.no_grad():
-            out = self.model(self.data.z, self.data.pos)
-        assert out.shape[0] == 1
+    model = DimeNetPlusPlus(
+        hidden_channels=5,
+        out_channels=1,
+        num_blocks=5,
+        out_emb_channels=3,
+        int_emb_size=5,
+        basis_emb_size=5,
+        num_spherical=5,
+        num_radial=5,
+        num_before_skip=2,
+        num_after_skip=2,
+    )
 
-    def test_overfit(self):
-        optimizer = torch.optim.Adam(self.model.parameters(), lr=0.1)
-        # scheduler = torch.optim.lr_scheduler.ReduceLROnPlateau(
-        # optimizer, mode='min', factor=0.5, patience=1, min_lr=0.00001)
-        loss_fn = nn.L1Loss()
-        y_target = torch.Tensor([1])
-        for i in range(1000):
-            optimizer.zero_grad()
-            out = self.model(self.data.z, self.data.pos)
-            loss = loss_fn(out, y_target)
-            loss.backward()
-            optimizer.step()
+    with torch.no_grad():
+        out = model(data.z, data.pos)
+        assert out.size() == (1, )
 
-        assert loss.item() < 10
+    optimizer = torch.optim.Adam(model.parameters(), lr=0.1)
+    for i in range(100):
+        optimizer.zero_grad()
+        out = model(data.z, data.pos)
+        loss = F.l1_loss(out, data.y)
+        loss.backward()
+        optimizer.step()
+    assert loss < 1

--- a/test/nn/models/test_dimenet.py
+++ b/test/nn/models/test_dimenet.py
@@ -1,4 +1,3 @@
-import pytest
 import torch
 import torch.nn as nn
 
@@ -27,8 +26,8 @@ class TestDimeNetPlusPlus:
 
     def test_overfit(self):
         optimizer = torch.optim.Adam(self.model.parameters(), lr=0.1)
-        scheduler = torch.optim.lr_scheduler.ReduceLROnPlateau(
-            optimizer, mode='min', factor=0.5, patience=1, min_lr=0.00001)
+        # scheduler = torch.optim.lr_scheduler.ReduceLROnPlateau(
+        # optimizer, mode='min', factor=0.5, patience=1, min_lr=0.00001)
         loss_fn = nn.L1Loss()
         y_target = torch.Tensor([1])
         for i in range(1000):

--- a/test/nn/models/test_dimenet.py
+++ b/test/nn/models/test_dimenet.py
@@ -1,0 +1,41 @@
+import pytest
+import torch
+import torch.nn as nn
+
+from torch_geometric.data import Data
+from torch_geometric.nn.models.dimenet import DimeNetPlusPlus
+
+
+class TestDimeNetPlusPlus:
+    def setup(self):
+        n_atoms = 20
+        z = torch.randint(1, 10, size=(n_atoms, ))
+        pos = torch.randn(n_atoms, 3)
+        self.data = Data(
+            z=z,
+            pos=pos)  # A molecule's atomic numbers and positional coordinates
+        self.model = DimeNetPlusPlus(hidden_channels=5, out_channels=1,
+                                     num_blocks=5, out_emb_channels=3,
+                                     int_emb_size=5, basis_emb_size=5,
+                                     num_spherical=5, num_radial=5,
+                                     num_before_skip=2, num_after_skip=2)
+
+    def test_output(self):
+        with torch.no_grad():
+            out = self.model(self.data.z, self.data.pos)
+        assert out.shape[0] == 1
+
+    def test_overfit(self):
+        optimizer = torch.optim.Adam(self.model.parameters(), lr=0.1)
+        scheduler = torch.optim.lr_scheduler.ReduceLROnPlateau(
+            optimizer, mode='min', factor=0.5, patience=1, min_lr=0.00001)
+        loss_fn = nn.L1Loss()
+        y_target = torch.Tensor([1])
+        for i in range(1000):
+            optimizer.zero_grad()
+            out = self.model(self.data.z, self.data.pos)
+            loss = loss_fn(out, y_target)
+            loss.backward()
+            optimizer.step()
+
+        assert loss.item() < 10

--- a/torch_geometric/nn/models/__init__.py
+++ b/torch_geometric/nn/models/__init__.py
@@ -8,7 +8,7 @@ from .signed_gcn import SignedGCN
 from .re_net import RENet
 from .graph_unet import GraphUNet
 from .schnet import SchNet
-from .dimenet import DimeNet
+from .dimenet import DimeNet, DimeNetPlusPlus
 from .explainer import Explainer, to_captum
 from .gnn_explainer import GNNExplainer
 from .metapath2vec import MetaPath2Vec
@@ -42,6 +42,7 @@ __all__ = [
     'GraphUNet',
     'SchNet',
     'DimeNet',
+    'DimeNetPlusPlus',
     'Explainer',
     'to_captum',
     'GNNExplainer',

--- a/torch_geometric/nn/models/dimenet.py
+++ b/torch_geometric/nn/models/dimenet.py
@@ -344,12 +344,30 @@ class OutputPPBlock(torch.nn.Module):
 class OutputBlock(OutputPPBlock):
     def __init__(self, num_radial, hidden_channels, out_channels, num_layers,
                  act=swish):
-        super().__init__(num_radial, hidden_channels, hidden_channels,
-                         out_channels, num_layers, act=swish)
-        import warnings
-        warnings.warn(
-            "OutputBlock will be depreciated in PyG 2.1.0. Use OutputPPBlock instead",  # noqa
-            FutureWarning)
+        super().__init__()
+        self.act = act
+
+        self.lin_rbf = Linear(num_radial, hidden_channels, bias=False)
+        self.lins = torch.nn.ModuleList()
+        for _ in range(num_layers):
+            self.lins.append(Linear(hidden_channels, hidden_channels))
+        self.lin = Linear(hidden_channels, out_channels, bias=False)
+
+        self.reset_parameters()
+
+    def reset_parameters(self):
+        glorot_orthogonal(self.lin_rbf.weight, scale=2.0)
+        for lin in self.lins:
+            glorot_orthogonal(lin.weight, scale=2.0)
+            lin.bias.data.fill_(0)
+        self.lin.weight.data.fill_(0)
+
+    def forward(self, x, rbf, i, num_nodes=None):
+        x = self.lin_rbf(rbf) * x
+        x = scatter(x, i, dim=0, dim_size=num_nodes)
+        for lin in self.lins:
+            x = self.act(lin(x))
+        return self.lin(x)
 
 
 class DimeNet(torch.nn.Module):

--- a/torch_geometric/nn/models/dimenet.py
+++ b/torch_geometric/nn/models/dimenet.py
@@ -219,6 +219,96 @@ class InteractionBlock(torch.nn.Module):
         return h
 
 
+class InteractionPPBlock(torch.nn.Module):
+    """
+    The interaction block transforms each message embedding using
+    multiple residual blocks.
+    """
+    def __init__(self, hidden_channels, int_emb_size, basis_emb_size,
+                 num_spherical, num_radial, num_before_skip, num_after_skip,
+                 act=swish):
+        super(InteractionPPBlock, self).__init__()
+        self.act = act
+
+        # Transformation of Bessel and spherical basis representations
+        self.lin_rbf1 = Linear(num_radial, basis_emb_size, bias=False)
+        self.lin_rbf2 = Linear(basis_emb_size, hidden_channels, bias=False)
+
+        self.lin_sbf1 = Linear(num_spherical * num_radial, basis_emb_size,
+                               bias=False)
+        self.lin_sbf2 = Linear(basis_emb_size, int_emb_size, bias=False)
+
+        # Hidden transformation of input message
+        self.lin_kj = Linear(hidden_channels, hidden_channels)
+        self.lin_ji = Linear(hidden_channels, hidden_channels)
+
+        # Embedding projections for interaction triplets
+        self.lin_down = Linear(hidden_channels, int_emb_size, bias=False)
+        self.lin_up = Linear(int_emb_size, hidden_channels, bias=False)
+        # Residual layers before and after skip connection
+        self.layers_before_skip = torch.nn.ModuleList([
+            ResidualLayer(hidden_channels, act) for _ in range(num_before_skip)
+        ])
+        self.lin = Linear(hidden_channels, hidden_channels)
+        self.layers_after_skip = torch.nn.ModuleList([
+            ResidualLayer(hidden_channels, act) for _ in range(num_before_skip)
+        ])
+
+        self.reset_parameters()
+
+    def reset_parameters(self):
+        glorot_orthogonal(self.lin_rbf1.weight, scale=2.0)
+        glorot_orthogonal(self.lin_rbf2.weight, scale=2.0)
+        glorot_orthogonal(self.lin_sbf1.weight, scale=2.0)
+        glorot_orthogonal(self.lin_sbf2.weight, scale=2.0)
+
+        glorot_orthogonal(self.lin_kj.weight, scale=2.0)
+        self.lin_kj.bias.data.fill_(0)
+        glorot_orthogonal(self.lin_ji.weight, scale=2.0)
+        self.lin_ji.bias.data.fill_(0)
+
+        glorot_orthogonal(self.lin_down.weight, scale=2.0)
+        glorot_orthogonal(self.lin_up.weight, scale=2.0)
+
+        for res_layer in self.layers_before_skip:
+            res_layer.reset_parameters()
+        glorot_orthogonal(self.lin.weight, scale=2.0)
+        self.lin.bias.data.fill_(0)
+        for res_layer in self.layers_before_skip:
+            res_layer.reset_parameters()
+
+    def forward(self, x, rbf, sbf, idx_kj, idx_ji):
+        # Initial transformation
+        x_ji = self.act(self.lin_ji(x))
+        x_kj = self.act(self.lin_kj(x))
+
+        # Transformation via Bessel basis
+        rbf = self.lin_rbf1(rbf)
+        rbf = self.lin_rbf2(rbf)
+        x_kj = x_kj * rbf
+
+        # Down project embedding and generating triple-interactions
+        x_kj = self.act(self.lin_down(x_kj))
+
+        # Transform via 2D spherical basis
+        sbf = self.lin_sbf1(sbf)
+        sbf = self.lin_sbf2(sbf)
+        x_kj = x_kj[idx_kj] * sbf
+
+        # Aggregate interactions and up-project embeddings
+        x_kj = scatter(x_kj, idx_ji, dim=0, dim_size=x.size(0))
+        x_kj = self.act(self.lin_up(x_kj))
+
+        h = x_ji + x_kj
+        for layer in self.layers_before_skip:
+            h = layer(h)
+        h = self.act(self.lin(h)) + x
+        for layer in self.layers_after_skip:
+            h = layer(h)
+
+        return h
+
+
 class OutputPPBlock(torch.nn.Module):
     def __init__(self, num_radial, hidden_channels, out_emb_channels,
                  out_channels, num_layers, act=swish):

--- a/torch_geometric/nn/models/dimenet.py
+++ b/torch_geometric/nn/models/dimenet.py
@@ -316,7 +316,8 @@ class OutputPPBlock(torch.nn.Module):
         self.act = act
 
         self.lin_rbf = Linear(num_radial, hidden_channels, bias=False)
-        self.lin_up = Linear(hidden_channels, out_emb_channels, bias=True)
+        # The up-projection layer
+        self.lin_up = Linear(hidden_channels, out_emb_channels, bias=False)
         self.lins = torch.nn.ModuleList()
         for _ in range(num_layers):
             self.lins.append(Linear(out_emb_channels, out_emb_channels))
@@ -341,7 +342,7 @@ class OutputPPBlock(torch.nn.Module):
         return self.lin(x)
 
 
-class OutputBlock(OutputPPBlock):
+class OutputBlock(torch.nn.Module):
     def __init__(self, num_radial, hidden_channels, out_channels, num_layers,
                  act=swish):
         super().__init__()
@@ -462,8 +463,10 @@ class DimeNet(torch.nn.Module):
 
         root = osp.expanduser(osp.normpath(root))
         path = osp.join(root, 'pretrained_dimenet', qm9_target_dict[target])
+
         makedirs(path)
         url = f'{DimeNet.url}/{qm9_target_dict[target]}'
+
         if not osp.exists(osp.join(path, 'checkpoint')):
             download_url(f'{url}/checkpoint', path)
             download_url(f'{url}/ckpt.data-00000-of-00002', path)
@@ -626,6 +629,9 @@ class DimeNetPlusPlus(DimeNet):
         act: (Callable, optional): The activation funtion.
             (default: :obj:`swish`)
     """
+    url = ('https://raw.githubusercontent.com/gasteigerjo/dimenet/'
+           'master/pretrained/dimenet_pp')
+
     def __init__(self, hidden_channels: int, out_channels: int,
                  num_blocks: int, int_emb_size: int, basis_emb_size: int,
                  out_emb_channels: int, num_spherical: int, num_radial: int,
@@ -643,6 +649,12 @@ class DimeNetPlusPlus(DimeNet):
                          num_after_skip=num_after_skip,
                          num_output_layers=num_output_layers, act=act)
 
+        # We are using the rbf, sbf and emb layer of DimeNet model and
+        # redefining output_block and interaction_block in DimeNet++
+        # Hence, it is to be noted that in the above initalisation, the
+        # variable num_bilinear do not have any purpose as it is used
+        # in OutputBlock of DimeNet, but it serves no purpose as
+        # OutputPPBlock of DimeNet++ does not use that argument
         self.output_blocks = torch.nn.ModuleList([
             OutputPPBlock(num_radial, hidden_channels, out_emb_channels,
                           out_channels, num_output_layers, act)
@@ -656,3 +668,104 @@ class DimeNetPlusPlus(DimeNet):
         ])
 
         self.reset_parameters()
+
+    @staticmethod
+    def from_qm9_pretrained(root: str, dataset: Dataset, target: int):
+        os.environ['TF_CPP_MIN_LOG_LEVEL'] = '3'
+        import tensorflow as tf
+
+        assert target >= 0 and target <= 12 and not target == 4
+
+        root = osp.expanduser(osp.normpath(root))
+        path = osp.join(root, 'pretrained_dimenet', qm9_target_dict[target])
+
+        makedirs(path)
+        url = f'{DimeNetPlusPlus.url}/{qm9_target_dict[target]}'
+
+        if not osp.exists(osp.join(path, 'checkpoint')):
+            download_url(f'{url}/checkpoint', path)
+            download_url(f'{url}/ckpt.data-00000-of-00002', path)
+            download_url(f'{url}/ckpt.data-00001-of-00002', path)
+            download_url(f'{url}/ckpt.index', path)
+
+        path = osp.join(path, 'ckpt')
+        reader = tf.train.load_checkpoint(path)
+
+        # Configuration from DimeNet++ configuration
+        # Ref:https://github.com/gasteigerjo/dimenet/blob/master/config_pp.yaml
+        model = DimeNetPlusPlus(hidden_channels=128, out_channels=1,
+                                num_blocks=4, int_emb_size=64,
+                                basis_emb_size=8, out_emb_channels=256,
+                                num_spherical=7, num_radial=6, cutoff=5.0,
+                                max_num_neighbors=32, envelope_exponent=5,
+                                num_before_skip=1, num_after_skip=2,
+                                num_output_layers=3)
+
+        def copy_(src, name, transpose=False):
+            init = reader.get_tensor(f'{name}/.ATTRIBUTES/VARIABLE_VALUE')
+            init = torch.from_numpy(init)
+            if name[-6:] == 'kernel':
+                init = init.t()
+            src.data.copy_(init)
+
+        copy_(model.rbf.freq, 'rbf_layer/frequencies')
+        copy_(model.emb.emb.weight, 'emb_block/embeddings')
+        copy_(model.emb.lin_rbf.weight, 'emb_block/dense_rbf/kernel')
+        copy_(model.emb.lin_rbf.bias, 'emb_block/dense_rbf/bias')
+        copy_(model.emb.lin.weight, 'emb_block/dense/kernel')
+        copy_(model.emb.lin.bias, 'emb_block/dense/bias')
+
+        for i, block in enumerate(model.output_blocks):
+            copy_(block.lin_rbf.weight, f'output_blocks/{i}/dense_rbf/kernel')
+            copy_(block.lin_up.weight,
+                  f'output_blocks/{i}/up_projection/kernel')
+            for j, lin in enumerate(block.lins):
+                copy_(lin.weight, f'output_blocks/{i}/dense_layers/{j}/kernel')
+                copy_(lin.bias, f'output_blocks/{i}/dense_layers/{j}/bias')
+            copy_(block.lin.weight, f'output_blocks/{i}/dense_final/kernel')
+
+        for i, block in enumerate(model.interaction_blocks):
+            copy_(block.lin_rbf1.weight, f'int_blocks/{i}/dense_rbf1/kernel')
+            copy_(block.lin_rbf2.weight, f'int_blocks/{i}/dense_rbf2/kernel')
+            copy_(block.lin_sbf1.weight, f'int_blocks/{i}/dense_sbf1/kernel')
+            copy_(block.lin_sbf2.weight, f'int_blocks/{i}/dense_sbf2/kernel')
+
+            copy_(block.lin_ji.weight, f'int_blocks/{i}/dense_ji/kernel')
+            copy_(block.lin_ji.bias, f'int_blocks/{i}/dense_ji/bias')
+            copy_(block.lin_kj.weight, f'int_blocks/{i}/dense_kj/kernel')
+            copy_(block.lin_kj.bias, f'int_blocks/{i}/dense_kj/bias')
+
+            copy_(block.lin_down.weight,
+                  f'int_blocks/{i}/down_projection/kernel')
+            copy_(block.lin_up.weight, f'int_blocks/{i}/up_projection/kernel')
+
+            for j, layer in enumerate(block.layers_before_skip):
+                copy_(layer.lin1.weight,
+                      f'int_blocks/{i}/layers_before_skip/{j}/dense_1/kernel')
+                copy_(layer.lin1.bias,
+                      f'int_blocks/{i}/layers_before_skip/{j}/dense_1/bias')
+                copy_(layer.lin2.weight,
+                      f'int_blocks/{i}/layers_before_skip/{j}/dense_2/kernel')
+                copy_(layer.lin2.bias,
+                      f'int_blocks/{i}/layers_before_skip/{j}/dense_2/bias')
+
+            copy_(block.lin.weight, f'int_blocks/{i}/final_before_skip/kernel')
+            copy_(block.lin.bias, f'int_blocks/{i}/final_before_skip/bias')
+
+            for j, layer in enumerate(block.layers_after_skip):
+                copy_(layer.lin1.weight,
+                      f'int_blocks/{i}/layers_after_skip/{j}/dense_1/kernel')
+                copy_(layer.lin1.bias,
+                      f'int_blocks/{i}/layers_after_skip/{j}/dense_1/bias')
+                copy_(layer.lin2.weight,
+                      f'int_blocks/{i}/layers_after_skip/{j}/dense_2/kernel')
+                copy_(layer.lin2.bias,
+                      f'int_blocks/{i}/layers_after_skip/{j}/dense_2/bias')
+
+        random_state = np.random.RandomState(seed=42)
+        perm = torch.from_numpy(random_state.permutation(np.arange(130831)))
+        train_idx = perm[:110000]
+        val_idx = perm[110000:120000]
+        test_idx = perm[120000:]
+
+        return model, (dataset[train_idx], dataset[val_idx], dataset[test_idx])


### PR DESCRIPTION
In this PR, I implemented DimeNet++ by subclassing DimeNet. The `InteractionPPBlock` and `OutputPPBlock` was based on this [implementation](https://github.com/Open-Catalyst-Project/ocp/blob/main/ocpmodels/models/dimenet_plus_plus.py).

Also, I depreciated `OutputBlock`, thereby DimeNet model will also be using `OutputPPBlock`. `OutputPPBlock` allows up-projection and down-projection of embeddings, thereby removing information bottlenecks.

Fixes #4427