### PR TITLE
Fixed an error in generated node features in `StochasticBlockModelDataset`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Added support for graph-level outputs in `to_hetero` ([#4582](https://github.com/pyg-team/pytorch_geometric/pull/4582))
 - Added `CHANGELOG.md` ([#4581](https://github.com/pyg-team/pytorch_geometric/pull/4581))
 ### Changed
+- The generated node features of `StochasticBlockModelDataset` are now ordered with respect to their labels ([#4617](https://github.com/pyg-team/pytorch_geometric/pull/4617))
 - The `bias` argument in `TAGConv` is now actually applied ([#4597](https://github.com/pyg-team/pytorch_geometric/pull/4597))
 - Fixed subclass behaviour of `process` and `download` in `Datsaet` ([#4586](https://github.com/pyg-team/pytorch_geometric/pull/4586))
 ### Removed

--- a/torch_geometric/datasets/sbm_dataset.py
+++ b/torch_geometric/datasets/sbm_dataset.py
@@ -1,6 +1,7 @@
 import os
 from typing import Callable, List, Optional, Union
 
+import numpy as np
 import torch
 from torch import Tensor
 
@@ -94,13 +95,14 @@ class StochasticBlockModelDataset(InMemoryDataset):
 
         x = None
         if self.num_channels is not None:
-            x, _ = make_classification(
+            x, y_not_sorted = make_classification(
                 n_samples=num_samples,
                 n_features=self.num_channels,
                 n_classes=num_classes,
                 weights=self.block_sizes / num_samples,
                 **self.kwargs,
             )
+            x = x[np.argsort(y_not_sorted)]
             x = torch.from_numpy(x).to(torch.float)
 
         y = torch.arange(num_classes).repeat_interleave(self.block_sizes)


### PR DESCRIPTION
If `n_clusters_per_class` in `make_classification` is bigger than 1 (default: 2), its output is not sorted with respect to the labels (`y`).