### PR TITLE
Automatically construct `ptr` for each graph type when doing "advanced mini-batching"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ## [2.0.5] - 2022-MM-DD
 ### Added
+- Added `ptr` vectors for `follow_batch` attributes within `Batch.from_data_list` ([#4723](https://github.com/pyg-team/pytorch_geometric/pull/4723))
 - Added `torch_geometric.nn.aggr` package ([#4687](https://github.com/pyg-team/pytorch_geometric/pull/4687), [#4721](https://github.com/pyg-team/pytorch_geometric/pull/4721))
 - Added the `DimeNet++` model ([#4432](https://github.com/pyg-team/pytorch_geometric/pull/4432), [#4699](https://github.com/pyg-team/pytorch_geometric/pull/4699), [#4700](https://github.com/pyg-team/pytorch_geometric/pull/4700))
 - Added an example of using PyG with PyTorch Ignite ([#4487](https://github.com/pyg-team/pytorch_geometric/pull/4487))

--- a/test/data/test_batch.py
+++ b/test/data/test_batch.py
@@ -70,10 +70,10 @@ def test_batch():
 
     assert str(batch) == ('DataBatch(x=[9], edge_index=[2, 12], y=[3], '
                           'x_sp=[9, 1, nnz=9], adj=[9, 9, nnz=12], s=[3], '
-                          's_batch=[3], array=[3], num_nodes=9, batch=[9], '
-                          'ptr=[4])')
+                          's_batch=[3], s_ptr=[4], array=[3], num_nodes=9, '
+                          'batch=[9], ptr=[4])')
     assert batch.num_graphs == 3
-    assert len(batch) == 11
+    assert len(batch) == 12
     assert batch.x.tolist() == [1, 2, 3, 1, 2, 1, 2, 3, 4]
     assert batch.y.tolist() == [1, 2, 3]
     assert batch.x_sp.to_dense().view(-1).tolist() == batch.x.tolist()

--- a/test/data/test_batch.py
+++ b/test/data/test_batch.py
@@ -83,6 +83,7 @@ def test_batch():
     assert edge_index.tolist() == batch.edge_index.tolist()
     assert batch.s == ['1', '2', '3']
     assert batch.s_batch.tolist() == [0, 1, 2]
+    assert batch.s_ptr.tolist() == [0, 1, 2, 3]
     assert batch.array == [['1', '2'], ['3', '4', '5'], ['6', '7', '8', '9']]
     assert batch.num_nodes == 9
     assert batch.batch.tolist() == [0, 0, 0, 1, 1, 2, 2, 2, 2]

--- a/test/loader/test_dataloader.py
+++ b/test/loader/test_dataloader.py
@@ -58,7 +58,7 @@ def test_dataloader(num_workers):
     assert len(loader) == 2
 
     for batch in loader:
-        assert len(batch) == 9
+        assert len(batch) == 10
         assert batch.edge_index_batch.tolist() == [0, 0, 0, 0, 1, 1, 1, 1]
 
 

--- a/torch_geometric/data/collate.py
+++ b/torch_geometric/data/collate.py
@@ -101,6 +101,7 @@ def collate(
                 repeats = slices[1:] - slices[:-1]
                 batch = repeat_interleave(repeats.tolist(), device=device)
                 out_store[f'{attr}_batch'] = batch
+                out_store[f'{attr}_ptr'] = cumsum(torch.tensor(repeats.tolist(), device=device))
 
         # In case the storage holds node, we add a top-level batch vector it:
         if (add_batch and isinstance(stores[0], NodeStorage)

--- a/torch_geometric/data/collate.py
+++ b/torch_geometric/data/collate.py
@@ -101,8 +101,8 @@ def collate(
                 repeats = slices[1:] - slices[:-1]
                 batch = repeat_interleave(repeats.tolist(), device=device)
                 out_store[f'{attr}_batch'] = batch
-                out_store[f'{attr}_ptr'] = cumsum(torch.tensor(
-                    repeats.tolist(), device=device))
+                out_store[f'{attr}_ptr'] = cumsum(
+                    torch.tensor(repeats.tolist(), device=device))
 
         # In case the storage holds node, we add a top-level batch vector it:
         if (add_batch and isinstance(stores[0], NodeStorage)

--- a/torch_geometric/data/collate.py
+++ b/torch_geometric/data/collate.py
@@ -101,8 +101,7 @@ def collate(
                 repeats = slices[1:] - slices[:-1]
                 batch = repeat_interleave(repeats.tolist(), device=device)
                 out_store[f'{attr}_batch'] = batch
-                out_store[f'{attr}_ptr'] = cumsum(
-                    torch.tensor(repeats.tolist(), device=device))
+                out_store[f'{attr}_ptr'] = cumsum(repeats.to(device))
 
         # In case the storage holds node, we add a top-level batch vector it:
         if (add_batch and isinstance(stores[0], NodeStorage)

--- a/torch_geometric/data/collate.py
+++ b/torch_geometric/data/collate.py
@@ -101,7 +101,8 @@ def collate(
                 repeats = slices[1:] - slices[:-1]
                 batch = repeat_interleave(repeats.tolist(), device=device)
                 out_store[f'{attr}_batch'] = batch
-                out_store[f'{attr}_ptr'] = cumsum(torch.tensor(repeats.tolist(), device=device))
+                out_store[f'{attr}_ptr'] = cumsum(torch.tensor(
+                    repeats.tolist(), device=device))
 
         # In case the storage holds node, we add a top-level batch vector it:
         if (add_batch and isinstance(stores[0], NodeStorage)


### PR DESCRIPTION
Covers [the issue 4718](https://github.com/pyg-team/pytorch_geometric/issues/4718) by modifying the `collate` function. I also changed two tests that involved the `follow_batch` dataloader argument.