### PR TITLE
Add TorchScript support for `AttentiveFP`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ## [2.2.0] - 2022-MM-DD
 ### Added
+- Added TorchScript support for `AttentiveFP `([#5868](https://github.com/pyg-team/pytorch_geometric/pull/5868))
 - Enable VTune ITT in inference benchmarks ([#5830](https://github.com/pyg-team/pytorch_geometric/pull/5830))
 - Add training benchmark ([#5774](https://github.com/pyg-team/pytorch_geometric/pull/5774))
 - Added a "Link Prediction on MovieLens" Colab notebook ([#5823](https://github.com/pyg-team/pytorch_geometric/pull/5823))

--- a/test/nn/models/test_attentive_fp.py
+++ b/test/nn/models/test_attentive_fp.py
@@ -1,0 +1,23 @@
+import torch
+
+from torch_geometric.nn import AttentiveFP
+from torch_geometric.testing import is_full_test
+
+
+def test_attentive_fp():
+    model = AttentiveFP(8, 16, 32, edge_dim=3, num_layers=2, num_timesteps=2)
+    assert str(model) == ('AttentiveFP(in_channels=8, hidden_channels=16, '
+                          'out_channels=32, edge_dim=3, num_layers=2, '
+                          'num_timesteps=2)')
+
+    x = torch.randn(4, 8)
+    edge_index = torch.tensor([[0, 0, 0, 1, 2, 3], [1, 2, 3, 0, 0, 0]])
+    edge_attr = torch.randn(edge_index.size(1), 3)
+    batch = torch.tensor([0, 0, 0, 0])
+
+    out = model(x, edge_index, edge_attr, batch)
+    assert out.size() == (1, 32)
+
+    if is_full_test():
+        jit = torch.jit.script(model.jittable())
+        assert torch.allclose(jit(x, edge_index, edge_attr, batch), out)

--- a/torch_geometric/nn/conv/message_passing.py
+++ b/torch_geometric/nn/conv/message_passing.py
@@ -707,7 +707,7 @@ class MessagePassing(torch.nn.Module):
         return handle
 
     @torch.jit.unused
-    def jittable(self, typing: Optional[str] = None):
+    def jittable(self, typing: Optional[str] = None) -> 'MessagePassing':
         r"""Analyzes the :class:`MessagePassing` instance and produces a new
         jittable module.
 

--- a/torch_geometric/nn/models/attentive_fp.py
+++ b/torch_geometric/nn/models/attentive_fp.py
@@ -79,17 +79,10 @@ class AttentiveFP(torch.nn.Module):
         dropout (float, optional): Dropout probability. (default: :obj:`0.0`)
 
     """
-    def __init__(
-        self,
-        in_channels: int,
-        hidden_channels: int,
-        out_channels: int,
-        edge_dim: int,
-        num_layers: int,
-        num_timesteps: int,
-        dropout: float = 0.0,
-        jittable: bool = False
-    ):
+    def __init__(self, in_channels: int, hidden_channels: int,
+                 out_channels: int, edge_dim: int, num_layers: int,
+                 num_timesteps: int, dropout: float = 0.0,
+                 jittable: bool = False):
         super().__init__()
 
         self.num_layers = num_layers
@@ -99,19 +92,18 @@ class AttentiveFP(torch.nn.Module):
         self.lin1 = Linear(in_channels, hidden_channels)
 
         conv = GATEConv(hidden_channels, hidden_channels, edge_dim, dropout)
-        if(jittable):
+        if (jittable):
             conv = conv.jittable()
         gru = GRUCell(hidden_channels, hidden_channels)
         self.gate_conv = conv
         self.gru = gru
-        
 
         self.atom_convs = torch.nn.ModuleList()
         self.atom_grus = torch.nn.ModuleList()
         for _ in range(num_layers - 1):
             conv = GATConv(hidden_channels, hidden_channels, dropout=dropout,
                            add_self_loops=False, negative_slope=0.01)
-            if(jittable):
+            if (jittable):
                 conv = conv.jittable()
             self.atom_convs.append(conv)
             self.atom_grus.append(GRUCell(hidden_channels, hidden_channels))
@@ -119,7 +111,7 @@ class AttentiveFP(torch.nn.Module):
         self.mol_conv = GATConv(hidden_channels, hidden_channels,
                                 dropout=dropout, add_self_loops=False,
                                 negative_slope=0.01)
-        if(jittable):
+        if (jittable):
             self.mol_conv = self.mol_conv.jittable()
         self.mol_gru = GRUCell(hidden_channels, hidden_channels)
 


### PR DESCRIPTION
Add TorchScript JIT support on AttentiveFP. 

Now AttentiveFP can use the following code to directly get TorchScript model.

`model = AttentiveFP(in_channels=..., jittable=True)`
`jit = torch.jit.script(model)` 

To do this, we first add the propagate type in GATEConv and then reorganize the ModuleList logic to satisfy TorchScript language syntax.