### PR TITLE
Add ratio adjustment in `RandomLinkSplit` when not enough negative edges exist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Added `BaseStorage.get()` functionality ([#5240](https://github.com/pyg-team/pytorch_geometric/pull/5240))
 - Added a test to confirm that `to_hetero` works with `SparseTensor` ([#5222](https://github.com/pyg-team/pytorch_geometric/pull/5222))
 ### Changed
+- Handle cases of not having enough possible negative edges in `RandomLinkSplit` ([#5642](https://github.com/pyg-team/pytorch_geometric/pull/5642))
 - Support `in_channels` with `tuple` in `GENConv` for bipartite message passing
 - Fix `RGCN+pyg-lib` for `LongTensor` input ([#5610](https://github.com/pyg-team/pytorch_geometric/pull/5610))
 - Improved type hint support ([#5603](https://github.com/pyg-team/pytorch_geometric/pull/5603))

--- a/test/transforms/test_random_link_split.py
+++ b/test/transforms/test_random_link_split.py
@@ -205,6 +205,6 @@ def test_random_link_split_insufficient_negative_edges():
                                 is_undirected=False, neg_sampling_ratio=2,
                                 split_labels=True)
     train_data, val_data, test_data = transform(data)
-    assert len(train_data.neg_edge_label) == 2
-    assert len(val_data.neg_edge_label) == 2
-    assert len(test_data.neg_edge_label) == 2
+    assert train_data.neg_edge_label_index.size() == (2, 2)
+    assert val_data.neg_edge_label_index.size() == (2, 2)
+    assert test_data.neg_edge_label_index.size() == (2, 2)

--- a/test/transforms/test_random_link_split.py
+++ b/test/transforms/test_random_link_split.py
@@ -199,12 +199,14 @@ def test_random_link_split_on_undirected_hetero_data():
 
 
 def test_random_link_split_insufficient_negative_edges():
-    data = Data()
-    data.edge_index = torch.tensor([[0, 0, 1, 1, 2, 2], [1, 3, 0, 2, 0, 1]])
+    edge_index = torch.tensor([[0, 0, 1, 1, 2, 2], [1, 3, 0, 2, 0, 1]])
+    data = Data(edge_index=edge_index, num_nodes=4)
+
     transform = RandomLinkSplit(num_val=0.34, num_test=0.34,
                                 is_undirected=False, neg_sampling_ratio=2,
                                 split_labels=True)
     train_data, val_data, test_data = transform(data)
+
     assert train_data.neg_edge_label_index.size() == (2, 2)
     assert val_data.neg_edge_label_index.size() == (2, 2)
     assert test_data.neg_edge_label_index.size() == (2, 2)

--- a/test/transforms/test_random_link_split.py
+++ b/test/transforms/test_random_link_split.py
@@ -196,3 +196,16 @@ def test_random_link_split_on_undirected_hetero_data():
                                 rev_edge_types=('p', 'p'))
     train_data, val_data, test_data = transform(data)
     assert train_data['p', 'p'].is_undirected()
+
+
+def test_random_link_split_insufficient_negative_edges():
+    data = Data()
+    data.edge_index = torch.tensor([[0, 0, 0, 1, 1, 2, 2],
+                                    [1, 2, 3, 0, 2, 0, 1]])
+    transform = RandomLinkSplit(num_val=0.33, num_test=0.33,
+                                is_undirected=False, neg_sampling_ratio=2,
+                                split_labels=True)
+    train_data, val_data, test_data = transform(data)
+    assert len(train_data.neg_edge_label) != 0
+    assert len(val_data.neg_edge_label) != 0
+    assert len(test_data.neg_edge_label) != 0

--- a/torch_geometric/transforms/random_link_split.py
+++ b/torch_geometric/transforms/random_link_split.py
@@ -210,7 +210,7 @@ class RandomLinkSplit(BaseTransform):
                                                method='sparse')
 
             # Adjust ratio if not enough negative edges exist
-            if len(neg_edge_index) < num_neg:
+            if neg_edge_index.size(1) < num_neg:
                 num_neg_found = neg_edge_index.size(1)
                 ratio = num_neg_found / num_neg
                 warnings.warn(

--- a/torch_geometric/transforms/random_link_split.py
+++ b/torch_geometric/transforms/random_link_split.py
@@ -216,7 +216,7 @@ class RandomLinkSplit(BaseTransform):
                 warnings.warn(
                     f"There are not enough negative edges to satisfy "
                     "the provided sampling ratio. The ratio will be "
-                    f"adjusted to {ratio}")
+                    f"adjusted to {ratio:.3f}")
                 num_neg_train = int(num_neg_train / num_neg * num_neg_found)
                 num_neg_val = int(num_neg_val / num_neg * num_neg_found)
                 num_neg_test = num_neg_found - num_neg_train - num_neg_val

--- a/torch_geometric/transforms/random_link_split.py
+++ b/torch_geometric/transforms/random_link_split.py
@@ -217,9 +217,9 @@ class RandomLinkSplit(BaseTransform):
                 warnings.warn(
                     f"There are not enough negative edges to satisfy "
                     "the provided sampling ratio. The ratio will be "
-                    f"adjusted to {ratio:.3f}")
-                num_neg_train = int(num_neg_train / num_neg * num_neg_found)
-                num_neg_val = int(num_neg_val / num_neg * num_neg_found)
+                    f"adjusted to {ratio:.2f}.")
+                num_neg_train = int((num_neg_train / num_neg) * num_neg_found)
+                num_neg_val = int((num_neg_val / num_neg) * num_neg_found)
                 num_neg_test = num_neg_found - num_neg_train - num_neg_val
 
             # Create labels:


### PR DESCRIPTION
This change addresses https://github.com/pyg-team/pytorch_geometric/issues/5581

The problem being solved is that it is possible for there to not be enough negative edges available to satisfy the requested sampling ratio.

This change makes it so that in this case the ratio assigned to each split should reflect the desired ratio between the splits. I.e, the % assigned to each of train, test and validation is the same as requested.