### PR TITLE
Add support for projecting features before aggregation in `SAGEConv`

### DIFF
--- a/test/nn/conv/test_sage_conv.py
+++ b/test/nn/conv/test_sage_conv.py
@@ -6,14 +6,15 @@ from torch_geometric.nn import SAGEConv
 from torch_geometric.testing import is_full_test
 
 
-def test_sage_conv():
+@pytest.mark.parametrize('project', [False, True])
+def test_sage_conv(project):
     x1 = torch.randn(4, 8)
     x2 = torch.randn(2, 16)
     edge_index = torch.tensor([[0, 1, 2, 3], [0, 0, 1, 1]])
     row, col = edge_index
     adj = SparseTensor(row=row, col=col, sparse_sizes=(4, 4))
 
-    conv = SAGEConv(8, 32)
+    conv = SAGEConv(8, 32, project=project)
     assert str(conv) == 'SAGEConv(8, 32, aggr=mean)'
     out = conv(x1, edge_index)
     assert out.size() == (4, 32)
@@ -31,7 +32,7 @@ def test_sage_conv():
         assert jit(x1, adj.t()).tolist() == out.tolist()
 
     adj = adj.sparse_resize((4, 2))
-    conv = SAGEConv((8, 16), 32)
+    conv = SAGEConv((8, 16), 32, project=project)
     assert str(conv) == 'SAGEConv((8, 16), 32, aggr=mean)'
     out1 = conv((x1, x2), edge_index)
     out2 = conv((x1, None), edge_index, (4, 2))

--- a/torch_geometric/nn/conv/sage_conv.py
+++ b/torch_geometric/nn/conv/sage_conv.py
@@ -20,6 +20,11 @@ class SAGEConv(MessagePassing):
     .. math::
         \mathbf{x}^{\prime}_i = \mathbf{W}_1 \mathbf{x}_i + \mathbf{W}_2 \cdot
         \mathrm{mean}_{j \in \mathcal{N(i)}} \mathbf{x}_j
+        \text{ mean }
+
+        \mathbf{x}^{\prime}_i = \mathbf{W}_1 \mathbf{x}_i + \mathbf{W}_2 \cdot
+        \mathrm{mean}_{j \in \mathcal{N(i)}} \sigma(\mathbf{W}_3
+        \cdot \mathbf{x}_j) \text{ mean pre\_transform}
 
     Args:
         in_channels (int or tuple): Size of each input sample, or :obj:`-1` to
@@ -40,6 +45,9 @@ class SAGEConv(MessagePassing):
             (default: :obj:`True`)
         bias (bool, optional): If set to :obj:`False`, the layer will not learn
             an additive bias. (default: :obj:`True`)
+        pre_transform (bool, optional): If set to :obj:`True`, the layer will
+            apply a linear transformation (with bias) followed by an activation function
+            before aggregating. (default: :obj:`False`)
         **kwargs (optional): Additional arguments of
             :class:`torch_geometric.nn.conv.MessagePassing`.
 
@@ -60,6 +68,7 @@ class SAGEConv(MessagePassing):
         normalize: bool = False,
         root_weight: bool = True,
         bias: bool = True,
+        pre_transform: bool = False,
         **kwargs,
     ):
         kwargs['aggr'] = aggr if aggr != 'lstm' else None
@@ -69,9 +78,13 @@ class SAGEConv(MessagePassing):
         self.out_channels = out_channels
         self.normalize = normalize
         self.root_weight = root_weight
+        self.pre_transform = pre_transform
 
         if isinstance(in_channels, int):
             in_channels = (in_channels, in_channels)
+
+        if self.pre_transform:
+            self.lin = Linear(in_channels[0], in_channels[0], bias=True)
 
         if self.aggr is None:
             self.fuse = False  # No "fused" message_and_aggregate.
@@ -89,6 +102,8 @@ class SAGEConv(MessagePassing):
         self.lin_l.reset_parameters()
         if self.root_weight:
             self.lin_r.reset_parameters()
+        if self.pre_transform is not None:
+            self.lin.reset_parameters()
 
     def forward(self, x: Union[Tensor, OptPairTensor], edge_index: Adj,
                 size: Size = None) -> Tensor:
@@ -119,6 +134,8 @@ class SAGEConv(MessagePassing):
 
     def aggregate(self, x: Tensor, index: Tensor, ptr: Optional[Tensor] = None,
                   dim_size: Optional[int] = None) -> Tensor:
+        if self.pre_transform:
+            x = F.relu(self.lin(x))
         if self.aggr is not None:
             return scatter(x, index, dim=self.node_dim, dim_size=dim_size,
                            reduce=self.aggr)
@@ -137,5 +154,7 @@ class SAGEConv(MessagePassing):
 
     def __repr__(self) -> str:
         aggr = self.aggr if self.aggr is not None else 'lstm'
+
         return (f'{self.__class__.__name__}({self.in_channels}, '
-                f'{self.out_channels}, aggr={aggr})')
+                f'{self.out_channels}, aggr={aggr}, '
+                f'pre_transform={self.pre_transform})')

--- a/torch_geometric/nn/conv/sage_conv.py
+++ b/torch_geometric/nn/conv/sage_conv.py
@@ -160,6 +160,5 @@ class SAGEConv(MessagePassing):
 
     def __repr__(self) -> str:
         aggr = self.aggr if self.aggr is not None else 'lstm'
-
         return (f'{self.__class__.__name__}({self.in_channels}, '
                 f'{self.out_channels}, aggr={aggr})')


### PR DESCRIPTION
This pull request adds the implementation for Max and Mean Pool aggregations for SAGEConv which were implemented in the original study [Inductive Representation Learning on Large Graphs](https://arxiv.org/pdf/1706.02216.pdf), it's a sequel to PR https://github.com/pyg-team/pytorch_geometric/pull/4379, which in turn is related to issue https://github.com/pyg-team/pytorch_geometric/issues/1147.

The implementation is a direct application of the Eq 3 of the original paper (for both `mean` and `max`):
![image](https://user-images.githubusercontent.com/24209192/162553540-620ab828-c3d7-4002-852b-8b1b8b3a46a2.png)

cc @hunarbatra 