### PR TITLE
Move `HeteroData` type warnings to `to_hetero()`

### DIFF
--- a/test/data/test_hetero_data.py
+++ b/test/data/test_hetero_data.py
@@ -422,9 +422,6 @@ def test_hetero_data_to_canonical():
 
 def test_hetero_data_invalid_names():
     data = HeteroData()
-    with pytest.warns(UserWarning, match="letters, numbers and underscores"):
-        data['my test'].x = torch.randn(10, 16)
-    assert data.node_types == ['my test']
     with pytest.warns(UserWarning, match="single underscores"):
         data['my test', 'a__b', 'my test'].edge_attr = torch.randn(10, 16)
     assert data.edge_types == [('my test', 'a__b', 'my test')]

--- a/test/nn/test_to_hetero_transformer.py
+++ b/test/nn/test_to_hetero_transformer.py
@@ -455,3 +455,11 @@ def test_hetero_transformer_self_loop_error():
     with pytest.raises(ValueError, match="incorrect message passing"):
         to_hetero(ModelLoops(), metadata=(['a', 'b'], [('a', 'to', 'b'),
                                                        ('b', 'to', 'a')]))
+
+
+def test_to_hetero_validate():
+    model = Net1()
+    metadata = (['my test'], [('my test', 'rel', 'my test')])
+
+    with pytest.warns(UserWarning, match="letters, numbers and underscores"):
+        model = to_hetero(model, metadata, debug=False)

--- a/test/nn/test_to_hetero_with_bases_transformer.py
+++ b/test/nn/test_to_hetero_with_bases_transformer.py
@@ -1,5 +1,6 @@
 from typing import Tuple
 
+import pytest
 import torch
 from torch import Tensor
 from torch.nn import Linear, ReLU, Sequential
@@ -281,3 +282,11 @@ def test_to_hetero_with_bases_and_rgcn_equal_output():
     out3 = model(x_dict, adj_t_dict)
     out3 = torch.cat([out3['paper'], out3['author']], dim=0)
     assert torch.allclose(out1, out3, atol=1e-6)
+
+
+def test_to_hetero_with_bases_validate():
+    model = Net1()
+    metadata = (['my test'], [('my test', 'rel', 'my test')])
+
+    with pytest.warns(UserWarning, match="letters, numbers and underscores"):
+        model = to_hetero_with_bases(model, metadata, num_bases=4, debug=False)

