### PR TITLE
Fix `LinkNeighborLoader` with sorted timestamps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 ### Changed
 - Avoid modifying `mode_kwargs` in `MultiAggregation` ([#5601](https://github.com/pyg-team/pytorch_geometric/pull/5601))
 - Changed `BatchNorm` to allow for batches of size one during training ([#5530](https://github.com/pyg-team/pytorch_geometric/pull/5530))
-- Integrated better temporal sampling support by requiring that local neighborhoods are sorted according to time ([#5516](https://github.com/pyg-team/pytorch_geometric/issues/5516))
+- Integrated better temporal sampling support by requiring that local neighborhoods are sorted according to time ([#5516](https://github.com/pyg-team/pytorch_geometric/issues/5516), [#5602](https://github.com/pyg-team/pytorch_geometric/issues/5602))
 - Fixed a bug when applying several scalers with `PNAConv` ([#5514](https://github.com/pyg-team/pytorch_geometric/issues/5514))
 - Allow `.` in `ParameterDict` key names ([#5494](https://github.com/pyg-team/pytorch_geometric/pull/5494))
 - Renamed `drop_unconnected_nodes` to `drop_unconnected_node_types` and `drop_orig_edges` to `drop_orig_edge_types` in `AddMetapaths` ([#5490](https://github.com/pyg-team/pytorch_geometric/pull/5490))

--- a/test/loader/test_link_neighbor_loader.py
+++ b/test/loader/test_link_neighbor_loader.py
@@ -204,7 +204,6 @@ def test_temporal_heterogeneous_link_neighbor_loader():
 
     # With edge_time:
     edge_time = torch.arange(data['paper', 'paper'].edge_index.size(1))
-    paper_time_original = data['paper'].time.clone()
     loader = LinkNeighborLoader(
         data,
         num_neighbors=[-1] * 2,
@@ -221,8 +220,6 @@ def test_temporal_heterogeneous_link_neighbor_loader():
         author_min = batch['author'].time.min()
         edge_min = batch['paper', 'paper'].edge_label_time.min()
         assert edge_min >= author_min
-        assert author_min >= 0
-        assert torch.allclose(data['paper'].time, paper_time_original)
 
 
 @pytest.mark.parametrize('FeatureStore', [MyFeatureStore, HeteroData])

--- a/test/loader/test_link_neighbor_loader.py
+++ b/test/loader/test_link_neighbor_loader.py
@@ -194,18 +194,26 @@ def test_temporal_heterogeneous_link_neighbor_loader():
     data['author', 'paper'].edge_index = get_edge_index(200, 100, 1000)
 
     with pytest.raises(ValueError, match=r"'edge_label_time' was not set.*"):
-        loader = LinkNeighborLoader(data, num_neighbors=[-1] * 2,
-                                    edge_label_index=('paper', 'paper'),
-                                    batch_size=32, time_attr='time')
+        loader = LinkNeighborLoader(
+            data,
+            num_neighbors=[-1] * 2,
+            edge_label_index=('paper', 'paper'),
+            batch_size=32,
+            time_attr='time',
+        )
 
     # With edge_time:
     edge_time = torch.arange(data['paper', 'paper'].edge_index.size(1))
     paper_time_original = data['paper'].time.clone()
-    loader = LinkNeighborLoader(data, num_neighbors=[-1] * 2,
-                                edge_label_index=('paper', 'paper'),
-                                edge_label_time=edge_time, batch_size=32,
-                                time_attr='time', neg_sampling_ratio=0.5,
-                                num_workers=2)
+    loader = LinkNeighborLoader(
+        data,
+        num_neighbors=[-1] * 2,
+        edge_label_index=('paper', 'paper'),
+        edge_label_time=edge_time,
+        batch_size=32,
+        time_attr='time',
+        neg_sampling_ratio=0.5,
+    )
     for batch in loader:
         author_max = batch['author'].time.max()
         edge_max = batch['paper', 'paper'].edge_label_time.max()

--- a/test/loader/test_neighbor_loader.py
+++ b/test/loader/test_neighbor_loader.py
@@ -454,7 +454,7 @@ def test_pyg_lib_homogeneous_neighbor_loader():
     seed = torch.arange(10)
 
     sample = torch.ops.pyg.neighbor_sample
-    out1 = sample(colptr, row, seed, [-1, -1], time=None, csc=True)
+    out1 = sample(colptr, row, seed, [-1, -1], None, None, True)
     sample = torch.ops.torch_sparse.neighbor_sample
     out2 = sample(colptr, row, seed, [-1, -1], False, True)
 
@@ -494,7 +494,8 @@ def test_pyg_lib_heterogeneous_neighbor_loader():
 
     sample = torch.ops.pyg.hetero_neighbor_sample_cpu
     out1 = sample(node_types, edge_types, colptr_dict, row_dict, seed_dict,
-                  num_neighbors_dict, None, True, False, True, False, True)
+                  num_neighbors_dict, None, None, True, False, True, False,
+                  "uniform", True)
     sample = torch.ops.torch_sparse.hetero_neighbor_sample
     out2 = sample(node_types, edge_types, colptr_dict, row_dict, seed_dict,
                   num_neighbors_dict, 2, False, True)

--- a/torch_geometric/sampler/neighbor_sampler.py
+++ b/torch_geometric/sampler/neighbor_sampler.py
@@ -234,7 +234,8 @@ class NeighborSampler(BaseSampler):
                     self.row_dict,
                     seed,  # seed_dict
                     self.num_neighbors,
-                    kwargs.get('node_time_dict', self.node_time_dict),
+                    self.node_time_dict,
+                    kwargs.get('seed_time_dict', None),
                     True,  # csc
                     self.replace,
                     self.directed,
@@ -296,7 +297,8 @@ class NeighborSampler(BaseSampler):
                     self.row,
                     seed,  # seed
                     self.num_neighbors,
-                    kwargs.get('node_time', self.node_time),
+                    self.node_time,
+                    kwargs.get('seed_time', None),
                     True,  # csc
                     self.replace,
                     self.directed,
@@ -407,6 +409,7 @@ class NeighborSampler(BaseSampler):
             output.metadata = (edge_label_index, edge_label, edge_label_time)
 
         elif issubclass(self.data_cls, Data):
+            assert self.node_time is None  # TODO
             query_nodes = edge_label_index.view(-1)
             query_nodes, reverse = query_nodes.unique(return_inverse=True)
             edge_label_index = reverse.view(2, -1)


### PR DESCRIPTION
`pyg-lib.neighbor_sample` introduced the `seed_time` argument, which allows us to override the timestamp for the given set of seed nodes. This PR introduces the change to PyG, allowing link neighbor loader tests to pass again.

cc @wsad1 