### PR TITLE
Adding Typing to JumpingKnowledge and Torch Script Support

### DIFF
--- a/torch_geometric/nn/models/jumping_knowledge.py
+++ b/torch_geometric/nn/models/jumping_knowledge.py
@@ -65,7 +65,7 @@ class JumpingKnowledge(torch.nn.Module):
         r"""Aggregates representations across different layers.
 
         Args:
-            xs (list or tuple): List containing layer-wise representations.
+            xs (list): List containing layer-wise representations.
         """
 
         assert isinstance(xs, list)


### PR DESCRIPTION
When attempting to serialize a model with a JumpingKnowledge layer using `torch.jit.script`, I would receive an error due to the lack of typing. In order to type them, I removed the ability to pass a tuple of tensors in, since Torch Script seems to only allow tuples of a set size (I could be wrong, please correct me if possible)

Torch also complained that `self.lstm` and `self.att` didn't exist, so I moved them out of the if statement in `__init__`.  Once again, if there is a way to allow this, please correct me.