### PR TITLE
Fix rank computation in the RGCN link prediction example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Added support for graph-level outputs in `to_hetero` ([#4582](https://github.com/pyg-team/pytorch_geometric/pull/4582))
 - Added `CHANGELOG.md` ([#4581](https://github.com/pyg-team/pytorch_geometric/pull/4581))
 ### Changed
+- Fixed the ranking protocol bug in the RGCN link prediction example ([#4688](https://github.com/pyg-team/pytorch_geometric/pull/4688))
 - Math support in Markdown ([#4683](https://github.com/pyg-team/pytorch_geometric/pull/4683))
 - Allow for `setter` properties in `Data` ([#4682](https://github.com/pyg-team/pytorch_geometric/pull/4682), [#4686](https://github.com/pyg-team/pytorch_geometric/pull/4686))
 - Allow for optional `edge_weight` in `GCN2Conv` ([#4670](https://github.com/pyg-team/pytorch_geometric/pull/4670))

--- a/examples/rgcn_link_pred.py
+++ b/examples/rgcn_link_pred.py
@@ -114,7 +114,8 @@ def test():
 
 @torch.no_grad()
 def compute_rank(ranks):
-    # fair ranking prediction as the average of optimistic and pessimistic ranking
+    # fair ranking prediction as the average
+    # of optimistic and pessimistic ranking
     true = ranks[0]
     optimistic = (ranks > true).sum() + 1
     pessimistic = (ranks >= true).sum()


### PR DESCRIPTION
This PR fixes a common problem in the ranking protocol of KG link prediction models. 

Right now, the script puts the true prediction at the very start of the entities lists to rank:
https://github.com/pyg-team/pytorch_geometric/blob/9761ccf4bfd42277b190bf6242307307d4d8d9eb/examples/rgcn_link_pred.py#L132

Then, the script is doing `argsort` over model scores:

https://github.com/pyg-team/pytorch_geometric/blob/9761ccf4bfd42277b190bf6242307307d4d8d9eb/examples/rgcn_link_pred.py#L138-L139

Here is the problem: 
When a model returns exactly the same scores for the true and other entities in the list, the ranking becomes incorrect - that is, overly optimistic. This behavior was identified in the [Sun et al ACL 2020 paper](https://aclanthology.org/2020.acl-main.489.pdf)

To fix this problem, the community (eg, in [PyKEEN](https://github.com/pykeen/pykeen/blob/master/src/pykeen/evaluation/ranks.py) ) resorts to "realistic" metric which is an average of the optimistic and pessimistic ranking:

```python
def compute_rank(ranks):
    # fair ranking prediction as the average of optimistic and pessimistic ranking
    true = ranks[0]
    optimistic = (ranks > true).sum() + 1
    pessimistic = (ranks >= true).sum()
    return (optimistic + pessimistic).float() * 0.5
```

The effect is easy to check feeding the vector of all zeros imitating the effect when model predicts exactly the same score for the true entity at position 0 and all other entities:

```python
def old_rank(ranks):
    perm = ranks.argsort(descending=True)
    rank =  int((perm==0).nonzero(as_tuple=False).view(-1)[0])
    return rank + 1

ranks = torch.zeros(10,)

print(old_rank(ranks))      # 1 - incorrect, overly optimistic
print(compute_rank(ranks))  # 5.5 - correct, realistic
```

This PR changes the ranking function in the example script to the realistic ranking
