### PR TITLE
Fix: `NeighborLoader` test with `Tuple[FeatureStore, GraphStore]`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ## [2.0.5] - 2022-MM-DD
 ### Added
-- Added support for `FeatureStore` and `GraphStore` in `NeighborLoader` ([#4817](https://github.com/pyg-team/pytorch_geometric/pull/4817))
+- Added support for `FeatureStore` and `GraphStore` in `NeighborLoader` ([#4817](https://github.com/pyg-team/pytorch_geometric/pull/4817), [#4851](https://github.com/pyg-team/pytorch_geometric/pull/4851))
 - Added a `normalize` parameter to `dense_diff_pool` ([#4847](https://github.com/pyg-team/pytorch_geometric/pull/4847))
 - Added `size=None` explanation to jittable `MessagePassing` modules in the documentation ([#4850](https://github.com/pyg-team/pytorch_geometric/pull/4850))
 - Added documentation to the `DataLoaderIterator` class ([#4838](https://github.com/pyg-team/pytorch_geometric/pull/4838))

--- a/test/loader/test_neighbor_loader.py
+++ b/test/loader/test_neighbor_loader.py
@@ -294,9 +294,8 @@ def test_custom_neighbor_loader(directed):
     torch.manual_seed(12345)
 
     # Possible feature and graph stores:
-    feature_stores = [MyFeatureStore(), HeteroData()]
-    graph_stores = [MyGraphStore(), HeteroData()]
-    hetero_data = HeteroData()
+    feature_stores = [MyFeatureStore, HeteroData]
+    graph_stores = [MyGraphStore, HeteroData]
 
     # Set up edge indices:
     def _get_edge_index(num_src, num_dst, num_edges):
@@ -316,6 +315,12 @@ def test_custom_neighbor_loader(directed):
     # `HeteroData` and `Data` both override dunder methods:
     for feature_store, graph_store in itertools.product(
             feature_stores, graph_stores):
+
+        # Initialize feature store, graph store, and reference:
+        feature_store = feature_store()
+        graph_store = graph_store()
+        hetero_data = HeteroData()
+
         # Set up node features:
         x = torch.arange(100)
         hetero_data['paper'].x = x


### PR DESCRIPTION
The previous test was not correctly re-initializing the feature store and graph store in each `itertools.product(...)` step.