### PR TITLE
Add `dropout_node` to `torch_geometric.utils`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ## [2.2.0] - 2022-MM-DD
 ### Added
+- Added `dropout_node` augmentation that randomly drops nodes from a graph ([#5481](https://github.com/pyg-team/pytorch_geometric/pull/5481))
 - Added `AddRandomMetaPaths` that adds edges based on random walks along a metapath ([#5397](https://github.com/pyg-team/pytorch_geometric/pull/5397))
 - Added `WLConvContinuous` for performing WL refinement with continuous attributes ([#5316](https://github.com/pyg-team/pytorch_geometric/pull/5316))
 - Added `print_summary` method for the `torch_geometric.data.Dataset` interface ([#5438](https://github.com/pyg-team/pytorch_geometric/pull/5438))

--- a/test/utils/test_dropout.py
+++ b/test/utils/test_dropout.py
@@ -1,6 +1,6 @@
 import torch
 
-from torch_geometric.utils import dropout_adj
+from torch_geometric.utils import dropout_adj, dropout_node
 
 
 def test_dropout_adj():
@@ -23,3 +23,21 @@ def test_dropout_adj():
     out = dropout_adj(edge_index, edge_attr, force_undirected=True)
     assert out[0].tolist() == [[0, 1, 1, 2], [1, 2, 0, 1]]
     assert out[1].tolist() == [1, 3, 1, 3]
+
+
+def test_dropout_node():
+    edge_index = torch.tensor([
+        [0, 1, 1, 2, 2, 3],
+        [1, 0, 2, 1, 3, 2],
+    ])
+
+    out = dropout_node(edge_index, training=False)
+    assert edge_index.tolist() == out[0].tolist()
+    assert out[1].tolist() == [False, False, False, False, False, False]
+    assert out[2].tolist() == [False, False, False, False]
+
+    torch.manual_seed(5)
+    out = dropout_node(edge_index)
+    assert out[0].tolist() == [[2, 3], [3, 2]]
+    assert out[1].tolist() == [False, False, False, False, True, True]
+    assert out[2].tolist() == [True, False, True, True]

--- a/torch_geometric/utils/__init__.py
+++ b/torch_geometric/utils/__init__.py
@@ -1,6 +1,6 @@
 from .degree import degree
 from .softmax import softmax
-from .dropout import dropout_adj
+from .dropout import dropout_adj, dropout_node
 from .sort_edge_index import sort_edge_index
 from .coalesce import coalesce
 from .undirected import is_undirected, to_undirected
@@ -39,6 +39,7 @@ __all__ = [
     'degree',
     'softmax',
     'dropout_adj',
+    'dropout_node',
     'sort_edge_index',
     'coalesce',
     'is_undirected',

--- a/torch_geometric/utils/dropout.py
+++ b/torch_geometric/utils/dropout.py
@@ -133,4 +133,5 @@ def dropout_node(edge_index: Tensor, edge_attr: OptTensor = None,
     mask = torch.full_like(nodes, 1 - p, dtype=torch.float32)
     mask = torch.bernoulli(mask).to(torch.bool)
     subset = nodes[mask]
-    return subgraph(subset, edge_index, edge_attr, relabel_nodes=relabel_nodes)
+    return subgraph(subset, edge_index, edge_attr, num_nodes=num_nodes,
+                    relabel_nodes=relabel_nodes)

--- a/torch_geometric/utils/dropout.py
+++ b/torch_geometric/utils/dropout.py
@@ -5,6 +5,9 @@ from torch import Tensor
 
 from torch_geometric.typing import OptTensor
 
+from .num_nodes import maybe_num_nodes
+from .subgraph import subgraph
+
 
 def filter_adj(row: Tensor, col: Tensor, edge_attr: OptTensor,
                mask: Tensor) -> Tuple[Tensor, Tensor, OptTensor]:
@@ -79,3 +82,55 @@ def dropout_adj(
         edge_index = torch.stack([row, col], dim=0)
 
     return edge_index, edge_attr
+
+
+def dropout_node(edge_index: Tensor, edge_attr: OptTensor = None,
+                 p: float = 0.5, num_nodes: Optional[int] = None,
+                 training: bool = True,
+                 relabel_nodes: bool = False) -> Tuple[Tensor, Tensor]:
+    r"""Randomly drops nodes from the adjacency matrix
+    :obj:`(edge_index, edge_attr)` with probability :obj:`p` using samples from
+    a Bernoulli distribution.
+
+    Args:
+        edge_index (LongTensor): The edge indices.
+        edge_attr (Tensor, optional): Edge weights or multi-dimensional
+            edge features. (default: :obj:`None`)
+        p (float, optional): Dropout probability. (default: :obj:`0.5`)
+        num_nodes (int, optional): The number of nodes, *i.e.*
+            :obj:`max_val + 1` of :attr:`edge_index`. (default: :obj:`None`)
+        training (bool, optional): If set to :obj:`False`, this operation is a
+            no-op. (default: :obj:`True`)
+        relabel_nodes (bool, optional): If set to :obj:`True`, the resulting
+            :obj:`edge_index` will be relabeled to hold consecutive indices
+            starting from zero. (default: :obj:`False`)
+
+    Examples:
+
+        >>> edge_index = torch.tensor([[0, 1, 1, 2, 2, 3],
+        ...                            [1, 0, 2, 1, 3, 2]])
+        >>> edge_attr = torch.tensor([1, 2, 3, 4, 5, 6])
+        >>> dropout_node(edge_index, edge_attr)
+        (tensor([[2, 3],
+                [3, 2]]),
+        tensor([5, 6]))
+
+        >>> # The nodes of returned graph is relabeled
+        >>> dropout_node(edge_index, edge_attr, relabel_nodes=True)
+        (tensor([[0, 1],
+                [1, 0]]),
+        tensor([5, 6]))
+    """
+    if p < 0. or p > 1.:
+        raise ValueError(f'Dropout probability has to be between 0 and 1 '
+                         f'(got {p}')
+
+    if not training or p == 0.0:
+        return edge_index, edge_attr
+
+    num_nodes = maybe_num_nodes(edge_index, num_nodes)
+    nodes = torch.arange(num_nodes, dtype=torch.long, device=edge_index.device)
+    mask = torch.full_like(nodes, 1 - p, dtype=torch.float32)
+    mask = torch.bernoulli(mask).to(torch.bool)
+    subset = nodes[mask]
+    return subgraph(subset, edge_index, edge_attr, relabel_nodes=relabel_nodes)

--- a/torch_geometric/utils/dropout.py
+++ b/torch_geometric/utils/dropout.py
@@ -86,8 +86,7 @@ def dropout_adj(
 
 def dropout_node(edge_index: Tensor, edge_attr: OptTensor = None,
                  p: float = 0.5, num_nodes: Optional[int] = None,
-                 training: bool = True,
-                 relabel_nodes: bool = False) -> Tuple[Tensor, Tensor]:
+                 training: bool = True) -> Tuple[Tensor, OptTensor]:
     r"""Randomly drops nodes from the adjacency matrix
     :obj:`(edge_index, edge_attr)` with probability :obj:`p` using samples from
     a Bernoulli distribution.
@@ -101,9 +100,6 @@ def dropout_node(edge_index: Tensor, edge_attr: OptTensor = None,
             :obj:`max_val + 1` of :attr:`edge_index`. (default: :obj:`None`)
         training (bool, optional): If set to :obj:`False`, this operation is a
             no-op. (default: :obj:`True`)
-        relabel_nodes (bool, optional): If set to :obj:`True`, the resulting
-            :obj:`edge_index` will be relabeled to hold consecutive indices
-            starting from zero. (default: :obj:`False`)
 
     Examples:
 
@@ -113,12 +109,6 @@ def dropout_node(edge_index: Tensor, edge_attr: OptTensor = None,
         >>> dropout_node(edge_index, edge_attr)
         (tensor([[2, 3],
                 [3, 2]]),
-        tensor([5, 6]))
-
-        >>> # The nodes of returned graph is relabeled
-        >>> dropout_node(edge_index, edge_attr, relabel_nodes=True)
-        (tensor([[0, 1],
-                [1, 0]]),
         tensor([5, 6]))
     """
     if p < 0. or p > 1.:
@@ -133,5 +123,4 @@ def dropout_node(edge_index: Tensor, edge_attr: OptTensor = None,
     mask = torch.full_like(nodes, 1 - p, dtype=torch.float32)
     mask = torch.bernoulli(mask).to(torch.bool)
     subset = nodes[mask]
-    return subgraph(subset, edge_index, edge_attr, num_nodes=num_nodes,
-                    relabel_nodes=relabel_nodes)
+    return subgraph(subset, edge_index, edge_attr, num_nodes=num_nodes)

--- a/torch_geometric/utils/dropout.py
+++ b/torch_geometric/utils/dropout.py
@@ -84,7 +84,7 @@ def dropout_adj(
     return edge_index, edge_attr
 
 
-def dropout_node(edge_index: Tensor, edge_attr: OptTensor = None,
+def dropout_node(edge_index: Tensor,
                  p: float = 0.5, num_nodes: Optional[int] = None,
                  training: bool = True) -> Tuple[Tensor, OptTensor]:
     r"""Randomly drops nodes from the adjacency matrix

--- a/torch_geometric/utils/dropout.py
+++ b/torch_geometric/utils/dropout.py
@@ -119,8 +119,7 @@ def dropout_node(edge_index: Tensor,
         return edge_index, edge_attr
 
     num_nodes = maybe_num_nodes(edge_index, num_nodes)
-    nodes = torch.arange(num_nodes, dtype=torch.long, device=edge_index.device)
-    mask = torch.full_like(nodes, 1 - p, dtype=torch.float32)
-    mask = torch.bernoulli(mask).to(torch.bool)
+    prob = torch.rand(num_nodes, device=edge_index.device)
+    mask = prob > p
     subset = nodes[mask]
     return subgraph(subset, edge_index, edge_attr, num_nodes=num_nodes)

--- a/torch_geometric/utils/dropout.py
+++ b/torch_geometric/utils/dropout.py
@@ -121,5 +121,4 @@ def dropout_node(edge_index: Tensor,
     num_nodes = maybe_num_nodes(edge_index, num_nodes)
     prob = torch.rand(num_nodes, device=edge_index.device)
     mask = prob > p
-    subset = nodes[mask]
-    return subgraph(subset, edge_index, edge_attr, num_nodes=num_nodes)
+    return subgraph(mask, edge_index, edge_attr, num_nodes=num_nodes)

--- a/torch_geometric/utils/dropout.py
+++ b/torch_geometric/utils/dropout.py
@@ -84,8 +84,8 @@ def dropout_adj(
     return edge_index, edge_attr
 
 
-def dropout_node(edge_index: Tensor,
-                 p: float = 0.5, num_nodes: Optional[int] = None,
+def dropout_node(edge_index: Tensor, p: float = 0.5,
+                 num_nodes: Optional[int] = None,
                  training: bool = True) -> Tuple[Tensor, OptTensor]:
     r"""Randomly drops nodes from the adjacency matrix
     :obj:`(edge_index, edge_attr)` with probability :obj:`p` using samples from


### PR DESCRIPTION
This PR is my first attempt to add graph augmentation methods into PyG. As discussed in https://github.com/pyg-team/pytorch_geometric/issues/5452, I start with a simple augmentation method `DropNode` proposed in [Graph Contrastive Learning with Augmentations](https://arxiv.org/abs/2010.139023).