### PR TITLE
add `num_nodes` to `filter_custom_store`

### DIFF
--- a/test/loader/test_neighbor_loader.py
+++ b/test/loader/test_neighbor_loader.py
@@ -368,7 +368,8 @@ def test_custom_neighbor_loader(FeatureStore, GraphStore):
     assert len(loader1) == len(loader2)
 
     for batch1, batch2 in zip(loader1, loader2):
-        assert len(batch1) == len(batch2)
+        # loader2 excplicitly adds `num_nodes` to the batch
+        assert len(batch1) + 1 == len(batch2)
         assert batch1['paper'].batch_size == batch2['paper'].batch_size
 
         # Mapped indices of neighbors may be differently sorted:

--- a/torch_geometric/loader/utils.py
+++ b/torch_geometric/loader/utils.py
@@ -184,6 +184,7 @@ def filter_custom_store(
         if attr.group_name in node_dict:
             attr.index = node_dict[attr.group_name]
             required_attrs.append(attr)
+            data[attr.group_name]['num_nodes'] = attr.index.size(0)
 
     # NOTE Here, we utilize `feature_store.multi_get` to give the feature store
     # full control over optimizing how it returns features (since the call is

--- a/torch_geometric/loader/utils.py
+++ b/torch_geometric/loader/utils.py
@@ -184,7 +184,7 @@ def filter_custom_store(
         if attr.group_name in node_dict:
             attr.index = node_dict[attr.group_name]
             required_attrs.append(attr)
-            data[attr.group_name]['num_nodes'] = attr.index.size(0)
+            data[attr.group_name].num_nodes = attr.index.size(0)
 
     # NOTE Here, we utilize `feature_store.multi_get` to give the feature store
     # full control over optimizing how it returns features (since the call is


### PR DESCRIPTION
Resolve a bug where custom stores came without node_num information.