### PR TITLE
Fix `graphgym` activation function dictionary, now not including instances anymore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Added support for graph-level outputs in `to_hetero` ([#4582](https://github.com/pyg-team/pytorch_geometric/pull/4582))
 - Added `CHANGELOG.md` ([#4581](https://github.com/pyg-team/pytorch_geometric/pull/4581))
 ### Changed
+- Changed `act_dict` (part of `graphgym`) to create individual instances instead of reusing the same ones everywhere ([4978](https://github.com/pyg-team/pytorch_geometric/pull/4978))
 - Fixed issue where one-hot tensors were passed to `F.one_hot` ([4970](https://github.com/pyg-team/pytorch_geometric/pull/4970))
 - Fixed `bool` arugments in `argparse` in `benchmark/` ([#4967](https://github.com/pyg-team/pytorch_geometric/pull/4967))
 - Fixed `BasicGNN` for `num_layers=1`, which now respects a desired number of `out_channels` ([#4943](https://github.com/pyg-team/pytorch_geometric/pull/4943))

--- a/test/graphgym/test_graphgym.py
+++ b/test/graphgym/test_graphgym.py
@@ -136,7 +136,7 @@ def test_graphgym_module(tmpdir):
     assert isinstance(scheduler[0], torch.optim.lr_scheduler.CosineAnnealingLR)
 
     cfg.params = params_count(model)
-    assert cfg.params == 23880
+    assert cfg.params == 23883
 
     keys = {"loss", "true", "pred_score", "step_end_time"}
     # test training step

--- a/test/graphgym/test_graphgym.py
+++ b/test/graphgym/test_graphgym.py
@@ -95,7 +95,7 @@ def test_run_single_graphgym(auto_resume, skip_train_eval, use_trivial_metric):
     assert isinstance(scheduler[0], torch.optim.lr_scheduler.CosineAnnealingLR)
 
     cfg.params = params_count(model)
-    assert cfg.params == 23880
+    assert cfg.params == 23883
 
     train(model, datamodule, logger=True,
           trainer_config={"enable_progress_bar": False})

--- a/test/graphgym/test_register.py
+++ b/test/graphgym/test_register.py
@@ -16,7 +16,7 @@ def test_register():
         'relu', 'selu', 'prelu', 'elu', 'lrelu_01', 'lrelu_025', 'lrelu_05',
         'identity'
     ]
-    assert str(register.act_dict['relu']) == 'ReLU()'
+    assert str(register.act_dict['relu']()) == 'ReLU()'
 
     register.register_act('lrelu_03', torch.nn.LeakyReLU(0.3))
     assert len(register.act_dict) == 9

--- a/torch_geometric/graphgym/models/act.py
+++ b/torch_geometric/graphgym/models/act.py
@@ -3,11 +3,40 @@ import torch.nn as nn
 from torch_geometric.graphgym.config import cfg
 from torch_geometric.graphgym.register import register_act
 
+
+def relu():
+    return nn.ReLU(inplace=cfg.mem.inplace)
+
+
+def selu():
+    return nn.SELU(inplace=cfg.mem.inplace)
+
+
+def prelu():
+    return nn.PReLU()
+
+
+def elu():
+    return nn.ELU(inplace=cfg.mem.inplace)
+
+
+def lrelu_01():
+    return nn.LeakyReLU(0.1, inplace=cfg.mem.inplace)
+
+
+def lrelu_025():
+    return nn.LeakyReLU(0.25, inplace=cfg.mem.inplace)
+
+
+def lrelu_05():
+    return nn.LeakyReLU(0.5, inplace=cfg.mem.inplace)
+
+
 if cfg is not None:
-    register_act('relu', nn.ReLU(inplace=cfg.mem.inplace))
-    register_act('selu', nn.SELU(inplace=cfg.mem.inplace))
-    register_act('prelu', nn.PReLU())
-    register_act('elu', nn.ELU(inplace=cfg.mem.inplace))
-    register_act('lrelu_01', nn.LeakyReLU(0.1, inplace=cfg.mem.inplace))
-    register_act('lrelu_025', nn.LeakyReLU(0.25, inplace=cfg.mem.inplace))
-    register_act('lrelu_05', nn.LeakyReLU(0.5, inplace=cfg.mem.inplace))
+    register_act('relu', relu)
+    register_act('selu', selu)
+    register_act('prelu', prelu)
+    register_act('elu', elu)
+    register_act('lrelu_01', lrelu_01)
+    register_act('lrelu_025', lrelu_025)
+    register_act('lrelu_05', lrelu_05)

--- a/torch_geometric/graphgym/models/layer.py
+++ b/torch_geometric/graphgym/models/layer.py
@@ -96,7 +96,7 @@ class GeneralLayer(nn.Module):
                 nn.Dropout(p=layer_config.dropout,
                            inplace=layer_config.mem_inplace))
         if layer_config.has_act:
-            layer_wrapper.append(register.act_dict[layer_config.act])
+            layer_wrapper.append(register.act_dict[layer_config.act]())
         self.post_layer = nn.Sequential(*layer_wrapper)
 
     def forward(self, batch):

--- a/torch_geometric/graphgym/models/layer.py
+++ b/torch_geometric/graphgym/models/layer.py
@@ -6,7 +6,6 @@ import torch.nn as nn
 import torch.nn.functional as F
 
 import torch_geometric as pyg
-import torch_geometric.graphgym.models.act
 import torch_geometric.graphgym.register as register
 from torch_geometric.graphgym.contrib.layer.generalconv import (
     GeneralConvLayer,

--- a/torch_geometric/graphgym/models/layer.py
+++ b/torch_geometric/graphgym/models/layer.py
@@ -6,6 +6,7 @@ import torch.nn as nn
 import torch.nn.functional as F
 
 import torch_geometric as pyg
+import torch_geometric.graphgym.models.act
 import torch_geometric.graphgym.register as register
 from torch_geometric.graphgym.contrib.layer.generalconv import (
     GeneralConvLayer,


### PR DESCRIPTION
Until now, the `act_dict` used by the `graphgym` part of this library contained instances of activation functions that were used to build models. This is okay for the activation functions that do not have parameters. However, in the case of PReLU, there is a parameter. This lead to the problem that every PReLU which is built using the `graphgym` infrastructure shared a single parameter, e.g. when PReLUs are used in multiple layers, or when PReLUs are used in several models that are trained alternatingly. The shared parameter caused unexpected changes to a network that was thought to be frozen while another network was trained.

The solution to this problem proposed in this PR is to include activation function constructors in the `act_dict` instead of instances, and create a new instance every time an activation function is used in a model.