### PR TITLE
Add connection type in `LargestConnectedComponents` transform

### DIFF
--- a/torch_geometric/transforms/largest_connected_components.py
+++ b/torch_geometric/transforms/largest_connected_components.py
@@ -15,9 +15,18 @@ class LargestConnectedComponents(BaseTransform):
     Args:
         num_components (int, optional): Number of largest components to keep
             (default: :obj:`1`)
+        connection (str, optional): Type of connection to use for directed
+            graphs, can be either :obj:`'strong'` or :obj:`'weak'`.
+            Nodes `i` and `j` are strongly connected if a path
+            exists both from `i` to `j` and from `j` to `i`. A directed graph
+            is weakly connected if replacing all of its directed edges with
+            undirected edges produces a connected (undirected) graph.
+            (default: :obj:`'weak'`)
     """
-    def __init__(self, num_components: int = 1):
+    def __init__(self, num_components: int = 1, connection: str = 'weak'):
+        assert connection in ['strong', 'weak'], 'Unknown connection type'
         self.num_components = num_components
+        self.connection = connection
 
     def __call__(self, data: Data) -> Data:
         import numpy as np
@@ -25,7 +34,7 @@ class LargestConnectedComponents(BaseTransform):
 
         adj = to_scipy_sparse_matrix(data.edge_index, num_nodes=data.num_nodes)
 
-        num_components, component = sp.csgraph.connected_components(adj)
+        num_components, component = sp.csgraph.connected_components(adj, connection=self.connection)
 
         if num_components <= self.num_components:
             return data

--- a/torch_geometric/transforms/largest_connected_components.py
+++ b/torch_geometric/transforms/largest_connected_components.py
@@ -34,7 +34,8 @@ class LargestConnectedComponents(BaseTransform):
 
         adj = to_scipy_sparse_matrix(data.edge_index, num_nodes=data.num_nodes)
 
-        num_components, component = sp.csgraph.connected_components(adj, connection=self.connection)
+        num_components, component = sp.csgraph.connected_components(
+            adj, connection=self.connection)
 
         if num_components <= self.num_components:
             return data


### PR DESCRIPTION
Add option to choose connection type in `LargestConnectedComponents` transform. The type of connection is relevant in the case of directed graphs.