### PR TITLE
modified link_loss to make it viable to not normalizing

### DIFF
--- a/torch_geometric/nn/dense/diff_pool.py
+++ b/torch_geometric/nn/dense/diff_pool.py
@@ -3,7 +3,7 @@ import torch
 EPS = 1e-15
 
 
-def dense_diff_pool(x, adj, s, mask=None):
+def dense_diff_pool(x, adj, s, mask=None, normalize=True):
     r"""The differentiable pooling operator from the `"Hierarchical Graph
     Representation Learning with Differentiable Pooling"
     <https://arxiv.org/abs/1806.08804>`_ paper
@@ -44,6 +44,8 @@ def dense_diff_pool(x, adj, s, mask=None):
         mask (BoolTensor, optional): Mask matrix
             :math:`\mathbf{M} \in {\{ 0, 1 \}}^{B \times N}` indicating
             the valid nodes for each graph. (default: :obj:`None`)
+        normalize (Bool, optional): Normalization indicator
+            :if True, will divide link_loss by size of graph. (default: True)
 
     :rtype: (:class:`Tensor`, :class:`Tensor`, :class:`Tensor`,
         :class:`Tensor`)
@@ -66,7 +68,8 @@ def dense_diff_pool(x, adj, s, mask=None):
 
     link_loss = adj - torch.matmul(s, s.transpose(1, 2))
     link_loss = torch.norm(link_loss, p=2)
-    link_loss = link_loss / adj.numel()
+    if normalize == True:
+        link_loss = link_loss / adj.numel()
 
     ent_loss = (-s * torch.log(s + EPS)).sum(dim=-1).mean()
 


### PR DESCRIPTION
I did this modification because:

- While I was using this function, I found the link_loss being exceptionally small and thus almost not contributing anything, making the graph structure hard to preserve and all nodes resulting in a few clusters. This is because adj.numel() are generally very large. After I recovered the result by multiplying adj.numel() back, results became reasonable.
- According to the original paper, the link_loss is not divided by the size of adjacency matrix
![image](https://user-images.githubusercontent.com/81068196/175115792-554d2d2e-a74c-4766-baea-8252231668d6.png)

- After communicating with people on slack, I think it makes more sense for us to allow users to have an option of not being normalized.
