### PR TITLE
Jittable fixes - `knn_interpolate` and `mlp`

### DIFF
--- a/torch_geometric/nn/models/mlp.py
+++ b/torch_geometric/nn/models/mlp.py
@@ -179,14 +179,14 @@ class MLP(torch.nn.Module):
 
     def forward(self, x: Tensor, return_emb: NoneType = None) -> Tensor:
         """"""
-        for lin, norm, dropout in zip(self.lins, self.norms, self.dropout):
+        for i, (lin, norm) in enumerate(zip(self.lins, self.norms)):
             x = lin(x)
             if self.act is not None and self.act_first:
                 x = self.act(x)
             x = norm(x)
             if self.act is not None and not self.act_first:
                 x = self.act(x)
-            x = F.dropout(x, p=dropout, training=self.training)
+            x = F.dropout(x, p=self.dropout[i], training=self.training)
             emb = x
 
         if self.plain_last:

--- a/torch_geometric/nn/unpool/knn_interpolate.py
+++ b/torch_geometric/nn/unpool/knn_interpolate.py
@@ -1,11 +1,13 @@
 import torch
+from torch_geometric.typing import OptTensor
 from torch_scatter import scatter_add
 
 from torch_geometric.nn import knn
 
 
-def knn_interpolate(x, pos_x, pos_y, batch_x=None, batch_y=None, k=3,
-                    num_workers=1):
+def knn_interpolate(x: torch.Tensor, pos_x: torch.Tensor, pos_y: torch.Tensor,
+                    batch_x: OptTensor = None, batch_y: OptTensor = None,
+                    k: int = 3, num_workers: int = 1):
     r"""The k-NN interpolation from the `"PointNet++: Deep Hierarchical
     Feature Learning on Point Sets in a Metric Space"
     <https://arxiv.org/abs/1706.02413>`_ paper.
@@ -44,7 +46,7 @@ def knn_interpolate(x, pos_x, pos_y, batch_x=None, batch_y=None, k=3,
     with torch.no_grad():
         assign_index = knn(pos_x, pos_y, k, batch_x=batch_x, batch_y=batch_y,
                            num_workers=num_workers)
-        y_idx, x_idx = assign_index
+        y_idx, x_idx = assign_index[0], assign_index[1]
         diff = pos_x[x_idx] - pos_y[y_idx]
         squared_distance = (diff * diff).sum(dim=-1, keepdim=True)
         weights = 1.0 / torch.clamp(squared_distance, min=1e-16)

--- a/torch_geometric/nn/unpool/knn_interpolate.py
+++ b/torch_geometric/nn/unpool/knn_interpolate.py
@@ -1,8 +1,8 @@
 import torch
-from torch_geometric.typing import OptTensor
 from torch_scatter import scatter_add
 
 from torch_geometric.nn import knn
+from torch_geometric.typing import OptTensor
 
 
 def knn_interpolate(x: torch.Tensor, pos_x: torch.Tensor, pos_y: torch.Tensor,


### PR DESCRIPTION
Some refactoring for ensuring models using `knn_interpolate` and `mlp` are jittable.

`knn_interpole` fix discussed in #5008.

For the `mlp` "fix", PR #4981 seems to have broken `torch.jit.script` support for that module. The error when calling `torch.jit.script()` on a model using this is:
```
Can not iterate over a module list or tuple with a value that does not have a statically determinable length
	:
	  File "d:\repos\pytorch_geometric\torch_geometric\nn\models\mlp.py", line 182
	    def forward(self, x: Tensor, return_emb: NoneType = None) -> Tensor:
	        """"""
	        for lin, norm, dropout in zip(self.lins, self.norms, self.dropout):
	                                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ <--- HERE
	            x = lin(x)
	            if self.act is not None and self.act_first:
```
This also occurs when running the full test suite: `FULL_TEST=1 pytest .\test\nn\models\test_mlp.py`

It seems that TorchScript doesn't like having the `self.dropout` array in the zip. The fix included here is essentially the same as in [this PyTorch forum post](https://discuss.pytorch.org/t/runtimeerror-can-not-iterate-over-a-module-list-or-tuple-with-a-value-that-does-not-have-a-statically-determinable-length/118555).