### PR TITLE
`ConfigStore`: do not strip group name from config name

### DIFF
--- a/torch_geometric/graphgym/config_store.py
+++ b/torch_geometric/graphgym/config_store.py
@@ -225,7 +225,6 @@ def register(
 
         pattern = re.compile(group or '', re.IGNORECASE)
         if group is not None and pattern.search(name):
-            name = pattern.sub('', name)
             get_config_store().store(name, data_cls, group)
             get_node(name)._metadata.orig_type = cls
 


### PR DESCRIPTION
We can recover this functionality by handling groups more properly in the future. But this should resolve inter-group naming conflicts for now.