### PR TITLE
Fix `DimeNet` envelope bug with missing clamping

### DIFF
--- a/torch_geometric/nn/models/dimenet.py
+++ b/torch_geometric/nn/models/dimenet.py
@@ -64,7 +64,7 @@ class BesselBasisLayer(torch.nn.Module):
         self.freq.requires_grad_()
 
     def forward(self, dist):
-        dist = (dist.unsqueeze(-1) / self.cutoff).clamp_max(1.0)
+        dist = (dist.unsqueeze(-1) / self.cutoff).clamp(max=1.0)
         return self.envelope(dist) * (self.freq * dist).sin()
 
 

--- a/torch_geometric/nn/models/dimenet.py
+++ b/torch_geometric/nn/models/dimenet.py
@@ -64,7 +64,7 @@ class BesselBasisLayer(torch.nn.Module):
         self.freq.requires_grad_()
 
     def forward(self, dist):
-        dist = dist.unsqueeze(-1) / self.cutoff
+        dist = (dist.unsqueeze(-1) / self.cutoff).clamp_max(1.0)
         return self.envelope(dist) * (self.freq * dist).sin()
 
 


### PR DESCRIPTION
# What does this fix?

In the `Envelope` class used in the radial basis function in DimeNet, there's a bug. More precisely, the `forward()` is not clamping `d/c` to 1, as is done in the [original implementation](https://github.com/gasteigerjo/dimenet/blob/master/dimenet/model/layers/envelope.py#L23). This could lead to exploding output of the Envelope when `d/c` is around 2 (values go up to 300). This lead to numerical instability for me.

Let me know in case you have any questions.