### PR TITLE
Bug Fix: `collate` method requires keys in dict to be strings, but if `Dict[int:Tensor]`, `_collate` fails

### DIFF
--- a/torch_geometric/data/collate.py
+++ b/torch_geometric/data/collate.py
@@ -125,15 +125,12 @@ def _collate(
         # Concatenate a list of `torch.Tensor` along the `cat_dim`.
         # NOTE: We need to take care of incrementing elements appropriately.
         key = str(key)
-            str_key = key
-        else:
-            str_key = str(key)
-        cat_dim = data_list[0].__cat_dim__(str_key, elem, stores[0])
+        cat_dim = data_list[0].__cat_dim__(key, elem, stores[0])
         if cat_dim is None or elem.dim() == 0:
             values = [value.unsqueeze(0) for value in values]
         slices = cumsum([value.size(cat_dim or 0) for value in values])
         if increment:
-            incs = get_incs(str_key, values, data_list, stores)
+            incs = get_incs(key, values, data_list, stores)
             if incs.dim() > 1 or int(incs[-1]) != 0:
                 values = [
                     value + inc.to(value.device)

--- a/torch_geometric/data/collate.py
+++ b/torch_geometric/data/collate.py
@@ -124,7 +124,7 @@ def _collate(
     if isinstance(elem, Tensor):
         # Concatenate a list of `torch.Tensor` along the `cat_dim`.
         # NOTE: We need to take care of incrementing elements appropriately.
-        if isinstance(key, str):
+        key = str(key)
             str_key = key
         else:
             str_key = str(key)

--- a/torch_geometric/data/collate.py
+++ b/torch_geometric/data/collate.py
@@ -124,12 +124,16 @@ def _collate(
     if isinstance(elem, Tensor):
         # Concatenate a list of `torch.Tensor` along the `cat_dim`.
         # NOTE: We need to take care of incrementing elements appropriately.
-        cat_dim = data_list[0].__cat_dim__(key, elem, stores[0])
+        if isinstance(key, str):
+            str_key = key
+        else:
+            str_key = str(key)
+        cat_dim = data_list[0].__cat_dim__(str_key, elem, stores[0])
         if cat_dim is None or elem.dim() == 0:
             values = [value.unsqueeze(0) for value in values]
         slices = cumsum([value.size(cat_dim or 0) for value in values])
         if increment:
-            incs = get_incs(key, values, data_list, stores)
+            incs = get_incs(str_key, values, data_list, stores)
             if incs.dim() > 1 or int(incs[-1]) != 0:
                 values = [
                     value + inc.to(value.device)

--- a/torch_geometric/data/collate.py
+++ b/torch_geometric/data/collate.py
@@ -158,6 +158,7 @@ def _collate(
     elif isinstance(elem, SparseTensor) and increment:
         # Concatenate a list of `SparseTensor` along the `cat_dim`.
         # NOTE: `cat_dim` may return a tuple to allow for diagonal stacking.
+        key = str(key)
         cat_dim = data_list[0].__cat_dim__(key, elem, stores[0])
         cat_dims = (cat_dim, ) if isinstance(cat_dim, int) else cat_dim
         repeats = [[value.size(dim) for dim in cat_dims] for value in values]

--- a/torch_geometric/data/data.py
+++ b/torch_geometric/data/data.py
@@ -502,7 +502,7 @@ class Data(BaseData, FeatureStore, GraphStore):
     def __cat_dim__(self, key: str, value: Any, *args, **kwargs) -> Any:
         if isinstance(value, SparseTensor) and 'adj' in key:
             return (0, 1)
-        elif 'index' in key or key == 'face':
+        elif isinstance(key, str) and ('index' in key or key == 'face'):
             return -1
         else:
             return 0

--- a/torch_geometric/data/data.py
+++ b/torch_geometric/data/data.py
@@ -502,7 +502,7 @@ class Data(BaseData, FeatureStore, GraphStore):
     def __cat_dim__(self, key: str, value: Any, *args, **kwargs) -> Any:
         if isinstance(value, SparseTensor) and 'adj' in key:
             return (0, 1)
-        elif isinstance(key, str) and ('index' in key or key == 'face'):
+        elif 'index' in key or key == 'face':
             return -1
         else:
             return 0

--- a/torch_geometric/data/separate.py
+++ b/torch_geometric/data/separate.py
@@ -59,6 +59,7 @@ def _separate(
     if isinstance(value, Tensor):
         # Narrow a `torch.Tensor` based on `slices`.
         # NOTE: We need to take care of decrementing elements appropriately.
+        key = str(key)
         cat_dim = batch.__cat_dim__(key, value, store)
         start, end = int(slices[idx]), int(slices[idx + 1])
         value = value.narrow(cat_dim or 0, start, end - start)
@@ -70,6 +71,7 @@ def _separate(
     elif isinstance(value, SparseTensor) and decrement:
         # Narrow a `SparseTensor` based on `slices`.
         # NOTE: `cat_dim` may return a tuple to allow for diagonal stacking.
+        key = str(key)
         cat_dim = batch.__cat_dim__(key, value, store)
         cat_dims = (cat_dim, ) if isinstance(cat_dim, int) else cat_dim
         for i, dim in enumerate(cat_dims):


### PR DESCRIPTION
`_collate` in `torch_geometric/data/collate.py` expects all keys to be strings.
In the case where you have a dictionary of Tensors, line 183 will bring you to line 127. Then `__cat_dim__(key, elem, stores[0])` expects the key from your original dict to be a string. For many dictionaries with keys which are hashable non-strings (such as ints) and mapped to Tensors `__cat_dim__` will then fail, as will `get_incs(key, values, data_list, stores)` on line 132. This is because many internal pyg methods expect keys to be strings. 

Instead of changing many internal methods (such as `__cat_dim__` and `__inc__` in `Data` objects) simply make a copy of the `key` as a string (`str_key`), since it is used as a check in this method (in `__cat_dim__` and `__inc__`) there is no reason to mutate `key`. Making a copy is safer. 

The first commit in this pull request is reverted by the second (I originally thought of checking if `key` is a `str` in `__cat_dim__` but opted changing `_collate`