### PR TITLE
added print statement for `--use-sparse-tensor` option

### DIFF
--- a/benchmark/inference/inference_benchmark.py
+++ b/benchmark/inference/inference_benchmark.py
@@ -75,7 +75,8 @@ def run(args: argparse.ArgumentParser) -> None:
                             f'Batch size={batch_size}, '
                             f'Layers amount={layers}, '
                             f'Num_neighbors={subgraph_loader.num_neighbors}, '
-                            f'Hidden features size={hidden_channels}')
+                            f'Hidden features size={hidden_channels}, '
+                            f'Sparse tensor={args.use_sparse_tensor}')
                         params = {
                             'inputs_channels': inputs_channels,
                             'hidden_channels': hidden_channels,


### PR DESCRIPTION
I added a print for status of --use-sparse-tensor in results in benchmark/inference/inference_benchmark.py
When reporting results of the benchmark, it will be easier to tell apart runs with and without this option turned on.