### PR TITLE
Add `DGraphFin` dynamic graph dataset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 ## [2.2.0] - 2022-MM-DD
 ### Added
 
+- Added the `DGraphFin` dynamic graph dataset ([#5504](https://github.com/pyg-team/pytorch_geometric/pull/5504))
 - Added `dropout_edge` augmentation that randomly drops edges from a graph - the usage of `dropout_adj` is now deprecated ([#5495](https://github.com/pyg-team/pytorch_geometric/pull/5495))
 - Add support for precomputed edges in `SchNet` model ([#5401](https://github.com/pyg-team/pytorch_geometric/pull/5401))
 - Added `dropout_node` augmentation that randomly drops nodes from a graph ([#5481](https://github.com/pyg-team/pytorch_geometric/pull/5481))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ## [2.2.0] - 2022-MM-DD
 ### Added
+- Added `DGraphFin` dynamic graph dataset  ([#5504](https://github.com/pyg-team/pytorch_geometric/pull/5504))
 - Add support for precomputed edges in `SchNet` model ([#5401](https://github.com/pyg-team/pytorch_geometric/pull/5401))
 - Added `dropout_node` augmentation that randomly drops nodes from a graph ([#5481](https://github.com/pyg-team/pytorch_geometric/pull/5481))
 - Added `AddRandomMetaPaths` that adds edges based on random walks along a metapath ([#5397](https://github.com/pyg-team/pytorch_geometric/pull/5397))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,6 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ## [2.2.0] - 2022-MM-DD
 ### Added
-
 - Added the `DGraphFin` dynamic graph dataset ([#5504](https://github.com/pyg-team/pytorch_geometric/pull/5504))
 - Added `dropout_edge` augmentation that randomly drops edges from a graph - the usage of `dropout_adj` is now deprecated ([#5495](https://github.com/pyg-team/pytorch_geometric/pull/5495))
 - Add support for precomputed edges in `SchNet` model ([#5401](https://github.com/pyg-team/pytorch_geometric/pull/5401))

--- a/torch_geometric/datasets/__init__.py
+++ b/torch_geometric/datasets/__init__.py
@@ -75,6 +75,7 @@ from .sbm_dataset import StochasticBlockModelDataset
 from .sbm_dataset import RandomPartitionGraphDataset
 from .linkx_dataset import LINKXDataset
 from .elliptic import EllipticBitcoinDataset
+from .dgraph import DGraphFin
 
 import torch_geometric.datasets.utils  # noqa
 
@@ -159,6 +160,7 @@ __all__ = [
     'RandomPartitionGraphDataset',
     'LINKXDataset',
     'EllipticBitcoinDataset',
+    'DGraphFin',
 ]
 
 classes = __all__

--- a/torch_geometric/datasets/dgraph.py
+++ b/torch_geometric/datasets/dgraph.py
@@ -17,7 +17,9 @@ class DGraphFin(InMemoryDataset):
     in financial industry.
     Node represents a Finvolution user, and an edge from one
     user to another means that the user regards the other user
-    as the emergency contact person.
+    as the emergency contact person. Each edge is associated with a
+    timestamp ranging from 1 to 821 and a type of emergency contact
+    ranging from 0 to 11.
 
 
     Args:

--- a/torch_geometric/datasets/dgraph.py
+++ b/torch_geometric/datasets/dgraph.py
@@ -58,7 +58,7 @@ class DGraphFin(InMemoryDataset):
 
     def process(self):
         extract_zip(self.raw_paths[0], self.raw_dir, log=False)
-        path = os.path.join(self.raw_dir, "DGraphFin.npz")
+        path = os.path.join(self.raw_dir, "dgraphfin.npz")
 
         with np.load(path) as loader:
             x = torch.from_numpy(loader['x']).to(torch.float)

--- a/torch_geometric/datasets/dgraph.py
+++ b/torch_geometric/datasets/dgraph.py
@@ -90,7 +90,7 @@ class DGraphFin(InMemoryDataset):
             train_mask = index_to_mask(train_nodes, size=x.size(0))
             val_mask = index_to_mask(val_nodes, size=x.size(0))
             test_mask = index_to_mask(test_nodes, size=x.size(0))
-            data = Data(x=x, edge_index=edge_index.t(), edge_attr=edge_attr,
+            data = Data(x=x, edge_index=edge_index.t(), edge_type=edge_type,
                         edge_time=edge_time, y=y, train_mask=train_mask,
                         val_mask=val_mask, test_mask=test_mask)
 

--- a/torch_geometric/datasets/dgraph.py
+++ b/torch_geometric/datasets/dgraph.py
@@ -1,0 +1,82 @@
+import os
+from typing import Callable, Optional
+
+import numpy as np
+import torch
+
+from torch_geometric.data import Data, InMemoryDataset, extract_zip
+from torch_geometric.utils import index_to_mask
+
+
+class DGraphFin(InMemoryDataset):
+    r"""The DGraphFin networks from the
+    `"DGraph: A Large-Scale Financial Dataset for Graph Anomaly Detection"
+    <https://arxiv.org/abs/2207.03579>`_ paper.
+    It is a directed, unweighted dynamic graph consisting of millions of
+    nodes and edges, representing a realistic user-to-user social network
+    in financial industry.
+    Node represents a Finvolution user, and an edge from one
+    user to another means that the user regards the other user
+    as the emergency contact person.
+
+
+    Args:
+        root (string): Root directory where the dataset should be saved.
+        transform (callable, optional): A function/transform that takes in an
+            :obj:`torch_geometric.data.Data` object and returns a transformed
+            version. The data object will be transformed before every access.
+            (default: :obj:`None`)
+        pre_transform (callable, optional): A function/transform that takes in
+            an :obj:`torch_geometric.data.Data` object and returns a
+            transformed version. The data object will be transformed before
+            being saved to disk. (default: :obj:`None`)
+    """
+
+    url = "https://dgraph.xinye.com"
+
+    def __init__(self, root: str, transform: Optional[Callable] = None,
+                 pre_transform: Optional[Callable] = None):
+        super().__init__(root, transform, pre_transform)
+        self.data, self.slices = torch.load(self.processed_paths[0])
+
+    def download(self):
+        raise RuntimeError(
+            f"Dataset not found. Please download '{self.raw_file_names}' from "
+            f"'{self.url}' and move it to '{self.raw_dir}'")
+
+    @property
+    def raw_file_names(self) -> str:
+        return 'DGraphFin.zip'
+
+    @property
+    def processed_file_names(self) -> str:
+        return 'data.pt'
+
+    def process(self):
+        extract_zip(self.raw_paths[0], self.raw_dir, log=False)
+        path = os.path.join(self.raw_dir, "DGraphFin.npz")
+
+        with np.load(path) as loader:
+            x = torch.from_numpy(loader['x']).to(torch.float)
+            y = torch.from_numpy(loader['y']).to(torch.long)
+            edge_index = torch.from_numpy(loader['edge_index']).to(torch.long)
+            edge_attr = torch.from_numpy(loader['edge_type']).to(torch.long)
+            edge_time = torch.from_numpy(loader['edge_timestamp']).to(
+                torch.long)
+            train_nodes = torch.from_numpy(loader['train_mask']).to(torch.long)
+            val_nodes = torch.from_numpy(loader['valid_mask']).to(torch.long)
+            test_nodes = torch.from_numpy(loader['test_mask']).to(torch.long)
+
+            train_mask = index_to_mask(train_nodes, size=x.size(0))
+            val_mask = index_to_mask(val_nodes, size=x.size(0))
+            test_mask = index_to_mask(test_nodes, size=x.size(0))
+            data = Data(x=x, edge_index=edge_index.t(), edge_attr=edge_attr,
+                        edge_time=edge_time, y=y, train_mask=train_mask,
+                        val_mask=val_mask, test_mask=test_mask)
+
+        data = data if self.pre_transform is None else self.pre_transform(data)
+        data, slices = self.collate([data])
+        torch.save((data, slices), self.processed_paths[0])
+
+    def __repr__(self) -> str:
+        return f'{self.__class__.__name__}()'

--- a/torch_geometric/datasets/dgraph.py
+++ b/torch_geometric/datasets/dgraph.py
@@ -30,6 +30,20 @@ class DGraphFin(InMemoryDataset):
             an :obj:`torch_geometric.data.Data` object and returns a
             transformed version. The data object will be transformed before
             being saved to disk. (default: :obj:`None`)
+
+    Stats:
+        .. list-table::
+            :widths: 10 10 10 10
+            :header-rows: 1
+
+            * - #nodes
+              - #edges
+              - #features
+              - #classes
+            * - 3,700,550
+              - 4,300,999
+              - 17
+              - 2
     """
 
     url = "https://dgraph.xinye.com"

--- a/torch_geometric/datasets/dgraph.py
+++ b/torch_geometric/datasets/dgraph.py
@@ -80,7 +80,7 @@ class DGraphFin(InMemoryDataset):
             x = torch.from_numpy(loader['x']).to(torch.float)
             y = torch.from_numpy(loader['y']).to(torch.long)
             edge_index = torch.from_numpy(loader['edge_index']).to(torch.long)
-            edge_attr = torch.from_numpy(loader['edge_type']).to(torch.long)
+            edge_type = torch.from_numpy(loader['edge_type']).to(torch.long)
             edge_time = torch.from_numpy(loader['edge_timestamp']).to(
                 torch.long)
             train_nodes = torch.from_numpy(loader['train_mask']).to(torch.long)

--- a/torch_geometric/datasets/dgraph.py
+++ b/torch_geometric/datasets/dgraph.py
@@ -81,6 +81,3 @@ class DGraphFin(InMemoryDataset):
         data = data if self.pre_transform is None else self.pre_transform(data)
         data, slices = self.collate([data])
         torch.save((data, slices), self.processed_paths[0])
-
-    def __repr__(self) -> str:
-        return f'{self.__class__.__name__}()'

--- a/torch_geometric/datasets/dgraph.py
+++ b/torch_geometric/datasets/dgraph.py
@@ -52,6 +52,10 @@ class DGraphFin(InMemoryDataset):
     def processed_file_names(self) -> str:
         return 'data.pt'
 
+    @property
+    def num_classes(self) -> int:
+        return 2
+
     def process(self):
         extract_zip(self.raw_paths[0], self.raw_dir, log=False)
         path = os.path.join(self.raw_dir, "DGraphFin.npz")


### PR DESCRIPTION
This PR is a re-opened one of https://github.com/pyg-team/pytorch_geometric/pull/5466. The major difference it that this PR enforces manual download and just provides a process script for the dataset.


+ Home page:https://dgraph.xinye.com/introduction
+ Paper: https://openreview.net/forum?id=2rQPxsmjKF&referrer=%5Bthe%20
+ Baselines: https://github.com/DGraphXinye/DGraphFin_baseline

## Usage
```python
from torch_geometric.datasets import DGraphFin
dataset = DGraphFin("data/DGraphFin")
data = dataset[0]
>>> data
Data(x=[3700550, 17], edge_index=[2, 4300999], edge_attr=[4300999], y=[3700550], edge_time=[4300999], train_mask=[3700550], val_mask=[3700550], test_mask=[3700550])
```

For now, I used `Data` instead of `TemporalData` for storing this dataset. 


cc: @Padarn @rusty1s 