### PR TITLE
Add support for precomputed edges in `SchNet` model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ## [2.2.0] - 2022-MM-DD
 ### Added
+- Add support for precomputed edges in `SchNet` model ([#5401](https://github.com/pyg-team/pytorch_geometric/pull/5401))
 - Added `AddRandomMetaPaths` that adds edges based on random walks along a metapath ([#5397](https://github.com/pyg-team/pytorch_geometric/pull/5397))
 - Added `WLConvContinuous` for performing WL refinement with continuous attributes ([#5316](https://github.com/pyg-team/pytorch_geometric/pull/5316))
 - Added `print_summary` method for the `torch_geometric.data.Dataset` interface ([#5438](https://github.com/pyg-team/pytorch_geometric/pull/5438))

--- a/examples/qm9_pretrained_schnet.py
+++ b/examples/qm9_pretrained_schnet.py
@@ -55,7 +55,10 @@ for target in range(12):
     for data in tqdm(loader):
         data = data.to(device)
         with torch.no_grad():
-            pred = predict(model, data)
+            if not args.use_precomputed_edges:
+                 pred = model(data.z, data.pos, data.batch)
+            else:
+                 pred = model(data.z, data.pos, data.batch, data.edge_index)
         mae = (pred.view(-1) - data.y[:, target]).abs()
         maes.append(mae)
 

--- a/examples/qm9_pretrained_schnet.py
+++ b/examples/qm9_pretrained_schnet.py
@@ -8,7 +8,7 @@ from torch_geometric.datasets import QM9
 from torch_geometric.loader import DataLoader
 from torch_geometric.logging import log
 from torch_geometric.nn import SchNet
-from torch_geometric.transforms import Compose, Distance, RadiusGraph
+from torch_geometric.transforms import RadiusGraph
 
 parser = argparse.ArgumentParser()
 parser.add_argument('--cutoff', type=float, default=10.0,
@@ -26,10 +26,7 @@ if not args.use_precomputed_edges:
     dataset = QM9(path)
 else:
     path = osp.join(pwd, '..', 'data', f'QM9_{args.cutoff}')
-    pre_transform = Compose(
-        [RadiusGraph(args.cutoff),
-         Distance(norm=False, cat=False)])
-    dataset = QM9(path, pre_transform=pre_transform)
+    dataset = QM9(path, pre_transform=RadiusGraph(args.cutoff))
 
 device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
 
@@ -39,7 +36,7 @@ def default_predict(model, data):
 
 
 def precomputed_predict(model, data):
-    return model(data.z, data.batch, data.edge_index, data.edge_attr)
+    return model(data.z, data.pos, data.batch, data.edge_index)
 
 
 if args.use_precomputed_edges:

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,7 @@ graphgym_requires = [
 ]
 
 full_requires = graphgym_requires + [
+    'ase',
     'h5py',
     'numba',
     'sympy',

--- a/test/nn/models/test_schnet.py
+++ b/test/nn/models/test_schnet.py
@@ -11,7 +11,6 @@ def generate_data():
     return Data(
         z=torch.randint(1, 10, (20, )),
         pos=torch.randn(20, 3),
-        y=torch.tensor([1.]),
     )
 
 

--- a/test/nn/models/test_schnet.py
+++ b/test/nn/models/test_schnet.py
@@ -1,6 +1,5 @@
 import torch
 
-from torch_geometric import seed_everything
 from torch_geometric.data import Batch, Data
 from torch_geometric.nn import SchNet
 from torch_geometric.testing import withPackage
@@ -17,7 +16,6 @@ def generate_data():
 @withPackage('torch_cluster')
 @withPackage('ase')
 def test_schnet():
-    seed_everything(0)
     data = generate_data()
 
     model = SchNet(hidden_channels=16, num_filters=16, num_interactions=2,
@@ -30,7 +28,6 @@ def test_schnet():
 
 @withPackage('torch_cluster')
 def test_schnet_batch():
-    seed_everything(0)
     num_graphs = 3
     batch = [generate_data() for _ in range(num_graphs)]
     batch = Batch.from_data_list(batch)
@@ -45,7 +42,6 @@ def test_schnet_batch():
 
 @withPackage('torch_cluster')
 def test_schnet_pre_compute_edge_index():
-    seed_everything(0)
     num_graphs = 3
     cutoff = 6.0
 

--- a/test/nn/models/test_schnet.py
+++ b/test/nn/models/test_schnet.py
@@ -5,7 +5,7 @@ from torch_geometric import seed_everything
 from torch_geometric.data import Batch, Data
 from torch_geometric.nn import SchNet
 from torch_geometric.testing import onlyFullTest, withPackage
-from torch_geometric.transforms import Compose, Distance, RadiusGraph
+from torch_geometric.transforms import RadiusGraph
 
 
 def generate_data():
@@ -62,7 +62,7 @@ def test_schnet_batch_pre_compute():
     num_graphs = 3
     cutoff = 6.0
 
-    transform = Compose([RadiusGraph(cutoff), Distance(norm=False, cat=False)])
+    transform = RadiusGraph(cutoff)
 
     batch = [transform(generate_data()) for _ in range(num_graphs)]
     batch = Batch.from_data_list(batch)
@@ -71,6 +71,5 @@ def test_schnet_batch_pre_compute():
                    num_gaussians=10, cutoff=cutoff)
 
     with torch.no_grad():
-        out = model(batch.z, None, batch.batch, batch.edge_index,
-                    batch.edge_attr)
+        out = model(batch.z, batch.pos, batch.batch, batch.edge_index)
         assert out.size() == (num_graphs, 1)

--- a/test/nn/models/test_schnet.py
+++ b/test/nn/models/test_schnet.py
@@ -3,7 +3,7 @@ import torch
 from torch_geometric import seed_everything
 from torch_geometric.data import Batch, Data
 from torch_geometric.nn import SchNet
-from torch_geometric.testing import onlyFullTest, withPackage
+from torch_geometric.testing import withPackage
 from torch_geometric.transforms import RadiusGraph
 
 

--- a/test/nn/models/test_schnet.py
+++ b/test/nn/models/test_schnet.py
@@ -16,12 +16,13 @@ def generate_data():
 
 
 @withPackage('torch_cluster')
+@withPackage('ase')
 def test_schnet():
     seed_everything(0)
     data = generate_data()
 
     model = SchNet(hidden_channels=16, num_filters=16, num_interactions=2,
-                   num_gaussians=10, cutoff=6.0)
+                   num_gaussians=10, cutoff=6.0, dipole=True)
 
     with torch.no_grad():
         out = model(data.z, data.pos)

--- a/test/nn/models/test_schnet.py
+++ b/test/nn/models/test_schnet.py
@@ -4,7 +4,7 @@ import torch.nn.functional as F
 from torch_geometric import seed_everything
 from torch_geometric.data import Batch, Data
 from torch_geometric.nn import SchNet
-from torch_geometric.testing import onlyFullTest
+from torch_geometric.testing import onlyFullTest, withPackage
 from torch_geometric.transforms import Compose, Distance, RadiusGraph
 
 
@@ -41,6 +41,7 @@ def test_schnet():
     assert losses[num_steps - 1] < losses[0]
 
 
+@withPackage('torch_cluster')
 def test_schnet_batch():
     seed_everything(0)
     num_graphs = 3
@@ -55,6 +56,7 @@ def test_schnet_batch():
         assert out.size() == (num_graphs, 1)
 
 
+@withPackage('torch_cluster')
 def test_schnet_batch_pre_compute():
     seed_everything(0)
     num_graphs = 3

--- a/test/nn/models/test_schnet.py
+++ b/test/nn/models/test_schnet.py
@@ -16,7 +16,6 @@ def generate_data():
     )
 
 
-@onlyFullTest
 def test_schnet():
     seed_everything(0)
     data = generate_data()

--- a/test/nn/models/test_schnet.py
+++ b/test/nn/models/test_schnet.py
@@ -28,7 +28,6 @@ def test_schnet():
         assert out.size() == (1, 1)
 
 
-
 @withPackage('torch_cluster')
 def test_schnet_batch():
     seed_everything(0)

--- a/test/nn/models/test_schnet.py
+++ b/test/nn/models/test_schnet.py
@@ -28,17 +28,6 @@ def test_schnet():
         out = model(data.z, data.pos)
         assert out.size() == (1, 1)
 
-    num_steps = 10
-    losses = torch.empty(num_steps)
-    optimizer = torch.optim.Adam(model.parameters(), lr=0.01)
-    for i in range(num_steps):
-        optimizer.zero_grad()
-        out = model(data.z, data.pos)
-        loss = F.mse_loss(out.view(-1), data.y)
-        loss.backward()
-        optimizer.step()
-        losses[i] = loss.detach()
-    assert losses[num_steps - 1] < losses[0]
 
 
 @withPackage('torch_cluster')
@@ -57,7 +46,7 @@ def test_schnet_batch():
 
 
 @withPackage('torch_cluster')
-def test_schnet_batch_pre_compute():
+def test_schnet_pre_compute_edge_index():
     seed_everything(0)
     num_graphs = 3
     cutoff = 6.0

--- a/test/nn/models/test_schnet.py
+++ b/test/nn/models/test_schnet.py
@@ -69,6 +69,6 @@ def test_schnet_batch_pre_compute():
                    num_gaussians=10, cutoff=cutoff)
 
     with torch.no_grad():
-        out = model(batch.z, batch.pos, batch.batch, batch.edge_index,
+        out = model(batch.z, None, batch.batch, batch.edge_index,
                     batch.edge_attr)
         assert out.size() == (num_graphs, 1)

--- a/test/nn/models/test_schnet.py
+++ b/test/nn/models/test_schnet.py
@@ -1,5 +1,4 @@
 import torch
-import torch.nn.functional as F
 
 from torch_geometric import seed_everything
 from torch_geometric.data import Batch, Data

--- a/test/nn/models/test_schnet.py
+++ b/test/nn/models/test_schnet.py
@@ -1,0 +1,74 @@
+import torch
+import torch.nn.functional as F
+
+from torch_geometric import seed_everything
+from torch_geometric.data import Batch, Data
+from torch_geometric.nn import SchNet
+from torch_geometric.testing import onlyFullTest
+from torch_geometric.transforms import Compose, Distance, RadiusGraph
+
+
+def generate_data():
+    return Data(
+        z=torch.randint(1, 10, (20, )),
+        pos=torch.randn(20, 3),
+        y=torch.tensor([1.]),
+    )
+
+
+@onlyFullTest
+def test_schnet():
+    seed_everything(0)
+    data = generate_data()
+
+    model = SchNet(hidden_channels=16, num_filters=16, num_interactions=2,
+                   num_gaussians=10, cutoff=6.0)
+
+    with torch.no_grad():
+        out = model(data.z, data.pos)
+        assert out.size() == (1, 1)
+
+    num_steps = 10
+    losses = torch.empty(num_steps)
+    optimizer = torch.optim.Adam(model.parameters(), lr=0.01)
+    for i in range(num_steps):
+        optimizer.zero_grad()
+        out = model(data.z, data.pos)
+        loss = F.mse_loss(out.view(-1), data.y)
+        loss.backward()
+        optimizer.step()
+        losses[i] = loss.detach()
+    assert losses[num_steps - 1] < losses[0]
+
+
+def test_schnet_batch():
+    seed_everything(0)
+    num_graphs = 3
+    batch = [generate_data() for _ in range(num_graphs)]
+    batch = Batch.from_data_list(batch)
+
+    model = SchNet(hidden_channels=16, num_filters=16, num_interactions=2,
+                   num_gaussians=10, cutoff=6.0)
+
+    with torch.no_grad():
+        out = model(batch.z, batch.pos, batch.batch)
+        assert out.size() == (num_graphs, 1)
+
+
+def test_schnet_batch_pre_compute():
+    seed_everything(0)
+    num_graphs = 3
+    cutoff = 6.0
+
+    transform = Compose([RadiusGraph(cutoff), Distance(norm=False, cat=False)])
+
+    batch = [transform(generate_data()) for _ in range(num_graphs)]
+    batch = Batch.from_data_list(batch)
+
+    model = SchNet(hidden_channels=16, num_filters=16, num_interactions=2,
+                   num_gaussians=10, cutoff=cutoff)
+
+    with torch.no_grad():
+        out = model(batch.z, batch.pos, batch.batch, batch.edge_index,
+                    batch.edge_attr)
+        assert out.size() == (num_graphs, 1)

--- a/test/nn/models/test_schnet.py
+++ b/test/nn/models/test_schnet.py
@@ -16,6 +16,7 @@ def generate_data():
     )
 
 
+@withPackage('torch_cluster')
 def test_schnet():
     seed_everything(0)
     data = generate_data()

--- a/torch_geometric/logging.py
+++ b/torch_geometric/logging.py
@@ -25,7 +25,7 @@ def init_wandb(name: str, **kwargs):
 
 def log(**kwargs):
     def _map(value: Any) -> str:
-        if isinstance(value, int):
+        if isinstance(value, int) and not isinstance(value, bool):
             return f'{value:03d}'
         if isinstance(value, float):
             return f'{value:.4f}'

--- a/torch_geometric/nn/models/schnet.py
+++ b/torch_geometric/nn/models/schnet.py
@@ -226,33 +226,30 @@ class SchNet(torch.nn.Module):
         return net, (dataset[train_idx], dataset[val_idx], dataset[test_idx])
 
     @staticmethod
-    def _validate_fwd_args(z, pos, batch, edge_index, edge_weight):
+    def _validate_fwd_args(z, pos, batch, edge_index):
         assert z.dim() == 1 and z.dtype == torch.long
+        assert pos.dim() == 2 and pos.shape[1] == 3
 
         if batch is not None:
             assert batch.dim() == 1 and batch.dtype == torch.long
 
-        if pos is not None:
-            assert edge_index is None and edge_weight is None
-        else:
-            assert edge_index is not None and edge_weight is not None
+        if edge_index is not None:
+            assert edge_index.dim() == 2 and edge_index.shape[
+                0] == 2 and edge_index.dtype == torch.long
 
-    def forward(self, z, pos=None, batch=None, edge_index=None,
-                edge_weight=None):
+    def forward(self, z, pos, batch=None, edge_index=None):
         """"""
-        self._validate_fwd_args(z, pos, batch, edge_index, edge_weight)
+        self._validate_fwd_args(z, pos, batch, edge_index)
         batch = torch.zeros_like(z) if batch is None else batch
 
         h = self.embedding(z)
 
-        if edge_index is None and edge_weight is None:
+        if edge_index is None:
             edge_index = radius_graph(pos, r=self.cutoff, batch=batch,
                                       max_num_neighbors=self.max_num_neighbors)
-            row, col = edge_index
-            edge_weight = (pos[row] - pos[col]).norm(dim=-1)
-        else:
-            assert edge_index is not None and edge_weight is not None
 
+        row, col = edge_index
+        edge_weight = (pos[row] - pos[col]).norm(dim=-1)
         edge_attr = self.distance_expansion(edge_weight)
 
         for interaction in self.interactions:

--- a/torch_geometric/nn/models/schnet.py
+++ b/torch_geometric/nn/models/schnet.py
@@ -107,7 +107,7 @@ class SchNet(torch.nn.Module):
         atomic_mass = torch.from_numpy(ase.data.atomic_masses)
         self.register_buffer('atomic_mass', atomic_mass)
 
-        self.embedding = Embedding(100, hidden_channels)
+        self.embedding = Embedding(100, hidden_channels, padding_idx=0)
         self.distance_expansion = GaussianSmearing(0.0, cutoff, num_gaussians)
 
         self.interactions = ModuleList()

--- a/torch_geometric/nn/models/schnet.py
+++ b/torch_geometric/nn/models/schnet.py
@@ -228,6 +228,9 @@ class SchNet(torch.nn.Module):
     def _validate_fwd_args(z, pos, batch, edge_index, edge_weight):
         assert z.dim() == 1 and z.dtype == torch.long
 
+        if batch is not None:
+            assert batch.dim() == 1 and batch.dtype == torch.long
+
         if pos is not None:
             assert edge_index is None and edge_weight is None
         else:

--- a/torch_geometric/nn/models/schnet.py
+++ b/torch_geometric/nn/models/schnet.py
@@ -108,6 +108,8 @@ class SchNet(torch.nn.Module):
             atomic_mass = torch.from_numpy(ase.data.atomic_masses)
             self.register_buffer('atomic_mass', atomic_mass)
 
+        # Support z == 0 for padding atoms so that their embedding vectors
+        # are zeroed and do not receive any gradients.
         self.embedding = Embedding(100, hidden_channels, padding_idx=0)
         self.distance_expansion = GaussianSmearing(0.0, cutoff, num_gaussians)
 

--- a/torch_geometric/nn/models/schnet.py
+++ b/torch_geometric/nn/models/schnet.py
@@ -226,7 +226,7 @@ class SchNet(torch.nn.Module):
         return net, (dataset[train_idx], dataset[val_idx], dataset[test_idx])
 
     @staticmethod
-    def _validate_fwd_args(z, pos, batch, edge_index):
+    def _validate_fwd_args(z, pos, edge_index, batch):
         assert z.dim() == 1 and z.dtype == torch.long
         assert pos.dim() == 2 and pos.shape[1] == 3
 
@@ -237,9 +237,22 @@ class SchNet(torch.nn.Module):
             assert edge_index.dim() == 2 and edge_index.shape[
                 0] == 2 and edge_index.dtype == torch.long
 
-    def forward(self, z, pos, batch=None, edge_index=None):
-        """"""
-        self._validate_fwd_args(z, pos, batch, edge_index)
+    def forward(self, z, pos, edge_index=None, batch=None):
+        r"""Forward pass of the SchNet model
+
+        Args:
+            z (LongTensor): Atomic number of each atom with shape
+                :obj:`[num_atoms]`
+            pos (Tensor): Coordinates of each atom with shape
+                :obj:`[num_atoms, 3]`
+            edge_index (LongTensor, optional): Indices of interacting pairs of
+                atoms with shape :obj:`[2, num_edges]`. Will be computed in
+                every forward pass if not provided. (default: :obj:`None`)
+            batch (LongTensor, optional): Batch indices assigning each atom to
+                a seperate molecule with shape :obj:`[num_atoms]`.
+                (default: :obj:`None`)
+        """
+        self._validate_fwd_args(z, pos, edge_index, batch)
         batch = torch.zeros_like(z) if batch is None else batch
 
         h = self.embedding(z)

--- a/torch_geometric/nn/models/schnet.py
+++ b/torch_geometric/nn/models/schnet.py
@@ -89,8 +89,6 @@ class SchNet(torch.nn.Module):
                  atomref: Optional[torch.Tensor] = None):
         super().__init__()
 
-        import ase
-
         self.hidden_channels = hidden_channels
         self.num_filters = num_filters
         self.num_interactions = num_interactions
@@ -104,8 +102,11 @@ class SchNet(torch.nn.Module):
         self.std = std
         self.scale = None
 
-        atomic_mass = torch.from_numpy(ase.data.atomic_masses)
-        self.register_buffer('atomic_mass', atomic_mass)
+        if self.dipole:
+            import ase
+
+            atomic_mass = torch.from_numpy(ase.data.atomic_masses)
+            self.register_buffer('atomic_mass', atomic_mass)
 
         self.embedding = Embedding(100, hidden_channels, padding_idx=0)
         self.distance_expansion = GaussianSmearing(0.0, cutoff, num_gaussians)

--- a/torch_geometric/nn/models/schnet.py
+++ b/torch_geometric/nn/models/schnet.py
@@ -227,13 +227,12 @@ class SchNet(torch.nn.Module):
         return net, (dataset[train_idx], dataset[val_idx], dataset[test_idx])
 
     def forward(self, z, pos, batch=None, edge_index=None):
-        r"""Forward pass of the SchNet model
-
+        r"""
         Args:
             z (LongTensor): Atomic number of each atom with shape
-                :obj:`[num_atoms]`
+                :obj:`[num_atoms]`.
             pos (Tensor): Coordinates of each atom with shape
-                :obj:`[num_atoms, 3]`
+                :obj:`[num_atoms, 3]`.
             batch (LongTensor, optional): Batch indices assigning each atom to
                 a seperate molecule with shape :obj:`[num_atoms]`.
                 (default: :obj:`None`)

--- a/torch_geometric/nn/models/schnet.py
+++ b/torch_geometric/nn/models/schnet.py
@@ -225,19 +225,7 @@ class SchNet(torch.nn.Module):
 
         return net, (dataset[train_idx], dataset[val_idx], dataset[test_idx])
 
-    @staticmethod
-    def _validate_fwd_args(z, pos, edge_index, batch):
-        assert z.dim() == 1 and z.dtype == torch.long
-        assert pos.dim() == 2 and pos.shape[1] == 3
-
-        if batch is not None:
-            assert batch.dim() == 1 and batch.dtype == torch.long
-
-        if edge_index is not None:
-            assert edge_index.dim() == 2 and edge_index.shape[
-                0] == 2 and edge_index.dtype == torch.long
-
-    def forward(self, z, pos, edge_index=None, batch=None):
+    def forward(self, z, pos, batch=None, edge_index=None):
         r"""Forward pass of the SchNet model
 
         Args:
@@ -245,14 +233,14 @@ class SchNet(torch.nn.Module):
                 :obj:`[num_atoms]`
             pos (Tensor): Coordinates of each atom with shape
                 :obj:`[num_atoms, 3]`
-            edge_index (LongTensor, optional): Indices of interacting pairs of
-                atoms with shape :obj:`[2, num_edges]`. Will be computed in
-                every forward pass if not provided. (default: :obj:`None`)
             batch (LongTensor, optional): Batch indices assigning each atom to
                 a seperate molecule with shape :obj:`[num_atoms]`.
                 (default: :obj:`None`)
+            edge_index (LongTensor, optional): Indices of interacting pairs of
+                atoms with shape :obj:`[2, num_edges]`. Will be computed in
+                every forward pass if not provided. (default: :obj:`None`)
         """
-        self._validate_fwd_args(z, pos, edge_index, batch)
+        assert z.dim() == 1 and z.dtype == torch.long
         batch = torch.zeros_like(z) if batch is None else batch
 
         h = self.embedding(z)

--- a/torch_geometric/nn/models/schnet.py
+++ b/torch_geometric/nn/models/schnet.py
@@ -146,6 +146,7 @@ class SchNet(torch.nn.Module):
         import schnetpack as spk  # noqa
 
         assert target >= 0 and target <= 12
+        is_dipole = target == 0
 
         units = [1] * 12
         units[0] = ase.units.Debye
@@ -184,7 +185,7 @@ class SchNet(torch.nn.Module):
             state = torch.load(path, map_location='cpu')
 
         net = SchNet(hidden_channels=128, num_filters=128, num_interactions=6,
-                     num_gaussians=50, cutoff=10.0,
+                     num_gaussians=50, cutoff=10.0, dipole=is_dipole,
                      atomref=dataset.atomref(target))
 
         net.embedding.weight = state.representation.embedding.weight


### PR DESCRIPTION
The main feature this allows is to call a SchNet model instance with pre-calculated edges.  This can be more efficient if the radius graphs have been computed in a `pre_transform` of a PyG dataset since this calculation will only run once and the result is cached on disk.