### PR TITLE
Replace in-place operations by out-of-place ones

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Added `BaseStorage.get()` functionality ([#5240](https://github.com/pyg-team/pytorch_geometric/pull/5240))
 - Added a test to confirm that `to_hetero` works with `SparseTensor` ([#5222](https://github.com/pyg-team/pytorch_geometric/pull/5222))
 ### Changed
+- Replace in-place operations with out-of-place ones to align with `torch.scatter_reduce` API ([#5353](https://github.com/pyg-team/pytorch_geometric/pull/5353))
 - Breaking bugfix: `PointTransformerConv` now correctly uses `sum` aggregation ([#5332](https://github.com/pyg-team/pytorch_geometric/pull/5332))
 - Improve out-of-bounds error message in `MessagePassing` ([#5339](https://github.com/pyg-team/pytorch_geometric/pull/5339))
 - Allow file names of a `Dataset` to be specified as either property and method ([#5338](https://github.com/pyg-team/pytorch_geometric/pull/5338))

--- a/test/utils/test_scatter.py
+++ b/test/utils/test_scatter.py
@@ -27,7 +27,7 @@ def test_scatter_backward(reduce):
     index = torch.randint(0, 10, (100, ), dtype=torch.long)
 
     with torch_geometric.experimental_mode('scatter_reduce'):
-        out = scatter(src, index, dim=1, reduce=reduce).relu_()
+        out = torch.relu(scatter(src, index, dim=1, reduce=reduce))
     assert src.grad is None
     out.mean().backward()
     assert src.grad is not None

--- a/test/utils/test_scatter.py
+++ b/test/utils/test_scatter.py
@@ -27,7 +27,7 @@ def test_scatter_backward(reduce):
     index = torch.randint(0, 10, (100, ), dtype=torch.long)
 
     with torch_geometric.experimental_mode('scatter_reduce'):
-        out = torch.relu(scatter(src, index, dim=1, reduce=reduce))
+        out = scatter(src, index, dim=1, reduce=reduce).relu()
     assert src.grad is None
     out.mean().backward()
     assert src.grad is not None

--- a/torch_geometric/nn/conv/appnp.py
+++ b/torch_geometric/nn/conv/appnp.py
@@ -118,7 +118,7 @@ class APPNP(MessagePassing):
             x = self.propagate(edge_index, x=x, edge_weight=edge_weight,
                                size=None)
             x = x * (1 - self.alpha)
-            x += self.alpha * h
+            x = x + self.alpha * h
 
         return x
 

--- a/torch_geometric/nn/conv/arma_conv.py
+++ b/torch_geometric/nn/conv/arma_conv.py
@@ -128,10 +128,11 @@ class ARMAConv(MessagePassing):
                                  size=None)
 
             root = F.dropout(x, p=self.dropout, training=self.training)
-            out += root @ self.root_weight[0 if self.shared_weights else t]
+            root = root @ self.root_weight[0 if self.shared_weights else t]
+            out = out + root
 
             if self.bias is not None:
-                out += self.bias[0 if self.shared_weights else t]
+                out = out + self.bias[0 if self.shared_weights else t]
 
             if self.act is not None:
                 out = self.act(out)

--- a/torch_geometric/nn/conv/cg_conv.py
+++ b/torch_geometric/nn/conv/cg_conv.py
@@ -86,7 +86,7 @@ class CGConv(MessagePassing):
         # propagate_type: (x: PairTensor, edge_attr: OptTensor)
         out = self.propagate(edge_index, x=x, edge_attr=edge_attr, size=None)
         out = out if self.bn is None else self.bn(out)
-        out += x[1]
+        out = out + x[1]
         return out
 
     def message(self, x_i, x_j, edge_attr: OptTensor) -> Tensor:

--- a/torch_geometric/nn/conv/cheb_conv.py
+++ b/torch_geometric/nn/conv/cheb_conv.py
@@ -159,7 +159,7 @@ class ChebConv(MessagePassing):
             Tx_0, Tx_1 = Tx_1, Tx_2
 
         if self.bias is not None:
-            out += self.bias
+            out = out + self.bias
 
         return out
 

--- a/torch_geometric/nn/conv/dna_conv.py
+++ b/torch_geometric/nn/conv/dna_conv.py
@@ -53,7 +53,7 @@ class Linear(torch.nn.Module):
             out = torch.matmul(src, self.weight.squeeze(0))
 
         if self.bias is not None:
-            out += self.bias
+            out = out + self.bias
 
         return out
 

--- a/torch_geometric/nn/conv/eg_conv.py
+++ b/torch_geometric/nn/conv/eg_conv.py
@@ -191,7 +191,7 @@ class EGConv(MessagePassing):
         out = out.view(-1, self.out_channels)
 
         if self.bias is not None:
-            out += self.bias
+            out = out + self.bias
 
         return out
 

--- a/torch_geometric/nn/conv/fa_conv.py
+++ b/torch_geometric/nn/conv/fa_conv.py
@@ -149,7 +149,7 @@ class FAConv(MessagePassing):
         self._alpha = None
 
         if self.eps != 0.0:
-            out += self.eps * x_0
+            out = out + self.eps * x_0
 
         if isinstance(return_attention_weights, bool):
             assert alpha is not None

--- a/torch_geometric/nn/conv/feast_conv.py
+++ b/torch_geometric/nn/conv/feast_conv.py
@@ -96,7 +96,7 @@ class FeaStConv(MessagePassing):
         out = self.propagate(edge_index, x=x, size=None)
 
         if self.bias is not None:
-            out += self.bias
+            out = out + self.bias
 
         return out
 

--- a/torch_geometric/nn/conv/gat_conv.py
+++ b/torch_geometric/nn/conv/gat_conv.py
@@ -251,7 +251,7 @@ class GATConv(MessagePassing):
             out = out.mean(dim=1)
 
         if self.bias is not None:
-            out += self.bias
+            out = out + self.bias
 
         if isinstance(return_attention_weights, bool):
             if isinstance(edge_index, Tensor):

--- a/torch_geometric/nn/conv/gatv2_conv.py
+++ b/torch_geometric/nn/conv/gatv2_conv.py
@@ -245,7 +245,7 @@ class GATv2Conv(MessagePassing):
             out = out.mean(dim=1)
 
         if self.bias is not None:
-            out += self.bias
+            out = out + self.bias
 
         if isinstance(return_attention_weights, bool):
             assert alpha is not None
@@ -267,7 +267,7 @@ class GATv2Conv(MessagePassing):
             assert self.lin_edge is not None
             edge_attr = self.lin_edge(edge_attr)
             edge_attr = edge_attr.view(-1, self.heads, self.out_channels)
-            x += edge_attr
+            x = x + edge_attr
 
         x = F.leaky_relu(x, self.negative_slope)
         alpha = (x * self.att).sum(dim=-1)

--- a/torch_geometric/nn/conv/gcn2_conv.py
+++ b/torch_geometric/nn/conv/gcn2_conv.py
@@ -149,8 +149,8 @@ class GCN2Conv(MessagePassing):
         else:
             out = torch.addmm(x, x, self.weight1, beta=1. - self.beta,
                               alpha=self.beta)
-            out += torch.addmm(x_0, x_0, self.weight2, beta=1. - self.beta,
-                               alpha=self.beta)
+            out = out + torch.addmm(x_0, x_0, self.weight2,
+                                    beta=1. - self.beta, alpha=self.beta)
 
         return out
 

--- a/torch_geometric/nn/conv/gcn_conv.py
+++ b/torch_geometric/nn/conv/gcn_conv.py
@@ -198,7 +198,7 @@ class GCNConv(MessagePassing):
                              size=None)
 
         if self.bias is not None:
-            out += self.bias
+            out = out + self.bias
 
         return out
 

--- a/torch_geometric/nn/conv/gen_conv.py
+++ b/torch_geometric/nn/conv/gen_conv.py
@@ -162,7 +162,7 @@ class GENConv(MessagePassing):
 
         x_r = x[1]
         if x_r is not None:
-            out += x_r
+            out = out + x_r
 
         return self.mlp(out)
 

--- a/torch_geometric/nn/conv/general_conv.py
+++ b/torch_geometric/nn/conv/general_conv.py
@@ -148,7 +148,7 @@ class GeneralConv(MessagePassing):
         # propagate_type: (x: OptPairTensor)
         out = self.propagate(edge_index, x=x, size=size, edge_attr=edge_attr)
         out = out.mean(dim=1)  # todo: other approach to aggregate heads
-        out += self.lin_self(x_self)
+        out = out + self.lin_self(x_self)
         if self.normalize_l2:
             out = F.normalize(out, p=2, dim=-1)
         return out

--- a/torch_geometric/nn/conv/gin_conv.py
+++ b/torch_geometric/nn/conv/gin_conv.py
@@ -75,7 +75,7 @@ class GINConv(MessagePassing):
 
         x_r = x[1]
         if x_r is not None:
-            out += (1 + self.eps) * x_r
+            out = out + (1 + self.eps) * x_r
 
         return self.nn(out)
 
@@ -173,7 +173,7 @@ class GINEConv(MessagePassing):
 
         x_r = x[1]
         if x_r is not None:
-            out += (1 + self.eps) * x_r
+            out = out + (1 + self.eps) * x_r
 
         return self.nn(out)
 

--- a/torch_geometric/nn/conv/gmm_conv.py
+++ b/torch_geometric/nn/conv/gmm_conv.py
@@ -144,10 +144,10 @@ class GMMConv(MessagePassing):
 
         x_r = x[1]
         if x_r is not None and self.root is not None:
-            out += self.root(x_r)
+            out = out + self.root(x_r)
 
         if self.bias is not None:
-            out += self.bias
+            out = out + self.bias
 
         return out
 

--- a/torch_geometric/nn/conv/graph_conv.py
+++ b/torch_geometric/nn/conv/graph_conv.py
@@ -82,7 +82,7 @@ class GraphConv(MessagePassing):
 
         x_r = x[1]
         if x_r is not None:
-            out += self.lin_root(x_r)
+            out = out + self.lin_root(x_r)
 
         return out
 

--- a/torch_geometric/nn/conv/heat_conv.py
+++ b/torch_geometric/nn/conv/heat_conv.py
@@ -111,12 +111,12 @@ class HEATConv(MessagePassing):
 
         if self.concat:
             if self.root_weight:
-                out += x.view(-1, 1, self.out_channels)
+                out = out + x.view(-1, 1, self.out_channels)
             out = out.view(-1, self.heads * self.out_channels)
         else:
             out = out.mean(dim=1)
             if self.root_weight:
-                out += x
+                out = out + x
 
         return out
 

--- a/torch_geometric/nn/conv/mf_conv.py
+++ b/torch_geometric/nn/conv/mf_conv.py
@@ -101,7 +101,7 @@ class MFConv(MessagePassing):
             r = lin_l(h.index_select(self.node_dim, idx))
 
             if x_r is not None:
-                r += lin_r(x_r.index_select(self.node_dim, idx))
+                r = r + lin_r(x_r.index_select(self.node_dim, idx))
 
             out.index_copy_(self.node_dim, idx, r)
 

--- a/torch_geometric/nn/conv/nn_conv.py
+++ b/torch_geometric/nn/conv/nn_conv.py
@@ -102,10 +102,10 @@ class NNConv(MessagePassing):
 
         x_r = x[1]
         if x_r is not None and self.root_weight:
-            out += self.lin(x_r)
+            out = out + self.lin(x_r)
 
         if self.bias is not None:
-            out += self.bias
+            out = out + self.bias
 
         return out
 

--- a/torch_geometric/nn/conv/pdn_conv.py
+++ b/torch_geometric/nn/conv/pdn_conv.py
@@ -113,7 +113,7 @@ class PDNConv(MessagePassing):
         out = self.propagate(edge_index, x=x, edge_weight=edge_attr, size=None)
 
         if self.bias is not None:
-            out += self.bias
+            out = out + self.bias
 
         return out
 

--- a/torch_geometric/nn/conv/res_gated_graph_conv.py
+++ b/torch_geometric/nn/conv/res_gated_graph_conv.py
@@ -110,10 +110,10 @@ class ResGatedGraphConv(MessagePassing):
         out = self.propagate(edge_index, k=k, q=q, v=v, size=None)
 
         if self.root_weight:
-            out += self.lin_skip(x[1])
+            out = out + self.lin_skip(x[1])
 
         if self.bias is not None:
-            out += self.bias
+            out = out + self.bias
 
         return out
 

--- a/torch_geometric/nn/conv/rgcn_conv.py
+++ b/torch_geometric/nn/conv/rgcn_conv.py
@@ -222,7 +222,7 @@ class RGCNConv(MessagePassing):
                 h = self.propagate(tmp, x=x_l, edge_type_ptr=None, size=size)
                 h = h.view(-1, weight.size(1), weight.size(2))
                 h = torch.einsum('abc,bcd->abd', h, weight[i])
-                out += h.contiguous().view(-1, self.out_channels)
+                out = out + h.contiguous().view(-1, self.out_channels)
 
         else:  # No regularization/Basis-decomposition ========================
             if self._WITH_PYG_LIB and isinstance(edge_index, Tensor):
@@ -239,8 +239,12 @@ class RGCNConv(MessagePassing):
                     tmp = masked_edge_index(edge_index, edge_type == i)
 
                     if x_l.dtype == torch.long:
-                        out += self.propagate(tmp, x=weight[i, x_l],
-                                              edge_type_ptr=None, size=size)
+                        out = out + self.propagate(
+                            tmp,
+                            x=weight[i, x_l],
+                            edge_type_ptr=None,
+                            size=size,
+                        )
                     else:
                         h = self.propagate(tmp, x=x_l, edge_type_ptr=None,
                                            size=size)
@@ -248,10 +252,10 @@ class RGCNConv(MessagePassing):
 
         root = self.root
         if root is not None:
-            out += root[x_r] if x_r.dtype == torch.long else x_r @ root
+            out = out + (root[x_r] if x_r.dtype == torch.long else x_r @ root)
 
         if self.bias is not None:
-            out += self.bias
+            out = out + self.bias
 
         return out
 
@@ -298,10 +302,10 @@ class FastRGCNConv(RGCNConv):
 
         root = self.root
         if root is not None:
-            out += root[x_r] if x_r.dtype == torch.long else x_r @ root
+            out = out + (root[x_r] if x_r.dtype == torch.long else x_r @ root)
 
         if self.bias is not None:
-            out += self.bias
+            out = out + self.bias
 
         return out
 

--- a/torch_geometric/nn/conv/sage_conv.py
+++ b/torch_geometric/nn/conv/sage_conv.py
@@ -133,7 +133,7 @@ class SAGEConv(MessagePassing):
 
         x_r = x[1]
         if self.root_weight and x_r is not None:
-            out += self.lin_r(x_r)
+            out = out + self.lin_r(x_r)
 
         if self.normalize:
             out = F.normalize(out, p=2., dim=-1)

--- a/torch_geometric/nn/conv/signed_conv.py
+++ b/torch_geometric/nn/conv/signed_conv.py
@@ -104,11 +104,11 @@ class SignedConv(MessagePassing):
 
             out_pos = self.propagate(pos_edge_index, x=x, size=None)
             out_pos = self.lin_pos_l(out_pos)
-            out_pos += self.lin_pos_r(x[1])
+            out_pos = out_pos + self.lin_pos_r(x[1])
 
             out_neg = self.propagate(neg_edge_index, x=x, size=None)
             out_neg = self.lin_neg_l(out_neg)
-            out_neg += self.lin_neg_r(x[1])
+            out_neg = out_neg + self.lin_neg_r(x[1])
 
             return torch.cat([out_pos, out_neg], dim=-1)
 
@@ -121,7 +121,7 @@ class SignedConv(MessagePassing):
                                       x=(x[0][..., F_in:], x[1][..., F_in:]))
             out_pos = torch.cat([out_pos1, out_pos2], dim=-1)
             out_pos = self.lin_pos_l(out_pos)
-            out_pos += self.lin_pos_r(x[1][..., :F_in])
+            out_pos = out_pos + self.lin_pos_r(x[1][..., :F_in])
 
             out_neg1 = self.propagate(pos_edge_index, size=None,
                                       x=(x[0][..., F_in:], x[1][..., F_in:]))
@@ -129,7 +129,7 @@ class SignedConv(MessagePassing):
                                       x=(x[0][..., :F_in], x[1][..., :F_in]))
             out_neg = torch.cat([out_neg1, out_neg2], dim=-1)
             out_neg = self.lin_neg_l(out_neg)
-            out_neg += self.lin_neg_r(x[1][..., F_in:])
+            out_neg = out_neg + self.lin_neg_r(x[1][..., F_in:])
 
             return torch.cat([out_pos, out_neg], dim=-1)
 

--- a/torch_geometric/nn/conv/spline_conv.py
+++ b/torch_geometric/nn/conv/spline_conv.py
@@ -139,10 +139,10 @@ class SplineConv(MessagePassing):
 
         x_r = x[1]
         if x_r is not None and self.root_weight:
-            out += self.lin(x_r)
+            out = out + self.lin(x_r)
 
         if self.bias is not None:
-            out += self.bias
+            out = out + self.bias
 
         return out
 

--- a/torch_geometric/nn/conv/supergat_conv.py
+++ b/torch_geometric/nn/conv/supergat_conv.py
@@ -229,7 +229,7 @@ class SuperGATConv(MessagePassing):
             out = out.mean(dim=1)
 
         if self.bias is not None:
-            out += self.bias
+            out = out + self.bias
 
         return out
 

--- a/torch_geometric/nn/conv/tag_conv.py
+++ b/torch_geometric/nn/conv/tag_conv.py
@@ -88,10 +88,10 @@ class TAGConv(MessagePassing):
             # propagate_type: (x: Tensor, edge_weight: OptTensor)
             x = self.propagate(edge_index, x=x, edge_weight=edge_weight,
                                size=None)
-            out += lin.forward(x)
+            out = out + lin.forward(x)
 
         if self.bias is not None:
-            out += self.bias
+            out = out + self.bias
 
         return out
 

--- a/torch_geometric/nn/conv/transformer_conv.py
+++ b/torch_geometric/nn/conv/transformer_conv.py
@@ -191,7 +191,7 @@ class TransformerConv(MessagePassing):
                 beta = beta.sigmoid()
                 out = beta * x_r + (1 - beta) * out
             else:
-                out += x_r
+                out = out + x_r
 
         if isinstance(return_attention_weights, bool):
             assert alpha is not None
@@ -210,7 +210,7 @@ class TransformerConv(MessagePassing):
             assert edge_attr is not None
             edge_attr = self.lin_edge(edge_attr).view(-1, self.heads,
                                                       self.out_channels)
-            key_j += edge_attr
+            key_j = key_j + edge_attr
 
         alpha = (query_i * key_j).sum(dim=-1) / math.sqrt(self.out_channels)
         alpha = softmax(alpha, index, ptr, size_i)
@@ -219,9 +219,9 @@ class TransformerConv(MessagePassing):
 
         out = value_j
         if edge_attr is not None:
-            out += edge_attr
+            out = out + edge_attr
 
-        out *= alpha.view(-1, self.heads, 1)
+        out = out * alpha.view(-1, self.heads, 1)
         return out
 
     def __repr__(self) -> str:

--- a/torch_geometric/nn/dense/dense_graph_conv.py
+++ b/torch_geometric/nn/dense/dense_graph_conv.py
@@ -53,7 +53,7 @@ class DenseGraphConv(torch.nn.Module):
             out[out == float('-inf')] = 0.
 
         out = self.lin_rel(out)
-        out += self.lin_root(x)
+        out = out + self.lin_root(x)
 
         if mask is not None:
             out = out * mask.view(-1, N, 1).to(x.dtype)

--- a/torch_geometric/nn/models/attentive_fp.py
+++ b/torch_geometric/nn/models/attentive_fp.py
@@ -38,7 +38,7 @@ class GATEConv(MessagePassing):
 
     def forward(self, x: Tensor, edge_index: Adj, edge_attr: Tensor) -> Tensor:
         out = self.propagate(edge_index, x=x, edge_attr=edge_attr)
-        out += self.bias
+        out = out + self.bias
         return out
 
     def message(self, x_j: Tensor, x_i: Tensor, edge_attr: Tensor,

--- a/torch_geometric/nn/models/dimenet.py
+++ b/torch_geometric/nn/models/dimenet.py
@@ -599,7 +599,7 @@ class DimeNet(torch.nn.Module):
         for interaction_block, output_block in zip(self.interaction_blocks,
                                                    self.output_blocks[1:]):
             x = interaction_block(x, rbf, sbf, idx_kj, idx_ji)
-            P += output_block(x, rbf, i)
+            P = P + output_block(x, rbf, i)
 
         return P.sum(dim=0) if batch is None else scatter(P, batch, dim=0)
 

--- a/torch_geometric/nn/models/linkx.py
+++ b/torch_geometric/nn/models/linkx.py
@@ -36,7 +36,7 @@ class SparseLinear(MessagePassing):
         out = self.propagate(edge_index, weight=self.weight,
                              edge_weight=edge_weight, size=None)
         if self.bias is not None:
-            out += self.bias
+            out = out + self.bias
         return out
 
     def message(self, weight_j: Tensor, edge_weight: OptTensor) -> Tensor:
@@ -133,8 +133,8 @@ class LINKX(torch.nn.Module):
 
         if x is not None:
             x = self.node_mlp(x)
-            out += x
-            out += self.cat_lin2(x)
+            out = out + x
+            out = out + self.cat_lin2(x)
 
         return self.final_mlp(out.relu_())
 

--- a/torch_geometric/utils/scatter.py
+++ b/torch_geometric/utils/scatter.py
@@ -51,15 +51,8 @@ class ScatterImpl(torch.nn.Module):
                     size[dim] = 0
                 out = src.new_zeros(size)
 
-            out = out.scatter_reduce_(dim, index, src, reduce,
-                                      include_self=include_self)
-
-            # TODO: For now, we need the clone here since otherwise, autograd
-            # will complain about inplace modifications.
-            # See: https://github.com/pyg-team/pytorch_geometric/pull/5120
-            out = out.clone()
-
-            return out
+            return out.scatter_reduce_(dim, index, src, reduce,
+                                       include_self=include_self)
 
         return torch_scatter.scatter(src, index, dim, out, dim_size, reduce)
 


### PR DESCRIPTION
Goal of this PR is to align with `utils.scatter` (`torch.scatter_reduce` wrapper) operation, which do not allow user to perform in-place operation on its output, in case of training. Current walk-around is made by cloning tensor on return.

During training `autograd` complains about modification of tensor needed for backward step, such behavior can be also observed with `torch_scatter` implementation, when using `mul` algorithm (caused by [this](https://github.com/dszwicht/pytorch_scatter/blob/master/csrc/scatter.cpp#L95)).

Extensive training tests were made (based on example scripts) and here are some thought:
1) `in-place -> out-of-place` without experimental mode:
in most cases memory allocations take no more memory than in default case and maximum rise is up to 4%. In half of tested examples execution time shrinks (which is good).
2) experimental mode with `clone()` or `in-place -> out-of-place`:
between `clone()` and `in-place -> out-of-place` difference is negligible. In most cases both memory allocations and execution time is worse by up to 10% (comparing to the non-experimental mode).
3) `SAGEConv`:
All models based on `SAGEConv` appear to have much worse performance when using experimental mode. `torch_scatter` implementation of `mean` algorithm (based on `torch.scatter_add`) is approximately 2 times faster than `torch.scatter_reduce[mean]` - this issue was mentioned already here: #5120.

All experiments were made on CPU.