### PR TITLE
Support return embedding for MLP layer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ## [2.0.5] - 2022-MM-DD
 ### Added
-- Added support for return embedding for MLP layer ([#4625](https://github.com/pyg-team/pytorch_geometric/pull/4625))
+- Added support for returning embeddings in `MLP` models ([#4625](https://github.com/pyg-team/pytorch_geometric/pull/4625))
 - Added faster initialization of `NeighborLoader` in case edge indices are already sorted (via `is_sorted=True`) ([#4620](https://github.com/pyg-team/pytorch_geometric/pull/4620))
 - Added `AddPositionalEncoding` transform ([#4521](https://github.com/pyg-team/pytorch_geometric/pull/4521))
 - Added `HeteroData.is_undirected()` support ([#4604](https://github.com/pyg-team/pytorch_geometric/pull/4604))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ## [2.0.5] - 2022-MM-DD
 ### Added
+- Added support for return embedding for MLP layer ([#4625](https://github.com/pyg-team/pytorch_geometric/pull/4625))
 - Added faster initialization of `NeighborLoader` in case edge indices are already sorted (via `is_sorted=True`) ([#4620](https://github.com/pyg-team/pytorch_geometric/pull/4620))
 - Added `AddPositionalEncoding` transform ([#4521](https://github.com/pyg-team/pytorch_geometric/pull/4521))
 - Added `HeteroData.is_undirected()` support ([#4604](https://github.com/pyg-team/pytorch_geometric/pull/4604))

--- a/torch_geometric/nn/models/mlp.py
+++ b/torch_geometric/nn/models/mlp.py
@@ -61,9 +61,6 @@ class MLP(torch.nn.Module):
             learn additive biases. (default: :obj:`True`)
         relu_first (bool, optional): Deprecated in favor of :obj:`act_first`.
             (default: :obj:`False`)
-        return_emb (bool, optional): whether the layer will return embedding
-            as well. Embedding is defined as the output before the final
-            linear layer (default: :obj:`False`)
     """
     def __init__(
         self,
@@ -81,7 +78,6 @@ class MLP(torch.nn.Module):
         batch_norm_kwargs: Optional[Dict[str, Any]] = None,
         bias: bool = True,
         relu_first: bool = False,
-        return_emb: bool = False,
     ):
         super().__init__()
 
@@ -103,7 +99,6 @@ class MLP(torch.nn.Module):
         self.dropout = dropout
         self.act = activation_resolver(act, **(act_kwargs or {}))
         self.act_first = act_first
-        self.return_emb = return_emb
 
         self.lins = torch.nn.ModuleList()
         pairwise = zip(channel_list[:-1], channel_list[1:])
@@ -142,7 +137,7 @@ class MLP(torch.nn.Module):
             if hasattr(norm, 'reset_parameters'):
                 norm.reset_parameters()
 
-    def forward(self, x: Tensor) -> Tensor:
+    def forward(self, x: Tensor, return_emb: bool = False) -> Tensor:
         """"""
         x = self.lins[0](x)
         emb = x
@@ -156,7 +151,7 @@ class MLP(torch.nn.Module):
             x = F.dropout(x, p=self.dropout, training=self.training)
             x = lin.forward(x)
 
-        if self.return_emb:
+        if return_emb:
             return x, emb
         else:
             return x

--- a/torch_geometric/nn/models/mlp.py
+++ b/torch_geometric/nn/models/mlp.py
@@ -151,10 +151,7 @@ class MLP(torch.nn.Module):
             x = F.dropout(x, p=self.dropout, training=self.training)
             x = lin.forward(x)
 
-        if return_emb:
-            return x, emb
-        else:
-            return x
+        return x, emb if return_emb else x
 
     def __repr__(self) -> str:
         return f'{self.__class__.__name__}({str(self.channel_list)[1:-1]})'

--- a/torch_geometric/nn/models/mlp.py
+++ b/torch_geometric/nn/models/mlp.py
@@ -151,7 +151,7 @@ class MLP(torch.nn.Module):
             x = F.dropout(x, p=self.dropout, training=self.training)
             x = lin.forward(x)
 
-        return x, emb if return_emb else x
+        return (x, emb) if return_emb else x
 
     def __repr__(self) -> str:
         return f'{self.__class__.__name__}({str(self.channel_list)[1:-1]})'


### PR DESCRIPTION
The added `return_emb` layer is useful when user would like to extract embeddings along with predictions