### PR TITLE
Added batch vector for lists of tensors and other recursive data structures. 

### DIFF
--- a/test/data/test_batch.py
+++ b/test/data/test_batch.py
@@ -387,3 +387,42 @@ def test_batch_with_empty_list():
     assert batch.nontensor == [[], []]
     assert batch[0].nontensor == []
     assert batch[1].nontensor == []
+
+
+def test_nested_follow_batch():
+    def tr(n, m):
+        return torch.rand((n, m))
+
+    d1 = Data(xs=[tr(4, 3), tr(11, 4), tr(1, 2)],
+              a={"aa": tr(11, 3)}, x=tr(10, 5))
+    d2 = Data(xs=[tr(5, 3), tr(14, 4), tr(3, 2)],
+              a={"aa": tr(2, 3)}, x=tr(11, 5))
+    d3 = Data(xs=[tr(6, 3), tr(15, 4), tr(2, 2)],
+              a={"aa": tr(4, 3)}, x=tr(9, 5))
+    d4 = Data(xs=[tr(4, 3), tr(16, 4), tr(1, 2)],
+              a={"aa": tr(8, 3)}, x=tr(8, 5))
+
+    # Dataset
+    data_list = [d1, d2, d3, d4]
+
+    batch = Batch.from_data_list(data_list, follow_batch=['xs', 'a'])
+
+    # assert shapes
+    assert batch.xs[0].shape == (19, 3)
+    assert batch.xs[1].shape == (56, 4)
+    assert batch.xs[2].shape == (7, 2)
+    assert batch.a['aa'].shape == (25, 3)
+
+    assert len(batch.xs_batch) == 3
+    assert len(batch.a_batch) == 1
+
+    # assert _batch
+    assert batch.xs_batch[0].tolist() == \
+           [0, 0, 0, 0, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 3, 3, 3, 3]
+    assert batch.xs_batch[1].tolist() == \
+           [0] * 11 + [1] * 14 + [2] * 15 + [3] * 16
+    assert batch.xs_batch[2].tolist() == \
+           [0] * 1 + [1] * 3 + [2] * 2 + [3] * 1
+
+    assert batch.a_batch['aa'].tolist() == \
+           [0] * 11 + [1] * 2 + [2] * 4 + [3] * 8

--- a/test/data/test_batch.py
+++ b/test/data/test_batch.py
@@ -393,14 +393,14 @@ def test_nested_follow_batch():
     def tr(n, m):
         return torch.rand((n, m))
 
-    d1 = Data(xs=[tr(4, 3), tr(11, 4), tr(1, 2)],
-              a={"aa": tr(11, 3)}, x=tr(10, 5))
-    d2 = Data(xs=[tr(5, 3), tr(14, 4), tr(3, 2)],
-              a={"aa": tr(2, 3)}, x=tr(11, 5))
-    d3 = Data(xs=[tr(6, 3), tr(15, 4), tr(2, 2)],
-              a={"aa": tr(4, 3)}, x=tr(9, 5))
-    d4 = Data(xs=[tr(4, 3), tr(16, 4), tr(1, 2)],
-              a={"aa": tr(8, 3)}, x=tr(8, 5))
+    d1 = Data(xs=[tr(4, 3), tr(11, 4), tr(1, 2)], a={"aa": tr(11, 3)},
+              x=tr(10, 5))
+    d2 = Data(xs=[tr(5, 3), tr(14, 4), tr(3, 2)], a={"aa": tr(2, 3)},
+              x=tr(11, 5))
+    d3 = Data(xs=[tr(6, 3), tr(15, 4), tr(2, 2)], a={"aa": tr(4, 3)},
+              x=tr(9, 5))
+    d4 = Data(xs=[tr(4, 3), tr(16, 4), tr(1, 2)], a={"aa": tr(8, 3)},
+              x=tr(8, 5))
 
     # Dataset
     data_list = [d1, d2, d3, d4]
@@ -416,7 +416,7 @@ def test_nested_follow_batch():
     assert len(batch.xs_batch) == 3
     assert len(batch.a_batch) == 1
 
-    # assert _batch
+    # assert _batch, _ptr not tested currently
     assert batch.xs_batch[0].tolist() == \
            [0, 0, 0, 0, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 3, 3, 3, 3]
     assert batch.xs_batch[1].tolist() == \

--- a/test/data/test_batch.py
+++ b/test/data/test_batch.py
@@ -416,7 +416,7 @@ def test_nested_follow_batch():
     assert len(batch.xs_batch) == 3
     assert len(batch.a_batch) == 1
 
-    # assert _batch, _ptr not tested currently
+    # assert _batch
     assert batch.xs_batch[0].tolist() == \
            [0, 0, 0, 0, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 3, 3, 3, 3]
     assert batch.xs_batch[1].tolist() == \

--- a/torch_geometric/data/collate.py
+++ b/torch_geometric/data/collate.py
@@ -241,6 +241,7 @@ def _ptr(
         # Failure of ptr, usually due to slices.dim() != 1
         return None
 
+
 ###############################################################################
 
 

--- a/torch_geometric/data/collate.py
+++ b/torch_geometric/data/collate.py
@@ -229,12 +229,12 @@ def _ptr(
         return cumsum(repeats.to(device))
 
     elif isinstance(slices, Mapping):
-        # Recursively ptr elements of dictionaries.
+        # Recursively get ptr elements of dictionaries.
         return {k: _ptr(v, device) for k, v in slices.items()}
 
     elif (isinstance(slices, Sequence) and not isinstance(slices, str)
           and isinstance(slices[0], Tensor)):
-        # Recursively ptr elements of lists.
+        # Recursively get ptr elements of lists.
         return [_ptr(s, device) for s in slices]
 
     else:


### PR DESCRIPTION
Added support for calculating the batch vector for lists of tensors or nested dicts. Works analogous to _collate. See test_nested_follow_batch in test_batch.py for an example.