### PR TITLE
Let `Data` and `HeteroData` implement `FeatureStore`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ## [2.0.5] - 2022-MM-DD
 ### Added
+- Added `FeatureStore` support to `Data` and `HeteroData` ([#4807](https://github.com/pyg-team/pytorch_geometric/pull/4807))
 - Added TorchScript support to `JumpingKnowledge` module ([#4805](https://github.com/pyg-team/pytorch_geometric/pull/4805))
 - Added a `max_sample` argument to `AddMetaPaths` in order to tackle very dense metapath edges ([#4750](https://github.com/pyg-team/pytorch_geometric/pull/4750))
 - Test `HANConv` with empty tensors ([#4756](https://github.com/pyg-team/pytorch_geometric/pull/4756))

--- a/test/data/test_data.py
+++ b/test/data/test_data.py
@@ -239,3 +239,28 @@ def test_data_setter_properties():
     data.my_attr1 = 2
     assert 'my_attr1' not in data._store
     assert data.my_attr1 == 2
+
+
+# Feature Store ###############################################################
+
+
+def test_basic_feature_store():
+    data = Data()
+    x = torch.randn(20, 20)
+
+    # Put tensor:
+    assert data.put_tensor(copy.deepcopy(x), attr_name='x', index=None)
+    assert torch.equal(data.x, x)
+
+    # Put (modify) tensor slice:
+    x[15:] = 0
+    data.put_tensor(0, attr_name='x', index=slice(15, None, None))
+
+    # Get tensor:
+    out = data.get_tensor(attr_name='x', index=None)
+    assert torch.equal(x, out)
+
+    # Remove tensor:
+    assert 'x' in data.__dict__['_store']
+    data.remove_tensor(attr_name='x', index=None)
+    assert 'x' not in data.__dict__['_store']

--- a/test/data/test_hetero_data.py
+++ b/test/data/test_hetero_data.py
@@ -424,6 +424,6 @@ def test_basic_feature_store():
     assert torch.equal(x, out)
 
     # Remove tensor:
-    assert 'x' in data.__dict__['_mapping']
+    assert 'x' in data['paper'].__dict__['_mapping']
     data.remove_tensor(group_name='paper', attr_name='x', index=None)
     assert 'x' not in data['paper'].__dict__['_mapping']

--- a/test/data/test_hetero_data.py
+++ b/test/data/test_hetero_data.py
@@ -400,3 +400,30 @@ def test_hetero_data_to_canonical():
 
     with pytest.raises(TypeError, match="missing 1 required"):
         data['user', 'product']
+
+
+# Feature Store ###############################################################
+
+
+def test_basic_feature_store():
+    data = HeteroData()
+    x = torch.randn(20, 20)
+
+    # Put tensor:
+    assert data.put_tensor(copy.deepcopy(x), group_name='paper', attr_name='x',
+                           index=None)
+    assert torch.equal(data['paper'].x, x)
+
+    # Put (modify) tensor slice:
+    x[15:] = 0
+    data.put_tensor(0, group_name='paper', attr_name='x',
+                    index=slice(15, None, None))
+
+    # Get tensor:
+    out = data.get_tensor(group_name='paper', attr_name='x', index=None)
+    assert torch.equal(x, out)
+
+    # Remove tensor:
+    assert 'x' in data.__dict__['_mapping']
+    data.remove_tensor(group_name='paper', attr_name='x', index=None)
+    assert 'x' not in data['paper'].__dict__['_mapping']

--- a/torch_geometric/data/batch.py
+++ b/torch_geometric/data/batch.py
@@ -23,8 +23,12 @@ class DynamicInheritance(type):
             new_cls = base_cls
         else:
             name = f'{base_cls.__name__}{cls.__name__}'
+
+            class MetaResolver(type(cls), type(base_cls)):
+                pass
+
             if name not in globals():
-                globals()[name] = type(name, (cls, base_cls), {})
+                globals()[name] = MetaResolver(name, (cls, base_cls), {})
             new_cls = globals()[name]
 
         params = list(inspect.signature(base_cls.__init__).parameters.items())

--- a/torch_geometric/data/batch.py
+++ b/torch_geometric/data/batch.py
@@ -24,6 +24,10 @@ class DynamicInheritance(type):
         else:
             name = f'{base_cls.__name__}{cls.__name__}'
 
+            # NOTE `MetaResolver` is necessary to resolve metaclass conflict
+            # problems between `DynamicInheritance` and the metaclass of
+            # `base_cls`. In particular, it creates a new common metaclass
+            # from the defined metaclasses.
             class MetaResolver(type(cls), type(base_cls)):
                 pass
 

--- a/torch_geometric/data/data.py
+++ b/torch_geometric/data/data.py
@@ -739,11 +739,7 @@ class Data(BaseData, FeatureStore):
             # we set `index`. So, we assume here that indexing by `None` is
             # equivalent to not indexing at all, which is not in line with
             # Python semantics.
-            if attr.index is None:
-                return tensor
-
-            dim = self.__cat_dim__(attr.attr_name, tensor)
-            return torch.index_select(tensor, attr.index, dim=dim)
+            return tensor[attr.index] if attr.index is not None else tensor
         return None
 
     def _remove_tensor(self, attr: TensorAttr) -> bool:

--- a/torch_geometric/data/data.py
+++ b/torch_geometric/data/data.py
@@ -605,7 +605,7 @@ class Data(BaseData, FeatureStore):
         data = HeteroData()
 
         for i, key in enumerate(node_type_names):
-            for attr, value in self.items():
+            for attr, value in self._store.items():
                 if attr == 'node_type' or attr == 'edge_type':
                     continue
                 elif isinstance(value, Tensor) and self.is_node_attr(attr):
@@ -616,7 +616,7 @@ class Data(BaseData, FeatureStore):
 
         for i, key in enumerate(edge_type_names):
             src, _, dst = key
-            for attr, value in self.items():
+            for attr, value in self._store.items():
                 if attr == 'node_type' or attr == 'edge_type':
                     continue
                 elif attr == 'edge_index':
@@ -629,7 +629,7 @@ class Data(BaseData, FeatureStore):
 
         # Add global attributes.
         keys = set(data.keys) | {'node_type', 'edge_type', 'num_nodes'}
-        for attr, value in self.items():
+        for attr, value in self._store.items():
             if attr in keys:
                 continue
             if len(data.node_stores) == 1:

--- a/torch_geometric/data/data.py
+++ b/torch_geometric/data/data.py
@@ -750,9 +750,6 @@ class Data(BaseData, FeatureStore):
     def __len__(self) -> int:
         return BaseData.__len__(self)
 
-    def __iter__(self):
-        raise NotImplementedError
-
 
 ###############################################################################
 

--- a/torch_geometric/data/data.py
+++ b/torch_geometric/data/data.py
@@ -366,7 +366,7 @@ class Data(BaseData, FeatureStore):
                  pos: OptTensor = None, **kwargs):
         # `Data` doesn't support group_name, so we need to adjust `TensorAttr`
         # accordingly here to avoid requiring `group_name` to be set:
-        super(Data, self).__init__(attr_cls=DataTensorAttr)
+        super().__init__(attr_cls=DataTensorAttr)
 
         self.__dict__['_store'] = GlobalStorage(_parent=self)
 
@@ -717,6 +717,8 @@ class Data(BaseData, FeatureStore):
     # FeatureStore interface ###########################################
 
     def items(self):
+        r"""Returns an `ItemsView` over the stored attributes in the `Data`
+        object."""
         return self._store.items()
 
     def _put_tensor(self, tensor: FeatureTensorType, attr: TensorAttr) -> bool:

--- a/torch_geometric/data/data.py
+++ b/torch_geometric/data/data.py
@@ -605,7 +605,7 @@ class Data(BaseData, FeatureStore):
         data = HeteroData()
 
         for i, key in enumerate(node_type_names):
-            for attr, value in self._store.items():
+            for attr, value in self.items():
                 if attr == 'node_type' or attr == 'edge_type':
                     continue
                 elif isinstance(value, Tensor) and self.is_node_attr(attr):
@@ -616,7 +616,7 @@ class Data(BaseData, FeatureStore):
 
         for i, key in enumerate(edge_type_names):
             src, _, dst = key
-            for attr, value in self._store.items():
+            for attr, value in self.items():
                 if attr == 'node_type' or attr == 'edge_type':
                     continue
                 elif attr == 'edge_index':
@@ -629,7 +629,7 @@ class Data(BaseData, FeatureStore):
 
         # Add global attributes.
         keys = set(data.keys) | {'node_type', 'edge_type', 'num_nodes'}
-        for attr, value in self._store.items():
+        for attr, value in self.items():
             if attr in keys:
                 continue
             if len(data.node_stores) == 1:
@@ -715,6 +715,9 @@ class Data(BaseData, FeatureStore):
         return None
 
     # FeatureStore interface ###########################################
+
+    def items(self):
+        return self._store.items()
 
     def _put_tensor(self, tensor: FeatureTensorType, attr: TensorAttr) -> bool:
         r"""Stores a feature tensor in node storage."""

--- a/torch_geometric/data/feature_store.py
+++ b/torch_geometric/data/feature_store.py
@@ -245,7 +245,7 @@ class FeatureStore(MutableMapping):
         attributes by subclassing :class:`TensorAttr` and passing the subclass
         as :obj:`attr_cls`."""
         super().__init__()
-        self._attr_cls = attr_cls
+        self.__dict__['_attr_cls'] = attr_cls
 
     # Core (CRUD) #############################################################
 

--- a/torch_geometric/data/hetero_data.py
+++ b/torch_geometric/data/hetero_data.py
@@ -97,7 +97,7 @@ class HeteroData(BaseData, FeatureStore):
     DEFAULT_REL = 'to'
 
     def __init__(self, _mapping: Optional[Dict[str, Any]] = None, **kwargs):
-        super(HeteroData, self).__init__()
+        super().__init__()
 
         self.__dict__['_global_store'] = BaseStorage(_parent=self)
         self.__dict__['_node_store_dict'] = {}
@@ -632,10 +632,12 @@ class HeteroData(BaseData, FeatureStore):
 
         out = self._node_store_dict.get(attr.group_name, None)
         if out:
-            # Group name exists, handle index:
+            # Group name exists, handle index or create new attribute name:
             val = getattr(out, attr.attr_name)
             if val is not None:
                 val[attr.index] = tensor
+            else:
+                setattr(self[attr.group_name], attr.attr_name, tensor)
         else:
             # No node storage found, just store tensor in new one:
             setattr(self[attr.group_name], attr.attr_name, tensor)
@@ -644,7 +646,7 @@ class HeteroData(BaseData, FeatureStore):
     def _get_tensor(self, attr: TensorAttr) -> Optional[FeatureTensorType]:
         r"""Obtains a feature tensor from node storage."""
         # Retrieve tensor and index accordingly:
-        tensor = getattr(self[attr.group_name], attr.attr_name)
+        tensor = getattr(self[attr.group_name], attr.attr_name, None)
         if tensor is not None:
             # TODO this behavior is a bit odd, since TensorAttr requires that
             # we set `index`. So, we assume here that indexing by `None` is

--- a/torch_geometric/data/hetero_data.py
+++ b/torch_geometric/data/hetero_data.py
@@ -10,6 +10,11 @@ from torch import Tensor
 from torch_sparse import SparseTensor
 
 from torch_geometric.data.data import BaseData, Data, size_repr
+from torch_geometric.data.feature_store import (
+    FeatureStore,
+    FeatureTensorType,
+    TensorAttr,
+)
 from torch_geometric.data.storage import BaseStorage, EdgeStorage, NodeStorage
 from torch_geometric.typing import EdgeType, NodeType, QueryType
 from torch_geometric.utils import bipartite_subgraph, is_undirected
@@ -18,7 +23,7 @@ NodeOrEdgeType = Union[NodeType, EdgeType]
 NodeOrEdgeStorage = Union[NodeStorage, EdgeStorage]
 
 
-class HeteroData(BaseData):
+class HeteroData(BaseData, FeatureStore):
     r"""A data object describing a heterogeneous graph, holding multiple node
     and/or edge types in disjunct storage objects.
     Storage objects can hold either node-level, link-level or graph-level
@@ -104,6 +109,10 @@ class HeteroData(BaseData):
                 self[key].update(value)
             else:
                 setattr(self, key, value)
+
+        # `HeteroData` supports group_name, attr_name, and index, so we can
+        # initialize the feature store without modification:
+        FeatureStore.__init__(self)
 
     def __getattr__(self, key: str) -> Any:
         # `data.*_dict` => Link to node and edge stores.
@@ -615,6 +624,48 @@ class HeteroData(BaseData):
             data.edge_type = edge_type.repeat_interleave(sizes)
 
         return data
+
+    # :obj:`FeatureStore` interface ###########################################
+
+    def _put_tensor(self, tensor: FeatureTensorType, attr: TensorAttr) -> bool:
+        r"""Stores a feature tensor in node storage."""
+        if not attr.is_set('index'):
+            attr.index = None
+
+        out = self._node_store_dict.get(attr.group_name, None)
+        if out:
+            # Group name exists, handle index:
+            val = getattr(out, attr.attr_name)
+            if val is not None:
+                val[attr.index] = tensor
+        else:
+            # No group name, just store tensor in node storage:
+            setattr(self[attr.group_name], attr.attr_name, tensor)
+        return True
+
+    def _get_tensor(self, attr: TensorAttr) -> Optional[FeatureTensorType]:
+        r"""Obtains a feature tensor from node storage."""
+        # Retrieve tensor and index accordingly:
+        tensor = getattr(self[attr.group_name], attr.attr_name)
+        if tensor is not None:
+            # TODO this behavior is a bit odd, since TensorAttr requires that
+            # we set `index`. So, we assume here that indexing by `None` is
+            # equivalent to not indexing at all, which is not in line with
+            # Python semantics.
+            return tensor[attr.index] if attr.index is not None else tensor
+        return None
+
+    def _remove_tensor(self, attr: TensorAttr) -> bool:
+        r"""Deletes a feature tensor from node storage."""
+        # Remove tensor entirely:
+        delattr(self[attr.group_name], attr.attr_name)
+        return True
+
+    def __len__(self) -> int:
+        return BaseData.__len__(self)
+
+    def __iter__(self):
+        raise NotImplementedError
 
 
 # Helper functions ############################################################

--- a/torch_geometric/data/hetero_data.py
+++ b/torch_geometric/data/hetero_data.py
@@ -656,8 +656,7 @@ class HeteroData(BaseData, FeatureStore):
     def _remove_tensor(self, attr: TensorAttr) -> bool:
         r"""Deletes a feature tensor from node storage."""
         # Remove tensor entirely:
-        if (hasattr(self, attr.group_name)
-                and hasattr(self[attr.group_name], attr.attr_name)):
+        if hasattr(self[attr.group_name], attr.attr_name):
             delattr(self[attr.group_name], attr.attr_name)
             return True
         return False

--- a/torch_geometric/data/hetero_data.py
+++ b/torch_geometric/data/hetero_data.py
@@ -650,18 +650,17 @@ class HeteroData(BaseData, FeatureStore):
             # we set `index`. So, we assume here that indexing by `None` is
             # equivalent to not indexing at all, which is not in line with
             # Python semantics.
-            if attr.index is None:
-                return tensor
-
-            dim = self[attr.group_name].__cat_dim__(attr.attr_name, tensor)
-            return torch.index_select(tensor, attr.index, dim=dim)
+            return tensor[attr.index] if attr.index is not None else tensor
         return None
 
     def _remove_tensor(self, attr: TensorAttr) -> bool:
         r"""Deletes a feature tensor from node storage."""
         # Remove tensor entirely:
-        delattr(self[attr.group_name], attr.attr_name)
-        return True
+        if (hasattr(self, attr.group_name)
+                and hasattr(self[attr.group_name], attr.attr_name)):
+            delattr(self[attr.group_name], attr.attr_name)
+            return True
+        return False
 
     def __len__(self) -> int:
         return BaseData.__len__(self)


### PR DESCRIPTION
This PR lets `Data` and `HeteroData` implement the feature store abstraction. In particular, it defines `put_tensor`, `get_tensor`, and `remove_tensor` methods on both classes, and adds basic tests for these functionalities.