### PR TITLE
Added `return_semantic_attention_weights` parameter to `HANConv`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ## [2.2.0] - 2022-MM-DD
 ### Added
-- Added `return_semantic_attention_weights` argument to `forward` method of `HANConv` ([#5787](https://github.com/pyg-team/pytorch_geometric/pull/5787))
+- Added a `return_semantic_attention_weights` argument `HANConv` ([#5787](https://github.com/pyg-team/pytorch_geometric/pull/5787))
 - Added `disjoint` argument to `NeighborLoader` and `LinkNeighborLoader`  ([#5775](https://github.com/pyg-team/pytorch_geometric/pull/5775))
 - Added support for `input_time` in `NeighborLoader` ([#5763](https://github.com/pyg-team/pytorch_geometric/pull/5763))
 - Added `disjoint` mode for temporal `LinkNeighborLoader` ([#5717](https://github.com/pyg-team/pytorch_geometric/pull/5717))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ## [2.2.0] - 2022-MM-DD
 ### Added
+- Added `return_semantic_attention_weights` argument to `forward` method of `HANConv` ([#5787](https://github.com/pyg-team/pytorch_geometric/pull/5787))
 - Added `disjoint` argument to `NeighborLoader` and `LinkNeighborLoader`  ([#5775](https://github.com/pyg-team/pytorch_geometric/pull/5775))
 - Added support for `input_time` in `NeighborLoader` ([#5763](https://github.com/pyg-team/pytorch_geometric/pull/5763))
 - Added `disjoint` mode for temporal `LinkNeighborLoader` ([#5717](https://github.com/pyg-team/pytorch_geometric/pull/5717))

--- a/torch_geometric/nn/conv/han_conv.py
+++ b/torch_geometric/nn/conv/han_conv.py
@@ -12,7 +12,8 @@ from torch_geometric.utils import softmax
 
 
 def group(xs: List[Tensor], q: nn.Parameter, k_lin: nn.Module,
-          return_semantic_attention_weights=None):
+          return_semantic_attention_weights: bool = False) -> Union[OptTensor, Tuple[Tensor, Tensor]]:
+
     if len(xs) == 0:
         return None
     else:

--- a/torch_geometric/nn/conv/han_conv.py
+++ b/torch_geometric/nn/conv/han_conv.py
@@ -113,7 +113,7 @@ class HANConv(MessagePassing):
         edge_index_dict: Dict[EdgeType, Adj],
         return_semantic_attention_weights: bool = False,
     ) -> Union[Dict[NodeType, OptTensor], Tuple[Dict[NodeType, OptTensor],
-                                                Dict[NodeType, Tensor]]]:
+                                                Dict[NodeType, OptTensor]]]:
         r"""
         Args:
             x_dict (Dict[str, Tensor]): A dictionary holding input node

--- a/torch_geometric/nn/conv/han_conv.py
+++ b/torch_geometric/nn/conv/han_conv.py
@@ -109,7 +109,8 @@ class HANConv(MessagePassing):
 
     def forward(self, x_dict: Dict[NodeType, Tensor],
                 edge_index_dict: Dict[EdgeType, Adj],
-                return_semantic_attention_weights=None):
+                return_semantic_attention_weights: bool = False) -> Union[Dict[NodeType, OptTensor], TupleDict[NodeType, OptTensor], Tensor]]:
+
         r"""
         Args:
             x_dict (Dict[str, Tensor]): A dictionary holding input node

--- a/torch_geometric/nn/conv/han_conv.py
+++ b/torch_geometric/nn/conv/han_conv.py
@@ -23,7 +23,7 @@ def group(
         num_edge_types = len(xs)
         out = torch.stack(xs)
         if out.numel() == 0:
-            return out.view(0, out.size(-1))
+            return out.view(0, out.size(-1)), None
         attn_score = (q * torch.tanh(k_lin(out)).mean(1)).sum(-1)
         attn = F.softmax(attn_score, dim=0)
         out = torch.sum(attn.view(num_edge_types, 1, -1) * out, dim=0)

--- a/torch_geometric/nn/conv/han_conv.py
+++ b/torch_geometric/nn/conv/han_conv.py
@@ -174,7 +174,8 @@ class HANConv(MessagePassing):
                 out_dict[node_type] = None
                 continue
             out_dict[node_type] = out
-        if isinstance(return_semantic_attention_weights, bool):
+        if return_semantic_attention_weights:
+
             return out_dict, semantic_attention_weights
         return out_dict
 

--- a/torch_geometric/nn/conv/han_conv.py
+++ b/torch_geometric/nn/conv/han_conv.py
@@ -162,7 +162,8 @@ class HANConv(MessagePassing):
 
         # iterate over node types:
         for node_type, outs in out_dict.items():
-            if isinstance(return_semantic_attention_weights, bool):
+            if return_semantic_attention_weights:
+
                 out, semantic_attention_weights = group(
                     outs, self.q, self.k_lin,
                     return_semantic_attention_weights)

--- a/torch_geometric/nn/conv/han_conv.py
+++ b/torch_geometric/nn/conv/han_conv.py
@@ -24,7 +24,8 @@ def group(xs: List[Tensor], q: nn.Parameter, k_lin: nn.Module,
         attn_score = (q * torch.tanh(k_lin(out)).mean(1)).sum(-1)
         attn = F.softmax(attn_score, dim=0)
         out = torch.sum(attn.view(num_edge_types, 1, -1) * out, dim=0)
-        if isinstance(return_semantic_attention_weights, bool):
+        if return_semantic_attention_weights:
+
             return out, attn
         return out
 

--- a/torch_geometric/nn/conv/han_conv.py
+++ b/torch_geometric/nn/conv/han_conv.py
@@ -125,7 +125,8 @@ class HANConv(MessagePassing):
                 will additionally return the tensor
                 :obj:`semantic_attention_weights`, holding the computed
                 attention weights for each edge type
-                at semantic-level attention. (default: :obj:`None`)
+                at semantic-level attention. (default: :obj:`False`)
+
         """
         # NOTE: semantic_attention weights will be returned whenever
         # `return_attention_weights` is set to a value, regardless of its

--- a/torch_geometric/nn/conv/han_conv.py
+++ b/torch_geometric/nn/conv/han_conv.py
@@ -128,13 +128,6 @@ class HANConv(MessagePassing):
                 at semantic-level attention. (default: :obj:`False`)
 
         """
-        # NOTE: semantic_attention weights will be returned whenever
-        # `return_attention_weights` is set to a value, regardless of its
-        # actual value (might be `True` or `False`). This is a current somewhat
-        # hacky workaround to allow for TorchScript support via the
-        # `torch.jit._overload` decorator, as we can only change the output
-        # arguments conditioned on type (`None` or `bool`), not based on its
-        # actual value.
         H, D = self.heads, self.out_channels // self.heads
         x_node_dict, out_dict = {}, {}
 


### PR DESCRIPTION
Added return_semantic_attention_weights parameter to forward method of HANConv, in the same way GATConv returns its attention_weights. 

return_semantic_attention_weights (bool, optional): If set to :obj:`True`, will additionally return the tensor :obj:`semantic_attention_weights`, holding the computed attention weights for each edge type at semantic-level attention. (default: :obj:`None`). 

Further work could be dedicated to return also node-level attention weights as dictionary of (edge_type, attention_weights) items. 