### PR TITLE
Add experimental mode for `utils.scatter`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ## [2.2.0] - 2022-MM-DD
 ### Added
+- Added experimental mode for `utils.scatter` ([#5232](https://github.com/pyg-team/pytorch_geometric/pull/5232))
 - Added a test to confirm that `to_hetero` works with `SparseTensor` ([#5222](https://github.com/pyg-team/pytorch_geometric/pull/5222))
 ### Changed
 ### Removed

--- a/docs/source/modules/root.rst
+++ b/docs/source/modules/root.rst
@@ -9,3 +9,6 @@ torch_geometric
     :members:
     :undoc-members:
     :exclude-members: set_debug_enabled
+
+.. automodule:: torch_geometric.experimental
+    :members:

--- a/test/test_experimental.py
+++ b/test/test_experimental.py
@@ -1,29 +1,11 @@
 import pytest
 
-from torch_geometric import (
-    disable_all_experimental_options,
-    is_experimental_option_enabled,
-    set_experimental_options,
-)
+from torch_geometric import experimental_mode, is_experimental_mode_enabled
 
 
-@pytest.mark.parametrize('option', ['pytorch_scatter'])
-def test_experimental(option):
-    assert is_experimental_option_enabled(option) is False
-    set_experimental_options({option: True})
-    assert is_experimental_option_enabled(option) is True
-    set_experimental_options({option: False})
-    assert is_experimental_option_enabled(option) is False
-
-    set_experimental_options({option: True})
-    disable_all_experimental_options()
-    assert is_experimental_option_enabled(option) is False
-
-    with set_experimental_options({option: True}):
-        assert is_experimental_option_enabled(option) is True
-    assert is_experimental_option_enabled(option) is False
-
-    set_experimental_options({option: True})
-    with set_experimental_options({option: False}):
-        assert is_experimental_option_enabled(option) is False
-    assert is_experimental_option_enabled(option) is True
+@pytest.mark.parametrize('options', [None, 'scatter_reduce'])
+def test_experimental_mode(options):
+    assert is_experimental_mode_enabled(options) is False
+    with experimental_mode(options):
+        assert is_experimental_mode_enabled(options) is True
+    assert is_experimental_mode_enabled(options) is False

--- a/test/test_experimental.py
+++ b/test/test_experimental.py
@@ -1,0 +1,29 @@
+import pytest
+
+from torch_geometric import (
+    disable_all_experimental_options,
+    is_experimental_option_enabled,
+    set_experimental_options,
+)
+
+
+@pytest.mark.parametrize('option', ['pytorch_scatter'])
+def test_experimental(option):
+    assert is_experimental_option_enabled(option) is False
+    set_experimental_options({option: True})
+    assert is_experimental_option_enabled(option) is True
+    set_experimental_options({option: False})
+    assert is_experimental_option_enabled(option) is False
+
+    set_experimental_options({option: True})
+    disable_all_experimental_options()
+    assert is_experimental_option_enabled(option) is False
+
+    with set_experimental_options({option: True}):
+        assert is_experimental_option_enabled(option) is True
+    assert is_experimental_option_enabled(option) is False
+
+    set_experimental_options({option: True})
+    with set_experimental_options({option: False}):
+        assert is_experimental_option_enabled(option) is False
+    assert is_experimental_option_enabled(option) is True

--- a/test/utils/test_scatter.py
+++ b/test/utils/test_scatter.py
@@ -2,7 +2,7 @@ import pytest
 import torch
 import torch_scatter
 
-from torch_geometric import set_experimental_options
+import torch_geometric
 from torch_geometric.utils import scatter
 
 
@@ -13,7 +13,7 @@ def test_scatter(reduce):
     src = torch.randn(8, 100, 32)
     index = torch.randint(0, 10, (100, ), dtype=torch.long)
 
-    with set_experimental_options({'pytorch_scatter': True}):
+    with torch_geometric.experimental_mode('scatter_reduce'):
         out1 = scatter(src, index, dim=1, reduce=reduce)
     out2 = torch_scatter.scatter(src, index, dim=1, reduce=reduce)
     assert torch.allclose(out1, out2, atol=1e-6)
@@ -26,7 +26,7 @@ def test_scatter_backward(reduce):
     src = torch.randn(8, 100, 32).requires_grad_(True)
     index = torch.randint(0, 10, (100, ), dtype=torch.long)
 
-    with set_experimental_options({'pytorch_scatter': True}):
+    with torch_geometric.experimental_mode('scatter_reduce'):
         out = scatter(src, index, dim=1, reduce=reduce).relu_()
     assert src.grad is None
     out.mean().backward()
@@ -41,7 +41,7 @@ def test_scatter_with_out(reduce):
     index = torch.randint(0, 10, (100, ), dtype=torch.long)
     out = torch.randn(8, 10, 32)
 
-    with set_experimental_options({'pytorch_scatter': True}):
+    with torch_geometric.experimental_mode('scatter_reduce'):
         out1 = scatter(src, index, dim=1, out=out.clone(), reduce=reduce)
     out2 = torch_scatter.scatter(src, index, dim=1, out=out.clone(),
                                  reduce=reduce)

--- a/test/utils/test_scatter.py
+++ b/test/utils/test_scatter.py
@@ -2,6 +2,7 @@ import pytest
 import torch
 import torch_scatter
 
+from torch_geometric import set_experimental_options
 from torch_geometric.utils import scatter
 
 
@@ -12,7 +13,8 @@ def test_scatter(reduce):
     src = torch.randn(8, 100, 32)
     index = torch.randint(0, 10, (100, ), dtype=torch.long)
 
-    out1 = scatter(src, index, dim=1, reduce=reduce)
+    with set_experimental_options({'pytorch_scatter': True}):
+        out1 = scatter(src, index, dim=1, reduce=reduce)
     out2 = torch_scatter.scatter(src, index, dim=1, reduce=reduce)
     assert torch.allclose(out1, out2, atol=1e-6)
 
@@ -24,7 +26,8 @@ def test_scatter_backward(reduce):
     src = torch.randn(8, 100, 32).requires_grad_(True)
     index = torch.randint(0, 10, (100, ), dtype=torch.long)
 
-    out = scatter(src, index, dim=1, reduce=reduce).relu_()
+    with set_experimental_options({'pytorch_scatter': True}):
+        out = scatter(src, index, dim=1, reduce=reduce).relu_()
     assert src.grad is None
     out.mean().backward()
     assert src.grad is not None
@@ -38,7 +41,8 @@ def test_scatter_with_out(reduce):
     index = torch.randint(0, 10, (100, ), dtype=torch.long)
     out = torch.randn(8, 10, 32)
 
-    out1 = scatter(src, index, dim=1, out=out.clone(), reduce=reduce)
+    with set_experimental_options({'pytorch_scatter': True}):
+        out1 = scatter(src, index, dim=1, out=out.clone(), reduce=reduce)
     out2 = torch_scatter.scatter(src, index, dim=1, out=out.clone(),
                                  reduce=reduce)
     assert torch.allclose(out1, out2, atol=1e-6)

--- a/torch_geometric/__init__.py
+++ b/torch_geometric/__init__.py
@@ -1,15 +1,20 @@
-from types import ModuleType
 from importlib import import_module
+from types import ModuleType
 
 import torch_geometric.data
 import torch_geometric.loader
+import torch_geometric.profile
 import torch_geometric.transforms
 import torch_geometric.utils
-import torch_geometric.profile
 
-from .seed import seed_everything
+from .debug import debug, is_debug_enabled, set_debug
+from .experimental import (
+    disable_all_experimental_options,
+    is_experimental_option_enabled,
+    set_experimental_options,
+)
 from .home import get_home_dir, set_home_dir
-from .debug import is_debug_enabled, debug, set_debug
+from .seed import seed_everything
 
 
 # https://github.com/tensorflow/tensorflow/blob/master/tensorflow/
@@ -48,6 +53,9 @@ __all__ = [
     'is_debug_enabled',
     'debug',
     'set_debug',
+    'is_experimental_option_enabled',
+    'disable_all_experimental_options',
+    'set_experimental_options',
     'torch_geometric',
     '__version__',
 ]

--- a/torch_geometric/__init__.py
+++ b/torch_geometric/__init__.py
@@ -1,20 +1,16 @@
-from importlib import import_module
 from types import ModuleType
+from importlib import import_module
 
 import torch_geometric.data
 import torch_geometric.loader
-import torch_geometric.profile
 import torch_geometric.transforms
 import torch_geometric.utils
+import torch_geometric.profile
 
-from .debug import debug, is_debug_enabled, set_debug
-from .experimental import (
-    disable_all_experimental_options,
-    is_experimental_option_enabled,
-    set_experimental_options,
-)
-from .home import get_home_dir, set_home_dir
 from .seed import seed_everything
+from .home import get_home_dir, set_home_dir
+from .debug import debug, is_debug_enabled, set_debug
+from .experimental import experimental_mode, is_experimental_mode_enabled
 
 
 # https://github.com/tensorflow/tensorflow/blob/master/tensorflow/
@@ -53,9 +49,8 @@ __all__ = [
     'is_debug_enabled',
     'debug',
     'set_debug',
-    'is_experimental_option_enabled',
-    'disable_all_experimental_options',
-    'set_experimental_options',
+    'experimental_mode',
+    'is_experimental_mode_enabled',
     'torch_geometric',
     '__version__',
 ]

--- a/torch_geometric/__init__.py
+++ b/torch_geometric/__init__.py
@@ -1,5 +1,5 @@
-from importlib import import_module
 from types import ModuleType
+from importlib import import_module
 
 import torch_geometric.data
 import torch_geometric.loader
@@ -9,8 +9,8 @@ import torch_geometric.profile
 
 from .seed import seed_everything
 from .home import get_home_dir, set_home_dir
-from .debug import debug, is_debug_enabled, set_debug
-from .experimental import experimental_mode, is_experimental_mode_enabled
+from .debug import is_debug_enabled, debug, set_debug
+from .experimental import is_experimental_mode_enabled, experimental_mode
 
 
 # https://github.com/tensorflow/tensorflow/blob/master/tensorflow/

--- a/torch_geometric/experimental.py
+++ b/torch_geometric/experimental.py
@@ -1,0 +1,51 @@
+from typing import Dict
+
+__experimental_options__ = {'pytorch_scatter': False}
+
+
+def is_experimental_option_enabled(option: str) -> bool:
+    r"""Returns :obj:`True`, if the experimental :attr:`option` is enabled.
+    See :class:`~torch_geometric.experimental.set_experimental_options` for
+    a list of available options."""
+    return __experimental_options__.get(option, False)
+
+
+def disable_all_experimental_options() -> None:
+    r"""Disables all experimental options."""
+    for key in __experimental_options__:
+        __experimental_options__[key] = False
+
+
+class set_experimental_options:
+    r"""Context-manager that sets experimental options on or off.
+
+    :class:`set_experimental_options` will enable or disable experimental
+    options based on :attr:`options` argument. It can be used as a
+    context-manager or as a function.
+
+    Example:
+
+        >>> options = {'pytorch_scatter': True}
+        >>> with torch_geometric.set_experimental_options(options):
+        ...     out = model(data.x, data.edge_index)
+
+    Args:
+        options (Dict[str, bool]): Dictionary of experimental options to
+            enable/disable. Valid keys:
+
+                - **pytorch_scatter**: Enables usage of
+                  :meth:`torch.scatter_reduce` instead of
+                  :meth:`torch_scatter.scatter`. Requires :obj:`torch>=1.12`.
+    """
+    def __init__(self, options: Dict[str, bool]) -> None:
+        self.previous_state = __experimental_options__.copy()
+        for option, value in options.items():
+            if option in __experimental_options__:
+                __experimental_options__[option] = value
+
+    def __enter__(self) -> None:
+        pass
+
+    def __exit__(self, *args) -> bool:
+        __experimental_options__.update(self.previous_state)
+        return False

--- a/torch_geometric/experimental.py
+++ b/torch_geometric/experimental.py
@@ -5,7 +5,9 @@ __experimental_flag__ = {'scatter_reduce': False}
 
 def is_experimental_mode_enabled(
         options: Optional[Union[str, List[str]]] = None) -> bool:
-    r"""Returns :obj:`True` if the experimental mode is enabled."""
+    r"""Returns :obj:`True` if the experimental mode is enabled. See
+    :class:`torch_geometric.experimental_mode` for a list of (optional)
+    options."""
     if options is None:
         options = list(__experimental_flag__.keys())
     if isinstance(options, str):

--- a/torch_geometric/nn/aggr/basic.py
+++ b/torch_geometric/nn/aggr/basic.py
@@ -84,7 +84,7 @@ class VarAggregation(Aggregation):
 
     .. math::
         \mathrm{var}(\mathcal{X}) = \mathrm{mean}(\{ \mathbf{x}_i^2 : x \in
-        \mathcal{X} \}) - \mathrm{mean}(\mathcal{X}).
+        \mathcal{X} \}) - \mathrm{mean}(\mathcal{X})^2.
     """
     def forward(self, x: Tensor, index: Optional[Tensor] = None,
                 ptr: Optional[Tensor] = None, dim_size: Optional[int] = None,

--- a/torch_geometric/utils/scatter.py
+++ b/torch_geometric/utils/scatter.py
@@ -1,64 +1,79 @@
-import os
 import warnings
 from typing import Optional
 
 import torch
+import torch_scatter
 from torch import Tensor
+
+from torch_geometric.experimental import is_experimental_option_enabled
 
 major, minor, _ = torch.__version__.split('.', maxsplit=2)
 major, minor = int(major), int(minor)
-get_pytorch112 = major > 1 or (major == 1 and minor >= 12)
+required_torch_version_satisfied = major > 1 or (major == 1 and minor >= 12)
 
-experimental = os.environ.get('PYG_EXPERIMENTAL', False)
 
-# Requires PyTorch >= 1.12
-if experimental and get_pytorch112:  # pragma: no cover
-    warnings.filterwarnings('ignore', '.*scatter_reduce.*')
-
-    def scatter(src: Tensor, index: Tensor, dim: int = -1,
+def _scatter_pt(src: Tensor, index: Tensor, dim: int = -1,
                 out: Optional[Tensor] = None, dim_size: Optional[int] = None,
                 reduce: str = 'sum') -> Tensor:
+    reduce = 'sum' if reduce == 'add' else reduce
+    reduce = 'prod' if reduce == 'mul' else reduce
+    reduce = 'amin' if reduce == 'min' else reduce
+    reduce = 'amax' if reduce == 'max' else reduce
 
-        reduce = 'sum' if reduce == 'add' else reduce
-        reduce = 'prod' if reduce == 'mul' else reduce
-        reduce = 'amin' if reduce == 'min' else reduce
-        reduce = 'amax' if reduce == 'max' else reduce
+    # Broadcast `index`:
+    dim = src.dim() + dim if dim < 0 else dim
+    if index.dim() == 1:
+        for _ in range(0, dim):
+            index = index.unsqueeze(0)
+    for _ in range(index.dim(), src.dim()):
+        index = index.unsqueeze(-1)
+    index = index.expand(src.size())
 
-        # Broadcast `index`:
-        dim = src.dim() + dim if dim < 0 else dim
-        if index.dim() == 1:
-            for _ in range(0, dim):
-                index = index.unsqueeze(0)
-        for _ in range(index.dim(), src.dim()):
-            index = index.unsqueeze(-1)
-        index = index.expand(src.size())
+    include_self = out is not None
 
-        include_self = out is not None
+    if out is None:  # Generate `out` if not given:
+        size = list(src.size())
+        if dim_size is not None:
+            size[dim] = dim_size
+        elif index.numel() > 0:
+            size[dim] = int(index.max()) + 1
+        else:
+            size[dim] = 0
+        out = src.new_zeros(size)
 
-        if out is None:  # Generate `out` if not given:
-            size = list(src.size())
-            if dim_size is not None:
-                size[dim] = dim_size
-            elif index.numel() > 0:
-                size[dim] = int(index.max()) + 1
-            else:
-                size[dim] = 0
-            out = src.new_zeros(size)
+    out = out.scatter_reduce_(dim, index, src, reduce,
+                              include_self=include_self)
 
-        out = out.scatter_reduce_(dim, index, src, reduce,
-                                  include_self=include_self)
+    # TODO: For now, we need the clone here since otherwise, autograd will
+    # complain about inplace modifications.
+    # Reference: https://github.com/pyg-team/pytorch_geometric/pull/5120
+    out = out.clone()
 
-        # TODO For now, we need the clone here since otherwise, autograd will
-        # complain about inplace modifications.
-        # Reference: https://github.com/pyg-team/pytorch_geometric/pull/5120
-        out = out.clone()
+    return out
 
-        return out
 
-else:
-    import torch_scatter
-
-    def scatter(src: Tensor, index: Tensor, dim: int = -1,
+def _scatter_ts(src: Tensor, index: Tensor, dim: int = -1,
                 out: Optional[Tensor] = None, dim_size: Optional[int] = None,
-                reduce: str = "sum") -> Tensor:
-        return torch_scatter.scatter(src, index, dim, out, dim_size, reduce)
+                reduce: str = 'sum') -> Tensor:
+    return torch_scatter.scatter(src, index, dim, out, dim_size, reduce)
+
+
+class ScatterImpl(torch.nn.Module):
+    def forward(self, src: Tensor, index: Tensor, dim: int = -1,
+                out: Optional[Tensor] = None, dim_size: Optional[int] = None,
+                reduce: str = 'sum') -> Tensor:
+        if required_torch_version_satisfied and is_experimental_option_enabled(
+                'pytorch_scatter'):
+            warnings.filterwarnings('ignore', '.*scatter_reduce.*')
+            return _scatter_pt(src, index, dim, out, dim_size, reduce)
+        else:
+            return _scatter_ts(src, index, dim, out, dim_size, reduce)
+
+
+_scatter_impl = ScatterImpl()
+
+
+def scatter(src: Tensor, index: Tensor, dim: int = -1,
+            out: Optional[Tensor] = None, dim_size: Optional[int] = None,
+            reduce: str = 'sum') -> Tensor:
+    return _scatter_impl(src, index, dim, out, dim_size, reduce)

--- a/torch_geometric/utils/scatter.py
+++ b/torch_geometric/utils/scatter.py
@@ -5,69 +5,54 @@ import torch
 import torch_scatter
 from torch import Tensor
 
-from torch_geometric.experimental import is_experimental_option_enabled
-
-major, minor, _ = torch.__version__.split('.', maxsplit=2)
-major, minor = int(major), int(minor)
-required_torch_version_satisfied = major > 1 or (major == 1 and minor >= 12)
-
-
-def _scatter_pt(src: Tensor, index: Tensor, dim: int = -1,
-                out: Optional[Tensor] = None, dim_size: Optional[int] = None,
-                reduce: str = 'sum') -> Tensor:
-    reduce = 'sum' if reduce == 'add' else reduce
-    reduce = 'prod' if reduce == 'mul' else reduce
-    reduce = 'amin' if reduce == 'min' else reduce
-    reduce = 'amax' if reduce == 'max' else reduce
-
-    # Broadcast `index`:
-    dim = src.dim() + dim if dim < 0 else dim
-    if index.dim() == 1:
-        for _ in range(0, dim):
-            index = index.unsqueeze(0)
-    for _ in range(index.dim(), src.dim()):
-        index = index.unsqueeze(-1)
-    index = index.expand(src.size())
-
-    include_self = out is not None
-
-    if out is None:  # Generate `out` if not given:
-        size = list(src.size())
-        if dim_size is not None:
-            size[dim] = dim_size
-        elif index.numel() > 0:
-            size[dim] = int(index.max()) + 1
-        else:
-            size[dim] = 0
-        out = src.new_zeros(size)
-
-    out = out.scatter_reduce_(dim, index, src, reduce,
-                              include_self=include_self)
-
-    # TODO: For now, we need the clone here since otherwise, autograd will
-    # complain about inplace modifications.
-    # Reference: https://github.com/pyg-team/pytorch_geometric/pull/5120
-    out = out.clone()
-
-    return out
-
-
-def _scatter_ts(src: Tensor, index: Tensor, dim: int = -1,
-                out: Optional[Tensor] = None, dim_size: Optional[int] = None,
-                reduce: str = 'sum') -> Tensor:
-    return torch_scatter.scatter(src, index, dim, out, dim_size, reduce)
+import torch_geometric
 
 
 class ScatterImpl(torch.nn.Module):
     def forward(self, src: Tensor, index: Tensor, dim: int = -1,
                 out: Optional[Tensor] = None, dim_size: Optional[int] = None,
                 reduce: str = 'sum') -> Tensor:
-        if required_torch_version_satisfied and is_experimental_option_enabled(
-                'pytorch_scatter'):
+
+        if torch_geometric.is_experimental_mode_enabled('scatter_reduce'):
             warnings.filterwarnings('ignore', '.*scatter_reduce.*')
-            return _scatter_pt(src, index, dim, out, dim_size, reduce)
-        else:
-            return _scatter_ts(src, index, dim, out, dim_size, reduce)
+
+            reduce = 'sum' if reduce == 'add' else reduce
+            reduce = 'prod' if reduce == 'mul' else reduce
+            reduce = 'amin' if reduce == 'min' else reduce
+            reduce = 'amax' if reduce == 'max' else reduce
+
+            # Broadcast `index`:
+            dim = src.dim() + dim if dim < 0 else dim
+            if index.dim() == 1:
+                for _ in range(0, dim):
+                    index = index.unsqueeze(0)
+            for _ in range(index.dim(), src.dim()):
+                index = index.unsqueeze(-1)
+            index = index.expand(src.size())
+
+            include_self = out is not None
+
+            if out is None:  # Generate `out` if not given:
+                size = list(src.size())
+                if dim_size is not None:
+                    size[dim] = dim_size
+                elif index.numel() > 0:
+                    size[dim] = int(index.max()) + 1
+                else:
+                    size[dim] = 0
+                out = src.new_zeros(size)
+
+            out = out.scatter_reduce_(dim, index, src, reduce,
+                                      include_self=include_self)
+
+            # TODO: For now, we need the clone here since otherwise, autograd
+            # will complain about inplace modifications.
+            # See: https://github.com/pyg-team/pytorch_geometric/pull/5120
+            out = out.clone()
+
+            return out
+
+        return torch_scatter.scatter(src, index, dim, out, dim_size, reduce)
 
 
 _scatter_impl = ScatterImpl()


### PR DESCRIPTION
Add experimental mode for `utils.scatter`.

Introduces several functions that allow us to control experimental options (currently only `pytorch_scatter`).
Implementation of `utils.scatter` is selected now based on experimental option value instead of environment variable. Selection process also happens on the fly instead at the import time - for greater usage flexibility.

Related PR: #5120 