### PR TITLE
AQSOL dataset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ## [2.0.5] - 2022-MM-DD
 ### Added
+- Added support for returning embeddings in `MLP` models ([#4625](https://github.com/pyg-team/pytorch_geometric/pull/4625))
 - Added faster initialization of `NeighborLoader` in case edge indices are already sorted (via `is_sorted=True`) ([#4620](https://github.com/pyg-team/pytorch_geometric/pull/4620))
 - Added `AddPositionalEncoding` transform ([#4521](https://github.com/pyg-team/pytorch_geometric/pull/4521))
 - Added `HeteroData.is_undirected()` support ([#4604](https://github.com/pyg-team/pytorch_geometric/pull/4604))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ## [2.0.5] - 2022-MM-DD
 ### Added
+- Added `AQSOL` datasets to `torch_geometric.datasets` ([#4626](https://github.com/pyg-team/pytorch_geometric/pull/4626))
 - Added support for returning embeddings in `MLP` models ([#4625](https://github.com/pyg-team/pytorch_geometric/pull/4625))
 - Added faster initialization of `NeighborLoader` in case edge indices are already sorted (via `is_sorted=True`) ([#4620](https://github.com/pyg-team/pytorch_geometric/pull/4620))
 - Added `AddPositionalEncoding` transform ([#4521](https://github.com/pyg-team/pytorch_geometric/pull/4521))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ## [2.0.5] - 2022-MM-DD
 ### Added
-- Added `AQSOL` datasets to `torch_geometric.datasets` ([#4626](https://github.com/pyg-team/pytorch_geometric/pull/4626))
+- Added the `AQSOL` dataset ([#4626](https://github.com/pyg-team/pytorch_geometric/pull/4626))
 - Added support for returning embeddings in `MLP` models ([#4625](https://github.com/pyg-team/pytorch_geometric/pull/4625))
 - Added faster initialization of `NeighborLoader` in case edge indices are already sorted (via `is_sorted=True`) ([#4620](https://github.com/pyg-team/pytorch_geometric/pull/4620))
 - Added `AddPositionalEncoding` transform ([#4521](https://github.com/pyg-team/pytorch_geometric/pull/4521))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 ## [2.0.5] - 2022-MM-DD
 ### Added
 - Added the `AQSOL` dataset ([#4626](https://github.com/pyg-team/pytorch_geometric/pull/4626))
+- Added `HeteroData.node_items()` and `HeteroData.edge_items()` functionality ([#4644](https://github.com/pyg-team/pytorch_geometric/pull/4644))
+- Added PyTorch Lightning support in GraphGym ([#4531](https://github.com/pyg-team/pytorch_geometric/pull/4531))
 - Added support for returning embeddings in `MLP` models ([#4625](https://github.com/pyg-team/pytorch_geometric/pull/4625))
 - Added faster initialization of `NeighborLoader` in case edge indices are already sorted (via `is_sorted=True`) ([#4620](https://github.com/pyg-team/pytorch_geometric/pull/4620))
 - Added `AddPositionalEncoding` transform ([#4521](https://github.com/pyg-team/pytorch_geometric/pull/4521))

--- a/torch_geometric/datasets/__init__.py
+++ b/torch_geometric/datasets/__init__.py
@@ -17,6 +17,7 @@ from .qm7 import QM7b
 from .qm9 import QM9
 from .md17 import MD17
 from .zinc import ZINC
+from .aqsol import AQSOL
 from .molecule_net import MoleculeNet
 from .entities import Entities
 from .rel_link_pred_dataset import RelLinkPredDataset
@@ -99,6 +100,7 @@ __all__ = [
     'QM9',
     'MD17',
     'ZINC',
+    'AQSOL',
     'MoleculeNet',
     'Entities',
     'RelLinkPredDataset',

--- a/torch_geometric/datasets/aqsol.py
+++ b/torch_geometric/datasets/aqsol.py
@@ -1,0 +1,133 @@
+import os
+import os.path as osp
+import shutil
+import pickle
+
+import torch
+from tqdm import tqdm
+from torch_geometric.data import (InMemoryDataset, Data, download_url,
+                                  extract_zip)
+
+
+class AQSOL(InMemoryDataset):
+    r"""The AQSOL dataset from `Benchmarking GNNs <http://arxiv.org/abs/2003.00982>`_,
+    based on `AqSolDB <https://www.nature.com/articles/s41597-019-0151-1>`
+    which is a standardized database of 9,982 molecular graphs with
+    their aqueous solubility values, collected from 9 different data sources. 
+    
+    The aqueous solubility targets are collected from experimental measurements and standardized
+    to LogS units in AqSolDB. These final values as the property to regress in the AQSOL dataset
+    which is the resultant collection in Benchmarking GNNs after filtering out few graphs
+    with no bonds/edges and a small number of graphs with missing node feature values.
+    
+    Thus, the total molecular graphs are 9,823. For each molecular graph, the node features are the
+    types of heavy atoms and the edge features are the types of bonds between them, similar as ZINC.
+    
+    Size of Dataset: 9,982 molecules.
+    Split: Scaffold split (8:1:1) following same code as OGB.
+    After cleaning: 7,831 train / 996 val / 996 test
+    Number of (unique) atoms: 65
+    Number of (unique) bonds: 5
+    Performance Metric: MAE, same as ZINC
+
+    Atom Dict: {'Br': 0, 'C': 1, 'N': 2, 'O': 3, 'Cl': 4, 'Zn': 5, 'F': 6, 'P': 7, 'S': 8, 'Na': 9, 'Al': 10,
+    'Si': 11, 'Mo': 12, 'Ca': 13, 'W': 14, 'Pb': 15, 'B': 16, 'V': 17, 'Co': 18, 'Mg': 19, 'Bi': 20, 'Fe': 21,
+    'Ba': 22, 'K': 23, 'Ti': 24, 'Sn': 25, 'Cd': 26, 'I': 27, 'Re': 28, 'Sr': 29, 'H': 30, 'Cu': 31, 'Ni': 32,
+    'Lu': 33, 'Pr': 34, 'Te': 35, 'Ce': 36, 'Nd': 37, 'Gd': 38, 'Zr': 39, 'Mn': 40, 'As': 41, 'Hg': 42, 'Sb':
+    43, 'Cr': 44, 'Se': 45, 'La': 46, 'Dy': 47, 'Y': 48, 'Pd': 49, 'Ag': 50, 'In': 51, 'Li': 52, 'Rh': 53,
+    'Nb': 54, 'Hf': 55, 'Cs': 56, 'Ru': 57, 'Au': 58, 'Sm': 59, 'Ta': 60, 'Pt': 61, 'Ir': 62, 'Be': 63, 'Ge': 64}
+    
+    Bond Dict: {'NONE': 0, 'SINGLE': 1, 'DOUBLE': 2, 'AROMATIC': 3, 'TRIPLE': 4}
+
+    Args:
+        root (string): Root directory where the dataset should be saved.
+        transform (callable, optional): A function/transform that takes in an
+            :obj:`torch_geometric.data.Data` object and returns a transformed
+            version. The data object will be transformed before every access.
+            (default: :obj:`None`)
+        pre_transform (callable, optional): A function/transform that takes in
+            an :obj:`torch_geometric.data.Data` object and returns a
+            transformed version. The data object will be transformed before
+            being saved to disk. (default: :obj:`None`)
+        pre_filter (callable, optional): A function that takes in an
+            :obj:`torch_geometric.data.Data` object and returns a boolean
+            value, indicating whether the data object should be included in the
+            final dataset. (default: :obj:`None`)
+    """
+    
+    url = 'https://www.dropbox.com/s/lzu9lmukwov12kt/aqsol_graph_raw.zip?dl=1'
+
+    def __init__(self, root, split='train', transform=None, pre_transform=None,
+                 pre_filter=None):
+        self.name = "AQSOL"
+        assert split in ['train', 'val', 'test']
+        super().__init__(root, transform, pre_transform, pre_filter)
+        path = osp.join(self.processed_dir, f'{split}.pt')
+        self.data, self.slices = torch.load(path)
+        
+    
+    @property
+    def raw_file_names(self):
+        return ['train.pickle', 'val.pickle', 'test.pickle']
+    
+    @property
+    def processed_file_names(self):
+        return ['train.pt', 'val.pt', 'test.pt']
+
+    def download(self):
+        shutil.rmtree(self.raw_dir)
+        path = download_url(self.url, self.root)
+        extract_zip(path, self.root)
+        os.rename(osp.join(self.root, 'asqol_graph_raw'), self.raw_dir)
+        os.unlink(path)
+    
+    def process(self):
+        for split in ['train', 'val', 'test']:
+            with open(osp.join(self.raw_dir, f'{split}.pickle'), 'rb') as f:
+                graphs = pickle.load(f)
+
+            indices = range(len(graphs))
+
+            pbar = tqdm(total=len(indices))
+            pbar.set_description(f'Processing {split} dataset')
+
+            data_list = []
+            for idx in indices:
+                graph = graphs[idx] 
+                
+                """
+                Each `graph` is a tuple (x, edge_attr, edge_index, y)
+                    Shape of x : [num_nodes, 1]
+                    Shape of edge_attr : [num_edges]
+                    Shape of edge_index : [2, num_edges]
+                    Shape of y : [1]
+                """
+                
+                x = torch.LongTensor(graph[0]).unsqueeze(-1)
+                edge_attr = torch.LongTensor(graph[1])#.unsqueeze(-1)
+                edge_index = torch.LongTensor(graph[2])
+                y = torch.tensor(graph[3])
+                
+                data = Data(edge_index=edge_index)
+                
+                if edge_index.shape[1] == 0:
+                    continue # skipping for graphs with no bonds/edges
+                
+                if data.num_nodes != len(x):
+                    continue # cleaning <10 graphs with this discrepancy
+
+                data = Data(x=x, edge_index=edge_index, edge_attr=edge_attr,
+                            y=y)
+                
+                if self.pre_filter is not None and not self.pre_filter(data):
+                    continue
+
+                if self.pre_transform is not None:
+                    data = self.pre_transform(data)
+
+                data_list.append(data)
+                pbar.update(1)
+
+            pbar.close()
+            torch.save(self.collate(data_list),
+                       osp.join(self.processed_dir, f'{split}.pt'))

--- a/torch_geometric/datasets/aqsol.py
+++ b/torch_geometric/datasets/aqsol.py
@@ -33,12 +33,13 @@ class AQSOL(InMemoryDataset):
     the node features are the types of heavy atoms and the edge features
     are the types of bonds between them, similar as ZINC.
 
-    Size of Dataset: 9,982 molecules
-    Split: Scaffold split (8:1:1) following same code as OGB
-    After cleaning: 7,831 train / 996 val / 996 test
-    Number of (unique) atoms: 65
-    Number of (unique) bonds: 5
-    Performance Metric: MAE, same as ZINC
+    - Task: Graph Regression
+    - Size of Dataset: 9,982 molecules
+    - Split: Scaffold split (8:1:1) following same code as OGB
+    - After cleaning: 7,831 train / 996 val / 996 test
+    - Number of (unique) atoms: 65
+    - Number of (unique) bonds: 5
+    - Performance Metric: MAE, same as ZINC
 
     Atom Dict: {'Br': 0, 'C': 1, 'N': 2, 'O': 3, 'Cl': 4, 'Zn': 5, 'F': 6,
     'P': 7, 'S': 8, 'Na': 9, 'Al': 10, 'Si': 11, 'Mo': 12, 'Ca': 13, 'W': 14,

--- a/torch_geometric/datasets/aqsol.py
+++ b/torch_geometric/datasets/aqsol.py
@@ -1,7 +1,7 @@
 import os
 import os.path as osp
-import shutil
 import pickle
+import shutil
 
 import torch
 from tqdm import tqdm
@@ -13,20 +13,21 @@ from torch_geometric.data import (
     extract_zip,
 )
 
+
 class AQSOL(InMemoryDataset):
     r"""The AQSOL dataset from `Benchmarking GNNs <http://arxiv.org/abs/2003.00982>`_,
     based on `AqSolDB <https://www.nature.com/articles/s41597-019-0151-1>`
     which is a standardized database of 9,982 molecular graphs with
-    their aqueous solubility values, collected from 9 different data sources. 
-    
+    their aqueous solubility values, collected from 9 different data sources.
+
     The aqueous solubility targets are collected from experimental measurements and standardized
     to LogS units in AqSolDB. These final values as the property to regress in the AQSOL dataset
     which is the resultant collection in Benchmarking GNNs after filtering out few graphs
     with no bonds/edges and a small number of graphs with missing node feature values.
-    
+
     Thus, the total molecular graphs are 9,823. For each molecular graph, the node features are the
     types of heavy atoms and the edge features are the types of bonds between them, similar as ZINC.
-    
+
     Size of Dataset: 9,982 molecules.
     Split: Scaffold split (8:1:1) following same code as OGB.
     After cleaning: 7,831 train / 996 val / 996 test
@@ -40,7 +41,7 @@ class AQSOL(InMemoryDataset):
     'Lu': 33, 'Pr': 34, 'Te': 35, 'Ce': 36, 'Nd': 37, 'Gd': 38, 'Zr': 39, 'Mn': 40, 'As': 41, 'Hg': 42, 'Sb':
     43, 'Cr': 44, 'Se': 45, 'La': 46, 'Dy': 47, 'Y': 48, 'Pd': 49, 'Ag': 50, 'In': 51, 'Li': 52, 'Rh': 53,
     'Nb': 54, 'Hf': 55, 'Cs': 56, 'Ru': 57, 'Au': 58, 'Sm': 59, 'Ta': 60, 'Pt': 61, 'Ir': 62, 'Be': 63, 'Ge': 64}
-    
+
     Bond Dict: {'NONE': 0, 'SINGLE': 1, 'DOUBLE': 2, 'AROMATIC': 3, 'TRIPLE': 4}
 
     Args:
@@ -58,7 +59,7 @@ class AQSOL(InMemoryDataset):
             value, indicating whether the data object should be included in the
             final dataset. (default: :obj:`None`)
     """
-    
+
     url = 'https://www.dropbox.com/s/lzu9lmukwov12kt/aqsol_graph_raw.zip?dl=1'
 
     def __init__(self, root, split='train', transform=None, pre_transform=None,
@@ -68,12 +69,11 @@ class AQSOL(InMemoryDataset):
         super().__init__(root, transform, pre_transform, pre_filter)
         path = osp.join(self.processed_dir, f'{split}.pt')
         self.data, self.slices = torch.load(path)
-        
-    
+
     @property
     def raw_file_names(self):
         return ['train.pickle', 'val.pickle', 'test.pickle']
-    
+
     @property
     def processed_file_names(self):
         return ['train.pt', 'val.pt', 'test.pt']
@@ -84,7 +84,7 @@ class AQSOL(InMemoryDataset):
         extract_zip(path, self.root)
         os.rename(osp.join(self.root, 'asqol_graph_raw'), self.raw_dir)
         os.unlink(path)
-    
+
     def process(self):
         for split in ['train', 'val', 'test']:
             with open(osp.join(self.raw_dir, f'{split}.pickle'), 'rb') as f:
@@ -97,8 +97,7 @@ class AQSOL(InMemoryDataset):
 
             data_list = []
             for idx in indices:
-                graph = graphs[idx] 
-                
+                graph = graphs[idx]
                 """
                 Each `graph` is a tuple (x, edge_attr, edge_index, y)
                     Shape of x : [num_nodes, 1]
@@ -106,23 +105,23 @@ class AQSOL(InMemoryDataset):
                     Shape of edge_index : [2, num_edges]
                     Shape of y : [1]
                 """
-                
+
                 x = torch.LongTensor(graph[0]).unsqueeze(-1)
-                edge_attr = torch.LongTensor(graph[1])#.unsqueeze(-1)
+                edge_attr = torch.LongTensor(graph[1])  #.unsqueeze(-1)
                 edge_index = torch.LongTensor(graph[2])
                 y = torch.tensor(graph[3])
-                
+
                 data = Data(edge_index=edge_index)
-                
+
                 if edge_index.shape[1] == 0:
-                    continue # skipping for graphs with no bonds/edges
-                
+                    continue  # skipping for graphs with no bonds/edges
+
                 if data.num_nodes != len(x):
-                    continue # cleaning <10 graphs with this discrepancy
+                    continue  # cleaning <10 graphs with this discrepancy
 
                 data = Data(x=x, edge_index=edge_index, edge_attr=edge_attr,
                             y=y)
-                
+
                 if self.pre_filter is not None and not self.pre_filter(data):
                     continue
 

--- a/torch_geometric/datasets/aqsol.py
+++ b/torch_geometric/datasets/aqsol.py
@@ -15,18 +15,18 @@ from torch_geometric.data import (
 
 
 class AQSOL(InMemoryDataset):
-    r"""The AQSOL dataset from `Benchmarking GNNs 
+    r"""The AQSOL dataset from `Benchmarking GNNs
     <http://arxiv.org/abs/2003.00982>`_,
     based on `AqSolDB <https://www.nature.com/articles/s41597-019-0151-1>`
     which is a standardized database of 9,982 molecular graphs with
     their aqueous solubility values, collected from 9 different data
     sources.
 
-    The aqueous solubility targets are collected from experimental 
+    The aqueous solubility targets are collected from experimental
     measurements and standardized to LogS units in AqSolDB. These final
     values as the property to regress in the AQSOL dataset which is the
     resultant collection in Benchmarking GNNs after filtering out few graphs
-    with no bonds/edges and a small number of graphs with missing node 
+    with no bonds/edges and a small number of graphs with missing node
     feature values.
 
     Thus, the total molecular graphs are 9,823. For each molecular graph,
@@ -42,7 +42,7 @@ class AQSOL(InMemoryDataset):
 
     Atom Dict: {'Br': 0, 'C': 1, 'N': 2, 'O': 3, 'Cl': 4, 'Zn': 5, 'F': 6,
     'P': 7, 'S': 8, 'Na': 9, 'Al': 10, 'Si': 11, 'Mo': 12, 'Ca': 13, 'W': 14,
-    'Pb': 15, 'B': 16, 'V': 17, 'Co': 18, 'Mg': 19, 'Bi': 20, 'Fe': 21, 
+    'Pb': 15, 'B': 16, 'V': 17, 'Co': 18, 'Mg': 19, 'Bi': 20, 'Fe': 21,
     'Ba': 22, 'K': 23, 'Ti': 24, 'Sn': 25, 'Cd': 26, 'I': 27, 'Re': 28,
     'Sr': 29, 'H': 30, 'Cu': 31, 'Ni': 32, 'Lu': 33, 'Pr': 34, 'Te': 35,
     'Ce': 36, 'Nd': 37, 'Gd': 38, 'Zr': 39, 'Mn': 40, 'As': 41, 'Hg': 42,
@@ -51,7 +51,7 @@ class AQSOL(InMemoryDataset):
     'Ru': 57, 'Au': 58, 'Sm': 59, 'Ta': 60, 'Pt': 61, 'Ir': 62, 'Be': 63,
     'Ge': 64}
 
-    Bond Dict: {'NONE': 0, 'SINGLE': 1, 'DOUBLE': 2, 'AROMATIC': 3, 
+    Bond Dict: {'NONE': 0, 'SINGLE': 1, 'DOUBLE': 2, 'AROMATIC': 3,
     'TRIPLE': 4}
 
     Args:
@@ -72,8 +72,8 @@ class AQSOL(InMemoryDataset):
 
     url = 'https://www.dropbox.com/s/lzu9lmukwov12kt/aqsol_graph_raw.zip?dl=1'
 
-    def __init__(self, root, split='train', transform=None, 
-                 pre_transform=None, pre_filter=None):
+    def __init__(self, root, split='train', transform=None, pre_transform=None,
+                 pre_filter=None):
         self.name = "AQSOL"
         assert split in ['train', 'val', 'test']
         super().__init__(root, transform, pre_transform, pre_filter)
@@ -116,7 +116,7 @@ class AQSOL(InMemoryDataset):
                 #     Shape of y : [1]
 
                 x = torch.LongTensor(graph[0]).unsqueeze(-1)
-                edge_attr = torch.LongTensor(graph[1])  
+                edge_attr = torch.LongTensor(graph[1])
                 edge_index = torch.LongTensor(graph[2])
                 y = torch.tensor(graph[3])
 

--- a/torch_geometric/datasets/aqsol.py
+++ b/torch_geometric/datasets/aqsol.py
@@ -33,12 +33,12 @@ class AQSOL(InMemoryDataset):
     the node features are the types of heavy atoms and the edge features
     are the types of bonds between them, similar as ZINC.
 
-    Size of Dataset: 9,982 molecules  
-    Split: Scaffold split (8:1:1) following same code as OGB  
-    After cleaning: 7,831 train / 996 val / 996 test  
-    Number of (unique) atoms: 65  
-    Number of (unique) bonds: 5  
-    Performance Metric: MAE, same as ZINC  
+    Size of Dataset: 9,982 molecules
+    Split: Scaffold split (8:1:1) following same code as OGB
+    After cleaning: 7,831 train / 996 val / 996 test
+    Number of (unique) atoms: 65
+    Number of (unique) bonds: 5
+    Performance Metric: MAE, same as ZINC
 
     Atom Dict: {'Br': 0, 'C': 1, 'N': 2, 'O': 3, 'Cl': 4, 'Zn': 5, 'F': 6,
     'P': 7, 'S': 8, 'Na': 9, 'Al': 10, 'Si': 11, 'Mo': 12, 'Ca': 13, 'W': 14,

--- a/torch_geometric/datasets/aqsol.py
+++ b/torch_geometric/datasets/aqsol.py
@@ -2,9 +2,9 @@ import os
 import os.path as osp
 import pickle
 import shutil
+from typing import Optional, Callable, List
 
 import torch
-from tqdm import tqdm
 
 from torch_geometric.data import (
     Data,
@@ -15,48 +15,27 @@ from torch_geometric.data import (
 
 
 class AQSOL(InMemoryDataset):
-    r"""The AQSOL dataset from `Benchmarking GNNs
-    <http://arxiv.org/abs/2003.00982>`_,
-    based on `AqSolDB <https://www.nature.com/articles/s41597-019-0151-1>`_
-    which is a standardized database of 9,982 molecular graphs with
-    their aqueous solubility values, collected from 9 different data
-    sources.
+    r"""The AQSOL dataset from the `Benchmarking Graph Neural Networks
+    <http://arxiv.org/abs/2003.00982>`_ paper based on
+    `AqSolDB <https://www.nature.com/articles/s41597-019-0151-1>`_, a
+    standardized database of 9,982 molecular graphs with their aqueous
+    solubility values, collected from 9 different data sources.
 
-    The aqueous solubility targets are collected from experimental
-    measurements and standardized to LogS units in AqSolDB. These final
-    values as the property to regress in the AQSOL dataset which is the
-    resultant collection in Benchmarking GNNs after filtering out few graphs
-    with no bonds/edges and a small number of graphs with missing node
-    feature values.
-
-    Thus, the total molecular graphs are 9,823. For each molecular graph,
-    the node features are the types of heavy atoms and the edge features
-    are the types of bonds between them, similar as ZINC.
-
-    - Task: Graph Regression
-    - Size of Dataset: 9,982 molecules
-    - Split: Scaffold split (8:1:1) following same code as OGB
-    - After cleaning: 7,831 train / 996 val / 996 test
-    - Number of (unique) atoms: 65
-    - Number of (unique) bonds: 5
-    - Performance Metric: MAE, same as ZINC
-
-    Atom Dict: {'Br': 0, 'C': 1, 'N': 2, 'O': 3, 'Cl': 4, 'Zn': 5, 'F': 6,
-    'P': 7, 'S': 8, 'Na': 9, 'Al': 10, 'Si': 11, 'Mo': 12, 'Ca': 13, 'W': 14,
-    'Pb': 15, 'B': 16, 'V': 17, 'Co': 18, 'Mg': 19, 'Bi': 20, 'Fe': 21,
-    'Ba': 22, 'K': 23, 'Ti': 24, 'Sn': 25, 'Cd': 26, 'I': 27, 'Re': 28,
-    'Sr': 29, 'H': 30, 'Cu': 31, 'Ni': 32, 'Lu': 33, 'Pr': 34, 'Te': 35,
-    'Ce': 36, 'Nd': 37, 'Gd': 38, 'Zr': 39, 'Mn': 40, 'As': 41, 'Hg': 42,
-    'Sb': 43, 'Cr': 44, 'Se': 45, 'La': 46, 'Dy': 47, 'Y': 48, 'Pd': 49,
-    'Ag': 50, 'In': 51, 'Li': 52, 'Rh': 53, 'Nb': 54, 'Hf': 55, 'Cs': 56,
-    'Ru': 57, 'Au': 58, 'Sm': 59, 'Ta': 60, 'Pt': 61, 'Ir': 62, 'Be': 63,
-    'Ge': 64}
-
-    Bond Dict: {'NONE': 0, 'SINGLE': 1, 'DOUBLE': 2, 'AROMATIC': 3,
-    'TRIPLE': 4}
+    The aqueous solubility targets are collected from experimental measurements
+    and standardized to LogS units in AqSolDB. These final values denote the
+    property to regress in the :class:`AQSOL` dataset. After filtering out few
+    graphs with no bonds/edges, the total number of molecular graphs is 9,833.
+    For each molecular graph, the node features are the types of heavy atoms
+    and the edge features are the types of bonds between them, similar as in
+    the :class:`~torch_geometric.datasets.ZINC` dataset.
 
     Args:
         root (string): Root directory where the dataset should be saved.
+        split (string, optional): If :obj:`"train"`, loads the training
+            dataset.
+            If :obj:`"val"`, loads the validation dataset.
+            If :obj:`"test"`, loads the test dataset.
+            (default: :obj:`"train"`)
         transform (callable, optional): A function/transform that takes in an
             :obj:`torch_geometric.data.Data` object and returns a transformed
             version. The data object will be transformed before every access.
@@ -70,23 +49,26 @@ class AQSOL(InMemoryDataset):
             value, indicating whether the data object should be included in
             the final dataset. (default: :obj:`None`)
     """
-
     url = 'https://www.dropbox.com/s/lzu9lmukwov12kt/aqsol_graph_raw.zip?dl=1'
 
-    def __init__(self, root, split='train', transform=None, pre_transform=None,
-                 pre_filter=None):
-        self.name = "AQSOL"
+    def __init__(self, root: str, split: str = 'train',
+                 transform: Optional[Callable] = None,
+                 pre_transform: Optional[Callable] = None,
+                 pre_filter: Optional[Callable] = None):
         assert split in ['train', 'val', 'test']
         super().__init__(root, transform, pre_transform, pre_filter)
         path = osp.join(self.processed_dir, f'{split}.pt')
         self.data, self.slices = torch.load(path)
 
     @property
-    def raw_file_names(self):
-        return ['train.pickle', 'val.pickle', 'test.pickle']
+    def raw_file_names(self) -> List[str]:
+        return [
+            'train.pickle', 'val.pickle', 'test.pickle', 'atom_dict.pickle',
+            'bond_dict.pickle'
+        ]
 
     @property
-    def processed_file_names(self):
+    def processed_file_names(self) -> List[str]:
         return ['train.pt', 'val.pt', 'test.pt']
 
     def download(self):
@@ -97,39 +79,21 @@ class AQSOL(InMemoryDataset):
         os.unlink(path)
 
     def process(self):
-        for split in ['train', 'val', 'test']:
-            with open(osp.join(self.raw_dir, f'{split}.pickle'), 'rb') as f:
+        for raw_path, path in zip(self.raw_paths, self.processed_paths):
+            with open(raw_path, 'rb') as f:
                 graphs = pickle.load(f)
 
-            indices = range(len(graphs))
+            data_list: List[Data] = []
+            for graph in graphs:
+                x, edge_attr, edge_index, y = graph
 
-            pbar = tqdm(total=len(indices))
-            pbar.set_description(f'Processing {split} dataset')
+                x = torch.from_numpy(x)
+                edge_attr = torch.from_numpy(edge_attr)
+                edge_index = torch.from_numpy(edge_index)
+                y = torch.tensor([y]).float()
 
-            data_list = []
-            for idx in indices:
-                graph = graphs[idx]
-
-                # Each `graph` is a tuple (x, edge_attr, edge_index, y)
-                #     Shape of x : [num_nodes, 1]
-                #     Shape of edge_attr : [num_edges]
-                #     Shape of edge_index : [2, num_edges]
-                #     Shape of y : [1]
-
-                x = torch.LongTensor(graph[0]).unsqueeze(-1)
-                edge_attr = torch.LongTensor(graph[1])
-                edge_index = torch.LongTensor(graph[2])
-                y = torch.tensor(graph[3])
-
-                data = Data(edge_index=edge_index)
-
-                if edge_index.shape[1] == 0:
-                    continue
-                    # skipping for graphs with no bonds/edges
-
-                if data.num_nodes != len(x):
-                    continue
-                    # cleaning <10 graphs with this discrepancy
+                if edge_index.numel() == 0:
+                    continue  # Skipping for graphs with no bonds/edges.
 
                 data = Data(x=x, edge_index=edge_index, edge_attr=edge_attr,
                             y=y)
@@ -141,8 +105,18 @@ class AQSOL(InMemoryDataset):
                     data = self.pre_transform(data)
 
                 data_list.append(data)
-                pbar.update(1)
 
-            pbar.close()
-            torch.save(self.collate(data_list),
-                       osp.join(self.processed_dir, f'{split}.pt'))
+            torch.save(self.collate(data_list), path)
+
+    def atoms(self) -> List[str]:
+        return [
+            'Br', 'C', 'N', 'O', 'Cl', 'Zn', 'F', 'P', 'S', 'Na', 'Al', 'Si',
+            'Mo', 'Ca', 'W', 'Pb', 'B', 'V', 'Co', 'Mg', 'Bi', 'Fe', 'Ba', 'K',
+            'Ti', 'Sn', 'Cd', 'I', 'Re', 'Sr', 'H', 'Cu', 'Ni', 'Lu', 'Pr',
+            'Te', 'Ce', 'Nd', 'Gd', 'Zr', 'Mn', 'As', 'Hg', 'Sb', 'Cr', 'Se',
+            'La', 'Dy', 'Y', 'Pd', 'Ag', 'In', 'Li', 'Rh', 'Nb', 'Hf', 'Cs',
+            'Ru', 'Au', 'Sm', 'Ta', 'Pt', 'Ir', 'Be', 'Ge'
+        ]
+
+    def bonds(self) -> List[str]:
+        return ['NONE', 'SINGLE', 'DOUBLE', 'AROMATIC', 'TRIPLE']

--- a/torch_geometric/datasets/aqsol.py
+++ b/torch_geometric/datasets/aqsol.py
@@ -5,9 +5,13 @@ import pickle
 
 import torch
 from tqdm import tqdm
-from torch_geometric.data import (InMemoryDataset, Data, download_url,
-                                  extract_zip)
 
+from torch_geometric.data import (
+    Data,
+    InMemoryDataset,
+    download_url,
+    extract_zip,
+)
 
 class AQSOL(InMemoryDataset):
     r"""The AQSOL dataset from `Benchmarking GNNs <http://arxiv.org/abs/2003.00982>`_,

--- a/torch_geometric/datasets/aqsol.py
+++ b/torch_geometric/datasets/aqsol.py
@@ -98,13 +98,12 @@ class AQSOL(InMemoryDataset):
             data_list = []
             for idx in indices:
                 graph = graphs[idx]
-                """
-                Each `graph` is a tuple (x, edge_attr, edge_index, y)
-                    Shape of x : [num_nodes, 1]
-                    Shape of edge_attr : [num_edges]
-                    Shape of edge_index : [2, num_edges]
-                    Shape of y : [1]
-                """
+
+                # Each `graph` is a tuple (x, edge_attr, edge_index, y)
+                #     Shape of x : [num_nodes, 1]
+                #     Shape of edge_attr : [num_edges]
+                #     Shape of edge_index : [2, num_edges]
+                #     Shape of y : [1]
 
                 x = torch.LongTensor(graph[0]).unsqueeze(-1)
                 edge_attr = torch.LongTensor(graph[1])  #.unsqueeze(-1)

--- a/torch_geometric/datasets/aqsol.py
+++ b/torch_geometric/datasets/aqsol.py
@@ -2,7 +2,7 @@ import os
 import os.path as osp
 import pickle
 import shutil
-from typing import Optional, Callable, List
+from typing import Callable, List, Optional
 
 import torch
 

--- a/torch_geometric/datasets/aqsol.py
+++ b/torch_geometric/datasets/aqsol.py
@@ -15,18 +15,23 @@ from torch_geometric.data import (
 
 
 class AQSOL(InMemoryDataset):
-    r"""The AQSOL dataset from `Benchmarking GNNs <http://arxiv.org/abs/2003.00982>`_,
+    r"""The AQSOL dataset from `Benchmarking GNNs 
+    <http://arxiv.org/abs/2003.00982>`_,
     based on `AqSolDB <https://www.nature.com/articles/s41597-019-0151-1>`
     which is a standardized database of 9,982 molecular graphs with
-    their aqueous solubility values, collected from 9 different data sources.
+    their aqueous solubility values, collected from 9 different data
+    sources.
 
-    The aqueous solubility targets are collected from experimental measurements and standardized
-    to LogS units in AqSolDB. These final values as the property to regress in the AQSOL dataset
-    which is the resultant collection in Benchmarking GNNs after filtering out few graphs
-    with no bonds/edges and a small number of graphs with missing node feature values.
+    The aqueous solubility targets are collected from experimental 
+    measurements and standardized to LogS units in AqSolDB. These final
+    values as the property to regress in the AQSOL dataset which is the
+    resultant collection in Benchmarking GNNs after filtering out few graphs
+    with no bonds/edges and a small number of graphs with missing node 
+    feature values.
 
-    Thus, the total molecular graphs are 9,823. For each molecular graph, the node features are the
-    types of heavy atoms and the edge features are the types of bonds between them, similar as ZINC.
+    Thus, the total molecular graphs are 9,823. For each molecular graph,
+    the node features are the types of heavy atoms and the edge features
+    are the types of bonds between them, similar as ZINC.
 
     Size of Dataset: 9,982 molecules.
     Split: Scaffold split (8:1:1) following same code as OGB.
@@ -35,14 +40,19 @@ class AQSOL(InMemoryDataset):
     Number of (unique) bonds: 5
     Performance Metric: MAE, same as ZINC
 
-    Atom Dict: {'Br': 0, 'C': 1, 'N': 2, 'O': 3, 'Cl': 4, 'Zn': 5, 'F': 6, 'P': 7, 'S': 8, 'Na': 9, 'Al': 10,
-    'Si': 11, 'Mo': 12, 'Ca': 13, 'W': 14, 'Pb': 15, 'B': 16, 'V': 17, 'Co': 18, 'Mg': 19, 'Bi': 20, 'Fe': 21,
-    'Ba': 22, 'K': 23, 'Ti': 24, 'Sn': 25, 'Cd': 26, 'I': 27, 'Re': 28, 'Sr': 29, 'H': 30, 'Cu': 31, 'Ni': 32,
-    'Lu': 33, 'Pr': 34, 'Te': 35, 'Ce': 36, 'Nd': 37, 'Gd': 38, 'Zr': 39, 'Mn': 40, 'As': 41, 'Hg': 42, 'Sb':
-    43, 'Cr': 44, 'Se': 45, 'La': 46, 'Dy': 47, 'Y': 48, 'Pd': 49, 'Ag': 50, 'In': 51, 'Li': 52, 'Rh': 53,
-    'Nb': 54, 'Hf': 55, 'Cs': 56, 'Ru': 57, 'Au': 58, 'Sm': 59, 'Ta': 60, 'Pt': 61, 'Ir': 62, 'Be': 63, 'Ge': 64}
+    Atom Dict: {'Br': 0, 'C': 1, 'N': 2, 'O': 3, 'Cl': 4, 'Zn': 5, 'F': 6,
+    'P': 7, 'S': 8, 'Na': 9, 'Al': 10, 'Si': 11, 'Mo': 12, 'Ca': 13, 'W': 14,
+    'Pb': 15, 'B': 16, 'V': 17, 'Co': 18, 'Mg': 19, 'Bi': 20, 'Fe': 21, 
+    'Ba': 22, 'K': 23, 'Ti': 24, 'Sn': 25, 'Cd': 26, 'I': 27, 'Re': 28,
+    'Sr': 29, 'H': 30, 'Cu': 31, 'Ni': 32, 'Lu': 33, 'Pr': 34, 'Te': 35,
+    'Ce': 36, 'Nd': 37, 'Gd': 38, 'Zr': 39, 'Mn': 40, 'As': 41, 'Hg': 42,
+    'Sb': 43, 'Cr': 44, 'Se': 45, 'La': 46, 'Dy': 47, 'Y': 48, 'Pd': 49,
+    'Ag': 50, 'In': 51, 'Li': 52, 'Rh': 53, 'Nb': 54, 'Hf': 55, 'Cs': 56,
+    'Ru': 57, 'Au': 58, 'Sm': 59, 'Ta': 60, 'Pt': 61, 'Ir': 62, 'Be': 63,
+    'Ge': 64}
 
-    Bond Dict: {'NONE': 0, 'SINGLE': 1, 'DOUBLE': 2, 'AROMATIC': 3, 'TRIPLE': 4}
+    Bond Dict: {'NONE': 0, 'SINGLE': 1, 'DOUBLE': 2, 'AROMATIC': 3, 
+    'TRIPLE': 4}
 
     Args:
         root (string): Root directory where the dataset should be saved.
@@ -56,14 +66,14 @@ class AQSOL(InMemoryDataset):
             being saved to disk. (default: :obj:`None`)
         pre_filter (callable, optional): A function that takes in an
             :obj:`torch_geometric.data.Data` object and returns a boolean
-            value, indicating whether the data object should be included in the
-            final dataset. (default: :obj:`None`)
+            value, indicating whether the data object should be included in
+            the final dataset. (default: :obj:`None`)
     """
 
     url = 'https://www.dropbox.com/s/lzu9lmukwov12kt/aqsol_graph_raw.zip?dl=1'
 
-    def __init__(self, root, split='train', transform=None, pre_transform=None,
-                 pre_filter=None):
+    def __init__(self, root, split='train', transform=None, 
+                 pre_transform=None, pre_filter=None):
         self.name = "AQSOL"
         assert split in ['train', 'val', 'test']
         super().__init__(root, transform, pre_transform, pre_filter)
@@ -106,17 +116,19 @@ class AQSOL(InMemoryDataset):
                 #     Shape of y : [1]
 
                 x = torch.LongTensor(graph[0]).unsqueeze(-1)
-                edge_attr = torch.LongTensor(graph[1])  #.unsqueeze(-1)
+                edge_attr = torch.LongTensor(graph[1])  
                 edge_index = torch.LongTensor(graph[2])
                 y = torch.tensor(graph[3])
 
                 data = Data(edge_index=edge_index)
 
                 if edge_index.shape[1] == 0:
-                    continue  # skipping for graphs with no bonds/edges
+                    continue
+                    # skipping for graphs with no bonds/edges
 
                 if data.num_nodes != len(x):
-                    continue  # cleaning <10 graphs with this discrepancy
+                    continue
+                    # cleaning <10 graphs with this discrepancy
 
                 data = Data(x=x, edge_index=edge_index, edge_attr=edge_attr,
                             y=y)

--- a/torch_geometric/datasets/aqsol.py
+++ b/torch_geometric/datasets/aqsol.py
@@ -17,7 +17,7 @@ from torch_geometric.data import (
 class AQSOL(InMemoryDataset):
     r"""The AQSOL dataset from `Benchmarking GNNs
     <http://arxiv.org/abs/2003.00982>`_,
-    based on `AqSolDB <https://www.nature.com/articles/s41597-019-0151-1>`
+    based on `AqSolDB <https://www.nature.com/articles/s41597-019-0151-1>`_
     which is a standardized database of 9,982 molecular graphs with
     their aqueous solubility values, collected from 9 different data
     sources.
@@ -33,12 +33,12 @@ class AQSOL(InMemoryDataset):
     the node features are the types of heavy atoms and the edge features
     are the types of bonds between them, similar as ZINC.
 
-    Size of Dataset: 9,982 molecules.
-    Split: Scaffold split (8:1:1) following same code as OGB.
-    After cleaning: 7,831 train / 996 val / 996 test
-    Number of (unique) atoms: 65
-    Number of (unique) bonds: 5
-    Performance Metric: MAE, same as ZINC
+    Size of Dataset: 9,982 molecules  
+    Split: Scaffold split (8:1:1) following same code as OGB  
+    After cleaning: 7,831 train / 996 val / 996 test  
+    Number of (unique) atoms: 65  
+    Number of (unique) bonds: 5  
+    Performance Metric: MAE, same as ZINC  
 
     Atom Dict: {'Br': 0, 'C': 1, 'N': 2, 'O': 3, 'Cl': 4, 'Zn': 5, 'F': 6,
     'P': 7, 'S': 8, 'Na': 9, 'Al': 10, 'Si': 11, 'Mo': 12, 'Ca': 13, 'W': 14,

--- a/torch_geometric/nn/models/mlp.py
+++ b/torch_geometric/nn/models/mlp.py
@@ -137,10 +137,12 @@ class MLP(torch.nn.Module):
             if hasattr(norm, 'reset_parameters'):
                 norm.reset_parameters()
 
-    def forward(self, x: Tensor) -> Tensor:
+    def forward(self, x: Tensor, return_emb: bool = False) -> Tensor:
         """"""
         x = self.lins[0](x)
+        emb = x
         for lin, norm in zip(self.lins[1:], self.norms):
+            emb = x
             if self.act is not None and self.act_first:
                 x = self.act(x)
             x = norm(x)
@@ -148,7 +150,8 @@ class MLP(torch.nn.Module):
                 x = self.act(x)
             x = F.dropout(x, p=self.dropout, training=self.training)
             x = lin.forward(x)
-        return x
+
+        return (x, emb) if return_emb else x
 
     def __repr__(self) -> str:
         return f'{self.__class__.__name__}({str(self.channel_list)[1:-1]})'


### PR DESCRIPTION
This PR adds the AQSOL dataset from updated [Benchmarking GNNs](http://arxiv.org/abs/2003.00982), based on [AqSolDB](https://www.nature.com/articles/s41597-019-0151-1) which is a standardized database of 9,982 molecular graphs with their aqueous solubility values, collected from 9 different data sources. 
    
The aqueous solubility targets are collected from experimental measurements and standardized to LogS units in AqSolDB. These final values are the property to regress in the AQSOL dataset, similar to ZINC. This version of the dataset filters out few graphs with no bonds/edges and a small number of graphs with missing node feature values.

The resultant total molecular graphs are 9,823. For each molecular graph, the node features are the types of heavy atoms and the edge features are the types of bonds between them, similar as ZINC.
  
Dataset overview:
- Task: Graph Regression
- Size of Dataset: 9,982 molecules.
- Split: Scaffold split (8:1:1) following same code as OGB.
- After cleaning: 7,831 train / 996 val / 996 test
- Number of (unique) atoms: 65 (Dict below)
- Number of (unique) bonds: 5 (Dict below)
- Performance Metric: MAE, same as ZINC

```
Atom Dict: {'Br': 0, 'C': 1, 'N': 2, 'O': 3, 'Cl': 4, 'Zn': 5, 'F': 6, 'P': 7, 'S': 8, 'Na': 9,
'Al': 10, 'Si': 11, 'Mo': 12, 'Ca': 13, 'W': 14, 'Pb': 15, 'B': 16, 'V': 17, 'Co': 18,
'Mg': 19, 'Bi': 20, 'Fe': 21, 'Ba': 22, 'K': 23, 'Ti': 24, 'Sn': 25, 'Cd': 26, 'I': 27,
'Re': 28, 'Sr': 29, 'H': 30, 'Cu': 31, 'Ni': 32, 'Lu': 33, 'Pr': 34, 'Te': 35, 'Ce': 36,
'Nd': 37, 'Gd': 38, 'Zr': 39, 'Mn': 40, 'As': 41, 'Hg': 42, 'Sb': 43, 'Cr': 44, 'Se': 45,
'La': 46, 'Dy': 47, 'Y': 48, 'Pd': 49, 'Ag': 50, 'In': 51, 'Li': 52, 'Rh': 53, 'Nb': 54,
'Hf': 55, 'Cs': 56, 'Ru': 57, 'Au': 58, 'Sm': 59, 'Ta': 60, 'Pt': 61, 'Ir': 62, 'Be': 63, 'Ge': 64}
    
Bond Dict: {'NONE': 0, 'SINGLE': 1, 'DOUBLE': 2, 'AROMATIC': 3, 'TRIPLE': 4}
```