### PR TITLE
Set `num_workers=0` for Windows OS in node2vec example

### DIFF
--- a/examples/node2vec.py
+++ b/examples/node2vec.py
@@ -20,10 +20,7 @@ def main():
                      context_size=10, walks_per_node=10,
                      num_negative_samples=1, p=1, q=1, sparse=True).to(device)
 
-    if sys.platform.startswith('win'):
-        num_workers = 0
-    else:
-        num_workers = 4
+    num_workers = 0 if sys.platform.startswith('win') else 4
     loader = model.loader(batch_size=128, shuffle=True,
                           num_workers=num_workers)
     optimizer = torch.optim.SparseAdam(list(model.parameters()), lr=0.01)

--- a/examples/node2vec.py
+++ b/examples/node2vec.py
@@ -1,4 +1,5 @@
 import os.path as osp
+import sys
 
 import matplotlib.pyplot as plt
 import torch
@@ -19,7 +20,12 @@ def main():
                      context_size=10, walks_per_node=10,
                      num_negative_samples=1, p=1, q=1, sparse=True).to(device)
 
-    loader = model.loader(batch_size=128, shuffle=True, num_workers=4)
+    if sys.platform.startswith('win'):
+        num_workers = 0
+    else:
+        num_workers = 4
+    loader = model.loader(batch_size=128, shuffle=True,
+                          num_workers=num_workers)
     optimizer = torch.optim.SparseAdam(list(model.parameters()), lr=0.01)
 
     def train():


### PR DESCRIPTION
This PR is to fix the bug in the node2vec example on a Windows machine, as discussed in [this discussion](https://github.com/pyg-team/pytorch_geometric/discussions/5428). Actually, this is a bug of PyTorch Dataloader rather than PyG. Also, it is not common (only on Windows OS) and I think it might not be necessary to fix.