### PR TITLE
Parameterize the `run_batch.sh` script for GraphGym

### DIFF
--- a/graphgym/run_batch.sh
+++ b/graphgym/run_batch.sh
@@ -1,11 +1,11 @@
 #!/usr/bin/env bash
 
-CONFIG=example_node
-GRID=example
-REPEAT=3
-MAX_JOBS=8
-SLEEP=1
-MAIN=main
+CONFIG=${CONFIG:="example_node"}
+GRID=${GRID:="example"}
+REPEAT=${REPEAT:="3"}
+MAX_JOBS=${MAX_JOBS:="8"}
+SLEEP=${SLEEP:="1"}
+MAIN=${MAIN:="main"}
 
 # generate configs (after controlling computational budget)
 # please remove --config_budget, if don't control computational budget

--- a/graphgym/run_batch.sh
+++ b/graphgym/run_batch.sh
@@ -1,11 +1,11 @@
 #!/usr/bin/env bash
 
-CONFIG=${CONFIG:="example_node"}
-GRID=${GRID:="example"}
-REPEAT=${REPEAT:="3"}
-MAX_JOBS=${MAX_JOBS:="8"}
-SLEEP=${SLEEP:="1"}
-MAIN=${MAIN:="main"}
+CONFIG=${CONFIG:-example_node}
+GRID=${GRID:-example}
+REPEAT=${REPEAT:-3}
+MAX_JOBS=${MAX_JOBS:-8}
+SLEEP=${SLEEP:-1}
+MAIN=${MAIN:-main}
 
 # generate configs (after controlling computational budget)
 # please remove --config_budget, if don't control computational budget


### PR DESCRIPTION
Add bash defaults for the variables in the script.
Enables overriding the variable values on the commandline so the script
can easily reference different experiment, grid, etc values at runtime.