### PR TITLE
Add random negative sampling to `LinkNeighborLoader`

### DIFF
--- a/test/loader/test_link_neighbor_loader.py
+++ b/test/loader/test_link_neighbor_loader.py
@@ -34,17 +34,17 @@ def test_homogeneous_link_neighbor_loader(directed, negative_sampling):
     data.edge_attr = torch.arange(500)
 
     neg_sampling_ratio = 0.5 if negative_sampling else 0
-    negative_samples = int(neg_sampling_ratio * 20)
-    n_batch = 20 + negative_samples
+    n_batch = 20
 
-    loader = LinkNeighborLoader(data, num_neighbors=[-1] * 2, batch_size=20,
+    loader = LinkNeighborLoader(data, num_neighbors=[-1] * 2,
+                                batch_size=n_batch,
                                 edge_label_index=edge_label_index,
                                 edge_label=edge_label, directed=directed,
                                 neg_sampling_ratio=neg_sampling_ratio,
                                 shuffle=True)
 
     assert str(loader) == 'LinkNeighborLoader()'
-    assert len(loader) == 1000 / 20
+    assert len(loader) == 100 if negative_sampling else 50
 
     for batch in loader:
         assert isinstance(batch, Data)
@@ -90,16 +90,16 @@ def test_heterogeneous_link_neighbor_loader(directed, negative_sampling):
     data['author', 'paper'].edge_attr = torch.arange(1500, 2500)
 
     neg_sampling_ratio = 0.5 if negative_sampling else 0
-    negative_samples = int(neg_sampling_ratio * 20)
-    n_batch = 20 + negative_samples
+    n_batch = 20
 
     loader = LinkNeighborLoader(data, num_neighbors=[-1] * 2,
                                 edge_label_index=('paper', 'author'),
-                                batch_size=20, directed=directed, shuffle=True,
+                                batch_size=n_batch, directed=directed,
+                                shuffle=True,
                                 neg_sampling_ratio=neg_sampling_ratio)
 
     assert str(loader) == 'LinkNeighborLoader()'
-    assert len(loader) == int(1000 / 20)
+    assert len(loader) == 100 if negative_sampling else 50
 
     for batch in loader:
         assert isinstance(batch, HeteroData)

--- a/torch_geometric/loader/link_neighbor_loader.py
+++ b/torch_geometric/loader/link_neighbor_loader.py
@@ -202,8 +202,11 @@ class LinkNeighborLoader(torch.utils.data.DataLoader):
             (default: :obj:`None`)
         neg_sampling_ratio (float, optional): The ratio of sampled negative
             edges to the number of positive edges. (default: :obj:`0`).
-            If set, the edge labels cannot be provided, as the labels now
-            become :obj:`0` for positive edges and  :obj:`1` for positive.
+            If set, and edge_labels are not provided, all provided edges will
+            be assumed to be positive and given a label of :obj:`1`. The
+            negative edges will have label :obj:`0`.
+            Note that these edges will be added to the batch, increasing the
+            batch size.
             If the data is :class:`~torch_geometric.data.HeteroData` then
             the edge type that is being sampled will be the edge type for
             which negative edges are added.


### PR DESCRIPTION
This PR continues the work discussed in https://github.com/pyg-team/pytorch_geometric/issues/4026, adding a simple mechanism to do negative sampling.

The interface looks like the following:

```
loader = LinkNeighborLoader(..., neg_sampling_ratio=neg_sampling_ratio)
```

Then each batch returned will have `int(neg_sampling_ratio)*batch_size` negative samples, and 
`batch_size - int(neg_sampling_ratio)*batch_size` positive samples.

> Note that the sampling is not checked for false negatives
