### PR TITLE
Hotfix: Remove duplicate `node_types` in `NeighborLoader` with `FeatureStore`

### DIFF
--- a/torch_geometric/data/feature_store.py
+++ b/torch_geometric/data/feature_store.py
@@ -329,7 +329,8 @@ class FeatureStore(MutableMapping):
         return self._to_type(attr, tensor)
 
     def _multi_get_tensor(
-            self, attrs: List[TensorAttr]) -> Optional[FeatureTensorType]:
+            self,
+            attrs: List[TensorAttr]) -> List[Optional[FeatureTensorType]]:
         r"""To be implemented by :class:`FeatureStore` subclasses.
 
         .. note::

--- a/torch_geometric/loader/neighbor_loader.py
+++ b/torch_geometric/loader/neighbor_loader.py
@@ -108,9 +108,7 @@ class NeighborSampler:
             node_attrs = feature_store.get_all_tensor_attrs()
             edge_attrs = graph_store.get_all_edge_attrs()
 
-            self.node_types = [
-                node_attr.group_name for node_attr in node_attrs
-            ]
+            self.node_types = list(set(node_attr.group_name for node_attr in node_attrs))
             self.edge_types = [edge_attr.edge_type for edge_attr in edge_attrs]
 
             # Set other required parameters:


### PR DESCRIPTION
Also fixed a return type typo.