### PR TITLE
Fix typo in docs of `nn.ARGVA`

### DIFF
--- a/torch_geometric/nn/models/autoencoder.py
+++ b/torch_geometric/nn/models/autoencoder.py
@@ -237,7 +237,6 @@ class ARGVA(ARGA):
     r"""The Adversarially Regularized Variational Graph Auto-Encoder model from
     the `"Adversarially Regularized Graph Autoencoder for Graph Embedding"
     <https://arxiv.org/abs/1802.04407>`_ paper.
-    paper.
 
     Args:
         encoder (Module): The encoder module to compute :math:`\mu` and


### PR DESCRIPTION
Fixes a small typo of the docstring of `nn.ARGVA`