### PR TITLE
Enable experimental mode in inference benchmarks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ## [2.2.0] - 2022-MM-DD
 ### Added
+- Added experimental mode in inference benchmarks ([#5254](https://github.com/pyg-team/pytorch_geometric/pull/5254))
 - Added node classification example instrumented with [Weights and Biases (W&B) logging](https://wandb.com) and [W&B Sweeps](https://wandb.com/sweeps) ([#5192](https://github.com/pyg-team/pytorch_geometric/pull/5192))
 - Added experimental mode for `utils.scatter` ([#5232](https://github.com/pyg-team/pytorch_geometric/pull/5232), [#5241](https://github.com/pyg-team/pytorch_geometric/pull/5241))
 - Added missing test labels in `HGBDataset` ([#5233](https://github.com/pyg-team/pytorch_geometric/pull/5233))

--- a/benchmark/inference/inference_benchmark.py
+++ b/benchmark/inference/inference_benchmark.py
@@ -4,6 +4,7 @@ from timeit import default_timer
 import torch
 from utils import get_dataset, get_model
 
+import torch_geometric
 from torch_geometric.loader import NeighborLoader
 from torch_geometric.nn import PNAConv
 
@@ -93,8 +94,13 @@ def run(args: argparse.ArgumentParser) -> None:
                         model.eval()
 
                         start = default_timer()
-                        model.inference(subgraph_loader, device,
-                                        progress_bar=True)
+                        if args.experimental_mode:
+                            with torch_geometric.experimental_mode():
+                                model.inference(subgraph_loader, device,
+                                                progress_bar=True)
+                        else:
+                            model.inference(subgraph_loader, device,
+                                            progress_bar=True)
                         stop = default_timer()
                         print(f'Inference time={stop-start:.3f} seconds\n')
 
@@ -121,6 +127,8 @@ if __name__ == '__main__':
         '--hetero-num-neighbors', default=-1, type=int,
         help='number of neighbors to sample per layer for hetero workloads')
     argparser.add_argument('--num-workers', default=2, type=int)
+    argparser.add_argument('--experimental-mode', action='store_true',
+                           help='use experimental mode')
 
     args = argparser.parse_args()
 

--- a/torch_geometric/experimental.py
+++ b/torch_geometric/experimental.py
@@ -31,7 +31,7 @@ class experimental_mode:
               :meth:`torch.scatter_reduce` instead of
               :meth:`torch_scatter.scatter`. Requires :obj:`torch>=1.12`.
     """
-    def __init__(self, options: Optional[Union[str, List[str]]]):
+    def __init__(self, options: Optional[Union[str, List[str]]] = None):
         if options is None:
             options = list(__experimental_flag__.keys())
         if isinstance(options, str):


### PR DESCRIPTION
Enable experimental mode in inference benchmarks.

Related PRs: #5120, #5232