### PR TITLE
PyTorch nightly `fx` tracing fix

### DIFF
--- a/torch_geometric/nn/fx.py
+++ b/torch_geometric/nn/fx.py
@@ -319,7 +319,12 @@ def symbolic_trace(
             @st.functools.wraps(st._orig_module_getattr)
             def module_getattr_wrapper(mod, attr):
                 attr_val = st._orig_module_getattr(mod, attr)
-                return self.getattr(attr, attr_val, parameter_proxy_cache)
+                # Support for PyTorch > 1.12, see:
+                # https://github.com/pytorch/pytorch/pull/84011
+                if hasattr(self, 'getattr'):
+                    return self.getattr(attr, attr_val, parameter_proxy_cache)
+                return self._module_getattr(attr, attr_val,
+                                            parameter_proxy_cache)
 
             @st.functools.wraps(st._orig_module_call)
             def module_call_wrapper(mod, *args, **kwargs):

--- a/torch_geometric/nn/fx.py
+++ b/torch_geometric/nn/fx.py
@@ -319,8 +319,7 @@ def symbolic_trace(
             @st.functools.wraps(st._orig_module_getattr)
             def module_getattr_wrapper(mod, attr):
                 attr_val = st._orig_module_getattr(mod, attr)
-                return self._module_getattr(attr, attr_val,
-                                            parameter_proxy_cache)
+                return self.getattr(attr, attr_val, parameter_proxy_cache)
 
             @st.functools.wraps(st._orig_module_call)
             def module_call_wrapper(mod, *args, **kwargs):


### PR DESCRIPTION
Fix for inference_benchmark.py failing with an error:
```
return self._module_getattr(attr, attr_val,parameter_proxy_cache)
AttributeError: 'Tracer' object has no attribute '_module_getattr'
```
Replace not implemented Tracer._module_getattr with Tracer.getattr to return the value of nn.Module attr.