### PR TITLE
Fix broken url in `MD17` dataset

### DIFF
--- a/torch_geometric/datasets/md17.py
+++ b/torch_geometric/datasets/md17.py
@@ -101,8 +101,8 @@ class MD17(InMemoryDataset):
     url = 'http://quantum-machine.org/gdml/data/npz'
 
     file_names = {
-        'benzene FHI-aims': 'benzene_dft.npz',
-        'benzene': 'benzene_old_dft.npz',
+        'benzene FHI-aims': 'benzene2018_dft.npz',
+        'benzene': 'benzene2017_dft.npz',
         'benzene CCSD(T)': 'benzene_ccsd_t.zip',
         'uracil': 'uracil_dft.npz',
         'napthalene': 'naphthalene_dft.npz',


### PR DESCRIPTION
This PR is to fix the broken URL in `benzene` and `benzene FHI-aims` datasets as the dataset URLs are changed now:
```python
from torch_geometric.datasets import MD17
dataset = MD17("data/MD17/", "benzene")
# HTTPError: HTTP Error 404: Not Found
```