### PR TITLE
Explictly name the processed file

### DIFF
--- a/torch_geometric/datasets/movie_lens.py
+++ b/torch_geometric/datasets/movie_lens.py
@@ -38,8 +38,10 @@ class MovieLens(InMemoryDataset):
 
     def __init__(self, root, transform: Optional[Callable] = None,
                  pre_transform: Optional[Callable] = None,
-                 model_name: Optional[str] = "all-MiniLM-L6-v2"):
+                 model_name: Optional[str] = "all-MiniLM-L6-v2",
+                processed_file_name: Optional[str] = "all-MiniLM-L6-v2"):
         self.model_name = model_name
+        self.processed_file_name=processed_file_name
         super().__init__(root, transform, pre_transform)
         self.data, self.slices = torch.load(self.processed_paths[0])
 
@@ -52,7 +54,7 @@ class MovieLens(InMemoryDataset):
 
     @property
     def processed_file_names(self) -> str:
-        return f'data_{self.model_name}.pt'
+        return f'data_{self.processed_file_name}.pt'
 
     def download(self):
         path = download_url(self.url, self.raw_dir)

--- a/torch_geometric/datasets/movie_lens.py
+++ b/torch_geometric/datasets/movie_lens.py
@@ -39,9 +39,9 @@ class MovieLens(InMemoryDataset):
     def __init__(self, root, transform: Optional[Callable] = None,
                  pre_transform: Optional[Callable] = None,
                  model_name: Optional[str] = "all-MiniLM-L6-v2",
-                processed_file_name: Optional[str] = "all-MiniLM-L6-v2"):
+                 processed_file_name: Optional[str] = "all-MiniLM-L6-v2"):
         self.model_name = model_name
-        self.processed_file_name=processed_file_name
+        self.processed_file_name = processed_file_name
         super().__init__(root, transform, pre_transform)
         self.data, self.slices = torch.load(self.processed_paths[0])
 


### PR DESCRIPTION
Explictly name the processed pt file, in case this situation happening: https://github.com/pyg-team/pytorch_geometric/issues/5500
Maybe it's better to use it only when using local transformers model? I can't decide it quickly.
In detail: this pull request avoids the situation that using local transformers model and `/` in the model_name, so it's not able to dirrectly create the processed file.