### PR TITLE
Enable VTune ITT in inference benchmarks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ## [2.2.0] - 2022-MM-DD
 ### Added
+- Enable VTune ITT in inference benchmarks ([#5830](https://github.com/pyg-team/pytorch_geometric/pull/5830))
 - Add training_benchmark ([#5774](https://github.com/pyg-team/pytorch_geometric/pull/5774))
 - Added a "Link Prediction on MovieLens" Colab notebook ([#5823](https://github.com/pyg-team/pytorch_geometric/pull/5823))
 - Added custom `sampler` support in `LightningDataModule` ([#5820](https://github.com/pyg-team/pytorch_geometric/pull/5820))


### PR DESCRIPTION
Enable [VTune ITT ](https://github.com/pytorch/pytorch/blob/master/torch/autograd/profiler.py#L525) in inference benchmarks. ITT is a tool used for labeling trace data. It helps PyTorch OPs to better report themselves in different VTune results views.

After #5774 will get merged, ITT will be also enabled in training benchmarks.