### PR TITLE
Updating dimension accessed by `data.pos`

### DIFF
--- a/torch_geometric/transforms/delaunay.py
+++ b/torch_geometric/transforms/delaunay.py
@@ -10,16 +10,16 @@ class Delaunay(BaseTransform):
     r"""Computes the delaunay triangulation of a set of points
     (functional name: :obj:`delaunay`)."""
     def __call__(self, data):
-        if data.pos.size(0) < 2:
+        if data.pos.size(1) < 2:
             data.edge_index = torch.tensor([], dtype=torch.long,
                                            device=data.pos.device).view(2, 0)
-        if data.pos.size(0) == 2:
+        if data.pos.size(1) == 2:
             data.edge_index = torch.tensor([[0, 1], [1, 0]], dtype=torch.long,
                                            device=data.pos.device)
-        elif data.pos.size(0) == 3:
+        elif data.pos.size(1) == 3:
             data.face = torch.tensor([[0], [1], [2]], dtype=torch.long,
                                      device=data.pos.device)
-        if data.pos.size(0) > 3:
+        if data.pos.size(1) > 3:
             pos = data.pos.cpu().numpy()
             tri = scipy.spatial.Delaunay(pos, qhull_options='QJ')
             face = torch.from_numpy(tri.simplices)


### PR DESCRIPTION
As seen in https://pytorch-geometric.readthedocs.io/en/latest/_modules/torch_geometric/datasets/pascal.html#PascalVOCKeypoints, data.pos is saved as a tensor of shape `num_keypoints, 2`. Thus, data.pos.size(1) needs to be accessed for checking the dimension of the edge_index/face required.