### PR TITLE
Prevent absolute paths in `egg-info`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -75,5 +75,4 @@ setup(
         'dev': dev_requires,
     },
     packages=find_packages(),
-    include_package_data=True,
 )


### PR DESCRIPTION
Related to https://github.com/rusty1s/pytorch_cluster/pull/142.