### PR TITLE
Add `dropout_edge` and deprecate `dropout_adj`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ## [2.2.0] - 2022-MM-DD
 ### Added
+- Added `dropout_edge` augmentation that randomly drops edges from a graph - the usage of `dropout_adj` is now deprecated ([#5495](https://github.com/pyg-team/pytorch_geometric/pull/5495))
 - Add support for precomputed edges in `SchNet` model ([#5401](https://github.com/pyg-team/pytorch_geometric/pull/5401))
 - Added `dropout_node` augmentation that randomly drops nodes from a graph ([#5481](https://github.com/pyg-team/pytorch_geometric/pull/5481))
 - Added `AddRandomMetaPaths` that adds edges based on random walks along a metapath ([#5397](https://github.com/pyg-team/pytorch_geometric/pull/5397))

--- a/README.md
+++ b/README.md
@@ -308,7 +308,7 @@ PyG comes with a rich set of neural network operators that are commonly used in 
 They follow an extensible design: It is easy to apply these operators and graph utilities to existing GNN layers and models to further enhance model performance.
 
 * **[DropEdge](https://pytorch-geometric.readthedocs.io/en/latest/modules/utils.html#torch_geometric.utils.dropout_edge)** from Rong *et al.*: [DropEdge: Towards Deep Graph Convolutional Networks on Node Classification](https://openreview.net/forum?id=Hkx1qkrKPr) (ICLR 2020)
-* **[DropNode](https://pytorch-geometric.readthedocs.io/en/latest/modules/utils.html#torch_geometric.utils.dropout_node)** from You *et al. * [Graph Contrastive Learning with Augmentations](https://arxiv.org/abs/2010.13902) (NeurIPS 2020)
+* **[DropNode](https://pytorch-geometric.readthedocs.io/en/latest/modules/utils.html#torch_geometric.utils.dropout_node)** from You *et al.* [Graph Contrastive Learning with Augmentations](https://arxiv.org/abs/2010.13902) (NeurIPS 2020)
 * **[GraphNorm](https://pytorch-geometric.readthedocs.io/en/latest/modules/nn.html#torch_geometric.nn.norm.GraphNorm)** from Cai *et al.*: [GraphNorm: A Principled Approach to Accelerating Graph Neural Network Training](https://proceedings.mlr.press/v139/cai21e.html) (ICML 2021)
 * **[GDC](https://pytorch-geometric.readthedocs.io/en/latest/modules/transforms.html#torch_geometric.transforms.GDC)** from Klicpera *et al.*: [Diffusion Improves Graph Learning](https://arxiv.org/abs/1911.05485) (NeurIPS 2019) [[**Example**](https://github.com/pyg-team/pytorch_geometric/blob/master/examples/gcn.py)]
 

--- a/README.md
+++ b/README.md
@@ -307,7 +307,8 @@ New Benchmarks and Strong Simple Methods](https://arxiv.org/abs/2110.14446) (Neu
 PyG comes with a rich set of neural network operators that are commonly used in many GNN models.
 They follow an extensible design: It is easy to apply these operators and graph utilities to existing GNN layers and models to further enhance model performance.
 
-* **[DropEdge](https://pytorch-geometric.readthedocs.io/en/latest/modules/utils.html#torch_geometric.utils.dropout_adj)** from Rong *et al.*: [DropEdge: Towards Deep Graph Convolutional Networks on Node Classification](https://openreview.net/forum?id=Hkx1qkrKPr) (ICLR 2020)
+* **[DropEdge](https://pytorch-geometric.readthedocs.io/en/latest/modules/utils.html#torch_geometric.utils.dropout_edge)** from Rong *et al.*: [DropEdge: Towards Deep Graph Convolutional Networks on Node Classification](https://openreview.net/forum?id=Hkx1qkrKPr) (ICLR 2020)
+* **[DropNode](https://pytorch-geometric.readthedocs.io/en/latest/modules/utils.html#torch_geometric.utils.dropout_node)** from You *et al. * [Graph Contrastive Learning with Augmentations](https://arxiv.org/abs/2010.13902) (NeurIPS 2020)
 * **[GraphNorm](https://pytorch-geometric.readthedocs.io/en/latest/modules/nn.html#torch_geometric.nn.norm.GraphNorm)** from Cai *et al.*: [GraphNorm: A Principled Approach to Accelerating Graph Neural Network Training](https://proceedings.mlr.press/v139/cai21e.html) (ICML 2021)
 * **[GDC](https://pytorch-geometric.readthedocs.io/en/latest/modules/transforms.html#torch_geometric.transforms.GDC)** from Klicpera *et al.*: [Diffusion Improves Graph Learning](https://arxiv.org/abs/1911.05485) (NeurIPS 2019) [[**Example**](https://github.com/pyg-team/pytorch_geometric/blob/master/examples/gcn.py)]
 

--- a/examples/graph_unet.py
+++ b/examples/graph_unet.py
@@ -5,7 +5,7 @@ import torch.nn.functional as F
 
 from torch_geometric.datasets import Planetoid
 from torch_geometric.nn import GraphUNet
-from torch_geometric.utils import dropout_adj
+from torch_geometric.utils import dropout_edge
 
 dataset = 'Cora'
 path = osp.join(osp.dirname(osp.realpath(__file__)), '..', 'data', dataset)
@@ -21,10 +21,9 @@ class Net(torch.nn.Module):
                               depth=3, pool_ratios=pool_ratios)
 
     def forward(self):
-        edge_index, _ = dropout_adj(data.edge_index, p=0.2,
-                                    force_undirected=True,
-                                    num_nodes=data.num_nodes,
-                                    training=self.training)
+        edge_index, _ = dropout_edge(data.edge_index, p=0.2,
+                                     force_undirected=True,
+                                     training=self.training)
         x = F.dropout(data.x, p=0.92, training=self.training)
 
         x = self.unet(x, edge_index)

--- a/test/nn/test_to_hetero_transformer.py
+++ b/test/nn/test_to_hetero_transformer.py
@@ -16,9 +16,9 @@ from torch_geometric.nn import (
     SAGEConv,
     to_hetero,
 )
-from torch_geometric.utils import dropout_adj
+from torch_geometric.utils import dropout_edge
 
-torch.fx.wrap('dropout_adj')
+torch.fx.wrap('dropout_edge')
 
 
 class Net1(torch.nn.Module):
@@ -140,7 +140,7 @@ class Net10(torch.nn.Module):
 
     def forward(self, x: Tensor, edge_index: Tensor) -> Tensor:
         x = F.dropout(x, p=0.5, training=self.training)
-        edge_index, _ = dropout_adj(edge_index, p=0.5, training=self.training)
+        edge_index, _ = dropout_edge(edge_index, p=0.5, training=self.training)
         return self.conv(x, edge_index)
 
 

--- a/test/utils/test_dropout.py
+++ b/test/utils/test_dropout.py
@@ -48,7 +48,7 @@ def test_dropout_edge():
 
     out = dropout_edge(edge_index, training=False)
     assert edge_index.tolist() == out[0].tolist()
-    assert out[1].tolist() == [False, False, False, False, False, False]
+    assert out[1].tolist() == [True, True, True, True, True, True]
 
     torch.manual_seed(5)
     out = dropout_edge(edge_index)

--- a/test/utils/test_dropout.py
+++ b/test/utils/test_dropout.py
@@ -1,6 +1,6 @@
 import torch
 
-from torch_geometric.utils import dropout_adj, dropout_node
+from torch_geometric.utils import dropout_adj, dropout_edge, dropout_node
 
 
 def test_dropout_adj():
@@ -41,3 +41,21 @@ def test_dropout_node():
     assert out[0].tolist() == [[2, 3], [3, 2]]
     assert out[1].tolist() == [False, False, False, False, True, True]
     assert out[2].tolist() == [True, False, True, True]
+
+
+def test_dropout_edge():
+    edge_index = torch.tensor([[0, 1, 1, 2, 2, 3], [1, 0, 2, 1, 3, 2]])
+
+    out = dropout_edge(edge_index, training=False)
+    assert edge_index.tolist() == out[0].tolist()
+    assert out[1].tolist() == [False, False, False, False, False, False]
+
+    torch.manual_seed(5)
+    out = dropout_edge(edge_index)
+    assert out[0].tolist() == [[0, 1, 2, 2], [1, 2, 1, 3]]
+    assert out[1].tolist() == [True, False, True, True, True, False]
+
+    torch.manual_seed(6)
+    out = dropout_edge(edge_index, force_undirected=True)
+    assert out[0].tolist() == [[0, 1, 1, 2], [1, 2, 0, 1]]
+    assert out[1].tolist() == [0, 2, 0, 2]

--- a/torch_geometric/nn/conv/supergat_conv.py
+++ b/torch_geometric/nn/conv/supergat_conv.py
@@ -12,7 +12,7 @@ from torch_geometric.typing import OptTensor
 from torch_geometric.utils import (
     add_self_loops,
     batched_negative_sampling,
-    dropout_adj,
+    dropout_edge,
     is_undirected,
     negative_sampling,
     remove_self_loops,
@@ -259,9 +259,9 @@ class SuperGATConv(MessagePassing):
         return neg_edge_index
 
     def positive_sampling(self, edge_index: Tensor) -> Tensor:
-        pos_edge_index, _ = dropout_adj(edge_index,
-                                        p=1. - self.edge_sample_ratio,
-                                        training=self.training)
+        pos_edge_index, _ = dropout_edge(edge_index,
+                                         p=1. - self.edge_sample_ratio,
+                                         training=self.training)
         return pos_edge_index
 
     def get_attention(self, edge_index_i: Tensor, x_i: Tensor, x_j: Tensor,

--- a/torch_geometric/utils/__init__.py
+++ b/torch_geometric/utils/__init__.py
@@ -1,6 +1,6 @@
 from .degree import degree
 from .softmax import softmax
-from .dropout import dropout_adj, dropout_node
+from .dropout import dropout_adj, dropout_node, dropout_edge
 from .sort_edge_index import sort_edge_index
 from .coalesce import coalesce
 from .undirected import is_undirected, to_undirected
@@ -39,6 +39,7 @@ __all__ = [
     'degree',
     'softmax',
     'dropout_adj',
+    'dropout_edge',
     'dropout_node',
     'sort_edge_index',
     'coalesce',

--- a/torch_geometric/utils/__init__.py
+++ b/torch_geometric/utils/__init__.py
@@ -38,9 +38,9 @@ from .scatter import scatter
 __all__ = [
     'degree',
     'softmax',
-    'dropout_adj',
-    'dropout_edge',
     'dropout_node',
+    'dropout_edge',
+    'dropout_adj',
     'sort_edge_index',
     'coalesce',
     'is_undirected',

--- a/torch_geometric/utils/dropout.py
+++ b/torch_geometric/utils/dropout.py
@@ -153,7 +153,8 @@ def dropout_edge(edge_index: Tensor, p: float = 0.5,
     a Bernoulli distribution.
 
     The method returns (1) the retained :obj:`edge_index`, (2) the edge mask
-    indicating which edges were retained.
+    or index indicating which edges were retained, depending on the argument
+    :obj:`force_undirected`.
 
     Args:
         edge_index (LongTensor): The edge indices.
@@ -164,7 +165,7 @@ def dropout_edge(edge_index: Tensor, p: float = 0.5,
         training (bool, optional): If set to :obj:`False`, this operation is a
             no-op. (default: :obj:`True`)
 
-    :rtype: (:class:`LongTensor`, :class:`BoolTensor`)
+    :rtype: (:class:`LongTensor`, :class:`BoolTensor` or :class:`LongTensor`)
 
     Examples:
 
@@ -174,7 +175,7 @@ def dropout_edge(edge_index: Tensor, p: float = 0.5,
         >>> edge_index
         tensor([[0, 1, 2, 2],
                 [1, 2, 1, 3]])
-        >>> edge_mask
+        >>> edge_mask # masks indicating which edges are retained
         tensor([ True, False,  True,  True,  True, False])
 
         >>> edge_index, edge_mask = dropout_edge(edge_index,
@@ -182,7 +183,7 @@ def dropout_edge(edge_index: Tensor, p: float = 0.5,
         >>> edge_index
         tensor([[0, 1, 2, 1, 2, 3],
                 [1, 2, 3, 0, 1, 2]])
-        >>> edge_mask
+        >>> edge_mask # indices indicating which edges are retained
         >>> tensor([0, 2, 4, 0, 2, 4])
     """
     if p < 0. or p > 1.:

--- a/torch_geometric/utils/dropout.py
+++ b/torch_geometric/utils/dropout.py
@@ -178,12 +178,12 @@ def dropout_edge(edge_index: Tensor, p: float = 0.5,
         >>> edge_mask # masks indicating which edges are retained
         tensor([ True, False,  True,  True,  True, False])
 
-        >>> edge_index, edge_mask = dropout_edge(edge_index,
+        >>> edge_index, edge_id = dropout_edge(edge_index,
         ...                                      force_undirected=True)
         >>> edge_index
         tensor([[0, 1, 2, 1, 2, 3],
                 [1, 2, 3, 0, 1, 2]])
-        >>> edge_mask # indices indicating which edges are retained
+        >>> edge_id # indices indicating which edges are retained
         >>> tensor([0, 2, 4, 0, 2, 4])
     """
     if p < 0. or p > 1.:

--- a/torch_geometric/utils/dropout.py
+++ b/torch_geometric/utils/dropout.py
@@ -191,7 +191,7 @@ def dropout_edge(edge_index: Tensor, p: float = 0.5,
                          f'(got {p}')
 
     if not training or p == 0.0:
-        edge_mask = edge_index.new_zeros(edge_index.size(1), dtype=torch.bool)
+        edge_mask = edge_index.new_ones(edge_index.size(1), dtype=torch.bool)
         return edge_index, edge_mask
 
     row, col = edge_index

--- a/torch_geometric/utils/dropout.py
+++ b/torch_geometric/utils/dropout.py
@@ -28,6 +28,12 @@ def dropout_adj(
     :obj:`(edge_index, edge_attr)` with probability :obj:`p` using samples from
     a Bernoulli distribution.
 
+    .. warning::
+
+        :class:`~torch_geometric.utils.dropout_adj` is deprecated and will
+        be removed in a future release.
+        Use :class:`torch_geometric.utils.dropout_edge` instead.
+
     Args:
         edge_index (LongTensor): The edge indices.
         edge_attr (Tensor, optional): Edge weights or multi-dimensional

--- a/torch_geometric/utils/dropout.py
+++ b/torch_geometric/utils/dropout.py
@@ -94,8 +94,8 @@ def dropout_node(edge_index: Tensor, p: float = 0.5,
     a Bernoulli distribution.
 
     The method returns (1) the retained :obj:`edge_index`, (2) the edge mask
-    indicating which edges were dropped. (3) the node mask indicating
-    which nodes were dropped.
+    indicating which edges were retained. (3) the node mask indicating
+    which nodes were retained.
 
     Args:
         edge_index (LongTensor): The edge indices.


### PR DESCRIPTION
This is a follow-up PR for https://github.com/pyg-team/pytorch_geometric/issues/5452. This PR added `dropout_edge` and deprecated `dropout_adj`. 
TODO: Make `edge_mask` align with `edge_index` when `force_undirected=True`

I also fixed the doc-string in `dropout_node`, as it returned the `edge_mask` and `node_mask` indicate where edges and nodes are retained rather than dropped/masked. Sorry for the mess!