### PR TITLE
Fix dimension in edge filter selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,4 +18,5 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Removed unnecessary colons and fixed typos in the documentation ([#4616](https://github.com/pyg-team/pytorch_geometric/pull/4616))
 - The `bias` argument in `TAGConv` is now actually applied ([#4597](https://github.com/pyg-team/pytorch_geometric/pull/4597))
 - Fixed subclass behaviour of `process` and `download` in `Datsaet` ([#4586](https://github.com/pyg-team/pytorch_geometric/pull/4586))
+- Fixed edge attribute filtering in loader utils ([#4629](https://github.com/pyg-team/pytorch_geometric/pull/4629))
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,5 +18,5 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Removed unnecessary colons and fixed typos in the documentation ([#4616](https://github.com/pyg-team/pytorch_geometric/pull/4616))
 - The `bias` argument in `TAGConv` is now actually applied ([#4597](https://github.com/pyg-team/pytorch_geometric/pull/4597))
 - Fixed subclass behaviour of `process` and `download` in `Datsaet` ([#4586](https://github.com/pyg-team/pytorch_geometric/pull/4586))
-- Fixed edge attribute filtering in loader utils ([#4629](https://github.com/pyg-team/pytorch_geometric/pull/4629))
+- Fixed filtering of attributes for loaders in case `__cat_dim__ != 0` ([#4629](https://github.com/pyg-team/pytorch_geometric/pull/4629))
 ### Removed

--- a/torch_geometric/loader/utils.py
+++ b/torch_geometric/loader/utils.py
@@ -101,7 +101,8 @@ def filter_node_store_(store: NodeStorage, out_store: NodeStorage,
 
         elif store.is_node_attr(key):
             index = index.to(value.device)
-            out_store[key] = index_select(value, index, dim=0)
+            dim = store._parent().__cat_dim__(key, value, store)
+            out_store[key] = index_select(value, index, dim=dim)
 
     return store
 

--- a/torch_geometric/loader/utils.py
+++ b/torch_geometric/loader/utils.py
@@ -21,7 +21,7 @@ def index_select(value: Tensor, index: Tensor, dim: int = 0) -> Tensor:
         numel = math.prod(size)
         storage = value.storage()._new_shared(numel)
         out = value.new(storage).view(size)
-    return torch.index_select(value, 0, index, out=out)
+    return torch.index_select(value, dim, index, out=out)
 
 
 def edge_type_to_str(edge_type: Union[EdgeType, str]) -> str:
@@ -132,13 +132,14 @@ def filter_edge_store_(store: EdgeStorage, out_store: EdgeStorage, row: Tensor,
                                            is_sorted=False, trust_data=True)
 
         elif store.is_edge_attr(key):
+            dim = store._parent().__cat_dim__(key, value, store)
             if perm is None:
                 index = index.to(value.device)
-                out_store[key] = index_select(value, index, dim=0)
+                out_store[key] = index_select(value, index, dim=dim)
             else:
                 perm = perm.to(value.device)
                 index = index.to(value.device)
-                out_store[key] = index_select(value, perm[index], dim=0)
+                out_store[key] = index_select(value, perm[index], dim=dim)
 
     return store
 


### PR DESCRIPTION
Aims to fix an issue reported in https://github.com/pyg-team/pytorch_geometric/issues/4026. The filtering of attributes that have the same shape as `edge_index` are not handled correctly. This PR tries to fix that behaviour 