### PR TITLE
Add `class-resolver` for `Aggregation`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ## [2.0.5] - 2022-MM-DD
 ### Added
+- Added [`class_resolver`](https://github.com/cthoyt/class-resolver) support for `torch_geometric.nn.aggr`
 - Added `torch_geometric.nn.aggr` package ([#4687](https://github.com/pyg-team/pytorch_geometric/pull/4687))
 - Added the `DimeNet++` model ([#4432](https://github.com/pyg-team/pytorch_geometric/pull/4432), [#4699](https://github.com/pyg-team/pytorch_geometric/pull/4699), [#4700](https://github.com/pyg-team/pytorch_geometric/pull/4700))
 - Added an example of using PyG with PyTorch Ignite ([#4487](https://github.com/pyg-team/pytorch_geometric/pull/4487))

--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,7 @@ install_requires = [
     'requests',
     'pyparsing',
     'scikit-learn',
+    'class_resolver',
 ]
 
 graphgym_requires = [

--- a/torch_geometric/nn/aggr/__init__.py
+++ b/torch_geometric/nn/aggr/__init__.py
@@ -1,3 +1,14 @@
+"""A module containing aggregation classes.
+
+Example usage::
+
+>>> import torch
+>>> from torch_geometric.nn.aggr import aggregation_resolver
+>>> aggregation = aggregation_resolver.make("mean")
+>>> x = torch.randn(6, 16)
+>>> index = torch.tensor([0, 0, 1, 1, 1, 2])
+>>> aggregation(x, index)
+"""
 from class_resolver import ClassResolver
 
 from .base import Aggregation

--- a/torch_geometric/nn/aggr/__init__.py
+++ b/torch_geometric/nn/aggr/__init__.py
@@ -1,3 +1,5 @@
+from class_resolver import ClassResolver
+
 from .base import Aggregation
 from .basic import (
     MeanAggregation,
@@ -11,7 +13,11 @@ from .basic import (
 )
 
 __all__ = classes = [
+    # Abstract Class
     'Aggregation',
+    # Utilities
+    'aggregation_resolver',
+    # Concrete Classes
     'MeanAggregation',
     'SumAggregation',
     'MaxAggregation',
@@ -21,3 +27,5 @@ __all__ = classes = [
     'SoftmaxAggregation',
     'PowerMeanAggregation',
 ]
+
+aggregation_resolver = ClassResolver.from_subclasses(Aggregation)


### PR DESCRIPTION
As a follow-up to #4687, this pull request adds a `class-resolver` for aggregations in `torch_geometric.nn.aggr`. It also adds a class docstring with an example on how to use it.

Note that `class_resolver` is a pure python package with no dependencies. 