### PR TITLE
Support multiple node type sampling in `NeighborLoader`  

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ## [2.2.0] - 2022-MM-DD
 ### Added
+- Add support for sampling multiple node types in `NeighborLoader` [#5013](https://github.com/pyg-team/pytorch_geometric/pull/5013))
 - Added `pyg_lib.segment_matmul` integration within `HeteroLinear` ([#5330](https://github.com/pyg-team/pytorch_geometric/pull/5330), [#5347](https://github.com/pyg-team/pytorch_geometric/pull/5347)))
 - Enabled `bf16` support in benchmark scripts ([#5293](https://github.com/pyg-team/pytorch_geometric/pull/5293), [#5341](https://github.com/pyg-team/pytorch_geometric/pull/5341))
 - Added `Aggregation.set_validate_args` option to skip validation of `dim_size` ([#5290](https://github.com/pyg-team/pytorch_geometric/pull/5290))

--- a/test/loader/test_neighbor_loader.py
+++ b/test/loader/test_neighbor_loader.py
@@ -187,9 +187,9 @@ def test_heterogeneous_neighbor_loader_mixed_input(directed):
         ('paper', None)
     ], batch_size=batch_size, directed=directed, shuffle=False)
 
-    loader2 = NeighborLoader(data, num_neighbors=[10] * 2, input_nodes=[
-        ('paper', None)
-    ], batch_size=batch_size, directed=directed, shuffle=False)
+    loader2 = NeighborLoader(data, num_neighbors=[10] * 2, input_nodes='paper',
+                             batch_size=batch_size, directed=directed,
+                             shuffle=False)
 
     loader3 = NeighborLoader(
         data, num_neighbors=[10] * 2, input_nodes=[

--- a/test/loader/test_neighbor_loader.py
+++ b/test/loader/test_neighbor_loader.py
@@ -201,6 +201,17 @@ def test_heterogeneous_neighbor_loader_mixed_input(directed):
         assert torch.equal(batch1['paper'].x, batch2['paper'].x)
         assert torch.equal(batch2['paper'].x, batch3['paper'].x)
 
+    loader = NeighborLoader(data, num_neighbors=[10] * 2, input_nodes=[
+        ('paper', None), ('author', None)
+    ], batch_size=batch_size, directed=directed, shuffle=False)
+
+    for batch in loader:
+        paper_size = (batch['paper'].batch_size if hasattr(
+            batch['paper'], 'batch_size') else 0)
+        author_size = (batch['author'].batch_size if hasattr(
+            batch['author'], 'batch_size') else 0)
+        assert paper_size + author_size == batch_size
+
 
 @pytest.mark.parametrize('directed', [True, False])
 def test_homogeneous_neighbor_loader_on_cora(get_dataset, directed):

--- a/test/loader/test_neighbor_loader.py
+++ b/test/loader/test_neighbor_loader.py
@@ -198,8 +198,8 @@ def test_heterogeneous_neighbor_loader_mixed_input(directed):
         ], batch_size=batch_size, directed=directed, shuffle=False)
 
     for batch1, batch2, batch3 in zip(loader, loader2, loader3):
-        assert torch.equal(batch1['paper'].x, batch2['paper'].x)
-        assert torch.equal(batch2['paper'].x, batch3['paper'].x)
+        assert torch.allclose(batch1['paper'].x, batch2['paper'].x)
+        assert torch.allclose(batch2['paper'].x, batch3['paper'].x)
 
     loader = NeighborLoader(data, num_neighbors=[10] * 2, input_nodes=[
         ('paper', None), ('author', None)

--- a/torch_geometric/data/lightning_datamodule.py
+++ b/torch_geometric/data/lightning_datamodule.py
@@ -16,7 +16,7 @@ from torch_geometric.loader.link_neighbor_loader import (
 from torch_geometric.loader.neighbor_loader import (
     NeighborLoader,
     NeighborSampler,
-    get_input_nodes,
+    get_sampling_nodes,
 )
 from torch_geometric.typing import InputEdges, InputNodes
 
@@ -303,7 +303,7 @@ class LightningNodeData(LightningDataModule):
                 num_neighbors=kwargs.get('num_neighbors', None),
                 replace=kwargs.get('replace', False),
                 directed=kwargs.get('directed', True),
-                input_type=get_input_nodes(data, input_train_nodes)[0],
+                input_type=get_sampling_nodes(data, input_train_nodes)[0],
                 time_attr=kwargs.get('time_attr', None),
                 is_sorted=kwargs.get('is_sorted', False),
                 share_memory=num_workers > 0,

--- a/torch_geometric/loader/neighbor_loader.py
+++ b/torch_geometric/loader/neighbor_loader.py
@@ -437,7 +437,8 @@ class NeighborLoader(torch.utils.data.DataLoader):
 
         return data if self.transform is None else self.transform(data)
 
-    def collate_fn(self, index: Union[List[int], Tensor]) -> Any:
+    def collate_fn(self, index: Union[List[int], Tensor,
+                                      HeteroNodeList]) -> Any:
         out = self.neighbor_sampler(index)
         if self.filter_per_worker:
             # We execute `filter_fn` in the worker process.

--- a/torch_geometric/loader/neighbor_loader.py
+++ b/torch_geometric/loader/neighbor_loader.py
@@ -435,11 +435,12 @@ class NeighborLoader(torch.utils.data.DataLoader):
 
         else:  # Tuple[FeatureStore, GraphStore]
             # TODO support for feature stores with no edge types
-            node_dict, row_dict, col_dict, edge_dict, batch_size = out
+            node_dict, row_dict, col_dict, edge_dict, batch_dict = out
             feature_store, graph_store = self.data
             data = filter_custom_store(feature_store, graph_store, node_dict,
                                        row_dict, col_dict, edge_dict)
-            data[self.neighbor_sampler.input_type].batch_size = batch_size
+            for node_type, batch_size in batch_dict.items():
+                data[node_type].batch_size = batch_size
 
         return data if self.transform is None else self.transform(data)
 

--- a/torch_geometric/loader/neighbor_loader.py
+++ b/torch_geometric/loader/neighbor_loader.py
@@ -173,6 +173,7 @@ class NeighborSampler:
         if isinstance(index, List) and isinstance(index[0], Tuple):
             index_dict = from_hetero_list(index)
         else:
+            index = torch.LongTensor(index)
             index_dict = {self.input_type: index}
 
         if self.node_time_dict is None:

--- a/torch_geometric/loader/neighbor_loader.py
+++ b/torch_geometric/loader/neighbor_loader.py
@@ -211,7 +211,7 @@ class NeighborSampler:
         if self.data_cls == 'custom' or issubclass(self.data_cls, HeteroData):
 
             if isinstance(index, List) and isinstance(index[0], Tuple):
-                index_dict = from_hetero_list(index)
+                index_dict = from_node_list(index)
             else:
                 index = torch.LongTensor(index)
                 index_dict = {self.input_type: index}
@@ -535,18 +535,18 @@ def get_mixed_sampling_nodes(data: HeteroData,
                              input_nodes: List[InputNodes]) -> SamplingNodes:
     for i in range(len(input_nodes)):
         input_nodes[i] = get_sampling_nodes(data, input_nodes[i])
-    return to_hetero_types(input_nodes), to_hetero_list(input_nodes)
+    return get_node_types(input_nodes), get_node_list(input_nodes)
 
 
 def get_node_types(input_nodes: List[Tuple[str, Tensor]]) -> List[str]:
     return [node_type for node_type, index in input_nodes]
 
 
-def to_hetero_list(input_nodes: List[Tuple[str, Tensor]]) -> HeteroNodeList:
+def get_node_list(input_nodes: List[Tuple[str, Tensor]]) -> HeteroNodeList:
     return [(node_type, i) for node_type, index in input_nodes for i in index]
 
 
-def from_hetero_list(node_list: HeteroNodeList) -> Dict[str, Tensor]:
+def from_node_list(node_list: HeteroNodeList) -> Dict[str, Tensor]:
     node_dicts = defaultdict(list)
     for t, node in node_list:
         node_dicts[t].append(node)

--- a/torch_geometric/loader/neighbor_loader.py
+++ b/torch_geometric/loader/neighbor_loader.py
@@ -169,7 +169,7 @@ class NeighborSampler:
                                        **kwargs):
 
         if isinstance(index, List) and isinstance(index[0], Tuple):
-            index_dict = deconvert_hetero(index)
+            index_dict = from_hetero_list(index)
         else:
             if not isinstance(index, torch.LongTensor):
                 index = torch.LongTensor(index)
@@ -517,11 +517,12 @@ def get_input_nodes(
         return node_type, input_nodes.index
 
 
-def convert_hetero(node_type: str, index: Tensor) -> HeteroNodeList:
-    return [(node_type, i) for i in index]
+def to_hetero_list(input_nodes: Dict[str, Tensor]) -> HeteroNodeList:
+    return [(node_type, i) for node_type, index in input_nodes.items()
+            for i in index]
 
 
-def deconvert_hetero(node_list: HeteroNodeList) -> Dict[str, Tensor]:
+def from_hetero_list(node_list: HeteroNodeList) -> Dict[str, Tensor]:
     node_dicts = defaultdict(list)
     for t, node in node_list:
         node_dicts[t].append(node)

--- a/torch_geometric/loader/neighbor_loader.py
+++ b/torch_geometric/loader/neighbor_loader.py
@@ -167,7 +167,7 @@ class NeighborSampler:
 
     def _hetero_sparse_neighbor_sample(self, index_dict: Dict[str,
                                                               torch.Tensor],
-                                       **kwargs):
+                                       **kwargs,):
 
         if self.node_time_dict is None:
             fn = torch.ops.torch_sparse.hetero_neighbor_sample

--- a/torch_geometric/loader/neighbor_loader.py
+++ b/torch_geometric/loader/neighbor_loader.py
@@ -538,7 +538,7 @@ def get_mixed_sampling_nodes(data: HeteroData,
     return to_hetero_types(input_nodes), to_hetero_list(input_nodes)
 
 
-def to_hetero_types(input_nodes: List[Tuple[str, Tensor]]) -> List[str]:
+def get_node_types(input_nodes: List[Tuple[str, Tensor]]) -> List[str]:
     return [node_type for node_type, index in input_nodes]
 
 

--- a/torch_geometric/typing.py
+++ b/torch_geometric/typing.py
@@ -42,6 +42,8 @@ NoneType = Optional[Tensor]
 
 # Types for sampling ##########################################################
 
-InputNodes = Union[OptTensor, NodeType, Tuple[NodeType, OptTensor]]
+InputNodes = Union[OptTensor, NodeType, Tuple[NodeType, OptTensor],
+                   List[Tuple[NodeType, OptTensor]]]
 InputEdges = Union[OptTensor, EdgeType, Tuple[EdgeType, OptTensor]]
 NumNeighbors = Union[List[int], Dict[EdgeType, List[int]]]
+HeteroNodeList = List[Tuple[str, Tensor]]

--- a/torch_geometric/typing.py
+++ b/torch_geometric/typing.py
@@ -1,3 +1,4 @@
+from collections.abc import Sequence
 from typing import Dict, List, Optional, Tuple, Union
 
 import numpy as np
@@ -47,3 +48,4 @@ InputNodes = Union[OptTensor, NodeType, Tuple[NodeType, OptTensor],
 InputEdges = Union[OptTensor, EdgeType, Tuple[EdgeType, OptTensor]]
 NumNeighbors = Union[List[int], Dict[EdgeType, List[int]]]
 HeteroNodeList = List[Tuple[str, Tensor]]
+SamplingNodes = Union[Tuple[Optional[Union[str, List[str]]], Sequence]]


### PR DESCRIPTION
This PR adds functionality to allow for multiple node types to be sampled in `NeighbourLoader`. 

The interface looks as was discussed in the roadmap (https://github.com/pyg-team/pytorch_geometric/issues/4765):
```
NeighbourLoader(
   input_nodes=[
     ('paper', torch.LongTensor([0,1,2])), 
     ('author', torch.LongTensor([0,1,2])) 
   ]
  ...
)
```
Internally, it converts this to a list of tuples. 
```
[('paper', 0), ('paper', 1),....]
```
This is not very efficient, but benchmarks https://github.com/pyg-team/pytorch_geometric/issues/4765#issuecomment-1147105584 showed it to be acceptable.

TODO:
- [x] Add tests 
- [x] Add support for `None` instead of providing specific nodes for some node types

Addresses https://github.com/pyg-team/pytorch_geometric/issues/4765