### PR TITLE
Fix graphgym example for activation functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -158,5 +158,6 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Fixed a bug in which `nn.models.GAT` did not produce `out_channels`-many output channels ([#4299](https://github.com/pyg-team/pytorch_geometric/pull/4299))
 - Fixed mini-batching with empty lists as attributes ([#4293](https://github.com/pyg-team/pytorch_geometric/pull/4293))
 - Fixed a bug in which `GCNConv` could not be combined with `to_hetero` on heterogeneous graphs with one node type ([#4279](https://github.com/pyg-team/pytorch_geometric/pull/4279))
+- Fixed a bug in which the custom activation functions in GraphGym did not work. ([#5243](https://github.com/pyg-team/pytorch_geometric/pull/5243))
 ### Removed
 - Remove internal metrics in favor of `torchmetrics` ([#4287](https://github.com/pyg-team/pytorch_geometric/pull/4287))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Added `BaseStorage.get()` functionality ([#5240](https://github.com/pyg-team/pytorch_geometric/pull/5240))
 - Added a test to confirm that `to_hetero` works with `SparseTensor` ([#5222](https://github.com/pyg-team/pytorch_geometric/pull/5222))
 ### Changed
+- Fixed a bug for the initialization of activation function examples in `custom_graphgym`. ([#5243](https://github.com/pyg-team/pytorch_geometric/pull/5243))
 ### Removed
 
 ## [2.1.0] - 2022-08-17
@@ -158,6 +159,5 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Fixed a bug in which `nn.models.GAT` did not produce `out_channels`-many output channels ([#4299](https://github.com/pyg-team/pytorch_geometric/pull/4299))
 - Fixed mini-batching with empty lists as attributes ([#4293](https://github.com/pyg-team/pytorch_geometric/pull/4293))
 - Fixed a bug in which `GCNConv` could not be combined with `to_hetero` on heterogeneous graphs with one node type ([#4279](https://github.com/pyg-team/pytorch_geometric/pull/4279))
-- Fixed a bug in which the custom activation functions in GraphGym did not work. ([#5243](https://github.com/pyg-team/pytorch_geometric/pull/5243))
 ### Removed
 - Remove internal metrics in favor of `torchmetrics` ([#4287](https://github.com/pyg-team/pytorch_geometric/pull/4287))

--- a/graphgym/custom_graphgym/act/example.py
+++ b/graphgym/custom_graphgym/act/example.py
@@ -1,3 +1,5 @@
+from functools import partial
+
 import torch
 import torch.nn as nn
 
@@ -18,5 +20,5 @@ class SWISH(nn.Module):
             return x * torch.sigmoid(x)
 
 
-register_act('swish', SWISH(inplace=cfg.mem.inplace))
-register_act('lrelu_03', nn.LeakyReLU(0.3, inplace=cfg.mem.inplace))
+register_act('swish', partial(SWISH, inplace=cfg.mem.inplace))
+register_act('lrelu_03', partial(nn.LeakyReLU,0.3, inplace=cfg.mem.inplace))

--- a/graphgym/custom_graphgym/act/example.py
+++ b/graphgym/custom_graphgym/act/example.py
@@ -21,4 +21,4 @@ class SWISH(nn.Module):
 
 
 register_act('swish', partial(SWISH, inplace=cfg.mem.inplace))
-register_act('lrelu_03', partial(nn.LeakyReLU,0.3, inplace=cfg.mem.inplace))
+register_act('lrelu_03', partial(nn.LeakyReLU, 0.3, inplace=cfg.mem.inplace))

--- a/graphgym/custom_graphgym/act/example.py
+++ b/graphgym/custom_graphgym/act/example.py
@@ -20,5 +20,5 @@ class SWISH(nn.Module):
             return x * torch.sigmoid(x)
 
 
-register_act('swish', partial(SWISH, inplace=cfg.mem.inplace))
+register_act('swish', lambda: SWISH(inplace=cfg.mem.inplace))
 register_act('lrelu_03', partial(nn.LeakyReLU, 0.3, inplace=cfg.mem.inplace))

--- a/graphgym/custom_graphgym/act/example.py
+++ b/graphgym/custom_graphgym/act/example.py
@@ -20,5 +20,5 @@ class SWISH(nn.Module):
             return x * torch.sigmoid(x)
 
 
-register_act('swish', lambda: SWISH(inplace=cfg.mem.inplace))
+register_act('swish', partial(SWISH, inplace=cfg.mem.inplace))
 register_act('lrelu_03', partial(nn.LeakyReLU, 0.3, inplace=cfg.mem.inplace))


### PR DESCRIPTION
If you choose one of the given example activation functions (`swish` or `lrelu_03`) you get the following error:
```
Traceback (most recent call last):
  File "C:\Users\morit\workspace\pytorch_geometric\graphgym\main.py", line 42, in <module>
    model = create_model()
  File "C:\Users\morit\.conda\envs\test\lib\site-packages\torch_geometric\graphgym\model_builder.py", line 79, in create_model
    model = GraphGymModule(dim_in, dim_out, cfg)
  File "C:\Users\morit\.conda\envs\test\lib\site-packages\torch_geometric\graphgym\model_builder.py", line 20, in __init__
    self.model = network_dict[cfg.model.type](dim_in=dim_in,
  File "C:\Users\morit\.conda\envs\test\lib\site-packages\torch_geometric\graphgym\models\gnn.py", line 147, in __init__
    self.mp = GNNStage(dim_in=dim_in, dim_out=cfg.gnn.dim_inner,
  File "C:\Users\morit\.conda\envs\test\lib\site-packages\torch_geometric\graphgym\models\gnn.py", line 69, in __init__
    layer = GNNLayer(d_in, dim_out)
  File "C:\Users\morit\.conda\envs\test\lib\site-packages\torch_geometric\graphgym\models\gnn.py", line 27, in GNNLayer
    return GeneralLayer(
  File "C:\Users\morit\.conda\envs\test\lib\site-packages\torch_geometric\graphgym\models\layer.py", line 99, in __init__
    layer_wrapper.append(register.act_dict[layer_config.act]())
  File "C:\Users\morit\.conda\envs\test\lib\site-packages\torch\nn\modules\module.py", line 1130, in _call_impl
    return forward_call(*input, **kwargs)
TypeError: forward() missing 1 required positional argument: 'x'
```
This happens because the classes are initialized before registering and `layer.py` later tries to initialize them again. 
My proposal: Use `partial` to specify the arguments without initializing the class.