### PR TITLE
[Benchmark] Replace `to_hetero` models by `BasicGNN` versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ## [2.0.5] - 2022-MM-DD
 ### Added
+- Replace the to_hetero models by basic_gnn in inference bench([#5107](https://github.com/pyg-team/pytorch_geometric/pull/5107))
 - `NeighborSampler` supports graphs without edges ([#5072](https://github.com/pyg-team/pytorch_geometric/pull/5072))
 - Added the `MeanSubtractionNorm` layer ([#5068](https://github.com/pyg-team/pytorch_geometric/pull/5068))
 - Added `pyg_lib.segment_matmul` integration within `RGCNConv` ([#5052](https://github.com/pyg-team/pytorch_geometric/pull/5052), [#5096](https://github.com/pyg-team/pytorch_geometric/pull/5096))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,6 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ## [2.0.5] - 2022-MM-DD
 ### Added
-- Replace the to_hetero models by basic_gnn in inference bench([#5107](https://github.com/pyg-team/pytorch_geometric/pull/5107))
 - `NeighborSampler` supports graphs without edges ([#5072](https://github.com/pyg-team/pytorch_geometric/pull/5072))
 - Added the `MeanSubtractionNorm` layer ([#5068](https://github.com/pyg-team/pytorch_geometric/pull/5068))
 - Added `pyg_lib.segment_matmul` integration within `RGCNConv` ([#5052](https://github.com/pyg-team/pytorch_geometric/pull/5052), [#5096](https://github.com/pyg-team/pytorch_geometric/pull/5096))
@@ -17,7 +16,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Added fine grained options for setting `bias` and `dropout` per layer in the `MLP` model ([#4981](https://github.com/pyg-team/pytorch_geometric/pull/4981))
 - Added `EdgeCNN` model ([#4991](https://github.com/pyg-team/pytorch_geometric/pull/4991))
 - Added scalable `inference` mode in `BasicGNN` with layer-wise neighbor loading ([#4977](https://github.com/pyg-team/pytorch_geometric/pull/4977))
-- Added inference benchmarks ([#4892](https://github.com/pyg-team/pytorch_geometric/pull/4892))
+- Added inference benchmarks ([#4892](https://github.com/pyg-team/pytorch_geometric/pull/4892), [#5107](https://github.com/pyg-team/pytorch_geometric/pull/5107))
 - Added PyTorch 1.12 support  ([#4975](https://github.com/pyg-team/pytorch_geometric/pull/4975))
 - Added `unbatch_edge_index` functionality for splitting an `edge_index` tensor according to a `batch` vector ([#4903](https://github.com/pyg-team/pytorch_geometric/pull/4903))
 - Added node-wise normalization mode in `LayerNorm` ([#4944](https://github.com/pyg-team/pytorch_geometric/pull/4944))

--- a/benchmark/inference/hetero_gat.py
+++ b/benchmark/inference/hetero_gat.py
@@ -1,7 +1,7 @@
 import torch
 from tqdm import tqdm
 
-from torch_geometric.nn import to_hetero, GAT
+from torch_geometric.nn import GAT, to_hetero
 
 
 class HeteroGAT(torch.nn.Module):

--- a/benchmark/inference/hetero_gat.py
+++ b/benchmark/inference/hetero_gat.py
@@ -1,7 +1,8 @@
 import torch
 from tqdm import tqdm
 
-from torch_geometric.nn import GATConv, to_hetero
+from torch_geometric.nn import to_hetero
+from torch_geometric.nn.models.basic_gnn import GAT
 
 
 class HeteroGAT(torch.nn.Module):
@@ -9,8 +10,8 @@ class HeteroGAT(torch.nn.Module):
                  num_heads):
         super().__init__()
         self.model = to_hetero(
-            GATForHetero(hidden_channels, num_layers, output_channels,
-                         num_heads), metadata)  # TODO: replace by basic_gnn
+            GAT(-1, hidden_channels, num_layers, output_channels,
+                add_self_loops=False, heads=num_heads), metadata)
 
     @torch.no_grad()
     def inference(self, loader, device, progress_bar=False):
@@ -20,25 +21,3 @@ class HeteroGAT(torch.nn.Module):
         for batch in loader:
             batch = batch.to(device)
             self.model(batch.x_dict, batch.edge_index_dict)
-
-
-class GATForHetero(torch.nn.Module):
-    def __init__(self, hidden_channels, num_layers, out_channels, heads):
-        super().__init__()
-        self.convs = torch.nn.ModuleList()
-        self.convs.append(
-            GATConv((-1, -1), hidden_channels, heads=heads,
-                    add_self_loops=False))
-        for _ in range(num_layers - 2):
-            self.convs.append(
-                GATConv((-1, -1), hidden_channels, heads=heads,
-                        add_self_loops=False))
-        self.convs.append(
-            GATConv((-1, -1), out_channels, heads=heads, add_self_loops=False))
-
-    def forward(self, x, edge_index):
-        for i, conv in enumerate(self.convs):
-            x = conv(x, edge_index)
-            if i < len(self.convs) - 1:
-                x = x.relu_()
-        return x

--- a/benchmark/inference/hetero_gat.py
+++ b/benchmark/inference/hetero_gat.py
@@ -1,7 +1,7 @@
 import torch
 from tqdm import tqdm
 
-from torch_geometric.nn import to_hetero
+from torch_geometric.nn import to_hetero, GAT
 from torch_geometric.nn.models.basic_gnn import GAT
 
 

--- a/benchmark/inference/hetero_gat.py
+++ b/benchmark/inference/hetero_gat.py
@@ -10,7 +10,7 @@ class HeteroGAT(torch.nn.Module):
                  num_heads):
         super().__init__()
         self.model = to_hetero(
-            GAT(-1, hidden_channels, num_layers, output_channels,
+            GAT((-1, -1), hidden_channels, num_layers, output_channels,
                 add_self_loops=False, heads=num_heads), metadata)
 
     @torch.no_grad()

--- a/benchmark/inference/hetero_gat.py
+++ b/benchmark/inference/hetero_gat.py
@@ -2,7 +2,6 @@ import torch
 from tqdm import tqdm
 
 from torch_geometric.nn import to_hetero, GAT
-from torch_geometric.nn.models.basic_gnn import GAT
 
 
 class HeteroGAT(torch.nn.Module):

--- a/benchmark/inference/hetero_sage.py
+++ b/benchmark/inference/hetero_sage.py
@@ -1,7 +1,7 @@
 import torch
 from tqdm import tqdm
 
-from torch_geometric.nn import to_hetero
+from torch_geometric.nn import to_hetero, GraphSAGE
 from torch_geometric.nn.models.basic_gnn import GraphSAGE
 
 

--- a/benchmark/inference/hetero_sage.py
+++ b/benchmark/inference/hetero_sage.py
@@ -1,15 +1,16 @@
 import torch
 from tqdm import tqdm
 
-from torch_geometric.nn import SAGEConv, to_hetero
+from torch_geometric.nn import to_hetero
+from torch_geometric.nn.models.basic_gnn import GraphSAGE
 
 
 class HeteroGraphSAGE(torch.nn.Module):
     def __init__(self, metadata, hidden_channels, num_layers, output_channels):
         super().__init__()
         self.model = to_hetero(
-            SAGEForHetero(hidden_channels, num_layers, output_channels),
-            metadata)  # TODO: replace by basic_gnn
+            GraphSAGE(-1, hidden_channels, num_layers, output_channels),
+            metadata)
 
     @torch.no_grad()
     def inference(self, loader, device, progress_bar=False):
@@ -19,20 +20,3 @@ class HeteroGraphSAGE(torch.nn.Module):
         for batch in loader:
             batch = batch.to(device)
             self.model(batch.x_dict, batch.edge_index_dict)
-
-
-class SAGEForHetero(torch.nn.Module):
-    def __init__(self, hidden_channels, num_layers, out_channels):
-        super().__init__()
-        self.convs = torch.nn.ModuleList()
-        self.convs.append(SAGEConv((-1, -1), hidden_channels))
-        for i in range(num_layers - 2):
-            self.convs.append(SAGEConv((-1, -1), hidden_channels))
-        self.convs.append(SAGEConv((-1, -1), out_channels))
-
-    def forward(self, x, edge_index):
-        for i, conv in enumerate(self.convs):
-            x = conv(x, edge_index)
-            if i < len(self.convs) - 1:
-                x = x.relu_()
-        return x

--- a/benchmark/inference/hetero_sage.py
+++ b/benchmark/inference/hetero_sage.py
@@ -1,7 +1,7 @@
 import torch
 from tqdm import tqdm
 
-from torch_geometric.nn import to_hetero, GraphSAGE
+from torch_geometric.nn import GraphSAGE, to_hetero
 
 
 class HeteroGraphSAGE(torch.nn.Module):

--- a/benchmark/inference/hetero_sage.py
+++ b/benchmark/inference/hetero_sage.py
@@ -2,7 +2,6 @@ import torch
 from tqdm import tqdm
 
 from torch_geometric.nn import to_hetero, GraphSAGE
-from torch_geometric.nn.models.basic_gnn import GraphSAGE
 
 
 class HeteroGraphSAGE(torch.nn.Module):

--- a/benchmark/inference/hetero_sage.py
+++ b/benchmark/inference/hetero_sage.py
@@ -9,7 +9,7 @@ class HeteroGraphSAGE(torch.nn.Module):
     def __init__(self, metadata, hidden_channels, num_layers, output_channels):
         super().__init__()
         self.model = to_hetero(
-            GraphSAGE(-1, hidden_channels, num_layers, output_channels),
+            GraphSAGE((-1, -1), hidden_channels, num_layers, output_channels),
             metadata)
 
     @torch.no_grad()


### PR DESCRIPTION
Apply changes to use to_hetero models (GraphSAGE, GAT) with models from basic_gnn versions.