### PR TITLE
[ONNX] Prevent tensors to be detached during ONNX export

### DIFF
--- a/torch_geometric/nn/dense/linear.py
+++ b/torch_geometric/nn/dense/linear.py
@@ -145,12 +145,15 @@ class Linear(torch.nn.Module):
         delattr(self, '_hook')
 
     def _save_to_state_dict(self, destination, prefix, keep_vars):
-        if is_uninitialized_parameter(self.weight):
+        if is_uninitialized_parameter(self.weight) or torch.onnx.is_in_onnx_export():
             destination[prefix + 'weight'] = self.weight
         else:
             destination[prefix + 'weight'] = self.weight.detach()
         if self.bias is not None:
-            destination[prefix + 'bias'] = self.bias.detach()
+            if  torch.onnx.is_in_onnx_export():
+                destination[prefix + 'bias'] = self.bias
+            else:
+                destination[prefix + 'bias'] = self.bias.detach()
 
     def _lazy_load_hook(self, state_dict, prefix, local_metadata, strict,
                         missing_keys, unexpected_keys, error_msgs):

--- a/torch_geometric/nn/dense/linear.py
+++ b/torch_geometric/nn/dense/linear.py
@@ -145,8 +145,8 @@ class Linear(torch.nn.Module):
         delattr(self, '_hook')
 
     def _save_to_state_dict(self, destination, prefix, keep_vars):
-        if is_uninitialized_parameter(
-                self.weight) or torch.onnx.is_in_onnx_export():
+        if (is_uninitialized_parameter(
+                self.weight) or torch.onnx.is_in_onnx_export()):
             destination[prefix + 'weight'] = self.weight
         else:
             destination[prefix + 'weight'] = self.weight.detach()

--- a/torch_geometric/nn/dense/linear.py
+++ b/torch_geometric/nn/dense/linear.py
@@ -145,12 +145,13 @@ class Linear(torch.nn.Module):
         delattr(self, '_hook')
 
     def _save_to_state_dict(self, destination, prefix, keep_vars):
-        if is_uninitialized_parameter(self.weight) or torch.onnx.is_in_onnx_export():
+        if is_uninitialized_parameter(
+                self.weight) or torch.onnx.is_in_onnx_export():
             destination[prefix + 'weight'] = self.weight
         else:
             destination[prefix + 'weight'] = self.weight.detach()
         if self.bias is not None:
-            if  torch.onnx.is_in_onnx_export():
+            if torch.onnx.is_in_onnx_export():
                 destination[prefix + 'bias'] = self.bias
             else:
                 destination[prefix + 'bias'] = self.bias.detach()

--- a/torch_geometric/nn/dense/linear.py
+++ b/torch_geometric/nn/dense/linear.py
@@ -145,8 +145,8 @@ class Linear(torch.nn.Module):
         delattr(self, '_hook')
 
     def _save_to_state_dict(self, destination, prefix, keep_vars):
-        if (is_uninitialized_parameter(
-                self.weight) or torch.onnx.is_in_onnx_export()):
+        if (is_uninitialized_parameter(self.weight)
+                or torch.onnx.is_in_onnx_export()):
             destination[prefix + 'weight'] = self.weight
         else:
             destination[prefix + 'weight'] = self.weight.detach()


### PR DESCRIPTION
`torch.onnx.export` API has some limitations regarding detached tensors during tracing.

The goal of this PR checks skips tensor detaching when ONNX export is in progress. This change does not cause any behavior/performance change when export is not in progress, nor should cause any behavior change to the ONNX exported graph as well

A unit test for SAGEConv ONNX export will be added to PyTorch's repo.

Fix https://github.com/pytorch/pytorch/issues/65138