### PR TITLE
Fix `__repr__` in `Summary` when `progress_bar=True`

### DIFF
--- a/torch_geometric/data/summary.py
+++ b/torch_geometric/data/summary.py
@@ -57,6 +57,8 @@ class Summary:
                 will automatically decide whether to show a progress bar based
                 on dataset size. (default: :obj:`None`)
         """
+        name = dataset.__class__.__name__
+
         if progress_bar is None:
             progress_bar = len(dataset) >= 10000
 
@@ -69,7 +71,7 @@ class Summary:
             num_edges_list.append(data.num_edges)
 
         return cls(
-            name=dataset.__class__.__name__,
+            name=name,
             num_graphs=len(dataset),
             num_nodes=Stats.from_data(num_nodes_list),
             num_edges=Stats.from_data(num_edges_list),


### PR DESCRIPTION
This PR is to fix `__repr__` method in `Summary` when `progress_bar=True`. `dataset.__class__.__name__` would retrieve the class `tqdm` instead of dataset class.

+ Before
```python
>>> QM9(root="~/data/pyg/QM9").get_summary()

tqdm (#graphs=130831):
+------------+----------+----------+
|            |   #nodes |   #edges |
|------------+----------+----------|
| mean       |     18   |     37.3 |
| std        |      2.9 |      6.3 |
| min        |      3   |      4   |
| quantile25 |     16   |     34   |
| median     |     18   |     38   |
| quantile75 |     20   |     42   |
| max        |     29   |     56   |
+------------+----------+----------+
```

+ After
```python
>>> QM9(root="~/data/pyg/QM9").get_summary()

QM9 (#graphs=130831):
+------------+----------+----------+
|            |   #nodes |   #edges |
|------------+----------+----------|
| mean       |     18   |     37.3 |
| std        |      2.9 |      6.3 |
| min        |      3   |      4   |
| quantile25 |     16   |     34   |
| median     |     18   |     38   |
| quantile75 |     20   |     42   |
| max        |     29   |     56   |
+------------+----------+----------+
```
