### PR TITLE
`Explainer`: bug fix.

### DIFF
--- a/test/nn/models/test_gnn_explainer.py
+++ b/test/nn/models/test_gnn_explainer.py
@@ -40,7 +40,9 @@ class GNN(torch.nn.Module):
         self.conv2 = GCNConv(16, 16)
         self.lin = Linear(16, 7)
 
-    def forward(self, x, edge_index, batch):
+    def forward(self, x, edge_index, edge_attr, batch):
+        # edge_attr is for checking if explain can
+        # pass arguments in the right oder
         x = self.conv1(x, edge_index)
         x = F.relu(x)
         x = self.conv2(x, edge_index)
@@ -107,8 +109,10 @@ def test_gnn_explainer_explain_graph(model, return_type, allow_edge_mask,
     x = torch.randn(8, 3)
     edge_index = torch.tensor([[0, 1, 1, 2, 2, 3, 4, 5, 5, 6, 6, 7],
                                [1, 0, 2, 1, 3, 2, 5, 4, 6, 5, 7, 6]])
+    edge_attr = torch.randn(edge_index.shape[1], 2)
 
-    node_feat_mask, edge_mask = explainer.explain_graph(x, edge_index)
+    node_feat_mask, edge_mask = explainer.explain_graph(
+        x, edge_index, edge_attr=edge_attr)
     if feat_mask_type == 'scalar':
         _, _ = explainer.visualize_subgraph(-1, edge_index, edge_mask,
                                             y=torch.tensor(2), threshold=0.8,

--- a/torch_geometric/nn/models/explainer.py
+++ b/torch_geometric/nn/models/explainer.py
@@ -232,7 +232,7 @@ class Explainer(torch.nn.Module):
     def get_initial_prediction(self, x: Tensor, edge_index: Tensor,
                                batch: Optional[Tensor] = None, **kwargs):
         if batch is not None:
-            out = self.model(x, edge_index, batch, **kwargs)
+            out = self.model(x, edge_index, batch=batch, **kwargs)
         else:
             out = self.model(x, edge_index, **kwargs)
         if self.return_type == 'regression':


### PR DESCRIPTION
Fixes #5356.
In pooling models the `edge_attr` comes before `batch` see [here](https://pytorch-geometric.readthedocs.io/en/latest/modules/nn.html#torch_geometric.nn.pool.TopKPooling.forward). The `Explainer.get_model_prediction` assumed `batch` comes right after `x` and `edge_index`, this PR fixes that.