### PR TITLE
Quick fix for `dropout_node` when `training=False`

### DIFF
--- a/test/utils/test_dropout.py
+++ b/test/utils/test_dropout.py
@@ -33,8 +33,8 @@ def test_dropout_node():
 
     out = dropout_node(edge_index, training=False)
     assert edge_index.tolist() == out[0].tolist()
-    assert out[1].tolist() == [False, False, False, False, False, False]
-    assert out[2].tolist() == [False, False, False, False]
+    assert out[1].tolist() == [True, True, True, True, True, True]
+    assert out[2].tolist() == [True, True, True, True]
 
     torch.manual_seed(5)
     out = dropout_node(edge_index)

--- a/torch_geometric/utils/dropout.py
+++ b/torch_geometric/utils/dropout.py
@@ -133,8 +133,8 @@ def dropout_node(edge_index: Tensor, p: float = 0.5,
     num_nodes = maybe_num_nodes(edge_index, num_nodes)
 
     if not training or p == 0.0:
-        node_mask = edge_index.new_zeros(num_nodes, dtype=torch.bool)
-        edge_mask = edge_index.new_zeros(edge_index.size(1), dtype=torch.bool)
+        node_mask = edge_index.new_ones(num_nodes, dtype=torch.bool)
+        edge_mask = edge_index.new_ones(edge_index.size(1), dtype=torch.bool)
         return edge_index, edge_mask, node_mask
 
     prob = torch.rand(num_nodes, device=edge_index.device)


### PR DESCRIPTION
Still my careless error in dealing with `egde_mask` and `node_mask`, which should indicate which edges/nodes are retained, not masked.