### PR TITLE
Respect `flow` argument in `GCN` normalization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ## [2.0.5] - 2022-MM-DD
 ### Added
+- Added `flow` argument to `gcn_norm` to correctly normalize adjacency matrix for `GCNConv` when input is a directed graph ([#5149](https://github.com/pyg-team/pytorch_geometric/pull/5149))
 - `NeighborSampler` supports graphs without edges ([#5072](https://github.com/pyg-team/pytorch_geometric/pull/5072))
 - Added the `MeanSubtractionNorm` layer ([#5068](https://github.com/pyg-team/pytorch_geometric/pull/5068))
 - Added `pyg_lib.segment_matmul` integration within `RGCNConv` ([#5052](https://github.com/pyg-team/pytorch_geometric/pull/5052), [#5096](https://github.com/pyg-team/pytorch_geometric/pull/5096))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ## [2.0.5] - 2022-MM-DD
 ### Added
-- Added `flow` argument to `gcn_norm` to correctly normalize adjacency matrix for `GCNConv`. ([#5149](https://github.com/pyg-team/pytorch_geometric/pull/5149))
+- Added `flow` argument to `gcn_norm` to correctly normalize the adjacency matrix in `GCNConv` ([#5149](https://github.com/pyg-team/pytorch_geometric/pull/5149))
 - `NeighborSampler` supports graphs without edges ([#5072](https://github.com/pyg-team/pytorch_geometric/pull/5072))
 - Added the `MeanSubtractionNorm` layer ([#5068](https://github.com/pyg-team/pytorch_geometric/pull/5068))
 - Added `pyg_lib.segment_matmul` integration within `RGCNConv` ([#5052](https://github.com/pyg-team/pytorch_geometric/pull/5052), [#5096](https://github.com/pyg-team/pytorch_geometric/pull/5096))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ## [2.0.5] - 2022-MM-DD
 ### Added
-- Added `flow` argument to `gcn_norm` to correctly normalize adjacency matrix for `GCNConv` when input is a directed graph ([#5149](https://github.com/pyg-team/pytorch_geometric/pull/5149))
+- Added `flow` argument to `gcn_norm` to correctly normalize adjacency matrix for `GCNConv`. ([#5149](https://github.com/pyg-team/pytorch_geometric/pull/5149))
 - `NeighborSampler` supports graphs without edges ([#5072](https://github.com/pyg-team/pytorch_geometric/pull/5072))
 - Added the `MeanSubtractionNorm` layer ([#5068](https://github.com/pyg-team/pytorch_geometric/pull/5068))
 - Added `pyg_lib.segment_matmul` integration within `RGCNConv` ([#5052](https://github.com/pyg-team/pytorch_geometric/pull/5052), [#5096](https://github.com/pyg-team/pytorch_geometric/pull/5096))

--- a/test/nn/conv/test_gcn_conv.py
+++ b/test/nn/conv/test_gcn_conv.py
@@ -78,3 +78,14 @@ def test_static_gcn_conv():
     conv = GCNConv(16, 32)
     out = conv(x, edge_index)
     assert out.size() == (3, 4, 32)
+
+
+def test_gcn_conv_norm():
+    x = torch.randn(4, 16)
+    edge_index = torch.tensor([[0, 0, 0], [1, 2, 3]])
+
+    conv = GCNConv(16, 32, flow="source_to_target")
+    out1 = conv(x, edge_index)
+    conv.flow = "target_to_source"
+    out2 = conv(x, edge_index.flip(0))
+    assert torch.allclose(out1, out2, atol=1e-6)

--- a/test/nn/conv/test_gcn_conv.py
+++ b/test/nn/conv/test_gcn_conv.py
@@ -83,9 +83,18 @@ def test_static_gcn_conv():
 def test_gcn_conv_norm():
     x = torch.randn(4, 16)
     edge_index = torch.tensor([[0, 0, 0], [1, 2, 3]])
+    row, col = edge_index
+    value = torch.rand(row.size(0))
+    adj = SparseTensor(row=row, col=col, value=value, sparse_sizes=(4, 4))
 
     conv = GCNConv(16, 32, flow="source_to_target")
     out1 = conv(x, edge_index)
     conv.flow = "target_to_source"
     out2 = conv(x, edge_index.flip(0))
     assert torch.allclose(out1, out2, atol=1e-6)
+
+    conv.flow = "source_to_target"
+    out3 = conv(x, adj)
+    conv.flow = "target_to_source"
+    out4 = conv(x, edge_index, value)
+    assert torch.allclose(out3, out4, atol=1e-6)

--- a/test/nn/conv/test_gcn_conv.py
+++ b/test/nn/conv/test_gcn_conv.py
@@ -84,17 +84,9 @@ def test_gcn_conv_norm():
     x = torch.randn(4, 16)
     edge_index = torch.tensor([[0, 0, 0], [1, 2, 3]])
     row, col = edge_index
-    value = torch.rand(row.size(0))
-    adj = SparseTensor(row=row, col=col, value=value, sparse_sizes=(4, 4))
 
     conv = GCNConv(16, 32, flow="source_to_target")
     out1 = conv(x, edge_index)
     conv.flow = "target_to_source"
     out2 = conv(x, edge_index.flip(0))
     assert torch.allclose(out1, out2, atol=1e-6)
-
-    conv.flow = "source_to_target"
-    out3 = conv(x, adj)
-    conv.flow = "target_to_source"
-    out4 = conv(x, edge_index, value)
-    assert torch.allclose(out3, out4, atol=1e-6)

--- a/torch_geometric/nn/conv/appnp.py
+++ b/torch_geometric/nn/conv/appnp.py
@@ -85,7 +85,7 @@ class APPNP(MessagePassing):
                 if cache is None:
                     edge_index, edge_weight = gcn_norm(  # yapf: disable
                         edge_index, edge_weight, x.size(self.node_dim), False,
-                        self.add_self_loops, dtype=x.dtype)
+                        self.add_self_loops, self.flow, dtype=x.dtype)
                     if self.cached:
                         self._cached_edge_index = (edge_index, edge_weight)
                 else:
@@ -96,7 +96,7 @@ class APPNP(MessagePassing):
                 if cache is None:
                     edge_index = gcn_norm(  # yapf: disable
                         edge_index, edge_weight, x.size(self.node_dim), False,
-                        self.add_self_loops, dtype=x.dtype)
+                        self.add_self_loops, self.flow, dtype=x.dtype)
                     if self.cached:
                         self._cached_adj_t = edge_index
                 else:

--- a/torch_geometric/nn/conv/arma_conv.py
+++ b/torch_geometric/nn/conv/arma_conv.py
@@ -108,12 +108,12 @@ class ARMAConv(MessagePassing):
         if isinstance(edge_index, Tensor):
             edge_index, edge_weight = gcn_norm(  # yapf: disable
                 edge_index, edge_weight, x.size(self.node_dim),
-                add_self_loops=False, dtype=x.dtype)
+                add_self_loops=False, flow=self.flow, dtype=x.dtype)
 
         elif isinstance(edge_index, SparseTensor):
             edge_index = gcn_norm(  # yapf: disable
                 edge_index, edge_weight, x.size(self.node_dim),
-                add_self_loops=False, dtype=x.dtype)
+                add_self_loops=False, flow=self.flow, dtype=x.dtype)
 
         x = x.unsqueeze(-3)
         out = x

--- a/torch_geometric/nn/conv/dna_conv.py
+++ b/torch_geometric/nn/conv/dna_conv.py
@@ -275,7 +275,7 @@ class DNAConv(MessagePassing):
                 if cache is None:
                     edge_index, edge_weight = gcn_norm(  # yapf: disable
                         edge_index, edge_weight, x.size(self.node_dim), False,
-                        self.add_self_loops, dtype=x.dtype)
+                        self.add_self_loops, self.flow, dtype=x.dtype)
                     if self.cached:
                         self._cached_edge_index = (edge_index, edge_weight)
                 else:
@@ -286,7 +286,7 @@ class DNAConv(MessagePassing):
                 if cache is None:
                     edge_index = gcn_norm(  # yapf: disable
                         edge_index, edge_weight, x.size(self.node_dim), False,
-                        self.add_self_loops, dtype=x.dtype)
+                        self.add_self_loops, self.flow, dtype=x.dtype)
                     if self.cached:
                         self._cached_adj_t = edge_index
                 else:

--- a/torch_geometric/nn/conv/eg_conv.py
+++ b/torch_geometric/nn/conv/eg_conv.py
@@ -130,7 +130,8 @@ class EGConv(MessagePassing):
                 if cache is None:
                     edge_index, symnorm_weight = gcn_norm(  # yapf: disable
                         edge_index, None, num_nodes=x.size(self.node_dim),
-                        improved=False, add_self_loops=self.add_self_loops)
+                        improved=False, add_self_loops=self.add_self_loops,
+                        flow=self.flow)
                     if self.cached:
                         self._cached_edge_index = (edge_index, symnorm_weight)
                 else:
@@ -141,7 +142,8 @@ class EGConv(MessagePassing):
                 if cache is None:
                     edge_index = gcn_norm(  # yapf: disable
                         edge_index, None, num_nodes=x.size(self.node_dim),
-                        improved=False, add_self_loops=self.add_self_loops)
+                        improved=False, add_self_loops=self.add_self_loops,
+                        flow=self.flow)
                     if self.cached:
                         self._cached_adj_t = edge_index
                 else:

--- a/torch_geometric/nn/conv/fa_conv.py
+++ b/torch_geometric/nn/conv/fa_conv.py
@@ -115,7 +115,7 @@ class FAConv(MessagePassing):
                 if cache is None:
                     edge_index, edge_weight = gcn_norm(  # yapf: disable
                         edge_index, None, x.size(self.node_dim), False,
-                        self.add_self_loops, dtype=x.dtype)
+                        self.add_self_loops, self.flow, dtype=x.dtype)
                     if self.cached:
                         self._cached_edge_index = (edge_index, edge_weight)
                 else:
@@ -127,7 +127,7 @@ class FAConv(MessagePassing):
                 if cache is None:
                     edge_index = gcn_norm(  # yapf: disable
                         edge_index, None, x.size(self.node_dim), False,
-                        self.add_self_loops, dtype=x.dtype)
+                        self.add_self_loops, self.flow, dtype=x.dtype)
                     if self.cached:
                         self._cached_adj_t = edge_index
                 else:

--- a/torch_geometric/nn/conv/gcn2_conv.py
+++ b/torch_geometric/nn/conv/gcn2_conv.py
@@ -119,7 +119,7 @@ class GCN2Conv(MessagePassing):
                 if cache is None:
                     edge_index, edge_weight = gcn_norm(  # yapf: disable
                         edge_index, edge_weight, x.size(self.node_dim), False,
-                        self.add_self_loops, dtype=x.dtype)
+                        self.add_self_loops, self.flow, dtype=x.dtype)
                     if self.cached:
                         self._cached_edge_index = (edge_index, edge_weight)
                 else:
@@ -130,7 +130,7 @@ class GCN2Conv(MessagePassing):
                 if cache is None:
                     edge_index = gcn_norm(  # yapf: disable
                         edge_index, edge_weight, x.size(self.node_dim), False,
-                        self.add_self_loops, dtype=x.dtype)
+                        self.add_self_loops, self.flow, dtype=x.dtype)
                     if self.cached:
                         self._cached_adj_t = edge_index
                 else:

--- a/torch_geometric/nn/conv/gcn_conv.py
+++ b/torch_geometric/nn/conv/gcn_conv.py
@@ -24,7 +24,7 @@ def gcn_norm(edge_index, edge_weight=None, num_nodes=None, improved=False,
 
 @torch.jit._overload
 def gcn_norm(edge_index, edge_weight=None, num_nodes=None, improved=False,
-             add_self_loops=True, flow="source_to_target",  dtype=None):
+             add_self_loops=True, flow="source_to_target", dtype=None):
     # type: (SparseTensor, OptTensor, Optional[int], bool, bool, str, Optional[int]) -> SparseTensor  # noqa
     pass
 

--- a/torch_geometric/nn/conv/gcn_conv.py
+++ b/torch_geometric/nn/conv/gcn_conv.py
@@ -32,10 +32,10 @@ def gcn_norm(edge_index, edge_weight=None, num_nodes=None, improved=False,
 def gcn_norm(edge_index, edge_weight=None, num_nodes=None, improved=False,
              add_self_loops=True, flow="source_to_target", dtype=None):
 
-    assert flow in ["source_to_target", "target_to_source"]
     fill_value = 2. if improved else 1.
 
     if isinstance(edge_index, SparseTensor):
+        assert flow in ["source_to_target"]
         adj_t = edge_index
         if not adj_t.has_value():
             adj_t = adj_t.fill_value(1., dtype=dtype)
@@ -49,6 +49,7 @@ def gcn_norm(edge_index, edge_weight=None, num_nodes=None, improved=False,
         return adj_t
 
     else:
+        assert flow in ["source_to_target", "target_to_source"]
         num_nodes = maybe_num_nodes(edge_index, num_nodes)
 
         if edge_weight is None:

--- a/torch_geometric/nn/conv/gcn_conv.py
+++ b/torch_geometric/nn/conv/gcn_conv.py
@@ -17,21 +17,22 @@ from torch_geometric.utils.num_nodes import maybe_num_nodes
 
 @torch.jit._overload
 def gcn_norm(edge_index, edge_weight=None, num_nodes=None, improved=False,
-             add_self_loops=True, dtype=None):
-    # type: (Tensor, OptTensor, Optional[int], bool, bool, Optional[int]) -> PairTensor  # noqa
+             add_self_loops=True, flow="source_to_target", dtype=None):
+    # type: (Tensor, OptTensor, Optional[int], bool, bool, str, Optional[int]) -> PairTensor  # noqa
     pass
 
 
 @torch.jit._overload
 def gcn_norm(edge_index, edge_weight=None, num_nodes=None, improved=False,
-             add_self_loops=True, dtype=None):
-    # type: (SparseTensor, OptTensor, Optional[int], bool, bool, Optional[int]) -> SparseTensor  # noqa
+             add_self_loops=True, flow="source_to_target",  dtype=None):
+    # type: (SparseTensor, OptTensor, Optional[int], bool, bool, str, Optional[int]) -> SparseTensor  # noqa
     pass
 
 
 def gcn_norm(edge_index, edge_weight=None, num_nodes=None, improved=False,
-             add_self_loops=True, dtype=None):
+             add_self_loops=True, flow="source_to_target", dtype=None):
 
+    assert flow in ["source_to_target", "target_to_source"]
     fill_value = 2. if improved else 1.
 
     if isinstance(edge_index, SparseTensor):
@@ -61,7 +62,8 @@ def gcn_norm(edge_index, edge_weight=None, num_nodes=None, improved=False,
             edge_weight = tmp_edge_weight
 
         row, col = edge_index[0], edge_index[1]
-        deg = scatter_add(edge_weight, col, dim=0, dim_size=num_nodes)
+        idx = col if flow == "source_to_target" else row
+        deg = scatter_add(edge_weight, idx, dim=0, dim_size=num_nodes)
         deg_inv_sqrt = deg.pow_(-0.5)
         deg_inv_sqrt.masked_fill_(deg_inv_sqrt == float('inf'), 0)
         return edge_index, deg_inv_sqrt[row] * edge_weight * deg_inv_sqrt[col]
@@ -171,7 +173,7 @@ class GCNConv(MessagePassing):
                 if cache is None:
                     edge_index, edge_weight = gcn_norm(  # yapf: disable
                         edge_index, edge_weight, x.size(self.node_dim),
-                        self.improved, self.add_self_loops)
+                        self.improved, self.add_self_loops, self.flow)
                     if self.cached:
                         self._cached_edge_index = (edge_index, edge_weight)
                 else:
@@ -182,7 +184,7 @@ class GCNConv(MessagePassing):
                 if cache is None:
                     edge_index = gcn_norm(  # yapf: disable
                         edge_index, edge_weight, x.size(self.node_dim),
-                        self.improved, self.add_self_loops)
+                        self.improved, self.add_self_loops, self.flow)
                     if self.cached:
                         self._cached_adj_t = edge_index
                 else:

--- a/torch_geometric/nn/conv/lg_conv.py
+++ b/torch_geometric/nn/conv/lg_conv.py
@@ -42,11 +42,12 @@ class LGConv(MessagePassing):
         """"""
         if self.normalize and isinstance(edge_index, Tensor):
             out = gcn_norm(edge_index, edge_weight, x.size(self.node_dim),
-                           add_self_loops=False, dtype=x.dtype)
+                           add_self_loops=False, flow=self.flow, dtype=x.dtype)
             edge_index, edge_weight = out
         elif self.normalize and isinstance(edge_index, SparseTensor):
             edge_index = gcn_norm(edge_index, None, x.size(self.node_dim),
-                                  add_self_loops=False, dtype=x.dtype)
+                                  add_self_loops=False, flow=self.flow,
+                                  dtype=x.dtype)
 
         # propagate_type: (x: Tensor, edge_weight: OptTensor)
         return self.propagate(edge_index, x=x, edge_weight=edge_weight,

--- a/torch_geometric/nn/conv/pdn_conv.py
+++ b/torch_geometric/nn/conv/pdn_conv.py
@@ -100,10 +100,11 @@ class PDNConv(MessagePassing):
             if isinstance(edge_index, Tensor):
                 edge_index, edge_attr = gcn_norm(edge_index, edge_attr,
                                                  x.size(self.node_dim), False,
-                                                 self.add_self_loops)
+                                                 self.add_self_loops,
+                                                 self.flow)
             elif isinstance(edge_index, SparseTensor):
                 edge_index = gcn_norm(edge_index, None, x.size(self.node_dim),
-                                      False, self.add_self_loops)
+                                      False, self.add_self_loops, self.flow)
 
         x = self.lin(x)
 

--- a/torch_geometric/nn/conv/sg_conv.py
+++ b/torch_geometric/nn/conv/sg_conv.py
@@ -83,11 +83,11 @@ class SGConv(MessagePassing):
             if isinstance(edge_index, Tensor):
                 edge_index, edge_weight = gcn_norm(  # yapf: disable
                     edge_index, edge_weight, x.size(self.node_dim), False,
-                    self.add_self_loops, dtype=x.dtype)
+                    self.add_self_loops, self.flow, dtype=x.dtype)
             elif isinstance(edge_index, SparseTensor):
                 edge_index = gcn_norm(  # yapf: disable
                     edge_index, edge_weight, x.size(self.node_dim), False,
-                    self.add_self_loops, dtype=x.dtype)
+                    self.add_self_loops, self.flow, dtype=x.dtype)
 
             for k in range(self.K):
                 # propagate_type: (x: Tensor, edge_weight: OptTensor)

--- a/torch_geometric/nn/conv/tag_conv.py
+++ b/torch_geometric/nn/conv/tag_conv.py
@@ -75,12 +75,13 @@ class TAGConv(MessagePassing):
             if isinstance(edge_index, Tensor):
                 edge_index, edge_weight = gcn_norm(  # yapf: disable
                     edge_index, edge_weight, x.size(self.node_dim),
-                    improved=False, add_self_loops=False, dtype=x.dtype)
+                    improved=False, add_self_loops=False, flow=self.flow,
+                    dtype=x.dtype)
 
             elif isinstance(edge_index, SparseTensor):
                 edge_index = gcn_norm(  # yapf: disable
                     edge_index, edge_weight, x.size(self.node_dim),
-                    add_self_loops=False, dtype=x.dtype)
+                    add_self_loops=False, flow=self.flow, dtype=x.dtype)
 
         out = self.lins[0](x)
         for lin in self.lins[1:]:


### PR DESCRIPTION
Add flow to `gcn_norm` to correctly normalize adjacency matrix when `flow=target_to_source` for directed graphs. This is discussed in #5100.

A simple test is added to verify this new behavior.

@rusty1s Let me know if you need me to edit any thing.