### PR TITLE
Check `download`, `process` for class inheritance

### DIFF
--- a/torch_geometric/data/dataset.py
+++ b/torch_geometric/data/dataset.py
@@ -80,10 +80,12 @@ class Dataset(torch.utils.data.Dataset):
         self.pre_filter = pre_filter
         self._indices: Optional[Sequence] = None
 
-        if self.download.__qualname__.split('.')[0] != 'Dataset':
+        download_method = getattr(self, "download", None)
+        if callable(download_method):
             self._download()
-
-        if self.process.__qualname__.split('.')[0] != 'Dataset':
+        
+        process_method = getattr(self, "process", None)
+        if callable(process_method):
             self._process()
 
     def indices(self) -> Sequence:

--- a/torch_geometric/data/dataset.py
+++ b/torch_geometric/data/dataset.py
@@ -83,7 +83,7 @@ class Dataset(torch.utils.data.Dataset):
         download_method = getattr(self, "download", None)
         if callable(download_method):
             self._download()
-        
+
         process_method = getattr(self, "process", None)
         if callable(process_method):
             self._process()


### PR DESCRIPTION
Noticed the problem described in issue #4567 (closed) and saw the proposed fix. The fix (https://github.com/pyg-team/pytorch_geometric/pull/4586) doesn't check whether download or process exists, which the previous implementation does. Perhaps this change is closer to the intended behavior.