### PR TITLE
Fix bug in `EquilibriumAggregation`

### DIFF
--- a/torch_geometric/nn/aggr/equilibrium.py
+++ b/torch_geometric/nn/aggr/equilibrium.py
@@ -41,7 +41,7 @@ class ResNetPotential(torch.nn.Module):
             return h.mean()
 
         size = int(index.max().item() + 1)
-        return scatter(x, index, dim=0, dim_size=size, reduce='mean').sum()
+        return scatter(h, index, dim=0, dim_size=size, reduce='mean').sum()
 
 
 class MomentumOptimizer(torch.nn.Module):


### PR DESCRIPTION
Noticed when investigating https://github.com/pyg-team/pytorch_geometric/issues/5126, there was a small bug introduced when moving to the `nn.aggr` package.