### PR TITLE
Disjoint sampling

### DIFF
--- a/torch_geometric/loader/neighbor_loader.py
+++ b/torch_geometric/loader/neighbor_loader.py
@@ -211,8 +211,9 @@ class NeighborSampler:
             else:
                 result = []
                 for i in index.size(0):
-                    result.append(self._hetero_sparse_neighbor_sample(
-                        {self.input_type: index[i:i+1]}))
+                    result.append(
+                        self._hetero_sparse_neighbor_sample(
+                            {self.input_type: index[i:i + 1]}))
                 return tuple(map(list, zip(*result))) + (index.numel(), )
 
 

--- a/torch_geometric/loader/neighbor_loader.py
+++ b/torch_geometric/loader/neighbor_loader.py
@@ -35,6 +35,7 @@ class NeighborSampler:
         time_attr: Optional[str] = None,
         is_sorted: bool = False,
         share_memory: bool = False,
+        disjoint: bool = False,
     ):
         self.data_cls = data.__class__ if isinstance(
             data, (Data, HeteroData)) else 'custom'
@@ -42,6 +43,7 @@ class NeighborSampler:
         self.replace = replace
         self.directed = directed
         self.node_time = None
+        self.disjoint = disjoint
 
         # TODO Unify the following conditionals behind the `FeatureStore`
         # and `GraphStore` API

--- a/torch_geometric/loader/utils.py
+++ b/torch_geometric/loader/utils.py
@@ -1,6 +1,6 @@
 import copy
 import math
-from typing import Dict, Optional, Tuple, Union
+from typing import Dict, List, Optional, Tuple, Union
 
 import torch
 from torch import Tensor
@@ -184,6 +184,29 @@ def filter_hetero_data(
                            row_dict[edge_type_str], col_dict[edge_type_str],
                            edge_dict[edge_type_str], perm_dict[edge_type_str])
 
+    return out
+
+
+def filter_hetero_data_disjoint(
+    data: HeteroData,
+    node_dicts: List[Dict[str, Tensor]],
+    row_dicts: List[Dict[str, Tensor]],
+    col_dicts: List[Dict[str, Tensor]],
+    edge_dicts: List[Dict[str, Tensor]],
+    perm_dict: Dict[str, OptTensor],
+) -> HeteroData:
+    for node_dict, row_dict, col_dict, edge_dict in zip(
+            node_dicts, row_dicts, col_dicts, edge_dicts):
+        out = copy.copy(data)
+        for node_type in data.node_types:
+            filter_node_store_(data[node_type], out[node_type],
+                               node_dict[node_type])
+        for edge_type in data.edge_types:
+            edge_type_str = edge_type_to_str(edge_type)
+            filter_edge_store_(data[edge_type], out[edge_type],
+                            row_dict[edge_type_str], col_dict[edge_type_str],
+                            edge_dict[edge_type_str], perm_dict[edge_type_str])
+    # TODO: collate the filtered data object (out) from each iteration
     return out
 
 

--- a/torch_geometric/loader/utils.py
+++ b/torch_geometric/loader/utils.py
@@ -204,8 +204,10 @@ def filter_hetero_data_disjoint(
         for edge_type in data.edge_types:
             edge_type_str = edge_type_to_str(edge_type)
             filter_edge_store_(data[edge_type], out[edge_type],
-                            row_dict[edge_type_str], col_dict[edge_type_str],
-                            edge_dict[edge_type_str], perm_dict[edge_type_str])
+                               row_dict[edge_type_str],
+                               col_dict[edge_type_str],
+                               edge_dict[edge_type_str],
+                               perm_dict[edge_type_str])
     # TODO: collate the filtered data object (out) from each iteration
     return out
 


### PR DESCRIPTION
The main goal is to allow disjoint sampling (mostly used for temporal sampling use cases), in order to avoid the same node that are sampled multiple times have its timestamps overriding each other.

This is only a tentative prototype, since I find it somewhat difficult to directly integrate this feature into the c++ sampling routine in torch_sparse. But I'm happy to discuss alternatives and pros / cons and potentially revise it significantly.

I'm also yet to do the collation (mentioned in TODO), but it's not hard in python since we have existing routines. It's more difficult if I were to write this in c++.

One disadvantage of this workaround is that the sampling logic is somewhat exposed to the python side in PyG, which could be confusing. There might also be efficiency concerns, since we now loop it over in Python, rather than in c++.