### PR TITLE
Fix `from_networkx` in case where attributes are tensors

### DIFF
--- a/test/utils/test_convert.py
+++ b/test/utils/test_convert.py
@@ -68,26 +68,24 @@ def test_to_networkx():
 
 
 @withPackage('networkx')
-def test_to_networkx_tensors():
+def test_from_networkx_set_node_attributes():
     import networkx as nx
 
     G = nx.path_graph(3)
     attrs = {
         0: {
-            "attr1": torch.tensor([1, 1], dtype=torch.int64)
+            'x': torch.tensor([1, 0, 0])
         },
         1: {
-            "attr1": torch.tensor([1, 1], dtype=torch.int64)
+            'x': torch.tensor([0, 1, 0])
         },
         2: {
-            "attr1": torch.tensor([0, 1], dtype=torch.int64)
-        }
+            'x': torch.tensor([0, 0, 1])
+        },
     }
     nx.set_node_attributes(G, attrs)
 
-    data = from_networkx(G, group_node_attrs=['attr1'])
-
-    assert torch.allclose(data.x, torch.tensor([[1, 1], [1, 1], [0, 1]]))
+    assert from_networkx(G).x.tolist() == [[1, 0, 0], [0, 1, 0], [0, 0, 1]]
 
 
 @withPackage('networkx')

--- a/test/utils/test_convert.py
+++ b/test/utils/test_convert.py
@@ -68,6 +68,29 @@ def test_to_networkx():
 
 
 @withPackage('networkx')
+def test_to_networkx_tensors():
+    import networkx as nx
+
+    G = nx.path_graph(3)
+    attrs = {
+        0: {
+            "attr1": torch.tensor([1, 1], dtype=torch.int64)
+        },
+        1: {
+            "attr1": torch.tensor([1, 1], dtype=torch.int64)
+        },
+        2: {
+            "attr1": torch.tensor([0, 1], dtype=torch.int64)
+        }
+    }
+    nx.set_node_attributes(G, attrs)
+
+    data = from_networkx(G, group_node_attrs=['attr1'])
+
+    assert torch.allclose(data.x, torch.tensor([[1, 1], [1, 1], [0, 1]]))
+
+
+@withPackage('networkx')
 def test_to_networkx_undirected():
     import networkx as nx
 

--- a/torch_geometric/utils/convert.py
+++ b/torch_geometric/utils/convert.py
@@ -186,7 +186,11 @@ def from_networkx(G, group_node_attrs: Optional[Union[List[str], all]] = None,
 
     for key, value in data.items():
         try:
-            data[key] = torch.tensor(value)
+            if isinstance(value, List) & isinstance(value[0], Tensor):
+                value = torch.stack(value)
+            else:
+                value = torch.tensor(value)
+            data[key] = value
         except ValueError:
             pass
 

--- a/torch_geometric/utils/convert.py
+++ b/torch_geometric/utils/convert.py
@@ -185,14 +185,13 @@ def from_networkx(G, group_node_attrs: Optional[Union[List[str], all]] = None,
         data[str(key)] = value
 
     for key, value in data.items():
-        try:
-            if isinstance(value, List) & isinstance(value[0], Tensor):
-                value = torch.stack(value)
-            else:
-                value = torch.tensor(value)
-            data[key] = value
-        except ValueError:
-            pass
+        if isinstance(value, (tuple, list)) and isinstance(value[0], Tensor):
+            data[key] = torch.stack(value, dim=0)
+        else:
+            try:
+                data[key] = torch.tensor(value)
+            except ValueError:
+                pass
 
     data['edge_index'] = edge_index.view(2, -1)
     data = Data.from_dict(data)


### PR DESCRIPTION
Fixes problem reported in https://github.com/pyg-team/pytorch_geometric/issues/4445, the problem being that 

```torch.tensor([torch.Tensor([1,2,3], torch.Tensor([1,2,3]])```
 
does not work, they need to be stacked instead.