### PR TITLE
`LinkNeighborLoader` Refactoring (part 2)

### DIFF
--- a/test/loader/test_link_neighbor_loader.py
+++ b/test/loader/test_link_neighbor_loader.py
@@ -112,9 +112,8 @@ def test_heterogeneous_link_neighbor_loader(directed, neg_sampling_ratio):
         assert isinstance(batch, HeteroData)
         assert len(batch) == 5
         if neg_sampling_ratio == 0.0:
-
             # Assert only positive samples are present in the original graph:
-            assert batch['paper', 'author'].edge_label.sum() == 20
+            assert batch['paper', 'author'].edge_label.sum() == 0
             edge_index = unique_edge_pairs(batch['paper', 'author'].edge_index)
             edge_label_index = batch['paper', 'author'].edge_label_index
             edge_label_index = unique_edge_pairs(edge_label_index)

--- a/test/loader/test_link_neighbor_loader.py
+++ b/test/loader/test_link_neighbor_loader.py
@@ -178,7 +178,7 @@ def test_link_neighbor_loader_edge_label():
     )
 
     for batch in loader:
-        assert batch.edge_label.dtype == torch.float
+        assert batch.edge_label.dtype == torch.long
         assert torch.all(batch.edge_label[:10] == 2)
         assert torch.all(batch.edge_label[10:] == 0)
 

--- a/torch_geometric/loader/link_neighbor_loader.py
+++ b/torch_geometric/loader/link_neighbor_loader.py
@@ -58,29 +58,26 @@ class LinkNeighborSampler(NeighborSampler):
             self.num_dst_nodes = data[self.input_type[-1]].num_nodes
 
     def _create_label(self, edge_label_index, edge_label):
-
         num_pos_edges = edge_label_index.size(1)
         num_neg_edges = int(num_pos_edges * self.neg_sampling_ratio)
 
         if num_neg_edges == 0:
             return edge_label_index, edge_label
 
-        assert edge_label.dtype == torch.float
-        edge_label = edge_label + 1
-
         neg_row = torch.randint(self.num_src_nodes, (num_neg_edges, ))
         neg_col = torch.randint(self.num_dst_nodes, (num_neg_edges, ))
         neg_edge_label_index = torch.stack([neg_row, neg_col], dim=0)
-
-        neg_edge_label = edge_label.new_zeros((num_neg_edges, ) +
-                                              edge_label.size()[1:])
 
         edge_label_index = torch.cat([
             edge_label_index,
             neg_edge_label_index,
         ], dim=1)
 
-        edge_label = torch.cat([edge_label, neg_edge_label], dim=0)
+        pos_edge_label = edge_label + 1
+        neg_edge_label = edge_label.new_zeros((num_neg_edges, ) +
+                                              edge_label.size()[1:])
+
+        edge_label = torch.cat([pos_edge_label, neg_edge_label], dim=0)
 
         return edge_label_index, edge_label
 
@@ -291,10 +288,8 @@ class LinkNeighborLoader(torch.utils.data.DataLoader):
         edge_type, edge_label_index = get_edge_label_index(
             data, edge_label_index)
         if edge_label is None:
-            edge_label = edge_label_index.new_zeros(edge_label_index.size(1))
-            edge_label = (edge_label +
-                          1 if self.neg_sampling_ratio == 0 else edge_label)
-        self.edge_label = edge_label.to(torch.float)
+            edge_label = torch.zeros(edge_label_index.size(1),
+                                     device=edge_label_index.device)
         if neighbor_sampler is None:
             self.neighbor_sampler = LinkNeighborSampler(
                 data,
@@ -310,7 +305,7 @@ class LinkNeighborLoader(torch.utils.data.DataLoader):
                 share_memory=kwargs.get('num_workers', 0) > 0,
             )
 
-        super().__init__(Dataset(edge_label_index, self.edge_label),
+        super().__init__(Dataset(edge_label_index, edge_label),
                          collate_fn=self.collate_fn, **kwargs)
 
     def filter_fn(self, out: Any) -> Union[Data, HeteroData]:

--- a/torch_geometric/loader/link_neighbor_loader.py
+++ b/torch_geometric/loader/link_neighbor_loader.py
@@ -212,11 +212,12 @@ class LinkNeighborLoader(torch.utils.data.DataLoader):
             edges between all sampled nodes. (default: :obj:`True`)
         neg_sampling_ratio (float, optional): The ratio of sampled negative
             edges to the number of positive edges.
-            If :obj:`edge_label` does not exist, it will be automatically
-            created and represents a binary classification task
-            (:obj:`1` = edge, :obj:`0` = no edge).
-            If :obj:`edge_label` exists, it has to be a categorical label from
-            :obj:`0` to :obj:`num_classes - 1`.
+            If :obj:`neg_sampling_ratio > 0` and in case :obj:`edge_label`
+            does not exist, it will be automatically created and represents a
+            binary classification task (:obj:`1` = edge, :obj:`0` = no edge).
+            If :obj:`neg_sampling_ratio > 0` and in case :obj:`edge_label`
+            exists, it has to be a categorical label from :obj:`0` to
+            :obj:`num_classes - 1`.
             After negative sampling, label :obj:`0` represents negative edges,
             and labels :obj:`1` to :obj:`num_classes` represent the labels of
             positive edges.


### PR DESCRIPTION
We only want to use `torch.float` for binary classification. If `edge_label` is given, we do not need to cast its data type.