### PR TITLE
Ignore certain graph attributes in `from_networkx`

### DIFF
--- a/test/utils/test_convert.py
+++ b/test/utils/test_convert.py
@@ -53,7 +53,9 @@ def test_to_networkx():
     data = Data(x=x, pos=pos, edge_index=edge_index, weight=edge_attr)
 
     for remove_self_loops in [True, False]:
-        G = to_networkx(data, node_attrs=['x', 'pos'], edge_attrs=['weight'],
+        G = to_networkx(data,
+                        node_attrs=['x', 'pos'],
+                        edge_attrs=['weight'],
                         remove_self_loops=remove_self_loops)
 
         assert G.nodes[0]['x'] == [1, 2]
@@ -99,7 +101,9 @@ def test_to_networkx_undirected():
     data = Data(x=x, pos=pos, edge_index=edge_index, weight=edge_attr)
 
     for remove_self_loops in [True, False]:
-        G = to_networkx(data, node_attrs=['x', 'pos'], edge_attrs=['weight'],
+        G = to_networkx(data,
+                        node_attrs=['x', 'pos'],
+                        edge_attrs=['weight'],
                         remove_self_loops=remove_self_loops,
                         to_undirected=True)
 
@@ -149,9 +153,14 @@ def test_from_networkx_group_attrs():
     edge_attr1 = torch.randn(edge_index.size(1))
     edge_attr2 = torch.randn(edge_index.size(1))
     perm = torch.tensor([0, 2, 1])
-    data = Data(x=x, x1=x1, x2=x2, edge_index=edge_index,
-                edge_attr1=edge_attr1, edge_attr2=edge_attr2)
-    G = to_networkx(data, node_attrs=['x', 'x1', 'x2'],
+    data = Data(x=x,
+                x1=x1,
+                x2=x2,
+                edge_index=edge_index,
+                edge_attr1=edge_attr1,
+                edge_attr2=edge_attr2)
+    G = to_networkx(data,
+                    node_attrs=['x', 'x1', 'x2'],
                     edge_attrs=['edge_attr1', 'edge_attr2'])
     data = from_networkx(G, group_node_attrs=['x', 'x2'], group_edge_attrs=all)
     assert len(data) == 4
@@ -160,6 +169,7 @@ def test_from_networkx_group_attrs():
     assert data.edge_index.tolist() == edge_index[:, perm].tolist()
     assert data.edge_attr.tolist() == torch.stack([edge_attr1, edge_attr2],
                                                   dim=-1)[perm].tolist()
+
 
 @withPackage('networkx')
 def test_from_networkx_group_attrs():
@@ -170,24 +180,37 @@ def test_from_networkx_group_attrs():
     edge_attr1 = torch.randn(edge_index.size(1))
     edge_attr2 = torch.randn(edge_index.size(1))
     perm = torch.tensor([0, 2, 1])
-    data = Data(x=x, x1=x1, x2=x2, edge_index=edge_index,
-                edge_attr1=edge_attr1, edge_attr2=edge_attr2)
+    data = Data(x=x,
+                x1=x1,
+                x2=x2,
+                edge_index=edge_index,
+                edge_attr1=edge_attr1,
+                edge_attr2=edge_attr2)
 
-    G = to_networkx(data, node_attrs=['x', 'x1', 'x2'],
+    G = to_networkx(data,
+                    node_attrs=['x', 'x1', 'x2'],
                     edge_attrs=['edge_attr1', 'edge_attr2'])
     data = from_networkx(G, group_node_attrs=all, group_edge_attrs=all)
     assert data.x.tolist() == torch.cat([x, x1, x2], dim=-1).tolist()
     assert data.edge_attr.tolist() == torch.stack([edge_attr1, edge_attr2],
                                                   dim=-1)[perm].tolist()
 
-    data_reverse = Data(x=x, x1=x1, x2=x2, edge_index=edge_index,
-                edge_attr1=edge_attr1, edge_attr2=edge_attr2)
-    G_reverse = to_networkx(data_reverse, node_attrs=['x', 'x2', 'x1'],
-                    edge_attrs=['edge_attr2', 'edge_attr1'])
-    data_reverse = from_networkx(G_reverse, group_node_attrs=all, group_edge_attrs=all)
+    data_reverse = Data(x=x,
+                        x1=x1,
+                        x2=x2,
+                        edge_index=edge_index,
+                        edge_attr1=edge_attr1,
+                        edge_attr2=edge_attr2)
+    G_reverse = to_networkx(data_reverse,
+                            node_attrs=['x', 'x2', 'x1'],
+                            edge_attrs=['edge_attr2', 'edge_attr1'])
+    data_reverse = from_networkx(G_reverse,
+                                 group_node_attrs=all,
+                                 group_edge_attrs=all)
     assert data_reverse.x.tolist() == torch.cat([x, x2, x1], dim=-1).tolist()
-    assert data_reverse.edge_attr.tolist() == torch.stack([edge_attr2, edge_attr1],
-                                                  dim=-1)[perm].tolist()
+    assert data_reverse.edge_attr.tolist() == torch.stack(
+        [edge_attr2, edge_attr1], dim=-1)[perm].tolist()
+
 
 @withPackage('networkx')
 def test_networkx_vice_versa_convert():
@@ -297,22 +320,33 @@ def test_from_networkx_subgraph_convert():
     G = nx.complete_graph(5)
 
     edge_index = from_networkx(G).edge_index
-    sub_edge_index_1, _ = subgraph([0, 1, 3, 4], edge_index,
+    sub_edge_index_1, _ = subgraph([0, 1, 3, 4],
+                                   edge_index,
                                    relabel_nodes=True)
 
     sub_edge_index_2 = from_networkx(G.subgraph([0, 1, 3, 4])).edge_index
 
     assert sub_edge_index_1.tolist() == sub_edge_index_2.tolist()
 
+
 @withPackage('networkx')
 def test_from_networkx_node_attrs_ignore_missing():
     """
-    from_networkx should keep only node attributes that are systematically defined if ignore_missing_attrs set to True.
+    from_networkx should keep only node attributes that are systematically
+    defined if ignore_missing_attrs set to True.
     """
     import networkx as nx
 
     G = nx.Graph()
-    nodes = [(0, {'age': 1, 'height': 180}), (1, {'age': 6, 'height': 170}), (2, {'age': 6})]
+    nodes = [(0, {
+        'age': 1,
+        'height': 180
+    }), (1, {
+        'age': 6,
+        'height': 170
+    }), (2, {
+        'age': 6
+    })]
     edges = [(0, 1), (1, 2)]
     G.add_nodes_from(nodes)
     G.add_edges_from(edges)
@@ -322,10 +356,12 @@ def test_from_networkx_node_attrs_ignore_missing():
     assert data.age.tolist() == [node_attrs['age'] for _, node_attrs in nodes]
     assert 'height' not in data.to_dict()
 
+
 @withPackage('networkx')
 def test_from_networkx_edge_attrs_ignore_missing():
     """
-    from_networkx should keep only edge attributes that are systematically defined if ignore_missing_attrs set to True.
+    from_networkx should keep only edge attributes that are systematically
+    defined if ignore_missing_attrs set to True.
     """
     import networkx as nx
 
@@ -336,10 +372,15 @@ def test_from_networkx_edge_attrs_ignore_missing():
     G.add_edges_from(edges)
 
     data = from_networkx(G, ignore_missing_attrs=True)
-    
-    duplicated_weights = [weight for to_duplicate_weight in [edge_attrs['weight'] for _, _, edge_attrs in edges] for weight in [to_duplicate_weight]*2]
+
+    duplicated_weights = [
+        weight for to_duplicate_weight in
+        [edge_attrs['weight'] for _, _, edge_attrs in edges]
+        for weight in [to_duplicate_weight] * 2
+    ]
     assert data.weight.tolist() == duplicated_weights
     assert 'frequency' not in data.to_dict()
+
 
 @withPackage('networkx')
 def test_from_networkx_fails_when_partially_defined_attrs():
@@ -352,13 +393,13 @@ def test_from_networkx_fails_when_partially_defined_attrs():
     G_missing_node_attrs.add_edges_from(edges)
 
     try:
-        data = from_networkx(G_missing_node_attrs, ignore_missing_attrs=False)
+        from_networkx(G_missing_node_attrs, ignore_missing_attrs=False)
     except ValueError:
         assert True
     except Exception:
-       assert False
+        assert False
     else:
-       assert False
+        assert False
 
     G_missing_node_attrs = nx.Graph()
     nodes = [(0, {'age': 1}), (1, {'age': 6}), (2, {'age': 6})]
@@ -367,13 +408,14 @@ def test_from_networkx_fails_when_partially_defined_attrs():
     G_missing_node_attrs.add_edges_from(edges)
 
     try:
-        data = from_networkx(G_missing_node_attrs, ignore_missing_attrs=False)
+        from_networkx(G_missing_node_attrs, ignore_missing_attrs=False)
     except ValueError:
         assert True
     except Exception:
-       assert False
+        assert False
     else:
-       assert False
+        assert False
+
 
 @withPackage('trimesh')
 def test_trimesh():

--- a/test/utils/test_convert.py
+++ b/test/utils/test_convert.py
@@ -53,9 +53,7 @@ def test_to_networkx():
     data = Data(x=x, pos=pos, edge_index=edge_index, weight=edge_attr)
 
     for remove_self_loops in [True, False]:
-        G = to_networkx(data,
-                        node_attrs=['x', 'pos'],
-                        edge_attrs=['weight'],
+        G = to_networkx(data, node_attrs=['x', 'pos'], edge_attrs=['weight'],
                         remove_self_loops=remove_self_loops)
 
         assert G.nodes[0]['x'] == [1, 2]
@@ -101,9 +99,7 @@ def test_to_networkx_undirected():
     data = Data(x=x, pos=pos, edge_index=edge_index, weight=edge_attr)
 
     for remove_self_loops in [True, False]:
-        G = to_networkx(data,
-                        node_attrs=['x', 'pos'],
-                        edge_attrs=['weight'],
+        G = to_networkx(data, node_attrs=['x', 'pos'], edge_attrs=['weight'],
                         remove_self_loops=remove_self_loops,
                         to_undirected=True)
 
@@ -153,14 +149,9 @@ def test_from_networkx_group_attrs():
     edge_attr1 = torch.randn(edge_index.size(1))
     edge_attr2 = torch.randn(edge_index.size(1))
     perm = torch.tensor([0, 2, 1])
-    data = Data(x=x,
-                x1=x1,
-                x2=x2,
-                edge_index=edge_index,
-                edge_attr1=edge_attr1,
-                edge_attr2=edge_attr2)
-    G = to_networkx(data,
-                    node_attrs=['x', 'x1', 'x2'],
+    data = Data(x=x, x1=x1, x2=x2, edge_index=edge_index,
+                edge_attr1=edge_attr1, edge_attr2=edge_attr2)
+    G = to_networkx(data, node_attrs=['x', 'x1', 'x2'],
                     edge_attrs=['edge_attr1', 'edge_attr2'])
     data = from_networkx(G, group_node_attrs=['x', 'x2'], group_edge_attrs=all)
     assert len(data) == 4
@@ -180,32 +171,21 @@ def test_from_networkx_group_attrs():
     edge_attr1 = torch.randn(edge_index.size(1))
     edge_attr2 = torch.randn(edge_index.size(1))
     perm = torch.tensor([0, 2, 1])
-    data = Data(x=x,
-                x1=x1,
-                x2=x2,
-                edge_index=edge_index,
-                edge_attr1=edge_attr1,
-                edge_attr2=edge_attr2)
+    data = Data(x=x, x1=x1, x2=x2, edge_index=edge_index,
+                edge_attr1=edge_attr1, edge_attr2=edge_attr2)
 
-    G = to_networkx(data,
-                    node_attrs=['x', 'x1', 'x2'],
+    G = to_networkx(data, node_attrs=['x', 'x1', 'x2'],
                     edge_attrs=['edge_attr1', 'edge_attr2'])
     data = from_networkx(G, group_node_attrs=all, group_edge_attrs=all)
     assert data.x.tolist() == torch.cat([x, x1, x2], dim=-1).tolist()
     assert data.edge_attr.tolist() == torch.stack([edge_attr1, edge_attr2],
                                                   dim=-1)[perm].tolist()
 
-    data_reverse = Data(x=x,
-                        x1=x1,
-                        x2=x2,
-                        edge_index=edge_index,
-                        edge_attr1=edge_attr1,
-                        edge_attr2=edge_attr2)
-    G_reverse = to_networkx(data_reverse,
-                            node_attrs=['x', 'x2', 'x1'],
+    data_reverse = Data(x=x, x1=x1, x2=x2, edge_index=edge_index,
+                        edge_attr1=edge_attr1, edge_attr2=edge_attr2)
+    G_reverse = to_networkx(data_reverse, node_attrs=['x', 'x2', 'x1'],
                             edge_attrs=['edge_attr2', 'edge_attr1'])
-    data_reverse = from_networkx(G_reverse,
-                                 group_node_attrs=all,
+    data_reverse = from_networkx(G_reverse, group_node_attrs=all,
                                  group_edge_attrs=all)
     assert data_reverse.x.tolist() == torch.cat([x, x2, x1], dim=-1).tolist()
     assert data_reverse.edge_attr.tolist() == torch.stack(
@@ -320,8 +300,7 @@ def test_from_networkx_subgraph_convert():
     G = nx.complete_graph(5)
 
     edge_index = from_networkx(G).edge_index
-    sub_edge_index_1, _ = subgraph([0, 1, 3, 4],
-                                   edge_index,
+    sub_edge_index_1, _ = subgraph([0, 1, 3, 4], edge_index,
                                    relabel_nodes=True)
 
     sub_edge_index_2 = from_networkx(G.subgraph([0, 1, 3, 4])).edge_index

--- a/test/utils/test_convert.py
+++ b/test/utils/test_convert.py
@@ -161,6 +161,33 @@ def test_from_networkx_group_attrs():
     assert data.edge_attr.tolist() == torch.stack([edge_attr1, edge_attr2],
                                                   dim=-1)[perm].tolist()
 
+@withPackage('networkx')
+def test_from_networkx_group_attrs():
+    x = torch.randn(2, 2)
+    x1 = torch.randn(2, 4)
+    x2 = torch.randn(2, 8)
+    edge_index = torch.tensor([[0, 1, 0], [1, 0, 0]])
+    edge_attr1 = torch.randn(edge_index.size(1))
+    edge_attr2 = torch.randn(edge_index.size(1))
+    perm = torch.tensor([0, 2, 1])
+    data = Data(x=x, x1=x1, x2=x2, edge_index=edge_index,
+                edge_attr1=edge_attr1, edge_attr2=edge_attr2)
+
+    G = to_networkx(data, node_attrs=['x', 'x1', 'x2'],
+                    edge_attrs=['edge_attr1', 'edge_attr2'])
+    data = from_networkx(G, group_node_attrs=all, group_edge_attrs=all)
+    assert data.x.tolist() == torch.cat([x, x1, x2], dim=-1).tolist()
+    assert data.edge_attr.tolist() == torch.stack([edge_attr1, edge_attr2],
+                                                  dim=-1)[perm].tolist()
+
+    data_reverse = Data(x=x, x1=x1, x2=x2, edge_index=edge_index,
+                edge_attr1=edge_attr1, edge_attr2=edge_attr2)
+    G_reverse = to_networkx(data_reverse, node_attrs=['x', 'x2', 'x1'],
+                    edge_attrs=['edge_attr2', 'edge_attr1'])
+    data_reverse = from_networkx(G_reverse, group_node_attrs=all, group_edge_attrs=all)
+    assert data_reverse.x.tolist() == torch.cat([x, x2, x1], dim=-1).tolist()
+    assert data_reverse.edge_attr.tolist() == torch.stack([edge_attr2, edge_attr1],
+                                                  dim=-1)[perm].tolist()
 
 @withPackage('networkx')
 def test_networkx_vice_versa_convert():
@@ -316,6 +343,7 @@ def test_from_networkx_edge_attrs_ignore_missing():
 
 @withPackage('networkx')
 def test_from_networkx_fails_when_partially_defined_attrs():
+    import networkx as nx
 
     G_missing_node_attrs = nx.Graph()
     nodes = [(0, {'age': 1}), (1, {'age': 6}), (2, {'age': 6})]

--- a/torch_geometric/utils/convert.py
+++ b/torch_geometric/utils/convert.py
@@ -162,12 +162,12 @@ def from_networkx(G, group_node_attrs: Optional[Union[List[str], all]] = None,
     data = defaultdict(list)
 
     node_data = [feat_dict for _, feat_dict in G.nodes(data=True)]
-    node_union_attrs = set.union(*[set(nd) for nd in node_data])
-    node_intersection_attrs = set.intersection(*[set(nd) for nd in node_data])
+    node_union_attrs = set([]) if len(node_data) == 0 else set.union(*[set(nd) for nd in node_data])
+    node_intersection_attrs = set([]) if len(node_data) == 0 else set.intersection(*[set(nd) for nd in node_data])
 
     edge_data = [feat_dict for _, _, feat_dict in G.edges(data=True)]
-    edge_union_attrs = set.union(*[set(ed) for ed in edge_data])
-    edge_intersection_attrs = set.intersection(*[set(ed) for ed in edge_data])
+    edge_union_attrs = set([]) if len(edge_data) == 0 else set.union(*[set(ed) for ed in edge_data])
+    edge_intersection_attrs = set([]) if len(edge_data) == 0 else set.intersection(*[set(ed) for ed in edge_data])
 
     if not ignore_missing_attrs and len(node_union_attrs) > len(node_intersection_attrs):
         part_missing_node_attrs = node_union_attrs.difference(node_intersection_attrs)
@@ -177,8 +177,8 @@ def from_networkx(G, group_node_attrs: Optional[Union[List[str], all]] = None,
         part_missing_edge_attrs = edge_union_attrs.difference(edge_intersection_attrs)
         raise ValueError("Not all edges contain the same attributes. Edge attribute{} {} sometimes missing.".format('s' if len(part_missing_edge_attrs) > 1 else '', part_missing_edge_attrs))
 
-    node_attrs = node_intersection_attrs
-    edge_attrs = edge_intersection_attrs
+    node_attrs = [] if len(node_data) == 0 else [attr for attr in node_data[0] if attr in node_intersection_attrs]
+    edge_attrs = [] if len(edge_data) == 0 else [attr for attr in edge_data[0] if attr in edge_intersection_attrs]
 
     formatted_node_data = {key: [i[key] for i in node_data] for key in node_intersection_attrs}
     data = formatted_node_data

--- a/torch_geometric/utils/convert.py
+++ b/torch_geometric/utils/convert.py
@@ -48,7 +48,10 @@ def from_scipy_sparse_matrix(A):
     return edge_index, edge_weight
 
 
-def to_networkx(data, node_attrs=None, edge_attrs=None, graph_attrs=None,
+def to_networkx(data,
+                node_attrs=None,
+                edge_attrs=None,
+                graph_attrs=None,
                 to_undirected: Union[bool, str] = False,
                 remove_self_loops: bool = False):
     r"""Converts a :class:`torch_geometric.data.Data` instance to a
@@ -123,7 +126,8 @@ def to_networkx(data, node_attrs=None, edge_attrs=None, graph_attrs=None,
     return G
 
 
-def from_networkx(G, group_node_attrs: Optional[Union[List[str], all]] = None,
+def from_networkx(G,
+                  group_node_attrs: Optional[Union[List[str], all]] = None,
                   group_edge_attrs: Optional[Union[List[str], all]] = None,
                   ignore_missing_attrs: Optional[bool] = False):
     r"""Converts a :obj:`networkx.Graph` or :obj:`networkx.DiGraph` to a
@@ -162,29 +166,60 @@ def from_networkx(G, group_node_attrs: Optional[Union[List[str], all]] = None,
     data = defaultdict(list)
 
     node_data = [feat_dict for _, feat_dict in G.nodes(data=True)]
-    node_union_attrs = set([]) if len(node_data) == 0 else set.union(*[set(nd) for nd in node_data])
-    node_intersection_attrs = set([]) if len(node_data) == 0 else set.intersection(*[set(nd) for nd in node_data])
+    node_union_attrs = set([]) if len(node_data) == 0 else set.union(
+        *[set(nd) for nd in node_data])
+    node_intersection_attrs = set(
+        []) if len(node_data) == 0 else set.intersection(
+            *[set(nd) for nd in node_data])
 
     edge_data = [feat_dict for _, _, feat_dict in G.edges(data=True)]
-    edge_union_attrs = set([]) if len(edge_data) == 0 else set.union(*[set(ed) for ed in edge_data])
-    edge_intersection_attrs = set([]) if len(edge_data) == 0 else set.intersection(*[set(ed) for ed in edge_data])
+    edge_union_attrs = set([]) if len(edge_data) == 0 else set.union(
+        *[set(ed) for ed in edge_data])
+    edge_intersection_attrs = set(
+        []) if len(edge_data) == 0 else set.intersection(
+            *[set(ed) for ed in edge_data])
 
-    if not ignore_missing_attrs and len(node_union_attrs) > len(node_intersection_attrs):
-        part_missing_node_attrs = node_union_attrs.difference(node_intersection_attrs)
-        raise ValueError("Not all nodes contain the same attributes. Node attribute{} {} sometimes missing.".format('s' if len(part_missing_node_attrs) > 1 else '', part_missing_node_attrs))
+    if (not ignore_missing_attrs and len(
+            node_union_attrs) > len(node_intersection_attrs)):
+        part_missing_node_attrs = node_union_attrs.difference(
+            node_intersection_attrs)
+        raise ValueError(
+            """Not all nodes contain the same attributes.
+            Node attribute{} {} sometimes missing."""
+            .format('s' if len(part_missing_node_attrs) > 1 else '',
+                    part_missing_node_attrs))
 
-    if not ignore_missing_attrs and len(edge_union_attrs) > len(edge_intersection_attrs):
-        part_missing_edge_attrs = edge_union_attrs.difference(edge_intersection_attrs)
-        raise ValueError("Not all edges contain the same attributes. Edge attribute{} {} sometimes missing.".format('s' if len(part_missing_edge_attrs) > 1 else '', part_missing_edge_attrs))
+    if not ignore_missing_attrs and len(edge_union_attrs) > len(
+            edge_intersection_attrs):
+        part_missing_edge_attrs = edge_union_attrs.difference(
+            edge_intersection_attrs)
+        raise ValueError(
+            """Not all edges contain the same attributes.
+            Edge attribute{} {} sometimes missing."""
+            .format('s' if len(part_missing_edge_attrs) > 1 else '',
+                    part_missing_edge_attrs))
 
-    node_attrs = [] if len(node_data) == 0 else [attr for attr in node_data[0] if attr in node_intersection_attrs]
-    edge_attrs = [] if len(edge_data) == 0 else [attr for attr in edge_data[0] if attr in edge_intersection_attrs]
+    node_attrs = [] if len(node_data) == 0 else [
+        attr for attr in node_data[0] if attr in node_intersection_attrs
+    ]
+    edge_attrs = [] if len(edge_data) == 0 else [
+        attr for attr in edge_data[0] if attr in edge_intersection_attrs
+    ]
 
-    formatted_node_data = {key: [i[key] for i in node_data] for key in node_intersection_attrs}
+    formatted_node_data = {
+        key: [i[key] for i in node_data]
+        for key in node_intersection_attrs
+    }
     data = formatted_node_data
-    formatted_edge_data = {f'edge_{key}' if key in data else key: [i[key] for i in edge_data] for key in edge_intersection_attrs}
+    formatted_edge_data = {
+        f'edge_{key}' if key in data else key: [i[key] for i in edge_data]
+        for key in edge_intersection_attrs
+    }
     data = {**data, **formatted_edge_data}
-    formatted_graph_data = {f'graph_{key}' if key in data else key: value for key, value in G.graph.items()}
+    formatted_graph_data = {
+        f'graph_{key}' if key in data else key: value
+        for key, value in G.graph.items()
+    }
     data = {**data, **formatted_graph_data}
 
     for key, value in data.items():
@@ -256,7 +291,8 @@ def from_trimesh(mesh):
     return Data(pos=pos, face=face)
 
 
-def to_cugraph(edge_index: Tensor, edge_weight: Optional[Tensor] = None,
+def to_cugraph(edge_index: Tensor,
+               edge_weight: Optional[Tensor] = None,
                relabel_nodes: bool = True):
     r"""Converts a graph given by :obj:`edge_index` and optional
     :obj:`edge_weight` into a :obj:`cugraph` graph object.
@@ -276,7 +312,9 @@ def to_cugraph(edge_index: Tensor, edge_weight: Optional[Tensor] = None,
         df[2] = cudf.from_dlpack(to_dlpack(edge_weight))
 
     return cugraph.from_cudf_edgelist(
-        df, source=0, destination=1,
+        df,
+        source=0,
+        destination=1,
         edge_attr=2 if edge_weight is not None else None,
         renumber=relabel_nodes)
 

--- a/torch_geometric/utils/convert.py
+++ b/torch_geometric/utils/convert.py
@@ -48,10 +48,7 @@ def from_scipy_sparse_matrix(A):
     return edge_index, edge_weight
 
 
-def to_networkx(data,
-                node_attrs=None,
-                edge_attrs=None,
-                graph_attrs=None,
+def to_networkx(data, node_attrs=None, edge_attrs=None, graph_attrs=None,
                 to_undirected: Union[bool, str] = False,
                 remove_self_loops: bool = False):
     r"""Converts a :class:`torch_geometric.data.Data` instance to a
@@ -126,8 +123,7 @@ def to_networkx(data,
     return G
 
 
-def from_networkx(G,
-                  group_node_attrs: Optional[Union[List[str], all]] = None,
+def from_networkx(G, group_node_attrs: Optional[Union[List[str], all]] = None,
                   group_edge_attrs: Optional[Union[List[str], all]] = None,
                   ignore_missing_attrs: Optional[bool] = False):
     r"""Converts a :obj:`networkx.Graph` or :obj:`networkx.DiGraph` to a
@@ -179,25 +175,23 @@ def from_networkx(G,
         []) if len(edge_data) == 0 else set.intersection(
             *[set(ed) for ed in edge_data])
 
-    if (not ignore_missing_attrs and len(
-            node_union_attrs) > len(node_intersection_attrs)):
+    if (not ignore_missing_attrs
+            and len(node_union_attrs) > len(node_intersection_attrs)):
         part_missing_node_attrs = node_union_attrs.difference(
             node_intersection_attrs)
-        raise ValueError(
-            """Not all nodes contain the same attributes.
-            Node attribute{} {} sometimes missing."""
-            .format('s' if len(part_missing_node_attrs) > 1 else '',
-                    part_missing_node_attrs))
+        raise ValueError("""Not all nodes contain the same attributes.
+            Node attribute{} {} sometimes missing.""".format(
+            's' if len(part_missing_node_attrs) > 1 else '',
+            part_missing_node_attrs))
 
     if not ignore_missing_attrs and len(edge_union_attrs) > len(
             edge_intersection_attrs):
         part_missing_edge_attrs = edge_union_attrs.difference(
             edge_intersection_attrs)
-        raise ValueError(
-            """Not all edges contain the same attributes.
-            Edge attribute{} {} sometimes missing."""
-            .format('s' if len(part_missing_edge_attrs) > 1 else '',
-                    part_missing_edge_attrs))
+        raise ValueError("""Not all edges contain the same attributes.
+            Edge attribute{} {} sometimes missing.""".format(
+            's' if len(part_missing_edge_attrs) > 1 else '',
+            part_missing_edge_attrs))
 
     node_attrs = [] if len(node_data) == 0 else [
         attr for attr in node_data[0] if attr in node_intersection_attrs
@@ -291,8 +285,7 @@ def from_trimesh(mesh):
     return Data(pos=pos, face=face)
 
 
-def to_cugraph(edge_index: Tensor,
-               edge_weight: Optional[Tensor] = None,
+def to_cugraph(edge_index: Tensor, edge_weight: Optional[Tensor] = None,
                relabel_nodes: bool = True):
     r"""Converts a graph given by :obj:`edge_index` and optional
     :obj:`edge_weight` into a :obj:`cugraph` graph object.
@@ -312,9 +305,7 @@ def to_cugraph(edge_index: Tensor,
         df[2] = cudf.from_dlpack(to_dlpack(edge_weight))
 
     return cugraph.from_cudf_edgelist(
-        df,
-        source=0,
-        destination=1,
+        df, source=0, destination=1,
         edge_attr=2 if edge_weight is not None else None,
         renumber=relabel_nodes)
 

--- a/torch_geometric/utils/convert.py
+++ b/torch_geometric/utils/convert.py
@@ -124,7 +124,8 @@ def to_networkx(data, node_attrs=None, edge_attrs=None, graph_attrs=None,
 
 
 def from_networkx(G, group_node_attrs: Optional[Union[List[str], all]] = None,
-                  group_edge_attrs: Optional[Union[List[str], all]] = None):
+                  group_edge_attrs: Optional[Union[List[str], all]] = None,
+                  ignore_missing_attrs: Optional[bool] = False):
     r"""Converts a :obj:`networkx.Graph` or :obj:`networkx.DiGraph` to a
     :class:`torch_geometric.data.Data` instance.
 
@@ -135,6 +136,9 @@ def from_networkx(G, group_node_attrs: Optional[Union[List[str], all]] = None,
         group_edge_attrs (List[str] or all, optional): The edge attributes to
             be concatenated and added to :obj:`data.edge_attr`.
             (default: :obj:`None`)
+        ignore_missing_attrs (bool, optional): Whether to ignore attributes
+            that are not present in every node.
+            (default: :obj:`False`)
 
     .. note::
 
@@ -157,32 +161,31 @@ def from_networkx(G, group_node_attrs: Optional[Union[List[str], all]] = None,
 
     data = defaultdict(list)
 
-    if G.number_of_nodes() > 0:
-        node_attrs = list(next(iter(G.nodes(data=True)))[-1].keys())
-    else:
-        node_attrs = {}
+    node_data = [feat_dict for _, feat_dict in G.nodes(data=True)]
+    node_union_attrs = set.union(*[set(nd) for nd in node_data])
+    node_intersection_attrs = set.intersection(*[set(nd) for nd in node_data])
 
-    if G.number_of_edges() > 0:
-        edge_attrs = list(next(iter(G.edges(data=True)))[-1].keys())
-    else:
-        edge_attrs = {}
+    edge_data = [feat_dict for _, _, feat_dict in G.edges(data=True)]
+    edge_union_attrs = set.union(*[set(ed) for ed in edge_data])
+    edge_intersection_attrs = set.intersection(*[set(ed) for ed in edge_data])
 
-    for i, (_, feat_dict) in enumerate(G.nodes(data=True)):
-        if set(feat_dict.keys()) != set(node_attrs):
-            raise ValueError('Not all nodes contain the same attributes')
-        for key, value in feat_dict.items():
-            data[str(key)].append(value)
+    if not ignore_missing_attrs and len(node_union_attrs) > len(node_intersection_attrs):
+        part_missing_node_attrs = node_union_attrs.difference(node_intersection_attrs)
+        raise ValueError("Not all nodes contain the same attributes. Node attribute{} {} sometimes missing.".format('s' if len(part_missing_node_attrs) > 1 else '', part_missing_node_attrs))
 
-    for i, (_, _, feat_dict) in enumerate(G.edges(data=True)):
-        if set(feat_dict.keys()) != set(edge_attrs):
-            raise ValueError('Not all edges contain the same attributes')
-        for key, value in feat_dict.items():
-            key = f'edge_{key}' if key in node_attrs else key
-            data[str(key)].append(value)
+    if not ignore_missing_attrs and len(edge_union_attrs) > len(edge_intersection_attrs):
+        part_missing_edge_attrs = edge_union_attrs.difference(edge_intersection_attrs)
+        raise ValueError("Not all edges contain the same attributes. Edge attribute{} {} sometimes missing.".format('s' if len(part_missing_edge_attrs) > 1 else '', part_missing_edge_attrs))
 
-    for key, value in G.graph.items():
-        key = f'graph_{key}' if key in node_attrs else key
-        data[str(key)] = value
+    node_attrs = node_intersection_attrs
+    edge_attrs = edge_intersection_attrs
+
+    formatted_node_data = {key: [i[key] for i in node_data] for key in node_intersection_attrs}
+    data = formatted_node_data
+    formatted_edge_data = {f'edge_{key}' if key in data else key: [i[key] for i in edge_data] for key in edge_intersection_attrs}
+    data = {**data, **formatted_edge_data}
+    formatted_graph_data = {f'graph_{key}' if key in data else key: value for key, value in G.graph.items()}
+    data = {**data, **formatted_graph_data}
 
     for key, value in data.items():
         if isinstance(value, (tuple, list)) and isinstance(value[0], Tensor):


### PR DESCRIPTION
### Proposition: 
New feature for the utility function `from_networkx`
Possibility to ignore some of the graph attributes that are only partially defined.

### Motivation:
No easy function in networkx allows to delete a list of attributes from a graph to my knowledge. So it is always a hassle to do so when your input graph has this kind of flaw.

This situation has append to me more than once, and I thus wanted to propose an easy solution to that.

It would be a nice fit if on top of the `group_attrs` proposed, we could ignore those attributes that are outside of that list and we do not care about.

### Solution:
I hereby propose a boolean parameter to the function with a default value that keeps the old behavior.
If set to `True`, this will allow, if any attributes are missing from some nodes or edges, to ignore these attributes and simply go on to add all the ones that are correctly defined.

In doing so, I also refined the error message raised when some missing attribute exist & the boolean is set to False.

I also added a list of several unit tests to guarantee the correct behavior of the new functionality as well as some other ones that I found relevant.


