### PR TITLE
Add meaningful error message to `NeighborLoader` for `hetero_temporal_neighbor_sample` operator.

### DIFF
--- a/torch_geometric/loader/neighbor_loader.py
+++ b/torch_geometric/loader/neighbor_loader.py
@@ -218,7 +218,15 @@ class NeighborSampler:
                     self.directed,
                 )
             else:
-                fn = torch.ops.torch_sparse.hetero_temporal_neighbor_sample
+                try:
+                    fn = torch.ops.torch_sparse.hetero_temporal_neighbor_sample
+                except RuntimeError as e:
+                    raise RuntimeError(
+                        "'torch_sparse' operator "
+                        "'hetero_temporal_neighbor_sample' not "
+                        "found. Currently requires building "
+                        "'torch_sparse' from master.", e)
+
                 node_dict, row_dict, col_dict, edge_dict = fn(
                     self.node_types,
                     self.edge_types,


### PR DESCRIPTION
This gives users a more meaningful error message for temporal sampling. Useful if they want to run the benchmarks for `NeighborLoader`.