### PR TITLE
Fix a typo in the example code of `HGTLoader`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ## [2.0.5] - 2022-MM-DD
 ### Added
+- Fixed typos in the documentation ([#5161](https://github.com/pyg-team/pytorch_geometric/pull/5161))
 - `NeighborSampler` supports graphs without edges ([#5072](https://github.com/pyg-team/pytorch_geometric/pull/5072))
 - Added the `MeanSubtractionNorm` layer ([#5068](https://github.com/pyg-team/pytorch_geometric/pull/5068))
 - Added `pyg_lib.segment_matmul` integration within `RGCNConv` ([#5052](https://github.com/pyg-team/pytorch_geometric/pull/5052), [#5096](https://github.com/pyg-team/pytorch_geometric/pull/5096))

--- a/torch_geometric/loader/hgt_loader.py
+++ b/torch_geometric/loader/hgt_loader.py
@@ -52,7 +52,7 @@ class HGTLoader(torch.utils.data.DataLoader):
             num_samples={key: [512] * 4 for key in hetero_data.node_types},
             # Use a batch size of 128 for sampling training nodes of type paper
             batch_size=128,
-            input_nodes=('paper': hetero_data['paper'].train_mask),
+            input_nodes=('paper', hetero_data['paper'].train_mask),
         )
 
         sampled_hetero_data = next(iter(loader))


### PR DESCRIPTION
Fix a typo in the example code of HGTLoader().

https://pytorch-geometric.readthedocs.io/en/latest/modules/loader.html#torch_geometric.loader.HGTLoader

Previous
```
loader = HGTLoader(
    ...
    input_nodes=('paper': hetero_data['paper'].train_mask),
)
```

Fixed
```
loader = HGTLoader(
    ...
    input_nodes=('paper', hetero_data['paper'].train_mask),
)
```