### PR TITLE
Use class setter properties if present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Added support for graph-level outputs in `to_hetero` ([#4582](https://github.com/pyg-team/pytorch_geometric/pull/4582))
 - Added `CHANGELOG.md` ([#4581](https://github.com/pyg-team/pytorch_geometric/pull/4581))
 ### Changed
+- Allow for `setter` properties in `Data` and `HeteroData` ([#4682](https://github.com/pyg-team/pytorch_geometric/pull/4682))
 - Allow for optional `edge_weight` in `GCN2Conv` ([#4670](https://github.com/pyg-team/pytorch_geometric/pull/4670))
 - Fixed the interplay between `TUDataset` and `pre_transform` that modify node features ([#4669](https://github.com/pyg-team/pytorch_geometric/pull/4669))
 - Make use of the `pyg_sphinx_theme` documentation template ([#4664](https://github.com/pyg-team/pyg-lib/pull/4664), [#4667](https://github.com/pyg-team/pyg-lib/pull/4667))

--- a/test/data/test_data.py
+++ b/test/data/test_data.py
@@ -215,32 +215,27 @@ def test_data_share_memory():
         assert torch.allclose(data.x, torch.full((8, ), 4.))
 
 
-def test_data_subclass_setter():
-    class Graph(Data):
+def test_data_setter_properties():
+    class MyData(Data):
         def __init__(self):
             super().__init__()
-            self.my_attr = 1.0
+            self.my_attr1 = 1
             self.my_attr2 = 2
 
         @property
-        def my_attr(self):
-            return self._my_attr
+        def my_attr1(self):
+            return self._my_attr1
 
-        @my_attr.setter
-        def my_attr(self, value):
-            self._my_attr = int(value)
+        @my_attr1.setter
+        def my_attr1(self, value):
+            self._my_attr1 = value
 
-    g = Graph()
-    assert g._store == {'my_attr2': 2}
-    assert '_my_attr' in g._store.__dict__
-    assert isinstance(g.my_attr, int)
+    data = MyData()
+    assert data.my_attr2 == 2
 
-    x = torch.tensor([[1, 2], [3, 4]])
-    g.x = x
-    assert g._store == {'x': x, 'my_attr2': 2}
+    assert 'my_attr1' not in data._store
+    assert data.my_attr1 == 1
 
-    g.my_attr = 2.0
-    assert isinstance(g.my_attr, int)
-
-    g.my_attr2 = 'asdf'
-    assert g._store == {'x': x, 'my_attr2': 'asdf'}
+    data.my_attr1 = 2
+    assert 'my_attr1' not in data._store
+    assert data.my_attr1 == 2

--- a/test/data/test_data.py
+++ b/test/data/test_data.py
@@ -213,3 +213,38 @@ def test_data_share_memory():
     for data in data_list:
         assert data.x.is_shared()
         assert torch.allclose(data.x, torch.full((8, ), 4.))
+
+def test_data_subclass_setter():
+    class Graph(Data):
+        def __init__(self):
+            super().__init__()
+            self.my_attr = 1.0
+            self.my_attr2 = 2
+
+        @property
+        def my_attr(self):
+            return self._my_attr
+
+        @my_attr.setter
+        def my_attr(self, value):
+            self._my_attr = int(value)
+
+    g = Graph()
+    assert g._store == {'my_attr2': 2}
+    assert '_my_attr' in g._store.__dict__
+    assert isinstance(g.my_attr, int)
+
+    x = torch.tensor([[1,2], [3,4]])
+    g.x = x
+    assert g._store == {'x': x, 'my_attr2': 2}
+
+    g.my_attr = 2.0
+    assert isinstance(g.my_attr, int)
+
+    g.my_attr2 = 'asdf'
+    assert g._store == {'x': x, 'my_attr2': 'asdf'}
+
+
+
+
+

--- a/test/data/test_data.py
+++ b/test/data/test_data.py
@@ -208,11 +208,12 @@ def test_data_share_memory():
     for data in data_list:
         assert not data.x.is_shared()
 
-    mp.spawn(run, args=(data_list, ), nprocs=4, join=True)
+    mp.spawn(run, args=(data_list,), nprocs=4, join=True)
 
     for data in data_list:
         assert data.x.is_shared()
-        assert torch.allclose(data.x, torch.full((8, ), 4.))
+        assert torch.allclose(data.x, torch.full((8,), 4.))
+
 
 def test_data_subclass_setter():
     class Graph(Data):
@@ -234,7 +235,7 @@ def test_data_subclass_setter():
     assert '_my_attr' in g._store.__dict__
     assert isinstance(g.my_attr, int)
 
-    x = torch.tensor([[1,2], [3,4]])
+    x = torch.tensor([[1, 2], [3, 4]])
     g.x = x
     assert g._store == {'x': x, 'my_attr2': 2}
 
@@ -243,8 +244,3 @@ def test_data_subclass_setter():
 
     g.my_attr2 = 'asdf'
     assert g._store == {'x': x, 'my_attr2': 'asdf'}
-
-
-
-
-

--- a/test/data/test_data.py
+++ b/test/data/test_data.py
@@ -208,11 +208,11 @@ def test_data_share_memory():
     for data in data_list:
         assert not data.x.is_shared()
 
-    mp.spawn(run, args=(data_list,), nprocs=4, join=True)
+    mp.spawn(run, args=(data_list, ), nprocs=4, join=True)
 
     for data in data_list:
         assert data.x.is_shared()
-        assert torch.allclose(data.x, torch.full((8,), 4.))
+        assert torch.allclose(data.x, torch.full((8, ), 4.))
 
 
 def test_data_subclass_setter():

--- a/torch_geometric/data/data.py
+++ b/torch_geometric/data/data.py
@@ -375,7 +375,12 @@ class Data(BaseData):
         return getattr(self._store, key)
 
     def __setattr__(self, key: str, value: Any):
-        setattr(self._store, key, value)
+        propobj = getattr(self.__class__, key, None)
+        if propobj is None or propobj.fset is None:
+            setattr(self._store, key, value)
+        else:
+            propobj.fset(self, value)
+
 
     def __delattr__(self, key: str):
         delattr(self._store, key)

--- a/torch_geometric/data/data.py
+++ b/torch_geometric/data/data.py
@@ -381,7 +381,6 @@ class Data(BaseData):
         else:
             propobj.fset(self, value)
 
-
     def __delattr__(self, key: str):
         delattr(self._store, key)
 


### PR DESCRIPTION
# Objective
Add support of class properties when setting attributes. This pull request is based on this [discussion](https://github.com/pyg-team/pytorch_geometric/discussions/4638) with @rusty1s .

# Problem
If `Data` is subclassed all attributes are set with `__setattr__` method. This prevents users from implementing validation logic for attributes (like ensuring a certain `dtype`).  In the example below, the developer would like to ensure that `my_attr` can only hold `int` values. This is currently not possible with the implemented `__setattr__` method.

```python
  class Graph(Data):
      def __init__(self):
          super().__init__()
          self.my_attr = 1.0
          self.my_attr2 = 2

      @property
      def my_attr(self):
          return self._my_attr

      @my_attr.setter
      def my_attr(self, value):
          self._my_attr = int(value)
```

# Solution
The proposed solution checks if the class implements a setter method for the attribute or defaults to the standard behaviour
```python
    def __setattr__(self, key: str, value: Any):
        propobj = getattr(self.__class__, key, None)
        if propobj is None or propobj.fset is None:
            setattr(self._store, key, value)
        else:
            propobj.fset(self, value)
```
This implementation is tested with `test_data_subclass_setter` in `test/data/test_data.py`. Coverage of `data.py` is 89%

Best,
Adriano