### PR TITLE
fix device mismatch bug in metapath2vec example

### DIFF
--- a/examples/hetero/metapath2vec.py
+++ b/examples/hetero/metapath2vec.py
@@ -54,7 +54,7 @@ def train(epoch, log_steps=100, eval_steps=2000):
 def test(train_ratio=0.1):
     model.eval()
 
-    z = model('author', batch=data['author'].y_index)
+    z = model('author', batch=data['author'].y_index.to(device))
     y = data['author'].y
 
     perm = torch.randperm(z.size(0))


### PR DESCRIPTION
This PR fixes the device mismatch bug in [metapath2vec example](https://github.com/pyg-team/pytorch_geometric/blob/master/examples/hetero/metapath2vec.py). This bug was also mentioned in [this discussion](https://torchgeometricco.slack.com/archives/CRAR9HK2P/p1660639673925579).