--- a/torch_geometric/data/hetero_data.py
+++ b/torch_geometric/data/hetero_data.py
@@ -481,9 +481,9 @@ class HeteroData(BaseData, FeatureStore, GraphStore):
     def _check_type_name(self, name: str):
         if '__' in name:
             warnings.warn(f"The type '{name}' contains double underscores "
-                          f"('__') which might lead to unexpected behavior "
-                          f"down the line. To avoid any issues, ensure that "
-                          f"your type only contains single underscores.")
+                          f"('__') which may lead to unexpected behaviour. "
+                          f"To avoid any issues, ensure that your type names "
+                          f"only contain single underscores.")
 
     def get_node_store(self, key: NodeType) -> NodeStorage:
         r"""Gets the :class:`~torch_geometric.data.storage.NodeStorage` object

--- a/torch_geometric/data/hetero_data.py
+++ b/torch_geometric/data/hetero_data.py
@@ -479,12 +479,7 @@ class HeteroData(BaseData, FeatureStore, GraphStore):
         return mapping
 
     def _check_type_name(self, name: str):
-        if not name.isidentifier() and not name.isdigit():
-            warnings.warn(f"The type '{name}' contains invalid characters "
-                          f"which might lead to unexpected behavior down the "
-                          f"line. To avoid any issues, ensure that your type "
-                          f"only contains letters, numbers and underscores.")
-        elif '__' in name:
+        if '__' in name:
             warnings.warn(f"The type '{name}' contains double underscores "
                           f"('__') which might lead to unexpected behavior "
                           f"down the line. To avoid any issues, ensure that "

--- a/torch_geometric/nn/to_hetero_transformer.py
+++ b/torch_geometric/nn/to_hetero_transformer.py
@@ -141,7 +141,16 @@ class ToHeteroTransformer(Transformer):
     ):
         super().__init__(module, input_map, debug)
 
-        unused_node_types = get_unused_node_types(*metadata)
+        self.metadata = metadata
+        self.aggr = aggr
+        assert len(metadata) == 2
+        assert len(metadata[0]) > 0 and len(metadata[1]) > 0
+        assert aggr in self.aggrs.keys()
+
+        self.validate()
+
+    def validate(self):
+        unused_node_types = get_unused_node_types(*self.metadata)
         if len(unused_node_types) > 0:
             warnings.warn(
                 f"There exist node types ({unused_node_types}) whose "
@@ -149,11 +158,14 @@ class ToHeteroTransformer(Transformer):
                 f"as they do not occur as destination type in any edge type. "
                 f"This may lead to unexpected behaviour.")
 
-        self.metadata = metadata
-        self.aggr = aggr
-        assert len(metadata) == 2
-        assert len(metadata[0]) > 0 and len(metadata[1]) > 0
-        assert aggr in self.aggrs.keys()
+        names = self.metadata[0] + [rel for _, rel, _ in self.metadata[1]]
+        for name in names:
+            if not name.isidentifier():
+                warnings.warn(
+                    f"The type '{name}' contains invalid characters which "
+                    f"might lead to unexpected behaviour. To avoid any issues "
+                    f", ensure that your types only contain letters, numbers, "
+                    f"and single underscores.")
 
     def placeholder(self, node: Node, target: Any, name: str):
         # Adds a `get` call to the input dictionary for every node-type or

--- a/torch_geometric/nn/to_hetero_transformer.py
+++ b/torch_geometric/nn/to_hetero_transformer.py
@@ -165,7 +165,7 @@ class ToHeteroTransformer(Transformer):
                     f"The type '{name}' contains invalid characters which "
                     f"may lead to unexpected behaviour. To avoid any issues, "
                     f"ensure that your types only contain letters, numbers "
-                    f"and single underscores.")
+                    f"and underscores.")
 
     def placeholder(self, node: Node, target: Any, name: str):
         # Adds a `get` call to the input dictionary for every node-type or

--- a/torch_geometric/nn/to_hetero_transformer.py
+++ b/torch_geometric/nn/to_hetero_transformer.py
@@ -163,8 +163,8 @@ class ToHeteroTransformer(Transformer):
             if not name.isidentifier():
                 warnings.warn(
                     f"The type '{name}' contains invalid characters which "
-                    f"might lead to unexpected behaviour. To avoid any issues "
-                    f", ensure that your types only contain letters, numbers, "
+                    f"may lead to unexpected behaviour. To avoid any issues, "
+                    f"ensure that your types only contain letters, numbers "
                     f"and single underscores.")
 
     def placeholder(self, node: Node, target: Any, name: str):

--- a/torch_geometric/nn/to_hetero_with_bases_transformer.py
+++ b/torch_geometric/nn/to_hetero_with_bases_transformer.py
@@ -174,7 +174,7 @@ class ToHeteroWithBasesTransformer(Transformer):
                     f"The type '{name}' contains invalid characters which "
                     f"may lead to unexpected behaviour. To avoid any issues, "
                     f"ensure that your types only contain letters, numbers "
-                    f"and single underscores.")
+                    f"and underscores.")
 
     def transform(self) -> GraphModule:
         self._node_offset_dict_initialized = False

--- a/torch_geometric/nn/to_hetero_with_bases_transformer.py
+++ b/torch_geometric/nn/to_hetero_with_bases_transformer.py
@@ -172,8 +172,8 @@ class ToHeteroWithBasesTransformer(Transformer):
             if not name.isidentifier():
                 warnings.warn(
                     f"The type '{name}' contains invalid characters which "
-                    f"might lead to unexpected behaviour. To avoid any issues "
-                    f", ensure that your types only contain letters, numbers, "
+                    f"may lead to unexpected behaviour. To avoid any issues, "
+                    f"ensure that your types only contain letters, numbers "
                     f"and single underscores.")
 
     def transform(self) -> GraphModule:

--- a/torch_geometric/nn/to_hetero_with_bases_transformer.py
+++ b/torch_geometric/nn/to_hetero_with_bases_transformer.py
@@ -146,7 +146,20 @@ class ToHeteroWithBasesTransformer(Transformer):
     ):
         super().__init__(module, input_map, debug)
 
-        unused_node_types = get_unused_node_types(*metadata)
+        self.metadata = metadata
+        self.num_bases = num_bases
+        self.in_channels = in_channels or {}
+        assert len(metadata) == 2
+        assert len(metadata[0]) > 0 and len(metadata[1]) > 0
+
+        self.validate()
+
+        # Compute IDs for each node and edge type:
+        self.node_type2id = {k: i for i, k in enumerate(metadata[0])}
+        self.edge_type2id = {k: i for i, k in enumerate(metadata[1])}
+
+    def validate(self):
+        unused_node_types = get_unused_node_types(*self.metadata)
         if len(unused_node_types) > 0:
             warnings.warn(
                 f"There exist node types ({unused_node_types}) whose "
@@ -154,15 +167,14 @@ class ToHeteroWithBasesTransformer(Transformer):
                 f"as they do not occur as destination type in any edge type. "
                 f"This may lead to unexpected behaviour.")
 
-        self.metadata = metadata
-        self.num_bases = num_bases
-        self.in_channels = in_channels or {}
-        assert len(metadata) == 2
-        assert len(metadata[0]) > 0 and len(metadata[1]) > 0
-
-        # Compute IDs for each node and edge type:
-        self.node_type2id = {k: i for i, k in enumerate(metadata[0])}
-        self.edge_type2id = {k: i for i, k in enumerate(metadata[1])}
+        names = self.metadata[0] + [rel for _, rel, _ in self.metadata[1]]
+        for name in names:
+            if not name.isidentifier():
+                warnings.warn(
+                    f"The type '{name}' contains invalid characters which "
+                    f"might lead to unexpected behaviour. To avoid any issues "
+                    f", ensure that your types only contain letters, numbers, "
+                    f"and single underscores.")
 
     def transform(self) -> GraphModule:
         self._node_offset_dict_initialized = False


### PR DESCRIPTION
The current warnings are too restrictive for `HeteroData` as they are only needed for `to_hetero()`.