### PR TITLE
Add `Aggregation.set_validate_args` method to toggle validation of `dim_size`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Added missing test labels in `HGBDataset` ([#5233](https://github.com/pyg-team/pytorch_geometric/pull/5233))
 - Added `BaseStorage.get()` functionality ([#5240](https://github.com/pyg-team/pytorch_geometric/pull/5240))
 - Added a test to confirm that `to_hetero` works with `SparseTensor` ([#5222](https://github.com/pyg-team/pytorch_geometric/pull/5222))
+- Added `Aggregation.set_validate_args` option to skip eager validation of `dim_size`([#5290](https://github.com/pyg-team/pytorch_geometric/pull/5290))
 ### Changed
 - Improved name resolving of normalization layers ([#5277](https://github.com/pyg-team/pytorch_geometric/pull/5277))
 - Fail gracefully on `GLIBC` errors within `torch-spline-conv` ([#5276](https://github.com/pyg-team/pytorch_geometric/pull/5276))

--- a/test/nn/aggr/test_basic.py
+++ b/test/nn/aggr/test_basic.py
@@ -27,6 +27,16 @@ def test_validate():
     with pytest.raises(ValueError, match="invalid 'dim_size'"):
         aggr(x, ptr=ptr, dim_size=2)
 
+    with pytest.raises(ValueError, match="invalid 'dim_size'"):
+        aggr(x, index, dim_size=2)
+
+    aggr.set_validate_args(False)
+    with pytest.raises(RuntimeError, match="out of bounds"):
+        aggr(x, index, dim_size=2)
+
+    with pytest.raises(ValueError, match="value must be a bool"):
+        aggr.set_validate_args(0)
+
 
 @pytest.mark.parametrize('Aggregation', [
     MeanAggregation,

--- a/torch_geometric/nn/aggr/base.py
+++ b/torch_geometric/nn/aggr/base.py
@@ -106,10 +106,11 @@ class Aggregation(torch.nn.Module):
         if index is not None:
             if dim_size is None:
                 dim_size = int(index.max()) + 1 if index.numel() > 0 else 0
-            elif index.numel() > 0 and dim_size <= int(index.max()):
-                raise ValueError(f"Encountered invalid 'dim_size' (got "
-                                 f"'{dim_size}' but expected "
-                                 f">= '{int(index.max()) + 1}')")
+            elif self._validate:
+                if index.numel() > 0 and dim_size <= int(index.max()):
+                    raise ValueError(f"Encountered invalid 'dim_size' (got "
+                                     f"'{dim_size}' but expected "
+                                     f">= '{int(index.max()) + 1}')")
 
         return super().__call__(x, index, ptr, dim_size, dim, **kwargs)
 
@@ -164,6 +165,25 @@ class Aggregation(torch.nn.Module):
 
         return to_dense_batch(x, index, batch_size=dim_size,
                               fill_value=fill_value)
+
+    _validate = __debug__
+
+    @staticmethod
+    def set_validate_args(value):
+        r"""
+        Sets whether eager validation is enabled.
+
+        The default behaviour is set by the Python ``__debug__`` constant which
+        is ``True`` as long as Python was not started with an ``-O`` option.
+
+        This option can be used to skip the validation of arguments such as
+        ``dim_size``. This is useful for PyTorch execution backends that may
+        incur a performance penalty when eager validation is performed.
+        """
+        if not isinstance(value, bool):
+            raise ValueError("value must be a bool")
+
+        Aggregation._validate = value
 
 
 ###############################################################################


### PR DESCRIPTION
Proposal for #5289

This change should default to running the eager validation but allows a user to override this behaviour when using different PyTorch execution backend.