### PR TITLE
`LinkNeighborLoader`: Support `data` with no edges.

### DIFF
--- a/test/loader/test_link_neighbor_loader.py
+++ b/test/loader/test_link_neighbor_loader.py
@@ -287,3 +287,92 @@ def test_custom_heterogeneous_link_neighbor_loader(FeatureStore, GraphStore):
             'paper', 'to', 'author'].edge_index.size())
         assert (batch1['author', 'to', 'paper'].edge_index.size() == batch1[
             'author', 'to', 'paper'].edge_index.size())
+
+
+@pytest.mark.parametrize('directed', [True, False])
+@pytest.mark.parametrize('neg_sampling_ratio', [0.0, 1.0])
+def test_hetero_no_edge_graph_link_neighbor_loader(directed,
+                                                   neg_sampling_ratio):
+    data = HeteroData()
+
+    data['paper'].x = torch.arange(100)
+    edge_label_index = (('paper', 'paper'), get_edge_index(100, 100, 100))
+
+    loader = LinkNeighborLoader(
+        data,
+        num_neighbors=[],
+        edge_label_index=edge_label_index,
+        batch_size=20,
+        directed=directed,
+        neg_sampling_ratio=neg_sampling_ratio,
+        shuffle=True,
+    )
+
+    assert str(loader) == 'LinkNeighborLoader()'
+    assert len(loader) == 100 / 20
+
+    for batch in loader:
+        assert isinstance(batch, HeteroData)
+
+        if neg_sampling_ratio == 0.0:
+            assert len(batch) == 2
+
+            # Assert positive samples are present in the original graph:
+            assert batch['paper', 'paper'].edge_label_index.size(1) == 20
+            assert (batch['paper'].x.size(0) == len(
+                batch['paper', 'paper'].edge_label_index.unique()))
+        else:
+            assert len(batch) == 3
+
+            assert batch['paper', 'paper'].edge_label_index.size(1) == 40
+            assert torch.all(batch['paper', 'paper'].edge_label[:20] == 1)
+            assert torch.all(batch['paper', 'paper'].edge_label[20:] == 0)
+            assert (batch['paper'].x.size(0) == len(
+                batch['paper', 'paper'].edge_label_index.unique()))
+
+
+@pytest.mark.parametrize('directed', [True, False])
+@pytest.mark.parametrize('neg_sampling_ratio', [0.0, 1.0])
+def test_no_edge_homogeneous_link_neighbor_loader(directed,
+                                                  neg_sampling_ratio):
+    torch.manual_seed(12345)
+
+    pos_edge_index = get_edge_index(100, 50, 500)
+    neg_edge_index = get_edge_index(100, 50, 500)
+    neg_edge_index[1, :] += 50
+
+    edge_label_index = torch.cat([pos_edge_index, neg_edge_index], dim=-1)
+    edge_label = torch.cat([torch.ones(500), torch.zeros(500)], dim=0)
+
+    data = Data()
+
+    data.x = torch.arange(100)
+    loader = LinkNeighborLoader(
+        data,
+        num_neighbors=[],
+        batch_size=20,
+        edge_label_index=edge_label_index,
+        edge_label=edge_label if neg_sampling_ratio == 0.0 else None,
+        directed=directed,
+        neg_sampling_ratio=neg_sampling_ratio,
+        shuffle=True,
+    )
+
+    assert str(loader) == 'LinkNeighborLoader()'
+    assert len(loader) == 1000 / 20
+
+    for batch in loader:
+        assert isinstance(batch, Data)
+
+        assert len(batch) == 3
+        assert batch.x.size(0) <= 100
+        assert batch.x.min() >= 0 and batch.x.max() < 100
+
+        if neg_sampling_ratio == 0.0:
+            assert batch.edge_label_index.size(1) == 20
+            assert (batch.x.size(0) == len(batch.edge_label_index.unique()))
+
+        else:
+            assert batch.edge_label_index.size(1) == 40
+            assert batch.edge_label.sum() == 20
+            assert (batch.x.size(0) == len(batch.edge_label_index.unique()))

--- a/torch_geometric/loader/link_neighbor_loader.py
+++ b/torch_geometric/loader/link_neighbor_loader.py
@@ -356,6 +356,12 @@ class LinkNeighborLoader(torch.utils.data.DataLoader):
         self.filter_per_worker = filter_per_worker
         self.neighbor_sampler = neighbor_sampler
 
+        if not has_edge_index(data):
+            if isinstance(data, Data):
+                assert edge_label_index is not None
+            else:
+                assert len(edge_label_index) == 2
+
         edge_type, edge_label_index = get_edge_label_index(
             data, edge_label_index)
 

--- a/torch_geometric/loader/utils.py
+++ b/torch_geometric/loader/utils.py
@@ -224,3 +224,23 @@ def filter_feature_store(
         data[attr.group_name][attr.attr_name] = tensors[i]
 
     return data
+
+
+def has_edge_index(data: Union[Data, HeteroData, Tuple]) -> bool:
+    """Returns :obj:`True` if :obj:`data` has attribute
+    `edge_index`, `adj_t` or `adj`"""
+    def edge_present(edge_store: Union[Data, EdgeStorage]):
+        return ((hasattr(edge_store, 'edge_index')
+                 and edge_store.edge_index is not None) or
+                (hasattr(edge_store, 'adj_t') and edge_store.adj_t is not None)
+                or (hasattr(edge_store, 'adj') and edge_store.adj is not None))
+
+    if isinstance(data, Data):
+        return True if edge_present(data) else False
+    elif isinstance(data, HeteroData):
+        for store in data.edge_stores:
+            if edge_present(store):
+                return True
+        return False
+    else:  # assume graph store always has edge_index.
+        return True


### PR DESCRIPTION
Sometimes we have HeteroData objects where there's just one node_type and we'd like to predict links between nodes of the same type. With this PR LinkNeighborLoader supports this.  Check out `test_hetero_no_edge_graph_link_neighbor_loader` added in this PR for an example of such a graph.

What changes does this PR make

defines LinkSampler which is used instead of LinkNeighborSampler when data doesn't have edges. The __call__ simply returns the indices to select in the filter_fn.
defines LinkSamplerMixin which contains common function between LinkSampler and LinkNeighborSampler.