### PR TITLE
Unknown label support in `to_homogeneous`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ## [2.2.0] - 2022-MM-DD
 ### Added
+- Add support for filling labels with dummy values in `HeteroData.to_homogeneous()` ([#5540](https://github.com/pyg-team/pytorch_geometric/pull/5540))
 - Added the `DGraphFin` dynamic graph dataset ([#5504](https://github.com/pyg-team/pytorch_geometric/pull/5504))
 - Added `dropout_edge` augmentation that randomly drops edges from a graph - the usage of `dropout_adj` is now deprecated ([#5495](https://github.com/pyg-team/pytorch_geometric/pull/5495))
 - Add support for precomputed edges in `SchNet` model ([#5401](https://github.com/pyg-team/pytorch_geometric/pull/5401))

--- a/test/data/test_hetero_data.py
+++ b/test/data/test_hetero_data.py
@@ -265,7 +265,7 @@ def test_to_homogeneous_and_vice_versa():
     data = HeteroData()
 
     data['paper'].x = torch.randn(100, 128)
-    data['paper'].y = torch.randn(100)
+    data['paper'].y = torch.randint(0, 10, (100, ))
     data['author'].x = torch.randn(200, 128)
 
     data['paper', 'paper'].edge_index = get_edge_index(100, 100, 250)
@@ -297,6 +297,7 @@ def test_to_homogeneous_and_vice_versa():
     assert out.y.size() == (300, )
     assert torch.allclose(out.y[:100], data['paper'].y)
     assert torch.all(out.y[100:] == -1)
+    assert 'y' not in data['author']
 
     out = out.to_heterogeneous()
     assert len(out) == 5

--- a/test/data/test_hetero_data.py
+++ b/test/data/test_hetero_data.py
@@ -295,7 +295,8 @@ def test_to_homogeneous_and_vice_versa():
     assert len(out._node_type_names) == 2
     assert len(out._edge_type_names) == 3
     assert out.y.size() == (300, )
-    assert torch.allclose(out.y[-200:], torch.full((200, ), -1).float())
+    assert torch.allclose(out.y[:100], data['paper'].y)
+    assert torch.all(out.y[100:] == -1)
 
     out = out.to_heterogeneous()
     assert len(out) == 5

--- a/test/data/test_hetero_data.py
+++ b/test/data/test_hetero_data.py
@@ -295,12 +295,13 @@ def test_to_homogeneous_and_vice_versa():
     assert len(out._node_type_names) == 2
     assert len(out._edge_type_names) == 3
     assert out.y.size() == (300, )
-    assert (out.y[-200:] == torch.full((200, ), -1)).all()
+    assert torch.allclose(out.y[-200:], torch.full((200, ), -1))
 
     out = out.to_heterogeneous()
     assert len(out) == 5
     assert torch.allclose(data['paper'].x, out['paper'].x)
     assert torch.allclose(data['author'].x, out['author'].x)
+    assert torch.allclose(data['paper'].y, out['paper'].y)
 
     edge_index1 = data['paper', 'paper'].edge_index
     edge_index2 = out['paper', 'paper'].edge_index

--- a/test/data/test_hetero_data.py
+++ b/test/data/test_hetero_data.py
@@ -265,6 +265,7 @@ def test_to_homogeneous_and_vice_versa():
     data = HeteroData()
 
     data['paper'].x = torch.randn(100, 128)
+    data['paper'].y = torch.randn(100)
     data['author'].x = torch.randn(200, 128)
 
     data['paper', 'paper'].edge_index = get_edge_index(100, 100, 250)
@@ -293,6 +294,8 @@ def test_to_homogeneous_and_vice_versa():
     assert out.edge_type.max() == 2
     assert len(out._node_type_names) == 2
     assert len(out._edge_type_names) == 3
+    assert out.y.size() == (300, )
+    assert out.y[-200:] == torch.full((200,), -1)
 
     out = out.to_heterogeneous()
     assert len(out) == 4

--- a/test/data/test_hetero_data.py
+++ b/test/data/test_hetero_data.py
@@ -347,7 +347,7 @@ def test_to_homogeneous_and_vice_versa():
     del out._edge_type_names
     del out._node_type_names
     out = out.to_heterogeneous(node_type, edge_type)
-    assert len(out) == 4
+    assert len(out) == 5
     assert torch.allclose(data['paper'].x, out['0'].x)
     assert torch.allclose(data['author'].x, out['1'].x)
 

--- a/test/data/test_hetero_data.py
+++ b/test/data/test_hetero_data.py
@@ -298,7 +298,7 @@ def test_to_homogeneous_and_vice_versa():
     assert (out.y[-200:] == torch.full((200, ), -1)).all()
 
     out = out.to_heterogeneous()
-    assert len(out) == 4
+    assert len(out) == 5
     assert torch.allclose(data['paper'].x, out['paper'].x)
     assert torch.allclose(data['author'].x, out['author'].x)
 

--- a/test/data/test_hetero_data.py
+++ b/test/data/test_hetero_data.py
@@ -295,7 +295,7 @@ def test_to_homogeneous_and_vice_versa():
     assert len(out._node_type_names) == 2
     assert len(out._edge_type_names) == 3
     assert out.y.size() == (300, )
-    assert torch.allclose(out.y[-200:], torch.full((200, ), -1))
+    assert torch.allclose(out.y[-200:], torch.full((200, ), -1).float())
 
     out = out.to_heterogeneous()
     assert len(out) == 5

--- a/test/data/test_hetero_data.py
+++ b/test/data/test_hetero_data.py
@@ -281,7 +281,7 @@ def test_to_homogeneous_and_vice_versa():
     data['author', 'paper'].edge_attr = torch.randn(1000, 64)
 
     out = data.to_homogeneous()
-    assert len(out) == 6
+    assert len(out) == 7
     assert out.num_nodes == 300
     assert out.num_edges == 1750
     assert out.num_node_features == 128

--- a/test/data/test_hetero_data.py
+++ b/test/data/test_hetero_data.py
@@ -295,7 +295,7 @@ def test_to_homogeneous_and_vice_versa():
     assert len(out._node_type_names) == 2
     assert len(out._edge_type_names) == 3
     assert out.y.size() == (300, )
-    assert out.y[-200:] == torch.full((200,), -1)
+    assert out.y[-200:] == torch.full((200, ), -1)
 
     out = out.to_heterogeneous()
     assert len(out) == 4

--- a/test/data/test_hetero_data.py
+++ b/test/data/test_hetero_data.py
@@ -295,7 +295,7 @@ def test_to_homogeneous_and_vice_versa():
     assert len(out._node_type_names) == 2
     assert len(out._edge_type_names) == 3
     assert out.y.size() == (300, )
-    assert out.y[-200:] == torch.full((200, ), -1)
+    assert (out.y[-200:] == torch.full((200, ), -1)).all()
 
     out = out.to_heterogeneous()
     assert len(out) == 4

--- a/torch_geometric/data/hetero_data.py
+++ b/torch_geometric/data/hetero_data.py
@@ -907,5 +907,5 @@ def to_homogeneous_label(data: HeteroData) -> Tensor:
                 labeled_node_types.append(i)
                 y.append(data[node_type].y)
             else:
-                y.append(torch.full((data[node_type].num_nodes,), -1))
+                y.append(torch.full((data[node_type].num_nodes, ), -1))
         return torch.cat(y)

--- a/torch_geometric/data/hetero_data.py
+++ b/torch_geometric/data/hetero_data.py
@@ -45,42 +45,62 @@ class HeteroData(BaseData, FeatureStore, GraphStore):
     behaviour of a regular **nested** Python dictionary.
     In addition, it provides useful functionality for analyzing graph
     structures, and provides basic PyTorch tensor functionalities.
+
     .. code-block::
+
         from torch_geometric.data import HeteroData
+
         data = HeteroData()
+
         # Create two node types "paper" and "author" holding a feature matrix:
         data['paper'].x = torch.randn(num_papers, num_paper_features)
         data['author'].x = torch.randn(num_authors, num_authors_features)
+
         # Create an edge type "(author, writes, paper)" and building the
         # graph connectivity:
         data['author', 'writes', 'paper'].edge_index = ...  # [2, num_edges]
+
         data['paper'].num_nodes
         >>> 23
+
         data['author', 'writes', 'paper'].num_edges
         >>> 52
+
         # PyTorch tensor functionality:
         data = data.pin_memory()
         data = data.to('cuda:0', non_blocking=True)
+
     Note that there exists multiple ways to create a heterogeneous graph data,
     *e.g.*:
+
     * To initialize a node of type :obj:`"paper"` holding a node feature
       matrix :obj:`x_paper` named :obj:`x`:
+
       .. code-block:: python
+
         from torch_geometric.data import HeteroData
+
         data = HeteroData()
         data['paper'].x = x_paper
+
         data = HeteroData(paper={ 'x': x_paper })
+
         data = HeteroData({'paper': { 'x': x_paper }})
+
     * To initialize an edge from source node type :obj:`"author"` to
       destination node type :obj:`"paper"` with relation type :obj:`"writes"`
       holding a graph connectivity matrix :obj:`edge_index_author_paper` named
       :obj:`edge_index`:
+
       .. code-block:: python
+
         data = HeteroData()
         data['author', 'writes', 'paper'].edge_index = edge_index_author_paper
+
         data = HeteroData(author__writes__paper={
             'edge_index': edge_index_author_paper
         })
+
         data = HeteroData({
             ('author', 'writes', 'paper'):
             { 'edge_index': edge_index_author_paper }
@@ -412,11 +432,14 @@ class HeteroData(BaseData, FeatureStore, GraphStore):
     def metadata(self) -> Tuple[List[NodeType], List[EdgeType]]:
         r"""Returns the heterogeneous meta-data, *i.e.* its node and edge
         types.
+
         .. code-block:: python
+
             data = HeteroData()
             data['paper'].x = ...
             data['author'].x = ...
             data['author', 'writes', 'paper'].edge_index = ...
+
             print(data.metadata())
             >>> (['paper', 'author'], [('author', 'writes', 'paper')])
         """
@@ -424,13 +447,18 @@ class HeteroData(BaseData, FeatureStore, GraphStore):
 
     def collect(self, key: str) -> Dict[NodeOrEdgeType, Any]:
         r"""Collects the attribute :attr:`key` from all node and edge types.
+
         .. code-block:: python
+
             data = HeteroData()
             data['paper'].x = ...
             data['author'].x = ...
+
             print(data.collect('x'))
             >>> { 'paper': ..., 'author': ...}
+
         .. note::
+
             This is equivalent to writing :obj:`data.x_dict`.
         """
         mapping = {}
@@ -446,7 +474,9 @@ class HeteroData(BaseData, FeatureStore, GraphStore):
         If the storage is not present yet, will create a new
         :class:`torch_geometric.data.storage.NodeStorage` object for the given
         node type.
+
         .. code-block:: python
+
             data = HeteroData()
             node_storage = data.get_node_store('paper')
         """
@@ -462,7 +492,9 @@ class HeteroData(BaseData, FeatureStore, GraphStore):
         If the storage is not present yet, will create a new
         :class:`torch_geometric.data.storage.EdgeStorage` object for the given
         edge type.
+
         .. code-block:: python
+
             data = HeteroData()
             edge_storage = data.get_edge_store('author', 'writes', 'paper')
         """
@@ -494,7 +526,9 @@ class HeteroData(BaseData, FeatureStore, GraphStore):
     def subgraph(self, subset_dict: Dict[NodeType, Tensor]) -> 'HeteroData':
         r"""Returns the induced subgraph containing the node types and
         corresponding nodes in :obj:`subset_dict`.
+
         .. code-block:: python
+
             data = HeteroData()
             data['paper'].x = ...
             data['author'].x = ...
@@ -511,10 +545,12 @@ class HeteroData(BaseData, FeatureStore, GraphStore):
                 (author, to, paper)={ edge_index=[2, 30] },
                 (paper, to, conference)={ edge_index=[2, 25] }
             )
+
             subset_dict = {
                 'paper': torch.tensor([3, 4, 5, 6]),
                 'author': torch.tensor([0, 2]),
             }
+
             print(data.subgraph(subset_dict))
             >>> HeteroData(
                 paper={ x=[4, 16] },
@@ -522,6 +558,7 @@ class HeteroData(BaseData, FeatureStore, GraphStore):
                 (paper, cites, paper)={ edge_index=[2, 24] },
                 (author, to, paper)={ edge_index=[2, 5] }
             )
+
         Args:
             subset_dict (Dict[str, LongTensor or BoolTensor]): A dictonary
                 holding the nodes to keep for each node type.
@@ -611,6 +648,7 @@ class HeteroData(BaseData, FeatureStore, GraphStore):
         object, denoting node-level and edge-level vectors holding the
         node and edge type as integers, respectively.
         Additionally, labels will be merged, assigning the label -1 for unlabeled node types.
+
         Args:
             node_attrs (List[str], optional): The node features to combine
                 across all node types. These node features need to be of the
@@ -654,9 +692,7 @@ class HeteroData(BaseData, FeatureStore, GraphStore):
             data.edge_index = edge_index
         data._node_type_names = list(node_slices.keys())
         data._edge_type_names = list(edge_slices.keys())
-        node_labels = to_homogeneous_label(self)
-        if node_labels is not None:
-            data.y = node_labels
+
         # Combine node attributes into a single tensor:
         if node_attrs is None:
             node_attrs = _consistent_size(self.node_stores)
@@ -668,6 +704,11 @@ class HeteroData(BaseData, FeatureStore, GraphStore):
 
         if not data.can_infer_num_nodes:
             data.num_nodes = list(node_slices.values())[-1][1]
+
+        # Combine labels
+        node_labels = to_homogeneous_label(self)
+        if node_labels is not None:
+            data.y = node_labels
 
         # Combine edge attributes into a single tensor:
         if edge_attrs is None:
@@ -857,8 +898,9 @@ def to_homogeneous_edge_index(
 
     return edge_index, node_slices, edge_slices
 
-
-def to_homogeneous_label(data: HeteroData, ) -> Tensor:
+def to_homogeneous_label(
+    data: HeteroData,
+) -> Tensor:
     labeled_node_types = []
     y = []
     for i, node_type in enumerate(data.node_types):

--- a/torch_geometric/data/hetero_data.py
+++ b/torch_geometric/data/hetero_data.py
@@ -648,7 +648,7 @@ class HeteroData(BaseData, FeatureStore, GraphStore):
         object, denoting node-level and edge-level vectors holding the
         node and edge type as integers, respectively.
         Additionally, labels will be merged.
-        The label -1 will be assigned for unlabeled node types.
+        The label :obj:`-1` will be assigned for unlabeled node types.
 
         Args:
             node_attrs (List[str], optional): The node features to combine

--- a/torch_geometric/data/hetero_data.py
+++ b/torch_geometric/data/hetero_data.py
@@ -857,9 +857,8 @@ def to_homogeneous_edge_index(
 
     return edge_index, node_slices, edge_slices
 
-def to_homogeneous_label(
-    data: HeteroData,
-) -> Tensor:
+
+def to_homogeneous_label(data: HeteroData, ) -> Tensor:
     labeled_node_types = []
     y = []
     for i, node_type in enumerate(data.node_types):

--- a/torch_geometric/data/hetero_data.py
+++ b/torch_geometric/data/hetero_data.py
@@ -899,7 +899,7 @@ def to_homogeneous_edge_index(
     return edge_index, node_slices, edge_slices
 
 
-def to_homogeneous_label(data: HeteroData, ) -> Tensor:
+def to_homogeneous_label(data: HeteroData) -> Tensor:
     labeled_node_types = []
     y = []
     for i, node_type in enumerate(data.node_types):

--- a/torch_geometric/data/hetero_data.py
+++ b/torch_geometric/data/hetero_data.py
@@ -633,10 +633,14 @@ class HeteroData(BaseData, FeatureStore, GraphStore):
                 del data[node_type]
         return data
 
-    def to_homogeneous(self, node_attrs: Optional[List[str]] = None,
-                       edge_attrs: Optional[List[str]] = None,
-                       add_node_type: bool = True,
-                       add_edge_type: bool = True) -> Data:
+    def to_homogeneous(
+        self,
+        node_attrs: Optional[List[str]] = None,
+        edge_attrs: Optional[List[str]] = None,
+        add_node_type: bool = True,
+        add_edge_type: bool = True,
+        dummy_values: bool = True,
+    ) -> Data:
         """Converts a :class:`~torch_geometric.data.HeteroData` object to a
         homogeneous :class:`~torch_geometric.data.Data` object.
         By default, all features with same feature dimensionality across
@@ -647,8 +651,6 @@ class HeteroData(BaseData, FeatureStore, GraphStore):
         will be added to the returned :class:`~torch_geometric.data.Data`
         object, denoting node-level and edge-level vectors holding the
         node and edge type as integers, respectively.
-        Additionally, labels will be merged.
-        The label :obj:`-1` will be assigned for unlabeled node types.
 
         Args:
             node_attrs (List[str], optional): The node features to combine
@@ -669,21 +671,63 @@ class HeteroData(BaseData, FeatureStore, GraphStore):
                 add the edge-level vector :obj:`edge_type` to the returned
                 :class:`~torch_geometric.data.Data` object.
                 (default: :obj:`True`)
+            dummy_values (bool, optional): If set to :obj:`True`, will fill
+                attributes of remaining types with dummy values.
+                Dummy values are :obj:`NaN` for floating point attributes,
+                and :obj:`-1` for integers. (default: :obj:`True`)
         """
-        def _consistent_size(stores: List[BaseStorage]) -> List[str]:
+        def get_sizes(stores: List[BaseStorage]) -> Dict[str, List[Tuple]]:
             sizes_dict = defaultdict(list)
             for store in stores:
                 for key, value in store.items():
-                    if key in ['edge_index', 'adj_t']:
+                    if key in ['edge_index', 'adj', 'adj_t']:
                         continue
                     if isinstance(value, Tensor):
                         dim = self.__cat_dim__(key, value, store)
                         size = value.size()[:dim] + value.size()[dim + 1:]
                         sizes_dict[key].append(tuple(size))
+            return sizes_dict
+
+        def fill_dummy_(stores: List[BaseStorage],
+                        keys: Optional[List[str]] = None):
+            sizes_dict = get_sizes(stores)
+
+            if keys is not None:
+                sizes_dict = {
+                    key: sizes
+                    for key, sizes in sizes_dict.items() if key in keys
+                }
+
+            sizes_dict = {
+                key: sizes
+                for key, sizes in sizes_dict.items() if len(set(sizes)) == 1
+            }
+
+            for store in stores:  # Fill stores with dummy features:
+                for key, sizes in sizes_dict.items():
+                    if key not in store:
+                        ref = list(self.collect(key).values())[0]
+                        dim = self.__cat_dim__(key, ref, store)
+                        dummy = float('NaN') if ref.is_floating_point() else -1
+                        if isinstance(store, NodeStorage):
+                            dim_size = store.num_nodes
+                        else:
+                            dim_size = store.num_edges
+                        shape = sizes[0][:dim] + (dim_size, ) + sizes[0][dim:]
+                        store[key] = torch.full(shape, dummy, dtype=ref.dtype,
+                                                device=ref.device)
+
+        def _consistent_size(stores: List[BaseStorage]) -> List[str]:
+            sizes_dict = get_sizes(stores)
             return [
-                k for k, sizes in sizes_dict.items()
+                key for key, sizes in sizes_dict.items()
                 if len(sizes) == len(stores) and len(set(sizes)) == 1
             ]
+
+        if dummy_values:
+            self = copy.copy(self)
+            fill_dummy_(self.node_stores, node_attrs)
+            fill_dummy_(self.edge_stores, edge_attrs)
 
         edge_index, node_slices, edge_slices = to_homogeneous_edge_index(self)
         device = edge_index.device if edge_index is not None else None
@@ -705,10 +749,6 @@ class HeteroData(BaseData, FeatureStore, GraphStore):
 
         if not data.can_infer_num_nodes:
             data.num_nodes = list(node_slices.values())[-1][1]
-
-        # Combine labels
-        if 'y' not in data.keys:
-            data.y = to_homogeneous_label(self)
 
         # Combine edge attributes into a single tensor:
         if edge_attrs is None:

--- a/torch_geometric/data/hetero_data.py
+++ b/torch_geometric/data/hetero_data.py
@@ -906,6 +906,8 @@ def to_homogeneous_label(data: HeteroData, ) -> Tensor:
         if 'y' in data[node_type].keys():
             labeled_node_types.append(i)
             y.append(data[node_type].y)
+        else:
+            y.append(-1 * torch.ones(data[node_type].num_nodes))
 
     if labeled_node_types:
         return torch.cat(y)

--- a/torch_geometric/data/hetero_data.py
+++ b/torch_geometric/data/hetero_data.py
@@ -937,16 +937,3 @@ def to_homogeneous_edge_index(
         edge_index = torch.cat(edge_indices, dim=-1)
 
     return edge_index, node_slices, edge_slices
-
-
-def to_homogeneous_label(data: HeteroData) -> Tensor:
-    labeled_node_types = []
-    y = []
-    if len(data.y_dict) > 0:
-        for i, node_type in enumerate(data.node_types):
-            if 'y' in data[node_type].keys():
-                labeled_node_types.append(i)
-                y.append(data[node_type].y)
-            else:
-                y.append(torch.full((data[node_type].num_nodes, ), -1))
-        return torch.cat(y)

--- a/torch_geometric/data/hetero_data.py
+++ b/torch_geometric/data/hetero_data.py
@@ -907,5 +907,5 @@ def to_homogeneous_label(data: HeteroData) -> Tensor:
                 labeled_node_types.append(i)
                 y.append(data[node_type].y)
             else:
-                y.append(torch.full(data[node_type].num_nodes, -1))
+                y.append(torch.full((data[node_type].num_nodes,), -1))
         return torch.cat(y)

--- a/torch_geometric/data/hetero_data.py
+++ b/torch_geometric/data/hetero_data.py
@@ -898,9 +898,8 @@ def to_homogeneous_edge_index(
 
     return edge_index, node_slices, edge_slices
 
-def to_homogeneous_label(
-    data: HeteroData,
-) -> Tensor:
+
+def to_homogeneous_label(data: HeteroData, ) -> Tensor:
     labeled_node_types = []
     y = []
     for i, node_type in enumerate(data.node_types):

--- a/torch_geometric/data/hetero_data.py
+++ b/torch_geometric/data/hetero_data.py
@@ -647,7 +647,8 @@ class HeteroData(BaseData, FeatureStore, GraphStore):
         will be added to the returned :class:`~torch_geometric.data.Data`
         object, denoting node-level and edge-level vectors holding the
         node and edge type as integers, respectively.
-        Additionally, labels will be merged, assigning the label -1 for unlabeled node types.
+        Additionally, labels will be merged.
+        The label -1 will be assigned for unlabeled node types.
 
         Args:
             node_attrs (List[str], optional): The node features to combine


### PR DESCRIPTION
```
>>> x=torch_geometric.datasets.FakeHeteroDataset().data
>>> x.to_homogeneous().y
tensor([ 7.,  0.,  8.,  ..., -1., -1., -1.])
>>> x.to_homogeneous()
Data(edge_index=[2, 71136], y=[3497], node_type=[3497], edge_type=[71136])
```