### PR TITLE
Add missing test labels in `HGBDataset`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ## [2.2.0] - 2022-MM-DD
 ### Added
+- Added missing test labels in `HGBDataset` ([#5233](https://github.com/pyg-team/pytorch_geometric/pull/5233))
 - Added `BaseStorage.get()` functionality ([#5240](https://github.com/pyg-team/pytorch_geometric/pull/5240))
 - Added a test to confirm that `to_hetero` works with `SparseTensor` ([#5222](https://github.com/pyg-team/pytorch_geometric/pull/5222))
 ### Changed

--- a/torch_geometric/datasets/hgb_dataset.py
+++ b/torch_geometric/datasets/hgb_dataset.py
@@ -181,6 +181,11 @@ class HGBDataset(InMemoryDataset):
                 data[n_type].train_mask[n_id] = True
             for y in test_ys:
                 n_id, n_type = mapping_dict[int(y[0])], n_types[int(y[2])]
+                if data[n_type].y.dim() > 1:  # multi-label
+                    for v in y[3].split(','):
+                        data[n_type].y[n_id, int(v)] = 1
+                else:
+                    data[n_type].y[n_id] = int(y[3])
                 data[n_type].test_mask[n_id] = True
 
         else:  # Link prediction:


### PR DESCRIPTION
Hi, I found a bug when using `torch_geometric.dataset.HGBDataset`. Here are my codes to reproduce the bug:
```python

import torch
from torch_geometric.datasets import HGBDataset
from collections import Counter

datasets = ['acm', 'dblp', 'freebase', 'imdb']
labeled_types = ['paper', 'author', 'book', 'movie']

for name, types in zip(datasets, labeled_types):
    data = HGBDataset("~/data/pygdata/HGB", name)[0]
    if name != 'imdb':
        print(name, Counter(data[types].y[data[types].test_mask].tolist()))
    else:
        print(name, torch.any(data[types].y[data[types].test_mask]))
    
```
And the outputs are:
```bash
acm Counter({-1: 1059})
dblp Counter({-1: 1420})
freebase Counter({-1: 2784})
imdb tensor(False)
```
This indicates that all test labels are missing on four datasets.

I checked the code in `process` and found that it seems to have forgotten to assign values to the test labels. After adding these codes, the bug has been fixed. The output becomes:

```bash
acm Counter({2: 364, 0: 355, 1: 340})
dblp Counter({2: 404, 0: 404, 3: 354, 1: 258})
freebase Counter({1: 1372, 2: 591, 4: 347, 0: 146, 6: 141, 5: 127, 3: 60})
imdb tensor(True)
```