### PR TITLE
Add a `normalize` parameter to `dense_diff_pool`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ## [2.0.5] - 2022-MM-DD
 ### Added
+- Added a `normalize` parameter to `dense_diff_pool` ([#4847](https://github.com/pyg-team/pytorch_geometric/pull/4847))
 - Added documentation to the `DataLoaderIterator` class ([#4838](https://github.com/pyg-team/pytorch_geometric/pull/4838))
 - Added `GraphStore` support to `Data` and `HeteroData` ([#4816](https://github.com/pyg-team/pytorch_geometric/pull/4816))
 - Added `FeatureStore` support to `Data` and `HeteroData` ([#4807](https://github.com/pyg-team/pytorch_geometric/pull/4807))
@@ -37,7 +38,6 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Added `nn.glob.GlobalPooling` module with support for multiple aggregations ([#4582](https://github.com/pyg-team/pytorch_geometric/pull/4582))
 - Added support for graph-level outputs in `to_hetero` ([#4582](https://github.com/pyg-team/pytorch_geometric/pull/4582))
 - Added `CHANGELOG.md` ([#4581](https://github.com/pyg-team/pytorch_geometric/pull/4581))
-- Added `normalize` parameter to `dense_diff_pool` ([#4847](https://github.com/pyg-team/pytorch_geometric/pull/4847))
 ### Changed
 - Fixed a bug in `TUDataset` where `pre_filter` was not applied whenever `pre_transform` was present
 - Renamed `RandomTranslate` to `RandomJitter` - the usage of `RandomTranslate` is now deprecated ([#4828](https://github.com/pyg-team/pytorch_geometric/pull/4828))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Added `nn.glob.GlobalPooling` module with support for multiple aggregations ([#4582](https://github.com/pyg-team/pytorch_geometric/pull/4582))
 - Added support for graph-level outputs in `to_hetero` ([#4582](https://github.com/pyg-team/pytorch_geometric/pull/4582))
 - Added `CHANGELOG.md` ([#4581](https://github.com/pyg-team/pytorch_geometric/pull/4581))
+- Added `normalize` parameter([#4847](https://github.com/pyg-team/pytorch_geometric/pull/4847))
 ### Changed
 - Fixed a bug in `TUDataset` where `pre_filter` was not applied whenever `pre_transform` was present
 - Renamed `RandomTranslate` to `RandomJitter` - the usage of `RandomTranslate` is now deprecated ([#4828](https://github.com/pyg-team/pytorch_geometric/pull/4828))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Added `nn.glob.GlobalPooling` module with support for multiple aggregations ([#4582](https://github.com/pyg-team/pytorch_geometric/pull/4582))
 - Added support for graph-level outputs in `to_hetero` ([#4582](https://github.com/pyg-team/pytorch_geometric/pull/4582))
 - Added `CHANGELOG.md` ([#4581](https://github.com/pyg-team/pytorch_geometric/pull/4581))
-- Added `normalize` parameter([#4847](https://github.com/pyg-team/pytorch_geometric/pull/4847))
+- Added `normalize` parameter to `dense_diff_pool` ([#4847](https://github.com/pyg-team/pytorch_geometric/pull/4847))
 ### Changed
 - Fixed a bug in `TUDataset` where `pre_filter` was not applied whenever `pre_transform` was present
 - Renamed `RandomTranslate` to `RandomJitter` - the usage of `RandomTranslate` is now deprecated ([#4828](https://github.com/pyg-team/pytorch_geometric/pull/4828))

--- a/torch_geometric/nn/dense/diff_pool.py
+++ b/torch_geometric/nn/dense/diff_pool.py
@@ -44,8 +44,9 @@ def dense_diff_pool(x, adj, s, mask=None, normalize=True):
         mask (BoolTensor, optional): Mask matrix
             :math:`\mathbf{M} \in {\{ 0, 1 \}}^{B \times N}` indicating
             the valid nodes for each graph. (default: :obj:`None`)
-        normalize (Bool, optional): Normalization indicator
-            :if True, will divide link_loss by size of graph. (default: True)
+        normalize (bool, optional): If set to :obj:`False`, the link
+            prediction loss is not divided by :obj:`adj.numel()`.
+            (default: :obj:`True`)
 
     :rtype: (:class:`Tensor`, :class:`Tensor`, :class:`Tensor`,
         :class:`Tensor`)

--- a/torch_geometric/nn/dense/diff_pool.py
+++ b/torch_geometric/nn/dense/diff_pool.py
@@ -3,7 +3,7 @@ import torch
 EPS = 1e-15
 
 
-def dense_diff_pool(x, adj, s, mask=None):
+def dense_diff_pool(x, adj, s, mask=None, normalize=True):
     r"""The differentiable pooling operator from the `"Hierarchical Graph
     Representation Learning with Differentiable Pooling"
     <https://arxiv.org/abs/1806.08804>`_ paper
@@ -44,6 +44,8 @@ def dense_diff_pool(x, adj, s, mask=None):
         mask (BoolTensor, optional): Mask matrix
             :math:`\mathbf{M} \in {\{ 0, 1 \}}^{B \times N}` indicating
             the valid nodes for each graph. (default: :obj:`None`)
+        normalize (Bool, optional): Normalization indicator
+            :if True, will divide link_loss by size of graph. (default: True)
 
     :rtype: (:class:`Tensor`, :class:`Tensor`, :class:`Tensor`,
         :class:`Tensor`)
@@ -66,7 +68,8 @@ def dense_diff_pool(x, adj, s, mask=None):
 
     link_loss = adj - torch.matmul(s, s.transpose(1, 2))
     link_loss = torch.norm(link_loss, p=2)
-    link_loss = link_loss / adj.numel()
+    if normalize == True:
+        link_loss = link_loss / adj.numel()
 
     ent_loss = (-s * torch.log(s + EPS)).sum(dim=-1).mean()
 

--- a/torch_geometric/nn/dense/diff_pool.py
+++ b/torch_geometric/nn/dense/diff_pool.py
@@ -68,7 +68,7 @@ def dense_diff_pool(x, adj, s, mask=None, normalize=True):
 
     link_loss = adj - torch.matmul(s, s.transpose(1, 2))
     link_loss = torch.norm(link_loss, p=2)
-    if normalize == True:
+    if normalize is True:
         link_loss = link_loss / adj.numel()
 
     ent_loss = (-s * torch.log(s + EPS)).sum(dim=-1).mean()


### PR DESCRIPTION
I did this modification because:

While I was using this function, I found the link_loss being exceptionally small and thus almost not contributing anything, making the graph structure hard to preserve and all nodes resulting in a few clusters. This is because adj.numel() are generally very large. After I recovered the result by multiplying adj.numel() back, results became reasonable.

According to the original paper, the link_loss is not divided by the size of adjacency matrix
image
![image](https://user-images.githubusercontent.com/81068196/175121288-c3246904-efd7-4002-91e6-651645f087b9.png)

After communicating with people on slack, I think it makes more sense for us to allow users to have an option of not being normalized.