### PR TITLE
Improve distance cutoff in `DimeNet`

### DIFF
--- a/torch_geometric/nn/models/dimenet.py
+++ b/torch_geometric/nn/models/dimenet.py
@@ -104,7 +104,7 @@ class SphericalBasisLayer(torch.nn.Module):
                 self.bessel_funcs.append(bessel)
 
     def forward(self, dist, angle, idx_kj):
-        dist = (dist / self.cutoff)
+        dist = dist / self.cutoff
         rbf = torch.stack([f(dist) for f in self.bessel_funcs], dim=1)
         rbf = self.envelope(dist).unsqueeze(-1) * rbf
 

--- a/torch_geometric/nn/models/dimenet.py
+++ b/torch_geometric/nn/models/dimenet.py
@@ -46,7 +46,7 @@ class Envelope(torch.nn.Module):
         x_pow_p1 = x_pow_p0 * x
         x_pow_p2 = x_pow_p1 * x
         return (1. / x + a * x_pow_p0 + b * x_pow_p1 +
-                c * x_pow_p2) * (x < 1.0).float()
+                c * x_pow_p2) * (x < 1.0).to(x.dtype)
 
 
 class BesselBasisLayer(torch.nn.Module):

--- a/torch_geometric/nn/models/dimenet.py
+++ b/torch_geometric/nn/models/dimenet.py
@@ -45,7 +45,8 @@ class Envelope(torch.nn.Module):
         x_pow_p0 = x.pow(p - 1)
         x_pow_p1 = x_pow_p0 * x
         x_pow_p2 = x_pow_p1 * x
-        return (1. / x + a * x_pow_p0 + b * x_pow_p1 + c * x_pow_p2) * (x < 1.0).float()
+        return (1. / x + a * x_pow_p0 + b * x_pow_p1 +
+                c * x_pow_p2) * (x < 1.0).float()
 
 
 class BesselBasisLayer(torch.nn.Module):

--- a/torch_geometric/nn/models/dimenet.py
+++ b/torch_geometric/nn/models/dimenet.py
@@ -45,7 +45,7 @@ class Envelope(torch.nn.Module):
         x_pow_p0 = x.pow(p - 1)
         x_pow_p1 = x_pow_p0 * x
         x_pow_p2 = x_pow_p1 * x
-        return 1. / x + a * x_pow_p0 + b * x_pow_p1 + c * x_pow_p2
+        return (1. / x + a * x_pow_p0 + b * x_pow_p1 + c * x_pow_p2) * (x < 1.0).float()
 
 
 class BesselBasisLayer(torch.nn.Module):
@@ -64,7 +64,7 @@ class BesselBasisLayer(torch.nn.Module):
         self.freq.requires_grad_()
 
     def forward(self, dist):
-        dist = (dist.unsqueeze(-1) / self.cutoff).clamp(max=1.0)
+        dist = (dist.unsqueeze(-1) / self.cutoff)
         return self.envelope(dist) * (self.freq * dist).sin()
 
 
@@ -104,7 +104,7 @@ class SphericalBasisLayer(torch.nn.Module):
                 self.bessel_funcs.append(bessel)
 
     def forward(self, dist, angle, idx_kj):
-        dist = dist / self.cutoff
+        dist = (dist / self.cutoff)
         rbf = torch.stack([f(dist) for f in self.bessel_funcs], dim=1)
         rbf = self.envelope(dist).unsqueeze(-1) * rbf
 


### PR DESCRIPTION
Currently (as per my [recent PR](https://github.com/pyg-team/pytorch_geometric/pull/4506)) the clamping of `(dist / cutoff).clamp_max(1.0)` is done outside the envelope. However, this means that we need to repeat this for each place using the envelope (e.g., the [`SphericalBasisLayer`](https://github.com/pyg-team/pytorch_geometric/blob/master/torch_geometric/nn/models/dimenet.py#L109)). The clean way to do it is to have the masking inside the envelope; this is also how it's implemented in [`DimeNet`](https://github.com/gasteigerjo/dimenet/blob/09123a0e16e728d0a0e53e6686b04f859802aa81/dimenet/model/layers/envelope.py#L23).