### PR TITLE
Fixing `to_heterogeneous` to work with GPU

### DIFF
--- a/torch_geometric/data/data.py
+++ b/torch_geometric/data/data.py
@@ -657,7 +657,7 @@ class Data(BaseData, FeatureStore, GraphStore):
         node_ids, index_map = {}, torch.empty_like(node_type)
         for i, key in enumerate(node_type_names):
             node_ids[i] = (node_type == i).nonzero(as_tuple=False).view(-1)
-            index_map[node_ids[i]] = torch.arange(len(node_ids[i]))
+            index_map[node_ids[i]] = torch.arange(len(node_ids[i]), device=index_map.device)
 
         # We iterate over edge types to find the local edge indices:
         edge_ids = {}

--- a/torch_geometric/data/data.py
+++ b/torch_geometric/data/data.py
@@ -657,7 +657,8 @@ class Data(BaseData, FeatureStore, GraphStore):
         node_ids, index_map = {}, torch.empty_like(node_type)
         for i, key in enumerate(node_type_names):
             node_ids[i] = (node_type == i).nonzero(as_tuple=False).view(-1)
-            index_map[node_ids[i]] = torch.arange(len(node_ids[i]), device=index_map.device)
+            index_map[node_ids[i]] = torch.arange(len(node_ids[i]),
+                                                  device=index_map.device)
 
         # We iterate over edge types to find the local edge indices:
         edge_ids = {}


### PR DESCRIPTION
Dear Sir/Madam,

this small PR makes the to_heterogeneous function of torch_geometric.data.Data compatible with non CPU devices.

Previously, if the Data object was model to the GPU, the to_heterogeneous call would fail with:

```
Traceback (most recent call last):
  File "utils/transforms.py", line 102, in <module>
    main()
  File "utils/transforms.py", line 95, in main
    hdata = data.to_heterogeneous()
  File "/opt/pytorch_geometric/torch_geometric/data/data.py", line 660, in to_heterogeneous
    index_map[node_ids[i]] = torch.arange(len(node_ids[i]))
RuntimeError: Expected all tensors to be on the same device, but found at least two devices, cuda:0 and cpu!
```

Please let me know what you think.

Best regards
Thorsten