### PR TITLE
Rewrite tests to not depend on currently broken `dblp` dataset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Added `BaseStorage.get()` functionality ([#5240](https://github.com/pyg-team/pytorch_geometric/pull/5240))
 - Added a test to confirm that `to_hetero` works with `SparseTensor` ([#5222](https://github.com/pyg-team/pytorch_geometric/pull/5222))
 ### Changed
-- Changed tests relying on `dblp` datasets to instead se  synthetic data. ([#5250](https://github.com/pyg-team/pytorch_geometric/pull/5250))
+- Changed tests relying on `dblp` datasets to instead use  synthetic data. ([#5250](https://github.com/pyg-team/pytorch_geometric/pull/5250))
 ### Removed
 
 ## [2.1.0] - 2022-08-17

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Added `BaseStorage.get()` functionality ([#5240](https://github.com/pyg-team/pytorch_geometric/pull/5240))
 - Added a test to confirm that `to_hetero` works with `SparseTensor` ([#5222](https://github.com/pyg-team/pytorch_geometric/pull/5222))
 ### Changed
+- Changed tests relying on `dblp` datasets to instead se  synthetic data. ([#5250](https://github.com/pyg-team/pytorch_geometric/pull/5250))
 ### Removed
 
 ## [2.1.0] - 2022-08-17

--- a/test/data/test_lightning_datamodule.py
+++ b/test/data/test_lightning_datamodule.py
@@ -280,7 +280,7 @@ def test_lightning_hetero_node_data(get_dataset):
 @withCUDA
 @onlyFullTest
 @withPackage('pytorch_lightning')
-def test_lightning_hetero_link_data(get_dataset):
+def test_lightning_hetero_link_data():
     torch.manual_seed(12345)
 
     data = HeteroData()

--- a/test/data/test_lightning_datamodule.py
+++ b/test/data/test_lightning_datamodule.py
@@ -5,6 +5,7 @@ import torch
 import torch.nn.functional as F
 
 from torch_geometric.data import (
+    HeteroData,
     LightningDataset,
     LightningLinkData,
     LightningNodeData,
@@ -16,6 +17,12 @@ try:
     from pytorch_lightning import LightningModule
 except ImportError:
     LightningModule = torch.nn.Module
+
+
+def get_edge_index(num_src_nodes, num_dst_nodes, num_edges):
+    row = torch.randint(num_src_nodes, (num_edges, ), dtype=torch.long)
+    col = torch.randint(num_dst_nodes, (num_edges, ), dtype=torch.long)
+    return torch.stack([row, col], dim=0)
 
 
 class LinearGraphModule(LightningModule):
@@ -274,9 +281,17 @@ def test_lightning_hetero_node_data(get_dataset):
 @onlyFullTest
 @withPackage('pytorch_lightning')
 def test_lightning_hetero_link_data(get_dataset):
-    # TODO: Add more datasets.
-    dataset = get_dataset(name='DBLP')
-    data = dataset[0]
+    torch.manual_seed(12345)
+
+    data = HeteroData()
+
+    data['paper'].x = torch.arange(10)
+    data['author'].x = torch.arange(10)
+    data['term'].x = torch.arange(10)
+
+    data['paper', 'author'].edge_index = get_edge_index(10, 10, 10)
+    data['author', 'paper'].edge_index = get_edge_index(10, 10, 10)
+    data['paper', 'term'].edge_index = get_edge_index(10, 10, 10)
 
     datamodule = LightningLinkData(
         data,

--- a/test/loader/test_hgt_loader.py
+++ b/test/loader/test_hgt_loader.py
@@ -179,7 +179,7 @@ def test_hgt_loader_on_cora(get_dataset):
     assert torch.allclose(out1, out2, atol=1e-6)
 
 
-@pytest.skip("'dblp' dataset is broken")
+@pytest.mask.skip("'dblp' dataset is broken")
 @withPackage('torch_sparse>=0.6.15')
 def test_hgt_loader_on_dblp(get_dataset):
     data = get_dataset(name='dblp')[0]

--- a/test/loader/test_hgt_loader.py
+++ b/test/loader/test_hgt_loader.py
@@ -1,10 +1,12 @@
 import numpy as np
+import pytest
 import torch
 from torch_sparse import SparseTensor
 
 from torch_geometric.data import HeteroData
 from torch_geometric.loader import HGTLoader
 from torch_geometric.nn import GraphConv, to_hetero
+from torch_geometric.testing import withPackage
 from torch_geometric.utils import k_hop_subgraph
 
 
@@ -175,3 +177,14 @@ def test_hgt_loader_on_cora(get_dataset):
     out2 = hetero_model(hetero_batch.x_dict, hetero_batch.edge_index_dict,
                         hetero_batch.edge_weight_dict)['paper'][:batch_size]
     assert torch.allclose(out1, out2, atol=1e-6)
+
+
+@pytest.skip("'dblp' dataset is broken")
+@withPackage('torch_sparse>=0.6.15')
+def test_hgt_loader_on_dblp(get_dataset):
+    data = get_dataset(name='dblp')[0]
+    loader = HGTLoader(data, num_samples=[10, 10],
+                       input_nodes=('author', data['author'].train_mask))
+
+    for batch in loader:
+        assert set(batch.edge_types) == set(data.edge_types)

--- a/test/loader/test_hgt_loader.py
+++ b/test/loader/test_hgt_loader.py
@@ -179,7 +179,7 @@ def test_hgt_loader_on_cora(get_dataset):
     assert torch.allclose(out1, out2, atol=1e-6)
 
 
-@pytest.mask.skip("'dblp' dataset is broken")
+@pytest.mark.skip("'dblp' dataset is broken")
 @withPackage('torch_sparse>=0.6.15')
 def test_hgt_loader_on_dblp(get_dataset):
     data = get_dataset(name='dblp')[0]

--- a/test/loader/test_hgt_loader.py
+++ b/test/loader/test_hgt_loader.py
@@ -5,7 +5,6 @@ from torch_sparse import SparseTensor
 from torch_geometric.data import HeteroData
 from torch_geometric.loader import HGTLoader
 from torch_geometric.nn import GraphConv, to_hetero
-from torch_geometric.testing import withPackage
 from torch_geometric.utils import k_hop_subgraph
 
 
@@ -56,8 +55,9 @@ def test_hgt_loader():
     for batch in loader:
         assert isinstance(batch, HeteroData)
 
-        # Test node type selection:
+        # Test node and types:
         assert set(batch.node_types) == {'paper', 'author'}
+        assert set(batch.edge_types) == set(data.edge_types)
 
         assert len(batch['paper']) == 2
         assert batch['paper'].x.size() == (40, )  # 20 + 4 * 5
@@ -175,13 +175,3 @@ def test_hgt_loader_on_cora(get_dataset):
     out2 = hetero_model(hetero_batch.x_dict, hetero_batch.edge_index_dict,
                         hetero_batch.edge_weight_dict)['paper'][:batch_size]
     assert torch.allclose(out1, out2, atol=1e-6)
-
-
-@withPackage('torch_sparse>=0.6.15')
-def test_hgt_loader_on_dblp(get_dataset):
-    data = get_dataset(name='dblp')[0]
-    loader = HGTLoader(data, num_samples=[10, 10],
-                       input_nodes=('author', data['author'].train_mask))
-
-    for batch in loader:
-        assert set(batch.edge_types) == set(data.edge_types)


### PR DESCRIPTION
This PR changes tests that were using the `dblp` as it seems to be currently broken. 