### PR TITLE
Fix a typo in `gini` doc-string

### DIFF
--- a/torch_geometric/nn/functional/gini.py
+++ b/torch_geometric/nn/functional/gini.py
@@ -2,7 +2,7 @@ import torch
 
 
 def gini(w: torch.Tensor) -> torch.Tensor:
-    r"""The Gini coeffeicent from the `"Improving Molecular Graph Neural
+    r"""The Gini coefficient from the `"Improving Molecular Graph Neural
     Network Explainability with Orthonormalization and Induced Sparsity"
     <https://arxiv.org/abs/2105.04854>`_ paper
 


### PR DESCRIPTION
To address https://github.com/pyg-team/pytorch_geometric/issues/5579