### PR TITLE
Fix `collate_fn` type hints

### DIFF
--- a/torch_geometric/data/collate.py
+++ b/torch_geometric/data/collate.py
@@ -15,8 +15,8 @@ def collate(
     data_list: List[BaseData],
     increment: bool = True,
     add_batch: bool = True,
-    follow_batch: Optional[Union[List[str]]] = None,
-    exclude_keys: Optional[Union[List[str]]] = None,
+    follow_batch: Optional[List[str]] = None,
+    exclude_keys: Optional[List[str]] = None,
 ) -> Tuple[BaseData, Mapping, Mapping]:
     # Collates a list of `data` objects into a single object of type `cls`.
     # `collate` can handle both homogeneous and heterogeneous data objects by


### PR DESCRIPTION
I just cloned the repository and my VSCode extensions picked up on a Union of a single type.