### PR TITLE
Enable VTune ITT in training benchmarks

### DIFF
--- a/benchmark/inference/inference_benchmark.py
+++ b/benchmark/inference/inference_benchmark.py
@@ -2,20 +2,10 @@ import argparse
 
 import torch
 
-from benchmark.utils import get_dataset, get_model
+from benchmark.utils import emit_itt, get_dataset, get_model
 from torch_geometric.loader import NeighborLoader
 from torch_geometric.nn import PNAConv
 from torch_geometric.profile import rename_profile_file, timeit, torch_profile
-
-try:
-    from torch.autograd.profiler import emit_itt
-except ImportError:
-    from contextlib import contextmanager
-
-    @contextmanager
-    def emit_itt(*args, **kwargs):
-        yield
-
 
 supported_sets = {
     'ogbn-mag': ['rgat', 'rgcn'],

--- a/benchmark/utils/__init__.py
+++ b/benchmark/utils/__init__.py
@@ -1,7 +1,9 @@
+from .utils import emit_itt
 from .utils import get_dataset
 from .utils import get_model
 
 __all__ = [
+    'emit_itt',
     'get_dataset',
     'get_model',
 ]

--- a/benchmark/utils/utils.py
+++ b/benchmark/utils/utils.py
@@ -11,6 +11,16 @@ from torch_geometric.utils import index_to_mask
 from .hetero_gat import HeteroGAT
 from .hetero_sage import HeteroGraphSAGE
 
+try:
+    from torch.autograd.profiler import emit_itt
+except ImportError:
+    from contextlib import contextmanager
+
+    @contextmanager
+    def emit_itt(*args, **kwargs):
+        yield
+
+
 models_dict = {
     'edge_cnn': EdgeCNN,
     'gat': GAT,


### PR DESCRIPTION
Enable [VTune ITT ](https://github.com/pytorch/pytorch/blob/master/torch/autograd/profiler.py#L525) in training benchmarks. ITT is a tool used for labeling trace data. It helps PyTorch OPs to better report themselves in different VTune results views.