### PR TITLE
Add option for `BatchNorm` to handle batches of size one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Added `BaseStorage.get()` functionality ([#5240](https://github.com/pyg-team/pytorch_geometric/pull/5240))
 - Added a test to confirm that `to_hetero` works with `SparseTensor` ([#5222](https://github.com/pyg-team/pytorch_geometric/pull/5222))
 ### Changed
+- Changed `BatchNorm` to allow for batches of size one during training ([#5530](https://github.com/pyg-team/pytorch_geometric/pull/5530))
 - Fixed a bug when applying several scalers with `PNAConv` ([#5514](https://github.com/pyg-team/pytorch_geometric/issues/5514))
 - Allow `.` in `ParameterDict` key names ([#5494](https://github.com/pyg-team/pytorch_geometric/pull/5494))
 - Renamed `drop_unconnected_nodes` to `drop_unconnected_node_types` and `drop_orig_edges` to `drop_orig_edge_types` in `AddMetapaths` ([#5490](https://github.com/pyg-team/pytorch_geometric/pull/5490))

--- a/test/nn/norm/test_batch_norm.py
+++ b/test/nn/norm/test_batch_norm.py
@@ -23,6 +23,6 @@ def test_batch_norm(conf):
         _ = norm(x)
 
     norm = BatchNorm(16, affine=conf, track_running_stats=conf,
-                     allow_no_batch=True)
+                     allow_single_element=True)
     out = norm(x)
     assert torch.allclose(out, x)

--- a/test/nn/norm/test_batch_norm.py
+++ b/test/nn/norm/test_batch_norm.py
@@ -18,11 +18,18 @@ def test_batch_norm(conf):
     out = norm(x)
     assert out.size() == (100, 16)
 
-    x = torch.randn(1, 16)
-    with pytest.raises(ValueError):
-        _ = norm(x)
 
-    norm = BatchNorm(16, affine=conf, track_running_stats=conf,
-                     allow_single_element=True)
+def test_batch_norm_single_element():
+    x = torch.randn(1, 16)
+
+    norm = BatchNorm(16)
+    with pytest.raises(ValueError, match="Expected more than 1 value"):
+        norm(x)
+
+    with pytest.raises(ValueError, match="requires 'track_running_stats'"):
+        norm = BatchNorm(16, track_running_stats=False,
+                         allow_single_element=True)
+
+    norm = BatchNorm(16, track_running_stats=True, allow_single_element=True)
     out = norm(x)
     assert torch.allclose(out, x)

--- a/test/nn/norm/test_batch_norm.py
+++ b/test/nn/norm/test_batch_norm.py
@@ -23,6 +23,6 @@ def test_batch_norm(conf):
         _ = norm(x)
 
     norm = BatchNorm(16, affine=conf, track_running_stats=conf,
-                     skip_no_batch=True)
+                     allow_no_batch=True)
     out = norm(x)
     assert torch.allclose(out, x)

--- a/test/nn/norm/test_batch_norm.py
+++ b/test/nn/norm/test_batch_norm.py
@@ -17,3 +17,12 @@ def test_batch_norm(conf):
 
     out = norm(x)
     assert out.size() == (100, 16)
+
+    x = torch.randn(1, 16)
+    with pytest.raises(ValueError):
+        _ = norm(x)
+
+    norm = BatchNorm(16, affine=conf, track_running_stats=conf,
+                     skip_no_batch=True)
+    out = norm(x)
+    assert torch.allclose(out, x)

--- a/torch_geometric/nn/norm/batch_norm.py
+++ b/torch_geometric/nn/norm/batch_norm.py
@@ -30,18 +30,26 @@ class BatchNorm(torch.nn.Module):
             :obj:`False`, this module does not track such statistics and always
             uses batch statistics in both training and eval modes.
             (default: :obj:`True`)
+        skip_no_batch (bool, optional): If set to :obj:`True`, batches with
+            only a single element will skipped. (default: :obj:`False`)
     """
-    def __init__(self, in_channels, eps=1e-5, momentum=0.1, affine=True,
-                 track_running_stats=True):
+    def __init__(self, in_channels: int, eps: float = 1e-5,
+                 momentum: float = 0.1, affine: bool = True,
+                 track_running_stats: bool = True,
+                 skip_no_batch: bool = False):
         super().__init__()
         self.module = torch.nn.BatchNorm1d(in_channels, eps, momentum, affine,
                                            track_running_stats)
+        self.skip_no_batch = skip_no_batch
 
     def reset_parameters(self):
         self.module.reset_parameters()
 
     def forward(self, x: Tensor) -> Tensor:
         """"""
+        if self.skip_no_batch and x.size(0) <= 1:
+            return x
+
         return self.module(x)
 
     def __repr__(self):

--- a/torch_geometric/nn/norm/batch_norm.py
+++ b/torch_geometric/nn/norm/batch_norm.py
@@ -44,10 +44,6 @@ class BatchNorm(torch.nn.Module):
                                            track_running_stats)
         self.in_channels = in_channels
         self.allow_no_batch = allow_no_batch
-        self.default_mean = torch.zeros(self.in_channels)
-        self.default_var = torch.ones(self.in_channels)
-        self.register_buffer("default_mean", self.default_mean)
-        self.register_buffer("default_var", self.default_var)
 
     def reset_parameters(self):
         self.module.reset_parameters()
@@ -59,8 +55,10 @@ class BatchNorm(torch.nn.Module):
             running_mean = self.module.running_mean
             running_var = self.module.running_var
             if running_mean is None or running_var is None:
-                self.module.running_var = self.default_var
-                self.module.running_mean = self.default_mean
+                self.module.running_var = torch.ones(self.in_channels,
+                                                     device=x.device)
+                self.module.running_mean = torch.zeros(self.in_channels,
+                                                       device=x.device)
             self.module.eval()
             out = self.module(x)
             self.module.training = training

--- a/torch_geometric/nn/norm/batch_norm.py
+++ b/torch_geometric/nn/norm/batch_norm.py
@@ -41,9 +41,9 @@ class BatchNorm(torch.nn.Module):
                  allow_single_element: bool = False):
         super().__init__()
 
-        if allow_single_element:
-            assert track_running_stats, "'allow_single_element' requires " \
-                                        "'track_running_stats' to be True"
+        if allow_single_element and not track_running_stats:
+            raise ValueError("'allow_single_element' requires "
+                             "'track_running_stats' to be set to `True`")
 
         self.module = torch.nn.BatchNorm1d(in_channels, eps, momentum, affine,
                                            track_running_stats)

--- a/torch_geometric/nn/norm/batch_norm.py
+++ b/torch_geometric/nn/norm/batch_norm.py
@@ -42,8 +42,10 @@ class BatchNorm(torch.nn.Module):
         super().__init__()
         self.module = torch.nn.BatchNorm1d(in_channels, eps, momentum, affine,
                                            track_running_stats)
-        self.allow_no_batch = allow_no_batch
         self.in_channels = in_channels
+        self.allow_no_batch = allow_no_batch
+        self.default_mean = torch.zeros(self.in_channels)
+        self.default_var = torch.ones(self.in_channels)
 
     def reset_parameters(self):
         self.module.reset_parameters()
@@ -55,10 +57,8 @@ class BatchNorm(torch.nn.Module):
             running_mean = self.module.running_mean
             running_var = self.module.running_var
             if running_mean is None or running_var is None:
-                self.module.running_var = torch.ones(self.in_channels,
-                                                     device=x.device)
-                self.module.running_mean = torch.zeros(self.in_channels,
-                                                       device=x.device)
+                self.module.running_var = self.default_var
+                self.module.running_mean = self.default_mean
             self.module.eval()
             out = self.module(x)
             self.module.training = training

--- a/torch_geometric/nn/norm/batch_norm.py
+++ b/torch_geometric/nn/norm/batch_norm.py
@@ -30,27 +30,27 @@ class BatchNorm(torch.nn.Module):
             :obj:`False`, this module does not track such statistics and always
             uses batch statistics in both training and eval modes.
             (default: :obj:`True`)
-        allow_no_batch (bool, optional): If set to :obj:`True`, batches with
-            only a single element will work as though in training mode. That is
-            the running mean and variance will be used.
+        allow_single_element (bool, optional): If set to :obj:`True`, batches
+            with only a single element will work as though in training mode.
+            That is the running mean and variance will be used.
             (default: :obj:`False`)
     """
     def __init__(self, in_channels: int, eps: float = 1e-5,
                  momentum: float = 0.1, affine: bool = True,
                  track_running_stats: bool = True,
-                 allow_no_batch: bool = False):
+                 allow_single_element: bool = False):
         super().__init__()
         self.module = torch.nn.BatchNorm1d(in_channels, eps, momentum, affine,
                                            track_running_stats)
         self.in_channels = in_channels
-        self.allow_no_batch = allow_no_batch
+        self.allow_single_element = allow_single_element
 
     def reset_parameters(self):
         self.module.reset_parameters()
 
     def forward(self, x: Tensor) -> Tensor:
         """"""
-        if self.allow_no_batch and x.size(0) <= 1:
+        if self.allow_single_element and x.size(0) <= 1:
             training = self.module.training
             running_mean = self.module.running_mean
             running_var = self.module.running_var

--- a/torch_geometric/nn/norm/batch_norm.py
+++ b/torch_geometric/nn/norm/batch_norm.py
@@ -31,7 +31,7 @@ class BatchNorm(torch.nn.Module):
             uses batch statistics in both training and eval modes.
             (default: :obj:`True`)
         allow_single_element (bool, optional): If set to :obj:`True`, batches
-            with only a single element will work as though in evaluation.
+            with only a single element will work as during in evaluation.
             That is the running mean and variance will be used.
             Requires :obj:`track_running_stats=True`. (default: :obj:`False`)
     """

--- a/torch_geometric/nn/norm/batch_norm.py
+++ b/torch_geometric/nn/norm/batch_norm.py
@@ -46,6 +46,8 @@ class BatchNorm(torch.nn.Module):
         self.allow_no_batch = allow_no_batch
         self.default_mean = torch.zeros(self.in_channels)
         self.default_var = torch.ones(self.in_channels)
+        self.register_buffer("default_mean", self.default_mean)
+        self.register_buffer("default_var", self.default_var)
 
     def reset_parameters(self):
         self.module.reset_parameters()

--- a/torch_geometric/nn/norm/batch_norm.py
+++ b/torch_geometric/nn/norm/batch_norm.py
@@ -55,8 +55,10 @@ class BatchNorm(torch.nn.Module):
             running_mean = self.module.running_mean
             running_var = self.module.running_var
             if running_mean is None or running_var is None:
-                self.module.running_var = torch.ones(self.in_channels)
-                self.module.running_mean = torch.zeros(self.in_channels)
+                self.module.running_var = torch.ones(self.in_channels,
+                                                     device=x.device)
+                self.module.running_mean = torch.zeros(self.in_channels,
+                                                       device=x.device)
             self.module.eval()
             out = self.module(x)
             self.module.training = training


### PR DESCRIPTION
The purpose of this PR is to provide a way for `BatchNorm` to work even when the batch size is one. This comes up when training heterogeneous graphs with rare node  types.

This PR addresses https://github.com/pyg-team/pytorch_geometric/issues/5529. 
