### PR TITLE
fix minor bug in `LinkNeighborLoader` when data.x does not exist

### DIFF
--- a/torch_geometric/loader/link_neighbor_loader.py
+++ b/torch_geometric/loader/link_neighbor_loader.py
@@ -16,7 +16,7 @@ class LinkNeighborSampler(NeighborSampler):
         self.neg_sampling_ratio = neg_sampling_ratio
 
         if issubclass(self.data_cls, Data):
-            self.num_src_nodes = self.num_dst_nodes = len(data.x)
+            self.num_src_nodes = self.num_dst_nodes = data.num_nodes
         else:
             self.num_src_nodes = data[self.input_type[0]].num_nodes
             self.num_dst_nodes = data[self.input_type[-1]].num_nodes


### PR DESCRIPTION
Fixing a small bug that exists when `data.x` does not exist