### PR TITLE
Link prediction explanation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Added `BaseStorage.get()` functionality ([#5240](https://github.com/pyg-team/pytorch_geometric/pull/5240))
 - Added a test to confirm that `to_hetero` works with `SparseTensor` ([#5222](https://github.com/pyg-team/pytorch_geometric/pull/5222))
 - Added `torch_geometric.explain` module with base functionality for explainability methods ([#5804](https://github.com/pyg-team/pytorch_geometric/pull/5804))
+- Added support for link prediction in `torch_geometric.explain` module ([#6083](https://github.com/pyg-team/pytorch_geometric/pull/6083))
 ### Changed
 - Moved and adapted `GNNExplainer` from `torch_geometric.nn` to `torch_geometric.explain.algorithm` ([#5967](https://github.com/pyg-team/pytorch_geometric/pull/5967))
 - Optimized scatter implementations for CPU/GPU, both with and without backward computation ([#6051](https://github.com/pyg-team/pytorch_geometric/pull/6051), [#6052](https://github.com/pyg-team/pytorch_geometric/pull/6052))

--- a/examples/gnn_explainer_link_pred.py
+++ b/examples/gnn_explainer_link_pred.py
@@ -1,0 +1,111 @@
+import os.path as osp
+
+import torch
+from sklearn.metrics import roc_auc_score
+
+import torch_geometric.transforms as T
+from torch_geometric.datasets import Planetoid
+from torch_geometric.explain import Explainer, ExplainerConfig, ModelConfig
+from torch_geometric.explain.algorithm import GNNExplainer
+from torch_geometric.nn import GCNConv
+from torch_geometric.utils import negative_sampling
+
+dataset = 'Cora'
+path = osp.join(osp.dirname(osp.realpath(__file__)), '..', 'data', 'Planetoid')
+device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
+transform = T.Compose([
+    T.NormalizeFeatures(),
+    T.ToDevice(device),
+    T.RandomLinkSplit(num_val=0.05, num_test=0.1, is_undirected=True,
+                      add_negative_train_samples=False),
+])
+dataset = Planetoid(path, dataset, transform=transform)
+# After applying the `RandomLinkSplit` transform, the data is transformed from
+# a data object to a list of tuples (train_data, val_data, test_data), with
+# each element representing the corresponding split.
+train_data, val_data, test_data = dataset[0]
+
+
+class Net(torch.nn.Module):
+    def __init__(self, in_channels, hidden_channels, out_channels):
+        super().__init__()
+        self.conv1 = GCNConv(in_channels, hidden_channels)
+        self.conv2 = GCNConv(hidden_channels, out_channels)
+
+    def encode(self, x, edge_index):
+        x = self.conv1(x, edge_index).relu()
+        return self.conv2(x, edge_index)
+
+    def decode(self, z, edge_label_index):
+        return (z[edge_label_index[0]] * z[edge_label_index[1]]).sum(dim=-1)
+
+    def decode_all(self, z):
+        prob_adj = z @ z.t()
+        return (prob_adj > 0).nonzero(as_tuple=False).t()
+
+    def forward(self, x, edge_index, edge_label_index):
+        z = model.encode(x, edge_index)
+        return model.decode(z, edge_label_index).view(-1)
+
+
+model = Net(dataset.num_features, 128, 64).to(device)
+optimizer = torch.optim.Adam(params=model.parameters(), lr=0.01)
+criterion = torch.nn.BCEWithLogitsLoss()
+
+
+def train():
+    model.train()
+    optimizer.zero_grad()
+
+    # We perform a new round of negative sampling for every training epoch:
+    neg_edge_index = negative_sampling(
+        edge_index=train_data.edge_index, num_nodes=train_data.num_nodes,
+        num_neg_samples=train_data.edge_label_index.size(1), method='sparse')
+
+    edge_label_index = torch.cat(
+        [train_data.edge_label_index, neg_edge_index],
+        dim=-1,
+    )
+    edge_label = torch.cat([
+        train_data.edge_label,
+        train_data.edge_label.new_zeros(neg_edge_index.size(1))
+    ], dim=0)
+
+    out = model(train_data.x, train_data.edge_index, edge_label_index)
+    loss = criterion(out, edge_label)
+    loss.backward()
+    optimizer.step()
+    return loss
+
+
+@torch.no_grad()
+def test(data):
+    model.eval()
+    out = model(data.x, data.edge_index, data.edge_label_index).sigmoid()
+    return roc_auc_score(data.edge_label.cpu().numpy(), out.cpu().numpy())
+
+
+best_val_auc = final_test_auc = 0
+for epoch in range(1, 11):
+    loss = train()
+    val_auc = test(val_data)
+    test_auc = test(test_data)
+    if val_auc > best_val_auc:
+        best_val_auc = val_auc
+        final_test_auc = test_auc
+    print(f'Epoch: {epoch:03d}, Loss: {loss:.4f}, Val: {val_auc:.4f}, '
+          f'Test: {test_auc:.4f}')
+
+print(f'Final Test: {final_test_auc:.4f}')
+
+explainer = Explainer(
+    model=model, algorithm=GNNExplainer(epochs=200),
+    explainer_config=ExplainerConfig(explanation_type="model",
+                                     node_mask_type="attributes",
+                                     edge_mask_type="object"),
+    model_config=ModelConfig(mode="classification", task_level="edge",
+                             return_type="raw"))
+edge_idx = val_data.edge_label_index[:, 0]
+explanation = explainer(x=train_data.x, edge_index=train_data.edge_index,
+                        index=edge_idx, target_index=None)
+print(explanation.available_explanations)

--- a/torch_geometric/explain/algorithm/base.py
+++ b/torch_geometric/explain/algorithm/base.py
@@ -50,6 +50,7 @@ class ExplainerAlgorithm(torch.nn.Module):
             **kwargs (optional): Additional keyword arguments passed to
                 :obj:`model`.
         """
+        pass
 
     @abstractmethod
     def loss(self, y_hat: Tensor, y: Tensor, **kwargs) -> Tensor:
@@ -60,6 +61,7 @@ class ExplainerAlgorithm(torch.nn.Module):
                 (*e.g.*, the forward pass of the model with the mask applied).
             y (torch.Tensor): the reference output.
         """
+        pass
 
     @abstractmethod
     def supports(

--- a/torch_geometric/explain/config.py
+++ b/torch_geometric/explain/config.py
@@ -175,7 +175,7 @@ class ThresholdConfig(CastMixin):
                   The top obj:`value` elements of each mask are kept, the
                   others are set to :obj:`0`.
 
-                - :obj:`"topk_hard"`: Aame as :obj:`"topk"` but values are set
+                - :obj:`"topk_hard"`: Same as :obj:`"topk"` but values are set
                   to :obj:`1` for all elements which are kept.
 
         value (int or float, optional): The value to use when thresholding.


### PR DESCRIPTION
Closes https://github.com/pyg-team/pytorch_geometric/issues/5925

_This is still a draft, but I would be happy to get early feedback from reviewers._ 

**Done:**
 - evolution of `Explainer` to adapt link prediction model output to match format of node prediction output
 - minor changes in `GNNExplainer` to support link `"edge"` as `task_level`
 - example script `gnn_explainer_link_pred.py` training a link prediction model and getting the explanation for one output

The implemented solution has the **advantage** of requiring very minor changes to the explainer for it to support link prediction tasks.
The main **drawback** is that it kind of "tricks" the explainer into believing it is explaining a node classification task (the model output and index are transformed before being sent to the explainer).

**TODO:**
 - support `batch` explanations (I will probably wait for it to be supported for other tasks: https://github.com/pyg-team/pytorch_geometric/pull/5967#pullrequestreview-1191390904)
 - restrict the computation to the two nodes of interest and their computation graph 
   https://github.com/pyg-team/pytorch_geometric/blob/b3d4b83a615bdd10618f10ba90951a8917e1c241/torch_geometric/explain/algorithm/gnn_explainer.py#L131
 - add tests
