### PR TITLE
Fixed `BasicGNN` for `num_layers=1` and `out_channels` given

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Added support for graph-level outputs in `to_hetero` ([#4582](https://github.com/pyg-team/pytorch_geometric/pull/4582))
 - Added `CHANGELOG.md` ([#4581](https://github.com/pyg-team/pytorch_geometric/pull/4581))
 ### Changed
+- Fixed `BasicGNN` for 1 layer case, which now respects a desired number of `out_channels`([#4943](https://github.com/pyg-team/pytorch_geometric/pull/4943))
 - `len(batch)` will now return the number of graphs inside the batch, not the number of attributes ([#4931](https://github.com/pyg-team/pytorch_geometric/pull/4931))
 - Fixed `data.subgraph` generation for 0-dim tensors ([#4932](https://github.com/pyg-team/pytorch_geometric/pull/4932))
 - Removed unnecssary inclusion of self-loops when sampling negative edges ([#4880](https://github.com/pyg-team/pytorch_geometric/pull/4880))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,7 +50,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Added support for graph-level outputs in `to_hetero` ([#4582](https://github.com/pyg-team/pytorch_geometric/pull/4582))
 - Added `CHANGELOG.md` ([#4581](https://github.com/pyg-team/pytorch_geometric/pull/4581))
 ### Changed
-- Fixed `BasicGNN` for 1 layer case, which now respects a desired number of `out_channels`([#4943](https://github.com/pyg-team/pytorch_geometric/pull/4943))
+- Fixed `BasicGNN` for `num_layers=1`, which now respects a desired number of `out_channels`([#4943](https://github.com/pyg-team/pytorch_geometric/pull/4943))
 - `len(batch)` will now return the number of graphs inside the batch, not the number of attributes ([#4931](https://github.com/pyg-team/pytorch_geometric/pull/4931))
 - Fixed `data.subgraph` generation for 0-dim tensors ([#4932](https://github.com/pyg-team/pytorch_geometric/pull/4932))
 - Removed unnecssary inclusion of self-loops when sampling negative edges ([#4880](https://github.com/pyg-team/pytorch_geometric/pull/4880))

--- a/test/nn/models/test_basic_gnn.py
+++ b/test/nn/models/test_basic_gnn.py
@@ -15,6 +15,7 @@ dropouts = [0.0, 0.5]
 acts = [None, 'leaky_relu', torch.relu_, F.elu, ReLU()]
 norms = [None, BatchNorm1d(16), LayerNorm(16)]
 jks = [None, 'last', 'cat', 'max', 'lstm']
+num_layers = [2, 1]
 
 
 @pytest.mark.parametrize('out_dim,dropout,act,norm,jk',
@@ -56,22 +57,22 @@ def test_gin(out_dim, dropout, act, norm, jk):
     assert model(x, edge_index).size() == (3, out_channels)
 
 
-@pytest.mark.parametrize('out_dim,dropout,act,norm,jk',
-                         product(out_dims, dropouts, acts, norms, jks))
-def test_gat(out_dim, dropout, act, norm, jk):
+@pytest.mark.parametrize('out_dim,dropout,act,norm,jk,num_layer',
+                         product(out_dims, dropouts, acts, norms, jks, num_layers))
+def test_gat(out_dim, dropout, act, norm, jk, num_layer):
     x = torch.randn(3, 8)
     edge_index = torch.tensor([[0, 1, 1, 2], [1, 0, 2, 1]])
     out_channels = 16 if out_dim is None else out_dim
 
     for v2 in [False, True]:
-        model = GAT(8, 16, num_layers=2, out_channels=out_dim, v2=v2,
+        model = GAT(8, 16, num_layers=num_layer, out_channels=out_dim, v2=v2,
                     dropout=dropout, act=act, norm=norm, jk=jk)
-        assert str(model) == f'GAT(8, {out_channels}, num_layers=2)'
+        assert str(model) == f'GAT(8, {out_channels}, num_layers={num_layer})'
         assert model(x, edge_index).size() == (3, out_channels)
 
-        model = GAT(8, 16, num_layers=2, out_channels=out_dim, v2=v2,
+        model = GAT(8, 16, num_layers=num_layer, out_channels=out_dim, v2=v2,
                     dropout=dropout, act=act, norm=norm, jk=jk, heads=4)
-        assert str(model) == f'GAT(8, {out_channels}, num_layers=2)'
+        assert str(model) == f'GAT(8, {out_channels}, num_layers={num_layer})'
         assert model(x, edge_index).size() == (3, out_channels)
 
 

--- a/test/nn/models/test_basic_gnn.py
+++ b/test/nn/models/test_basic_gnn.py
@@ -58,7 +58,8 @@ def test_gin(out_dim, dropout, act, norm, jk):
 
 
 @pytest.mark.parametrize('out_dim,dropout,act,norm,jk,num_layer',
-                         product(out_dims, dropouts, acts, norms, jks, num_layers))
+                         product(out_dims, dropouts, acts, norms, jks,
+                                 num_layers))
 def test_gat(out_dim, dropout, act, norm, jk, num_layer):
     x = torch.randn(3, 8)
     edge_index = torch.tensor([[0, 1, 1, 2], [1, 0, 2, 1]])

--- a/test/nn/models/test_basic_gnn.py
+++ b/test/nn/models/test_basic_gnn.py
@@ -24,9 +24,9 @@ def test_gcn(out_dim, dropout, act, norm, jk):
     edge_index = torch.tensor([[0, 1, 1, 2], [1, 0, 2, 1]])
     out_channels = 16 if out_dim is None else out_dim
 
-    model = GCN(8, 16, num_layers=2, out_channels=out_dim, dropout=dropout,
+    model = GCN(8, 16, num_layers=3, out_channels=out_dim, dropout=dropout,
                 act=act, norm=norm, jk=jk)
-    assert str(model) == f'GCN(8, {out_channels}, num_layers=2)'
+    assert str(model) == f'GCN(8, {out_channels}, num_layers=3)'
     assert model(x, edge_index).size() == (3, out_channels)
 
 
@@ -37,9 +37,9 @@ def test_graph_sage(out_dim, dropout, act, norm, jk):
     edge_index = torch.tensor([[0, 1, 1, 2], [1, 0, 2, 1]])
     out_channels = 16 if out_dim is None else out_dim
 
-    model = GraphSAGE(8, 16, num_layers=2, out_channels=out_dim,
+    model = GraphSAGE(8, 16, num_layers=3, out_channels=out_dim,
                       dropout=dropout, act=act, norm=norm, jk=jk)
-    assert str(model) == f'GraphSAGE(8, {out_channels}, num_layers=2)'
+    assert str(model) == f'GraphSAGE(8, {out_channels}, num_layers=3)'
     assert model(x, edge_index).size() == (3, out_channels)
 
 
@@ -50,9 +50,9 @@ def test_gin(out_dim, dropout, act, norm, jk):
     edge_index = torch.tensor([[0, 1, 1, 2], [1, 0, 2, 1]])
     out_channels = 16 if out_dim is None else out_dim
 
-    model = GIN(8, 16, num_layers=2, out_channels=out_dim, dropout=dropout,
+    model = GIN(8, 16, num_layers=3, out_channels=out_dim, dropout=dropout,
                 act=act, norm=norm, jk=jk)
-    assert str(model) == f'GIN(8, {out_channels}, num_layers=2)'
+    assert str(model) == f'GIN(8, {out_channels}, num_layers=3)'
     assert model(x, edge_index).size() == (3, out_channels)
 
 
@@ -64,14 +64,14 @@ def test_gat(out_dim, dropout, act, norm, jk):
     out_channels = 16 if out_dim is None else out_dim
 
     for v2 in [False, True]:
-        model = GAT(8, 16, num_layers=2, out_channels=out_dim, v2=v2,
+        model = GAT(8, 16, num_layers=3, out_channels=out_dim, v2=v2,
                     dropout=dropout, act=act, norm=norm, jk=jk)
-        assert str(model) == f'GAT(8, {out_channels}, num_layers=2)'
+        assert str(model) == f'GAT(8, {out_channels}, num_layers=3)'
         assert model(x, edge_index).size() == (3, out_channels)
 
-        model = GAT(8, 16, num_layers=2, out_channels=out_dim, v2=v2,
+        model = GAT(8, 16, num_layers=3, out_channels=out_dim, v2=v2,
                     dropout=dropout, act=act, norm=norm, jk=jk, heads=4)
-        assert str(model) == f'GAT(8, {out_channels}, num_layers=2)'
+        assert str(model) == f'GAT(8, {out_channels}, num_layers=3)'
         assert model(x, edge_index).size() == (3, out_channels)
 
 
@@ -87,10 +87,10 @@ def test_pna(out_dim, dropout, act, norm, jk):
         'identity', 'amplification', 'attenuation', 'linear', 'inverse_linear'
     ]
 
-    model = PNA(8, 16, num_layers=2, out_channels=out_dim, dropout=dropout,
+    model = PNA(8, 16, num_layers=3, out_channels=out_dim, dropout=dropout,
                 act=act, norm=norm, jk=jk, aggregators=aggregators,
                 scalers=scalers, deg=deg)
-    assert str(model) == f'PNA(8, {out_channels}, num_layers=2)'
+    assert str(model) == f'PNA(8, {out_channels}, num_layers=3)'
     assert model(x, edge_index).size() == (3, out_channels)
 
 
@@ -110,7 +110,7 @@ def test_packaging():
     x = torch.randn(3, 8)
     edge_index = torch.tensor([[0, 1, 1, 2], [1, 0, 2, 1]])
 
-    model = GraphSAGE(8, 16, num_layers=2)
+    model = GraphSAGE(8, 16, num_layers=3)
     path = osp.join(torch.hub._get_torch_home(), 'pyg_test_model.pt')
     torch.save(model, path)
 
@@ -118,7 +118,7 @@ def test_packaging():
     with torch.no_grad():
         assert model(x, edge_index).size() == (3, 16)
 
-    model = GraphSAGE(8, 16, num_layers=2)
+    model = GraphSAGE(8, 16, num_layers=3)
     path = osp.join(torch.hub._get_torch_home(), 'pyg_test_package.pt')
     with torch.package.PackageExporter(path) as pe:
         pe.extern('torch_geometric.nn.**')

--- a/torch_geometric/nn/models/basic_gnn.py
+++ b/torch_geometric/nn/models/basic_gnn.py
@@ -244,8 +244,8 @@ class GIN(BasicGNN):
         norm (torch.nn.Module, optional): The normalization operator to use.
             (default: :obj:`None`)
         jk (str, optional): The Jumping Knowledge mode
-            (:obj:`"last"`, :obj:`"cat"`, :obj:`"max"`, :obj:`"lstm"`).
-            (default: :obj:`"last"`)
+            (:obj:`None`, :obj:`"last"`, :obj:`"cat"`, :obj:`"max"`,
+            :obj:`"lstm"`). (default: :obj:`None`)
         act_first (bool, optional): If set to :obj:`True`, activation is
             applied before normalization. (default: :obj:`False`)
         act_kwargs (Dict[str, Any], optional): Arguments passed to the
@@ -284,8 +284,8 @@ class GAT(BasicGNN):
         norm (torch.nn.Module, optional): The normalization operator to use.
             (default: :obj:`None`)
         jk (str, optional): The Jumping Knowledge mode
-            (:obj:`"last"`, :obj:`"cat"`, :obj:`"max"`, :obj:`"lstm"`).
-            (default: :obj:`"last"`)
+            (:obj:`None`, :obj:`"last"`, :obj:`"cat"`, :obj:`"max"`,
+            :obj:`"lstm"`). (default: :obj:`None`)
         act_first (bool, optional): If set to :obj:`True`, activation is
             applied before normalization. (default: :obj:`False`)
         act_kwargs (Dict[str, Any], optional): Arguments passed to the
@@ -338,8 +338,8 @@ class PNA(BasicGNN):
         norm (torch.nn.Module, optional): The normalization operator to use.
             (default: :obj:`None`)
         jk (str, optional): The Jumping Knowledge mode
-            (:obj:`"last"`, :obj:`"cat"`, :obj:`"max"`, :obj:`"lstm"`).
-            (default: :obj:`"last"`)
+            (:obj:`None`, :obj:`"last"`, :obj:`"cat"`, :obj:`"max"`,
+            :obj:`"lstm"`). (default: :obj:`None`)
         act_first (bool, optional): If set to :obj:`True`, activation is
             applied before normalization. (default: :obj:`False`)
         act_kwargs (Dict[str, Any], optional): Arguments passed to the

--- a/torch_geometric/nn/models/basic_gnn.py
+++ b/torch_geometric/nn/models/basic_gnn.py
@@ -177,9 +177,11 @@ class GCN(BasicGNN):
             use. (default: :obj:`"relu"`)
         norm (torch.nn.Module, optional): The normalization operator to use.
             (default: :obj:`None`)
-        jk (str, optional): The Jumping Knowledge mode
-            (:obj:`"last"`, :obj:`"cat"`, :obj:`"max"`, :obj:`"lstm"`).
-            (default: :obj:`"last"`)
+        jk (str, optional): The Jumping Knowledge mode. If specified, the model
+            will additionally apply a final linear transformation to transform
+            node embeddings to the expected output feature dimensionality.
+            (:obj:`None`, :obj:`"last"`, :obj:`"cat"`, :obj:`"max"`,
+            :obj:`"lstm"`). (default: :obj:`None`)
         act_first (bool, optional): If set to :obj:`True`, activation is
             applied before normalization. (default: :obj:`False`)
         act_kwargs (Dict[str, Any], optional): Arguments passed to the
@@ -210,9 +212,11 @@ class GraphSAGE(BasicGNN):
             use. (default: :obj:`"relu"`)
         norm (torch.nn.Module, optional): The normalization operator to use.
             (default: :obj:`None`)
-        jk (str, optional): The Jumping Knowledge mode
-            (:obj:`"last"`, :obj:`"cat"`, :obj:`"max"`, :obj:`"lstm"`).
-            (default: :obj:`"last"`)
+        jk (str, optional): The Jumping Knowledge mode. If specified, the model
+            will additionally apply a final linear transformation to transform
+            node embeddings to the expected output feature dimensionality.
+            (:obj:`None`, :obj:`"last"`, :obj:`"cat"`, :obj:`"max"`,
+            :obj:`"lstm"`). (default: :obj:`None`)
         act_first (bool, optional): If set to :obj:`True`, activation is
             applied before normalization. (default: :obj:`False`)
         act_kwargs (Dict[str, Any], optional): Arguments passed to the
@@ -243,7 +247,9 @@ class GIN(BasicGNN):
             (default: :obj:`torch.nn.ReLU(inplace=True)`)
         norm (torch.nn.Module, optional): The normalization operator to use.
             (default: :obj:`None`)
-        jk (str, optional): The Jumping Knowledge mode
+        jk (str, optional): The Jumping Knowledge mode. If specified, the model
+            will additionally apply a final linear transformation to transform
+            node embeddings to the expected output feature dimensionality.
             (:obj:`None`, :obj:`"last"`, :obj:`"cat"`, :obj:`"max"`,
             :obj:`"lstm"`). (default: :obj:`None`)
         act_first (bool, optional): If set to :obj:`True`, activation is
@@ -283,7 +289,9 @@ class GAT(BasicGNN):
             use. (default: :obj:`"relu"`)
         norm (torch.nn.Module, optional): The normalization operator to use.
             (default: :obj:`None`)
-        jk (str, optional): The Jumping Knowledge mode
+        jk (str, optional): The Jumping Knowledge mode. If specified, the model
+            will additionally apply a final linear transformation to transform
+            node embeddings to the expected output feature dimensionality.
             (:obj:`None`, :obj:`"last"`, :obj:`"cat"`, :obj:`"max"`,
             :obj:`"lstm"`). (default: :obj:`None`)
         act_first (bool, optional): If set to :obj:`True`, activation is
@@ -337,7 +345,9 @@ class PNA(BasicGNN):
             use. (default: :obj:`"relu"`)
         norm (torch.nn.Module, optional): The normalization operator to use.
             (default: :obj:`None`)
-        jk (str, optional): The Jumping Knowledge mode
+        jk (str, optional): The Jumping Knowledge mode. If specified, the model
+            will additionally apply a final linear transformation to transform
+            node embeddings to the expected output feature dimensionality.
             (:obj:`None`, :obj:`"last"`, :obj:`"cat"`, :obj:`"max"`,
             :obj:`"lstm"`). (default: :obj:`None`)
         act_first (bool, optional): If set to :obj:`True`, activation is

--- a/torch_geometric/nn/models/basic_gnn.py
+++ b/torch_geometric/nn/models/basic_gnn.py
@@ -80,26 +80,21 @@ class BasicGNN(torch.nn.Module):
             self.out_channels = hidden_channels
 
         self.convs = ModuleList()
-        if num_layers == 1:
-            if out_channels is not None and jk is None:
-                self.convs.append(
-                    self.init_conv(in_channels, out_channels, **kwargs))
-            else:
-                self.convs.append(
-                    self.init_conv(in_channels, hidden_channels, **kwargs))
+        if num_layers > 1:
+            self.convs.append(
+                self.init_conv(in_channels, hidden_channels, **kwargs))
+            in_channels = hidden_channels
+        for _ in range(num_layers - 2):
+            self.convs.append(
+                self.init_conv(in_channels, hidden_channels, **kwargs))
+            in_channels = hidden_channels
+        if out_channels is not None and jk is None:
+            self._is_conv_to_out = True
+            self.convs.append(
+                self.init_conv(in_channels, out_channels, **kwargs))
         else:
             self.convs.append(
                 self.init_conv(in_channels, hidden_channels, **kwargs))
-            for _ in range(num_layers - 2):
-                self.convs.append(
-                    self.init_conv(hidden_channels, hidden_channels, **kwargs))
-            if out_channels is not None and jk is None:
-                self._is_conv_to_out = True
-                self.convs.append(
-                    self.init_conv(hidden_channels, out_channels, **kwargs))
-            else:
-                self.convs.append(
-                    self.init_conv(hidden_channels, hidden_channels, **kwargs))
 
         self.norms = None
         if norm is not None:

--- a/torch_geometric/nn/models/basic_gnn.py
+++ b/torch_geometric/nn/models/basic_gnn.py
@@ -80,18 +80,26 @@ class BasicGNN(torch.nn.Module):
             self.out_channels = hidden_channels
 
         self.convs = ModuleList()
-        self.convs.append(
-            self.init_conv(in_channels, hidden_channels, **kwargs))
-        for _ in range(num_layers - 2):
-            self.convs.append(
-                self.init_conv(hidden_channels, hidden_channels, **kwargs))
-        if out_channels is not None and jk is None:
-            self._is_conv_to_out = True
-            self.convs.append(
-                self.init_conv(hidden_channels, out_channels, **kwargs))
+        if num_layers == 1:
+            if out_channels is not None and jk is None:
+                self.convs.append(
+                    self.init_conv(in_channels, out_channels, **kwargs))
+            else:
+                self.convs.append(
+                    self.init_conv(in_channels, hidden_channels, **kwargs))
         else:
             self.convs.append(
-                self.init_conv(hidden_channels, hidden_channels, **kwargs))
+                self.init_conv(in_channels, hidden_channels, **kwargs))
+            for _ in range(num_layers - 2):
+                self.convs.append(
+                    self.init_conv(hidden_channels, hidden_channels, **kwargs))
+            if out_channels is not None and jk is None:
+                self._is_conv_to_out = True
+                self.convs.append(
+                    self.init_conv(hidden_channels, out_channels, **kwargs))
+            else:
+                self.convs.append(
+                    self.init_conv(hidden_channels, hidden_channels, **kwargs))
 
         self.norms = None
         if norm is not None:


### PR DESCRIPTION
If a model based on `nn.BasicGNN` is created with a single layer and `out_channels` given, the existing code added two layers, where the last layer is a convolution bringing the channel size to `out_channels`. However, this second layer was never reached since in `forward`, the `for` loop only iterates up to `num_layers`. Therefore, the output graph has (counterintuitively) `hidden_channels` channels, instead of `out_channels`.

This PR adds a test for the 1 layer case, which fails with the existing code. Furthermore, the code for `nn.BasicGNN` is extended to properly handle the 1 layer case, making the test pass.