### PR TITLE
Add `to_smiles` function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ## [2.2.0] - 2022-MM-DD
 ### Added
+- Added a `to_smiles` function ([#6038](https://github.com/pyg-team/pytorch_geometric/pull/6038))
 - Added `HeteroData` support for `to_captum_model` and added `to_captum_input` ([#5934](https://github.com/pyg-team/pytorch_geometric/pull/5934))
 - Added `HeteroData` support in `RandomNodeLoader` ([#6007](https://github.com/pyg-team/pytorch_geometric/pull/6007))
 - Added bipartite `GraphSAGE` example ([#5834](https://github.com/pyg-team/pytorch_geometric/pull/5834))

--- a/test/utils/test_smiles.py
+++ b/test/utils/test_smiles.py
@@ -1,18 +1,22 @@
 import pytest
 
 from torch_geometric.testing import withPackage
-from torch_geometric.utils import smiles
+from torch_geometric.utils import from_smiles, to_smiles
 
 
 @withPackage('rdkit')
-@pytest.mark.parametrize('test_smile', [
-    'F/C=C/F', 'F/C=C\F', 'F/C=C\F',
-    'COc1cccc([C@@H]2Oc3ccc(OC)cc3/C(=N/OC[C@@H](C)[C@H](OCc3ccccc3)C(C)C)[C@@H]2O)c1',
-    'C/C(=C\C(=O)c1ccc(C)o1)Nc1ccc2c(c1)OCO2', 'F[B-](F)(F)c1cnc2ccccc2c1',
-    'COC(=O)[C@@]1(Cc2ccccc2)[C@H]2C(=O)N(C)C(=O)[C@H]2[C@H]2CN=C(SC)N21',
-    'O=C(O)c1ccc(NS(=O)(=O)c2ccc3c(c2)C(=O)c2cc(S(=O)(=O)Nc4ccc(C(=O)O)cc4)ccc2-3)cc1'
+@pytest.mark.parametrize('smiles', [
+    r'F/C=C/F',
+    r'F/C=C\F',
+    r'F/C=C\F',
+    (r'COc1cccc([C@@H]2Oc3ccc(OC)cc3/C(=N/OC[C@@H](C)[C@H](OCc3ccccc3)'
+     r'C(C)C)[C@@H]2O)c1'),
+    r'C/C(=C\C(=O)c1ccc(C)o1)Nc1ccc2c(c1)OCO2',
+    r'F[B-](F)(F)c1cnc2ccccc2c1',
+    r'COC(=O)[C@@]1(Cc2ccccc2)[C@H]2C(=O)N(C)C(=O)[C@H]2[C@H]2CN=C(SC)N21',
+    (r'O=C(O)c1ccc(NS(=O)(=O)c2ccc3c(c2)C(=O)c2cc(S(=O)(=O)Nc4ccc(C(=O)O)'
+     r'cc4)ccc2-3)cc1'),
 ])
-def test_from_to_smiles(test_smile):
-    data = smiles.from_smiles(test_smile)
-    smiles = smiles.to_smiles(data)
-    assert smiles == test_smile
+def test_from_to_smiles(smiles):
+    data = from_smiles(smiles)
+    assert to_smiles(data) == smiles

--- a/test/utils/test_smiles.py
+++ b/test/utils/test_smiles.py
@@ -1,0 +1,17 @@
+import pytest
+from torch_geometric.utils import smiles
+from torch_geometric.testing import withPackage
+
+@withPackage('rdkit')
+@pytest.mark.parametrize('test_smile', [
+'F/C=C/F', 'F/C=C\F', 'F/C=C\F', 
+'COc1cccc([C@@H]2Oc3ccc(OC)cc3/C(=N/OC[C@@H](C)[C@H](OCc3ccccc3)C(C)C)[C@@H]2O)c1',
+'C/C(=C\C(=O)c1ccc(C)o1)Nc1ccc2c(c1)OCO2',
+'F[B-](F)(F)c1cnc2ccccc2c1',
+'COC(=O)[C@@]1(Cc2ccccc2)[C@H]2C(=O)N(C)C(=O)[C@H]2[C@H]2CN=C(SC)N21',
+'O=C(O)c1ccc(NS(=O)(=O)c2ccc3c(c2)C(=O)c2cc(S(=O)(=O)Nc4ccc(C(=O)O)cc4)ccc2-3)cc1'])
+def test_from_to_smiles(test_smile):
+    data = smiles.from_smiles(test_smile)
+    smiles = smiles.to_smiles(data)
+    assert smiles == test_smile
+    

--- a/test/utils/test_smiles.py
+++ b/test/utils/test_smiles.py
@@ -1,17 +1,18 @@
 import pytest
-from torch_geometric.utils import smiles
+
 from torch_geometric.testing import withPackage
+from torch_geometric.utils import smiles
+
 
 @withPackage('rdkit')
 @pytest.mark.parametrize('test_smile', [
-'F/C=C/F', 'F/C=C\F', 'F/C=C\F', 
-'COc1cccc([C@@H]2Oc3ccc(OC)cc3/C(=N/OC[C@@H](C)[C@H](OCc3ccccc3)C(C)C)[C@@H]2O)c1',
-'C/C(=C\C(=O)c1ccc(C)o1)Nc1ccc2c(c1)OCO2',
-'F[B-](F)(F)c1cnc2ccccc2c1',
-'COC(=O)[C@@]1(Cc2ccccc2)[C@H]2C(=O)N(C)C(=O)[C@H]2[C@H]2CN=C(SC)N21',
-'O=C(O)c1ccc(NS(=O)(=O)c2ccc3c(c2)C(=O)c2cc(S(=O)(=O)Nc4ccc(C(=O)O)cc4)ccc2-3)cc1'])
+    'F/C=C/F', 'F/C=C\F', 'F/C=C\F',
+    'COc1cccc([C@@H]2Oc3ccc(OC)cc3/C(=N/OC[C@@H](C)[C@H](OCc3ccccc3)C(C)C)[C@@H]2O)c1',
+    'C/C(=C\C(=O)c1ccc(C)o1)Nc1ccc2c(c1)OCO2', 'F[B-](F)(F)c1cnc2ccccc2c1',
+    'COC(=O)[C@@]1(Cc2ccccc2)[C@H]2C(=O)N(C)C(=O)[C@H]2[C@H]2CN=C(SC)N21',
+    'O=C(O)c1ccc(NS(=O)(=O)c2ccc3c(c2)C(=O)c2cc(S(=O)(=O)Nc4ccc(C(=O)O)cc4)ccc2-3)cc1'
+])
 def test_from_to_smiles(test_smile):
     data = smiles.from_smiles(test_smile)
     smiles = smiles.to_smiles(data)
     assert smiles == test_smile
-    

--- a/torch_geometric/utils/__init__.py
+++ b/torch_geometric/utils/__init__.py
@@ -29,7 +29,7 @@ from .convert import to_scipy_sparse_matrix, from_scipy_sparse_matrix
 from .convert import to_networkx, from_networkx
 from .convert import to_trimesh, from_trimesh
 from .convert import to_cugraph
-from .smiles import from_smiles
+from .smiles import from_smiles, to_smiles
 from .random import (erdos_renyi_graph, stochastic_blockmodel_graph,
                      barabasi_albert_graph)
 from .negative_sampling import (negative_sampling, batched_negative_sampling,
@@ -88,6 +88,7 @@ __all__ = [
     'from_trimesh',
     'to_cugraph',
     'from_smiles',
+    'to_smiles',
     'erdos_renyi_graph',
     'stochastic_blockmodel_graph',
     'barabasi_albert_graph',

--- a/torch_geometric/utils/smiles.py
+++ b/torch_geometric/utils/smiles.py
@@ -1,6 +1,7 @@
-import torch 
-from torch_geometric.data import Data
+import torch
 from rdkit import Chem, RDLogger
+
+from torch_geometric.data import Data
 
 RDLogger.DisableLog('rdApp.*')
 
@@ -42,27 +43,10 @@ x_map = {
 
 e_map = {
     'bond_type': [
-        'UNSPECIFIED',
-        'SINGLE',
-        'DOUBLE',
-        'TRIPLE',
-        'QUADRUPLE',
-        'QUINTUPLE',
-        'HEXTUPLE',
-        'ONEANDAHALF',
-        'TWOANDAHALF',
-        'THREEANDAHALF',
-        'FOURANDAHALF',
-        'FIVEANDAHALF',
-        'AROMATIC',
-        'IONIC',
-        'HYDROGEN',
-        'THREECENTER',
-        'DATIVEONE',
-        'DATIVE',
-        'DATIVEL',
-        'DATIVER',
-        'OTHER',
+        'UNSPECIFIED', 'SINGLE', 'DOUBLE', 'TRIPLE', 'QUADRUPLE', 'QUINTUPLE',
+        'HEXTUPLE', 'ONEANDAHALF', 'TWOANDAHALF', 'THREEANDAHALF',
+        'FOURANDAHALF', 'FIVEANDAHALF', 'AROMATIC', 'IONIC', 'HYDROGEN',
+        'THREECENTER', 'DATIVEONE', 'DATIVE', 'DATIVEL', 'DATIVER', 'OTHER',
         'ZERO'
     ],
     'stereo': [
@@ -153,17 +137,17 @@ def to_smiles(data, kekulize: bool = False):
     mol = Chem.RWMol()
 
     for i in range(data.num_nodes):
-        atom = Chem.Atom(data.x[i, 0].item()) 
+        atom = Chem.Atom(data.x[i, 0].item())
         atom.SetChiralTag(Chem.rdchem.ChiralType.values[data.x[i, 1].item()])
         atom.SetFormalCharge(x_map['formal_charge'][data.x[i, 3].item()])
         atom.SetNumExplicitHs(x_map['num_hs'][data.x[i, 4].item()])
-        atom.SetNumRadicalElectrons(x_map['num_radical_electrons'][data.x[i, 5].item()])
-        atom.SetHybridization(Chem.rdchem.HybridizationType.values[data.x[i, 6].item()])
+        atom.SetNumRadicalElectrons(
+            x_map['num_radical_electrons'][data.x[i, 5].item()])
+        atom.SetHybridization(
+            Chem.rdchem.HybridizationType.values[data.x[i, 6].item()])
         atom.SetIsAromatic(data.x[i, 7].item())
         mol.AddAtom(atom)
 
-
-   
     edges = [tuple(i) for i in data.edge_index.t().tolist()]
     visited = set()
 
@@ -171,21 +155,21 @@ def to_smiles(data, kekulize: bool = False):
         i, j = edges[edge_idx]
         if tuple(sorted(edges[edge_idx])) in visited:
             continue
-    
-        bond_type = Chem.BondType.values[data.edge_attr[edge_idx, 0].item()] 
+
+        bond_type = Chem.BondType.values[data.edge_attr[edge_idx, 0].item()]
         mol.AddBond(i, j, bond_type)
 
         # Set stereochemistry.
-        stereo = Chem.rdchem.BondStereo.values[data.edge_attr[edge_idx, 1].item()]
+        stereo = Chem.rdchem.BondStereo.values[data.edge_attr[edge_idx,
+                                                              1].item()]
         if stereo != Chem.rdchem.BondStereo.STEREONONE:
             db = mol.GetBondBetweenAtoms(i, j)
             db.SetStereoAtoms(j, i)
             db.SetStereo(stereo)
 
-            
         # Set conjugation.
-        mol.GetBondBetweenAtoms(i, j).SetIsConjugated(
-            data.edge_attr[edge_idx, 2].item())
+        mol.GetBondBetweenAtoms(i, j).SetIsConjugated(data.edge_attr[edge_idx,
+                                                                     2].item())
 
         visited.add(tuple(sorted(edges[edge_idx])))
 

--- a/torch_geometric/utils/smiles.py
+++ b/torch_geometric/utils/smiles.py
@@ -1,9 +1,8 @@
+from typing import Any
+
 import torch
-from rdkit import Chem, RDLogger
 
-from torch_geometric.data import Data
-
-RDLogger.DisableLog('rdApp.*')
+import torch_geometric
 
 x_map = {
     'atomic_num':
@@ -43,11 +42,28 @@ x_map = {
 
 e_map = {
     'bond_type': [
-        'UNSPECIFIED', 'SINGLE', 'DOUBLE', 'TRIPLE', 'QUADRUPLE', 'QUINTUPLE',
-        'HEXTUPLE', 'ONEANDAHALF', 'TWOANDAHALF', 'THREEANDAHALF',
-        'FOURANDAHALF', 'FIVEANDAHALF', 'AROMATIC', 'IONIC', 'HYDROGEN',
-        'THREECENTER', 'DATIVEONE', 'DATIVE', 'DATIVEL', 'DATIVER', 'OTHER',
-        'ZERO'
+        'UNSPECIFIED',
+        'SINGLE',
+        'DOUBLE',
+        'TRIPLE',
+        'QUADRUPLE',
+        'QUINTUPLE',
+        'HEXTUPLE',
+        'ONEANDAHALF',
+        'TWOANDAHALF',
+        'THREEANDAHALF',
+        'FOURANDAHALF',
+        'FIVEANDAHALF',
+        'AROMATIC',
+        'IONIC',
+        'HYDROGEN',
+        'THREECENTER',
+        'DATIVEONE',
+        'DATIVE',
+        'DATIVEL',
+        'DATIVER',
+        'OTHER',
+        'ZERO',
     ],
     'stereo': [
         'STEREONONE',
@@ -62,7 +78,7 @@ e_map = {
 
 
 def from_smiles(smiles: str, with_hydrogen: bool = False,
-                kekulize: bool = False):
+                kekulize: bool = False) -> 'torch_geometric.data.Data':
     r"""Converts a SMILES string to a :class:`torch_geometric.data.Data`
     instance.
 
@@ -73,6 +89,11 @@ def from_smiles(smiles: str, with_hydrogen: bool = False,
         kekulize (bool, optional): If set to :obj:`True`, converts aromatic
             bonds to single/double bonds. (default: :obj:`False`)
     """
+    from rdkit import Chem, RDLogger
+
+    from torch_geometric.data import Data
+
+    RDLogger.DisableLog('rdApp.*')
 
     mol = Chem.MolFromSmiles(smiles)
 
@@ -124,7 +145,8 @@ def from_smiles(smiles: str, with_hydrogen: bool = False,
     return Data(x=x, edge_index=edge_index, edge_attr=edge_attr, smiles=smiles)
 
 
-def to_smiles(data, kekulize: bool = False):
+def to_smiles(data: 'torch_geometric.data.Data',
+              kekulize: bool = False) -> Any:
     """Converts a :class:`torch_geometric.data.Data` instance to a SMILES
     string.
 
@@ -133,6 +155,7 @@ def to_smiles(data, kekulize: bool = False):
         kekulize (bool, optional): If set to :obj:`True`, converts aromatic
             bonds to single/double bonds. (default: :obj:`False`)
     """
+    from rdkit import Chem
 
     mol = Chem.RWMol()
 
@@ -151,27 +174,26 @@ def to_smiles(data, kekulize: bool = False):
     edges = [tuple(i) for i in data.edge_index.t().tolist()]
     visited = set()
 
-    for edge_idx in range(len(edges)):
-        i, j = edges[edge_idx]
-        if tuple(sorted(edges[edge_idx])) in visited:
+    for i in range(len(edges)):
+        src, dst = edges[i]
+        if tuple(sorted(edges[i])) in visited:
             continue
 
-        bond_type = Chem.BondType.values[data.edge_attr[edge_idx, 0].item()]
-        mol.AddBond(i, j, bond_type)
+        bond_type = Chem.BondType.values[data.edge_attr[i, 0].item()]
+        mol.AddBond(src, dst, bond_type)
 
-        # Set stereochemistry.
-        stereo = Chem.rdchem.BondStereo.values[data.edge_attr[edge_idx,
-                                                              1].item()]
+        # Set stereochemistry:
+        stereo = Chem.rdchem.BondStereo.values[data.edge_attr[i, 1].item()]
         if stereo != Chem.rdchem.BondStereo.STEREONONE:
-            db = mol.GetBondBetweenAtoms(i, j)
-            db.SetStereoAtoms(j, i)
+            db = mol.GetBondBetweenAtoms(src, dst)
+            db.SetStereoAtoms(dst, src)
             db.SetStereo(stereo)
 
-        # Set conjugation.
-        mol.GetBondBetweenAtoms(i, j).SetIsConjugated(data.edge_attr[edge_idx,
-                                                                     2].item())
+        # Set conjugation:
+        is_conjugated = bool(data.edge_attr[i, 2].item())
+        mol.GetBondBetweenAtoms(src, dst).SetIsConjugated(is_conjugated)
 
-        visited.add(tuple(sorted(edges[edge_idx])))
+        visited.add(tuple(sorted(edges[i])))
 
     mol = mol.GetMol()
 


### PR DESCRIPTION
This PR:

- Adds a PyG Graph `to_smiles` function based on the `from_smiles` function.
- Adds further options to `x_map` and `e_map` to match RDkit's map indices
- Fixes kekulize in the `from_smiles` function
- Adds test to check `from_smiles` and `to_smiles` are consistent