### PR TITLE
change dataset behaviour when dataset is overridden

### DIFF
--- a/test/data/test_dataset.py
+++ b/test/data/test_dataset.py
@@ -1,6 +1,6 @@
 import torch
 
-from torch_geometric.data import Data, HeteroData, InMemoryDataset
+from torch_geometric.data import Data, Dataset, HeteroData, InMemoryDataset
 
 
 class MyTestDataset(InMemoryDataset):
@@ -99,3 +99,40 @@ def test_hetero_in_memory_dataset():
     assert dataset[1]['paper'].x.tolist() == data2['paper'].x.tolist()
     assert (dataset[1]['paper', 'paper'].edge_index.tolist() == data2[
         'paper', 'paper'].edge_index.tolist())
+
+
+def test_override_behaviour():
+    class DS(Dataset):
+        def _download(self):
+            self.test = True
+
+        def _process(self):
+            self.test2 = True
+
+        def download(self):
+            pass
+
+        def process(self):
+            pass
+
+    class DS2(DS):
+        def _process(self):
+            self.test2 = False
+
+        def proccess(self):
+            pass
+
+    class DS3(Dataset):
+        def _download(self):
+            self.test = True
+
+    ds = DS()
+    assert ds.test
+    assert ds.test2
+
+    ds = DS2()
+    assert ds.test
+    assert not ds.test2
+
+    ds = DS3()
+    assert not hasattr(ds, "test")

--- a/torch_geometric/data/dataset.py
+++ b/torch_geometric/data/dataset.py
@@ -80,10 +80,10 @@ class Dataset(torch.utils.data.Dataset):
         self.pre_filter = pre_filter
         self._indices: Optional[Sequence] = None
 
-        if 'download' in self.__class__.__dict__:
+        if self.download.__qualname__.split(".")[0] != 'Dataset':
             self._download()
 
-        if 'process' in self.__class__.__dict__:
+        if self.process.__qualname__.split(".")[0] != 'Dataset':
             self._process()
 
     def indices(self) -> Sequence:


### PR DESCRIPTION
PR to address https://github.com/pyg-team/pytorch_geometric/issues/4567

Changes in the behavior of how 'download' and 'process' are resolved by Dataset. Prior to this change, the functions needed to be defined in the child class, after this change they only need to be implemented in some class that is not the base `Dataset`.
