### PR TITLE
minor docs change and C&S fix for multilabel tasks

### DIFF
--- a/torch_geometric/loader/neighbor_loader.py
+++ b/torch_geometric/loader/neighbor_loader.py
@@ -263,9 +263,10 @@ class NeighborLoader(torch.utils.data.DataLoader):
     **homogeneous** graphs stored via :class:`~torch_geometric.data.Data` as
     well as **heterogeneous** graphs stored via
     :class:`~torch_geometric.data.HeteroData`.
-    When operating in heterogeneous graphs, more fine-grained control over
-    the amount of sampled neighbors of individual edge types is possible, but
-    not necessary:
+    When operating in heterogeneous graphs, up to :obj:`num_neighbors`
+    neighbors will be sampled for each :obj:`edge_type`.
+    However, more fine-grained control over
+    the amount of sampled neighbors of individual edge types is possible:
 
     .. code-block:: python
 

--- a/torch_geometric/nn/models/correct_and_smooth.py
+++ b/torch_geometric/nn/models/correct_and_smooth.py
@@ -87,7 +87,6 @@ class CorrectAndSmooth(torch.nn.Module):
             edge_weight (Tensor, optional): The edge weights.
                 (default: :obj:`None`)
         """
-        assert abs((float(y_soft.sum()) / y_soft.size(0)) - 1.0) < 1e-2
 
         numel = int(mask.sum()) if mask.dtype == torch.bool else mask.size(0)
         assert y_true.size(0) == numel


### PR DESCRIPTION
This PR adds a small clarification to the docs for heterogeneous neighbor sampling, and removes an assertion in `CorrectAndSmooth` to allow it to run for multi-label tasks.