### PR TITLE
Add `dropout_path` as a structured form of `dropout_edge`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ## [2.2.0] - 2022-MM-DD
 ### Added
+- Added `dropout_path` augmentation that drops edges from a graph based on random walks ([#5531](https://github.com/pyg-team/pytorch_geometric/pull/5531))
 - Added the `DGraphFin` dynamic graph dataset ([#5504](https://github.com/pyg-team/pytorch_geometric/pull/5504))
 - Added `dropout_edge` augmentation that randomly drops edges from a graph - the usage of `dropout_adj` is now deprecated ([#5495](https://github.com/pyg-team/pytorch_geometric/pull/5495))
 - Add support for precomputed edges in `SchNet` model ([#5401](https://github.com/pyg-team/pytorch_geometric/pull/5401))

--- a/README.md
+++ b/README.md
@@ -308,7 +308,8 @@ PyG comes with a rich set of neural network operators that are commonly used in 
 They follow an extensible design: It is easy to apply these operators and graph utilities to existing GNN layers and models to further enhance model performance.
 
 * **[DropEdge](https://pytorch-geometric.readthedocs.io/en/latest/modules/utils.html#torch_geometric.utils.dropout_edge)** from Rong *et al.*: [DropEdge: Towards Deep Graph Convolutional Networks on Node Classification](https://openreview.net/forum?id=Hkx1qkrKPr) (ICLR 2020)
-* **[DropNode](https://pytorch-geometric.readthedocs.io/en/latest/modules/utils.html#torch_geometric.utils.dropout_node)** from You *et al.* [Graph Contrastive Learning with Augmentations](https://arxiv.org/abs/2010.13902) (NeurIPS 2020)
+* **[DropNode](https://pytorch-geometric.readthedocs.io/en/latest/modules/utils.html#torch_geometric.utils.dropout_node)** from You *et al.*: [Graph Contrastive Learning with Augmentations](https://arxiv.org/abs/2010.13902) (NeurIPS 2020)
+* **[DropPath](https://pytorch-geometric.readthedocs.io/en/latest/modules/utils.html#torch_geometric.utils.dropout_path)** from Li *et al.*: [MaskGAE: Masked Graph Modeling Meets Graph Autoencoders](https://arxiv.org/abs/2205.10053) (arXiv 2022)
 * **[GraphNorm](https://pytorch-geometric.readthedocs.io/en/latest/modules/nn.html#torch_geometric.nn.norm.GraphNorm)** from Cai *et al.*: [GraphNorm: A Principled Approach to Accelerating Graph Neural Network Training](https://proceedings.mlr.press/v139/cai21e.html) (ICML 2021)
 * **[GDC](https://pytorch-geometric.readthedocs.io/en/latest/modules/transforms.html#torch_geometric.transforms.GDC)** from Klicpera *et al.*: [Diffusion Improves Graph Learning](https://arxiv.org/abs/1911.05485) (NeurIPS 2019) [[**Example**](https://github.com/pyg-team/pytorch_geometric/blob/master/examples/gcn.py)]
 

--- a/test/utils/test_dropout.py
+++ b/test/utils/test_dropout.py
@@ -75,24 +75,24 @@ def test_dropout_path():
     assert edge_index.tolist() == out[0].tolist()
     assert out[1].tolist() == [True, True, True, True, True, True]
 
-    torch.manual_seed(5)
-    out = dropout_path(edge_index)
-    assert out[0].tolist() == [[1, 2], [2, 1]]
-    assert out[1].tolist() == [False, False, True, True, False, False]
+    torch.manual_seed(4)
+    out = dropout_path(edge_index, p=0.2)
+    assert out[0].tolist() == [[0, 1], [1, 0]]
+    assert out[1].tolist() == [True, True, False, False, False, False]
     assert edge_index[:, out[1]].tolist() == out[0].tolist()
 
     # test with unsorted edges
-    torch.manual_seed(6)
-    edge_index = torch.tensor([[3, 3, 2, 2, 2, 1], [1, 0, 0, 1, 3, 2]])
-    out = dropout_path(edge_index)
-    assert out[0].tolist() == [[3, 2], [0, 0]]
-    assert out[1].tolist() == [False, True, True, False, False, False]
+    torch.manual_seed(5)
+    edge_index = torch.tensor([[3, 5, 2, 2, 2, 1], [1, 0, 0, 1, 3, 2]])
+    out = dropout_path(edge_index, p=0.2)
+    assert out[0].tolist() == [[3, 2, 2, 1], [1, 1, 3, 2]]
+    assert out[1].tolist() == [True, False, False, True, True, True]
     assert edge_index[:, out[1]].tolist() == out[0].tolist()
 
     # test with isolated nodes
     torch.manual_seed(7)
     edge_index = torch.tensor([[0, 1, 2, 3], [1, 0, 2, 4]])
-    out = dropout_path(edge_index)
+    out = dropout_path(edge_index, p=0.2)
     assert out[0].tolist() == [[2, 3], [2, 4]]
     assert out[1].tolist() == [False, False, True, True]
     assert edge_index[:, out[1]].tolist() == out[0].tolist()

--- a/test/utils/test_dropout.py
+++ b/test/utils/test_dropout.py
@@ -77,10 +77,20 @@ def test_dropout_path():
     out = dropout_path(edge_index)
     assert out[0].tolist() == [[1, 2], [2, 1]]
     assert out[1].tolist() == [False, False, True, True, False, False]
+    assert edge_index[:, out[1]].tolist() == out[0].tolist()
+
+    # test with unsorted edges
+    torch.manual_seed(6)
+    edge_index = torch.tensor([[3, 3, 2, 2, 2, 1], [1, 0, 0, 1, 3, 2]])
+    out = dropout_path(edge_index)
+    assert out[0].tolist() == [[3, 2], [0, 0]]
+    assert out[1].tolist() == [False, True, True, False, False, False]
+    assert edge_index[:, out[1]].tolist() == out[0].tolist()
 
     # test with isolated nodes
-    torch.manual_seed(8)
+    torch.manual_seed(7)
     edge_index = torch.tensor([[0, 1, 2, 3], [1, 0, 2, 4]])
     out = dropout_path(edge_index)
-    assert out[0].tolist() == [[2], [2]]
-    assert out[1].tolist() == [False, False, True, False]
+    assert out[0].tolist() == [[2, 3], [2, 4]]
+    assert out[1].tolist() == [False, False, True, True]
+    assert edge_index[:, out[1]].tolist() == out[0].tolist()

--- a/test/utils/test_dropout.py
+++ b/test/utils/test_dropout.py
@@ -1,6 +1,11 @@
 import torch
 
-from torch_geometric.utils import dropout_adj, dropout_edge, dropout_node
+from torch_geometric.utils import (
+    dropout_adj,
+    dropout_edge,
+    dropout_node,
+    dropout_path,
+)
 
 
 def test_dropout_adj():
@@ -59,3 +64,28 @@ def test_dropout_edge():
     out = dropout_edge(edge_index, force_undirected=True)
     assert out[0].tolist() == [[0, 1, 1, 2], [1, 2, 0, 1]]
     assert out[1].tolist() == [0, 2, 0, 2]
+
+
+def test_dropout_path():
+    edge_index = torch.tensor([[0, 1, 1, 2, 2, 3], [1, 0, 2, 1, 3, 2]])
+
+    out = dropout_path(edge_index, training=False)
+    assert edge_index.tolist() == out[0].tolist()
+    assert out[1].tolist() == [True, True, True, True, True, True]
+
+    torch.manual_seed(5)
+    out = dropout_path(edge_index)
+    assert out[0].tolist() == [[1, 2], [2, 1]]
+    assert out[1].tolist() == [False, False, True, True, False, False]
+
+    torch.manual_seed(7)
+    out = dropout_path(edge_index, force_undirected=True)
+    assert out[0].tolist() == [[0, 2, 1, 3], [1, 3, 0, 2]]
+    assert out[1].tolist() == [0, 4, 0, 4]
+
+    # test with isolated nodes
+    torch.manual_seed(8)
+    edge_index = torch.tensor([[0, 1, 2, 3], [1, 0, 2, 4]])
+    out = dropout_path(edge_index)
+    assert out[0].tolist() == [[2], [2]]
+    assert out[1].tolist() == [False, False, True, False]

--- a/test/utils/test_dropout.py
+++ b/test/utils/test_dropout.py
@@ -1,5 +1,6 @@
 import torch
 
+from torch_geometric.testing import withPackage
 from torch_geometric.utils import (
     dropout_adj,
     dropout_edge,
@@ -66,6 +67,7 @@ def test_dropout_edge():
     assert out[1].tolist() == [0, 2, 0, 2]
 
 
+@withPackage('torch_cluster')
 def test_dropout_path():
     edge_index = torch.tensor([[0, 1, 1, 2, 2, 3], [1, 0, 2, 1, 3, 2]])
 

--- a/test/utils/test_dropout.py
+++ b/test/utils/test_dropout.py
@@ -78,11 +78,6 @@ def test_dropout_path():
     assert out[0].tolist() == [[1, 2], [2, 1]]
     assert out[1].tolist() == [False, False, True, True, False, False]
 
-    torch.manual_seed(7)
-    out = dropout_path(edge_index, force_undirected=True)
-    assert out[0].tolist() == [[0, 2, 1, 3], [1, 3, 0, 2]]
-    assert out[1].tolist() == [0, 4, 0, 4]
-
     # test with isolated nodes
     torch.manual_seed(8)
     edge_index = torch.tensor([[0, 1, 2, 3], [1, 0, 2, 4]])

--- a/torch_geometric/utils/__init__.py
+++ b/torch_geometric/utils/__init__.py
@@ -1,6 +1,6 @@
 from .degree import degree
 from .softmax import softmax
-from .dropout import dropout_adj, dropout_node, dropout_edge
+from .dropout import dropout_adj, dropout_node, dropout_edge, dropout_path
 from .sort_edge_index import sort_edge_index
 from .coalesce import coalesce
 from .undirected import is_undirected, to_undirected
@@ -40,6 +40,7 @@ __all__ = [
     'softmax',
     'dropout_node',
     'dropout_edge',
+    'dropout_path',
     'dropout_adj',
     'sort_edge_index',
     'coalesce',

--- a/torch_geometric/utils/dropout.py
+++ b/torch_geometric/utils/dropout.py
@@ -232,7 +232,7 @@ def dropout_path(edge_index: Tensor, p: float = 0.2, walks_per_node: int = 1,
 
     Args:
         edge_index (LongTensor): The edge indices.
-        p (float, optional): Sampling probability. (default: :obj:`0.2`)
+        p (float, optional): Sample probability. (default: :obj:`0.2`)
         walks_per_node (int, optional): The number of walks per node, same as
             :class:`~torch_geometric.nn.models.Node2Vec`. (default: :obj:`1`)
         walk_length (int, optional): The walk length, same as
@@ -259,7 +259,7 @@ def dropout_path(edge_index: Tensor, p: float = 0.2, walks_per_node: int = 1,
     """
 
     if p < 0. or p > 1.:
-        raise ValueError(f'Sampling probability has to be between 0 and 1 '
+        raise ValueError(f'Sample probability has to be between 0 and 1 '
                          f'(got {p}')
 
     num_edges = edge_index.size(1)
@@ -279,10 +279,10 @@ def dropout_path(edge_index: Tensor, p: float = 0.2, walks_per_node: int = 1,
                                                   num_nodes=num_nodes)
 
     row, col = edge_index
-    deg = degree(row, num_nodes=num_nodes)
     sample_mask = torch.rand(row.size(0), device=edge_index.device) <= p
-    start = edge_index[:, sample_mask].view(-1).repeat(walks_per_node)
+    start = row[sample_mask].repeat(walks_per_node)
 
+    deg = degree(row, num_nodes=num_nodes)
     rowptr = row.new_zeros(num_nodes + 1)
     torch.cumsum(deg, 0, out=rowptr[1:])
     n_id, e_id = random_walk(rowptr, col, start, walk_length, 1.0, 1.0)

--- a/torch_geometric/utils/dropout.py
+++ b/torch_geometric/utils/dropout.py
@@ -220,11 +220,10 @@ def dropout_path(edge_index: Tensor, r: float = 0.5,
                  force_undirected: bool = False, walks_per_node: int = 1,
                  walk_length: int = 3, p: float = 1, q: float = 1,
                  num_nodes: Optional[int] = None,
-                 training: bool = True) -> Tuple[Tensor, Tensor, Tensor]:
-    r"""Drops edges from the adjacency matrix
-    :obj:`edge_index` based on random walks with probability :obj:`p`
-    using samples from
-    a Bernoulli distribution.
+                 training: bool = True) -> Tuple[Tensor, Tensor]:
+    r"""Drops edges from the adjacency matrix :obj:`edge_index`
+    based on random walks. The source nodes to start random walks from are
+    sampled with probability :obj:`r` from a Bernoulli distribution.
 
     The method returns (1) the retained :obj:`edge_index`, (2) the edge mask
     or index indicating which edges were retained, depending on the argument

--- a/torch_geometric/utils/dropout.py
+++ b/torch_geometric/utils/dropout.py
@@ -190,7 +190,7 @@ def dropout_edge(edge_index: Tensor, p: float = 0.5,
         tensor([[0, 1, 2, 1, 2, 3],
                 [1, 2, 3, 0, 1, 2]])
         >>> edge_id # indices indicating which edges are retained
-        >>> tensor([0, 2, 4, 0, 2, 4])
+        tensor([0, 2, 4, 0, 2, 4])
     """
     if p < 0. or p > 1.:
         raise ValueError(f'Dropout probability has to be between 0 and 1 '
@@ -232,10 +232,18 @@ def dropout_path(edge_index: Tensor, r: float = 0.5,
 
     Args:
         edge_index (LongTensor): The edge indices.
-        p (float, optional): Dropout probability. (default: :obj:`0.5`)
+        r (float, optional): The ratio of source nodes to start
+            random walks from. (default: :obj:`0.5`)
         force_undirected (bool, optional): If set to :obj:`True`, will either
             drop or keep both edges of an undirected edge.
             (default: :obj:`False`)
+        walks_per_node (int, optional): The number of walks per node.
+            (default: :obj:`1`)
+        walk_length (int, optional): The length per walk. (default: :obj:`3`)
+        p (float, optional): :obj:`p` in random walks. (default: :obj:`1`)
+        q (float, optional): :obj:`q` in random walks. (default: :obj:`1`)
+        num_nodes (int, optional): The number of nodes, *i.e.*
+            :obj:`max_val + 1` of :attr:`edge_index`. (default: :obj:`None`)
         training (bool, optional): If set to :obj:`False`, this operation is a
             no-op. (default: :obj:`True`)
 
@@ -247,19 +255,23 @@ def dropout_path(edge_index: Tensor, r: float = 0.5,
         ...                            [1, 0, 2, 1, 3, 2]])
         >>> edge_index, edge_mask = dropout_path(edge_index)
         >>> edge_index
-        tensor([[0, 1, 2, 2],
-                [1, 2, 1, 3]])
+        tensor([[1, 2],
+                [2, 3]])
         >>> edge_mask # masks indicating which edges are retained
-        tensor([ True, False,  True,  True,  True, False])
+        tensor([False, False,  True, False,  True, False])
 
         >>> edge_index, edge_id = dropout_path(edge_index,
         ...                                    force_undirected=True)
         >>> edge_index
-        tensor([[0, 1, 2, 1, 2, 3],
-                [1, 2, 3, 0, 1, 2]])
+        tensor([[2, 3],
+                [3, 2]])
         >>> edge_id # indices indicating which edges are retained
-        >>> tensor([0, 2, 4, 0, 2, 4])
+        tensor([4, 4])
     """
+
+    if r < 0. or r > 1.:
+        raise ValueError(f'Sampling ratio has to be between 0 and 1 '
+                         f'(got {r}')
 
     edge_mask = edge_index.new_ones(edge_index.size(1), dtype=torch.bool)
     if not training or r == 0.0:

--- a/torch_geometric/utils/dropout.py
+++ b/torch_geometric/utils/dropout.py
@@ -240,7 +240,7 @@ def dropout_path(edge_index: Tensor, p: float = 0.2, walks_per_node: int = 1,
         num_nodes (int, optional): The number of nodes, *i.e.*
             :obj:`max_val + 1` of :attr:`edge_index`. (default: :obj:`None`)
         is_sorted (bool, optional): If set to :obj:`True`, will expect
-            :obj:`edge_index` to be already sorted row-wise.
+            :obj:`edge_index` to be already sorted row-wise. (default: :obj:`False`)
         training (bool, optional): If set to :obj:`False`, this operation is a
             no-op. (default: :obj:`True`)
 

--- a/torch_geometric/utils/dropout.py
+++ b/torch_geometric/utils/dropout.py
@@ -240,7 +240,8 @@ def dropout_path(edge_index: Tensor, p: float = 0.2, walks_per_node: int = 1,
         num_nodes (int, optional): The number of nodes, *i.e.*
             :obj:`max_val + 1` of :attr:`edge_index`. (default: :obj:`None`)
         is_sorted (bool, optional): If set to :obj:`True`, will expect
-            :obj:`edge_index` to be already sorted row-wise. (default: :obj:`False`)
+            :obj:`edge_index` to be already sorted row-wise.
+            (default: :obj:`False`)
         training (bool, optional): If set to :obj:`False`, this operation is a
             no-op. (default: :obj:`True`)
 

--- a/torch_geometric/utils/dropout.py
+++ b/torch_geometric/utils/dropout.py
@@ -242,9 +242,11 @@ def dropout_path(edge_index: Tensor, r: float = 0.5,
             (default: :obj:`1`)
         walk_length (int, optional): The walk length. (default: :obj:`3`)
         p (float, optional): :obj:`p` in random walks,
-            same as :class:`~torch_geometric.nn.Node2Vec`. (default: :obj:`1`)
+            same as :class:`~torch_geometric.nn.models.Node2Vec`.
+            (default: :obj:`1`)
         q (float, optional): :obj:`q` in random walks,
-            same as :class:`~torch_geometric.nn.Node2Vec`. (default: :obj:`1`)
+            same as :class:`~torch_geometric.nn.models.Node2Vec`.
+            (default: :obj:`1`)
         num_nodes (int, optional): The number of nodes, *i.e.*
             :obj:`max_val + 1` of :attr:`edge_index`. (default: :obj:`None`)
         is_sorted (bool, optional): If set to :obj:`True`, will expect


### PR DESCRIPTION
This PR implements `DropPath` from [MaskGAE: Masked Graph Modeling Meets Graph Autoencoders](https://arxiv.org/abs/2205.10053). DropPath is a structured form of DropEdge, which drops a group of edges (paths) based on random walks.

DropPath follows three steps to sample edges to drop:
+ Sample a set of root nodes $R$ with probability `r` from a Bernoulli distribution. (0<=`r`<=1), 
+ Perform random walks starting from root nodes $R$
+ Drop edges sampled by random walks

Link to https://github.com/pyg-team/pytorch_geometric/issues/5452