### PR TITLE
Updates to extracting positions from sdf files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Added support for graph-level outputs in `to_hetero` ([#4582](https://github.com/pyg-team/pytorch_geometric/pull/4582))
 - Added `CHANGELOG.md` ([#4581](https://github.com/pyg-team/pytorch_geometric/pull/4581))
 ### Changed
+- Refactored reading molecular positions from sdf file for qm9 datasets ([4654](https://github.com/pyg-team/pytorch_geometric/pull/4654))
 - Fixed `MLP.jittable()` bug in case `return_emb=True` ([#4645](https://github.com/pyg-team/pytorch_geometric/pull/4645), [#4648](https://github.com/pyg-team/pytorch_geometric/pull/4648))
 - The generated node features of `StochasticBlockModelDataset` are now ordered with respect to their labels ([#4617](https://github.com/pyg-team/pytorch_geometric/pull/4617))
 - Removed unnecessary colons and fixed typos in the documentation ([#4616](https://github.com/pyg-team/pytorch_geometric/pull/4616))

--- a/torch_geometric/datasets/qm9.py
+++ b/torch_geometric/datasets/qm9.py
@@ -233,8 +233,8 @@ class QM9(InMemoryDataset):
 
             N = mol.GetNumAtoms()
 
-            pos = suppl.GetItemText(i).split('\n')[4:4 + N]
-            pos = [[float(x) for x in line.split()[:3]] for line in pos]
+            conf = mol.GetConformer()
+            pos = conf.GetPositions()
             pos = torch.tensor(pos, dtype=torch.float)
 
             type_idx = []


### PR DESCRIPTION
This PR updates extracting molecular positions from qm9 dataset. Earlier, the `sdf` file was read as a text file and positions were extracted using patterns in the text file. Now, we use rdkit's utils directly to extract atom position in molecules from sdf files.