### PR TITLE
Fix potentially overridden key `batch` and `ptr` in `ShaDowKHopSampler`

### DIFF
--- a/torch_geometric/loader/shadow.py
+++ b/torch_geometric/loader/shadow.py
@@ -88,7 +88,7 @@ class ShaDowKHopSampler(torch.utils.data.DataLoader):
             batch.edge_index = torch.stack([row, col], dim=0)
 
         for k, v in self.data:
-            if k in ['edge_index', 'adj_t', 'num_nodes']:
+            if k in ['edge_index', 'adj_t', 'num_nodes', 'batch', 'ptr']:
                 continue
             if k == 'y' and v.size(0) == self.data.num_nodes:
                 batch[k] = v[n_id][root_n_id]


### PR DESCRIPTION
This PR is to fix the bug mentioned in [this issue](https://github.com/pyg-team/pytorch_geometric/issues/5409) when `ShaDowKHopSampler` accepts `DataBatch` as inputs. This bug was caused by the duplicated key `'batch'` each sampled batch in the `ShaDowKHopSampler` data loader would be potentially overridden by the input `DataBatch`.

Currently, my solution is to exclude the key `'batch'` when iterating `self.data`.
+ Before
```python
        for k, v in self.data:
            if k in ['edge_index', 'adj_t', 'num_nodes']:
                continue
```
+ After
```python
        for k, v in self.data:
            if k in ['edge_index', 'adj_t', 'num_nodes', 'batch', 'ptr']:
                continue
```
I also excluded the key `ptr` to avoid the same problem.