### PR TITLE
Added `torch_geometric.optional_validation` context-manager 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ## [2.3.0] - 2023-MM-DD
 ### Added
+- Added `torch_geometric.optional_validation` method that creates context-manager for managing optional validation ([#6100](https://github.com/pyg-team/pytorch_geometric/pull/6100))
 - Added `summary` for PyG/PyTorch models ([#5859](https://github.com/pyg-team/pytorch_geometric/pull/5859), [#6161](https://github.com/pyg-team/pytorch_geometric/pull/6161))
 - Started adding `torch.sparse` support to PyG ([#5906](https://github.com/pyg-team/pytorch_geometric/pull/5906), [#5944](https://github.com/pyg-team/pytorch_geometric/pull/5944), [#6003](https://github.com/pyg-team/pytorch_geometric/pull/6003), [#6033](https://github.com/pyg-team/pytorch_geometric/pull/6033))
 - Add inputs_channels back in training benchmark ([#6154](https://github.com/pyg-team/pytorch_geometric/pull/6154))
@@ -21,7 +22,6 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ## [2.2.0] - 2022-12-01
 ### Added
-- Added `torch_geometric.optional_validation` method that creates context-manager for managing optional validation ([#6100](https://github.com/pyg-team/pytorch_geometric/pull/6100))
 - Extended `GNNExplainer` to support edge level explanations ([#6056](https://github.com/pyg-team/pytorch_geometric/pull/6056))
 - Added CPU affinitization for `NodeLoader` ([#6005](https://github.com/pyg-team/pytorch_geometric/pull/6005))
 - Added triplet sampling in `LinkNeighborLoader` ([#6004](https://github.com/pyg-team/pytorch_geometric/pull/6004))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ## [2.2.0] - 2022-12-01
 ### Added
-- Added `Aggregation.validation_context` method that creates context-manager for managing the validation of aggregation layers ([]())
+- Added `Aggregation.validation_context` method that creates context-manager for managing the validation of aggregation layers ([#6100](https://github.com/pyg-team/pytorch_geometric/pull/6100))
 - Extended `GNNExplainer` to support edge level explanations ([#6056](https://github.com/pyg-team/pytorch_geometric/pull/6056))
 - Added CPU affinitization for `NodeLoader` ([#6005](https://github.com/pyg-team/pytorch_geometric/pull/6005))
 - Added triplet sampling in `LinkNeighborLoader` ([#6004](https://github.com/pyg-team/pytorch_geometric/pull/6004))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ## [2.3.0] - 2023-MM-DD
 ### Added
-- Added `torch_geometric.optional_validation` method that creates context-manager for managing optional validation ([#6100](https://github.com/pyg-team/pytorch_geometric/pull/6100))
+- Added `torch_geometric.validate` method that creates context-manager for managing optional validation ([#6100](https://github.com/pyg-team/pytorch_geometric/pull/6100))
 - Added `summary` for PyG/PyTorch models ([#5859](https://github.com/pyg-team/pytorch_geometric/pull/5859), [#6161](https://github.com/pyg-team/pytorch_geometric/pull/6161))
 - Started adding `torch.sparse` support to PyG ([#5906](https://github.com/pyg-team/pytorch_geometric/pull/5906), [#5944](https://github.com/pyg-team/pytorch_geometric/pull/5944), [#6003](https://github.com/pyg-team/pytorch_geometric/pull/6003), [#6033](https://github.com/pyg-team/pytorch_geometric/pull/6033))
 - Add inputs_channels back in training benchmark ([#6154](https://github.com/pyg-team/pytorch_geometric/pull/6154))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ## [2.2.0] - 2022-12-01
 ### Added
+- Added `Aggregation.validation_context` method that creates context-manager for managing the validation of aggregation layers ([]())
 - Extended `GNNExplainer` to support edge level explanations ([#6056](https://github.com/pyg-team/pytorch_geometric/pull/6056))
 - Added CPU affinitization for `NodeLoader` ([#6005](https://github.com/pyg-team/pytorch_geometric/pull/6005))
 - Added triplet sampling in `LinkNeighborLoader` ([#6004](https://github.com/pyg-team/pytorch_geometric/pull/6004))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ## [2.2.0] - 2022-12-01
 ### Added
-- Added `Aggregation.validation_context` method that creates context-manager for managing the validation of aggregation layers ([#6100](https://github.com/pyg-team/pytorch_geometric/pull/6100))
+- Added `torch_geometric.optional_validation` method that creates context-manager for managing optional validation ([#6100](https://github.com/pyg-team/pytorch_geometric/pull/6100))
 - Extended `GNNExplainer` to support edge level explanations ([#6056](https://github.com/pyg-team/pytorch_geometric/pull/6056))
 - Added CPU affinitization for `NodeLoader` ([#6005](https://github.com/pyg-team/pytorch_geometric/pull/6005))
 - Added triplet sampling in `LinkNeighborLoader` ([#6004](https://github.com/pyg-team/pytorch_geometric/pull/6004))

--- a/test/nn/aggr/test_basic.py
+++ b/test/nn/aggr/test_basic.py
@@ -30,16 +30,6 @@ def test_validate():
     with pytest.raises(ValueError, match="invalid 'dim_size'"):
         aggr(x, index, dim_size=2)
 
-    aggr.set_validate_args(False)
-    assert not aggr.validate()
-    with pytest.raises(RuntimeError, match="out of bounds"):
-        aggr(x, index, dim_size=2)
-
-    with aggr.validation_context(True):
-        assert aggr.validate()
-
-    assert not aggr.validate()
-
 
 @pytest.mark.parametrize('Aggregation', [
     MeanAggregation,

--- a/test/nn/aggr/test_basic.py
+++ b/test/nn/aggr/test_basic.py
@@ -31,8 +31,14 @@ def test_validate():
         aggr(x, index, dim_size=2)
 
     aggr.set_validate_args(False)
+    assert not aggr.validate()
     with pytest.raises(RuntimeError, match="out of bounds"):
         aggr(x, index, dim_size=2)
+
+    with aggr.validation_context(True):
+        assert aggr.validate()
+
+    assert not aggr.validate()
 
 
 @pytest.mark.parametrize('Aggregation', [

--- a/test/test_validate.py
+++ b/test/test_validate.py
@@ -6,10 +6,14 @@ from torch_geometric import (
 
 
 def test_validate():
-    set_validation(False)
-    assert not is_validation_enabled()
+    try:
+        prev = is_validation_enabled()
+        set_validation(False)
+        assert not is_validation_enabled()
 
-    with optional_validation(True):
-        assert is_validation_enabled()
+        with optional_validation(True):
+            assert is_validation_enabled()
 
-    assert not is_validation_enabled()
+        assert not is_validation_enabled()
+    finally:
+        set_validation(prev)

--- a/test/test_validate.py
+++ b/test/test_validate.py
@@ -1,8 +1,4 @@
-from torch_geometric import (
-    is_validation_enabled,
-    optional_validation,
-    set_validation,
-)
+from torch_geometric import is_validation_enabled, set_validation, validate
 
 
 def test_validate():
@@ -11,7 +7,7 @@ def test_validate():
         set_validation(False)
         assert not is_validation_enabled()
 
-        with optional_validation(True):
+        with validate(True):
             assert is_validation_enabled()
 
         assert not is_validation_enabled()

--- a/test/test_validate.py
+++ b/test/test_validate.py
@@ -1,0 +1,15 @@
+from torch_geometric import (
+    is_validation_enabled,
+    optional_validation,
+    set_validation,
+)
+
+
+def test_validate():
+    set_validation(False)
+    assert not is_validation_enabled()
+
+    with optional_validation(True):
+        assert is_validation_enabled()
+
+    assert not is_validation_enabled()

--- a/torch_geometric/__init__.py
+++ b/torch_geometric/__init__.py
@@ -17,8 +17,6 @@ from .validate import (is_validation_enabled, optional_validation,
                        set_validation)
 from .lazy_loader import LazyLoader
 
-
-
 graphgym = LazyLoader('graphgym', globals(), 'torch_geometric.graphgym')
 
 __version__ = '2.2.0'

--- a/torch_geometric/__init__.py
+++ b/torch_geometric/__init__.py
@@ -13,7 +13,11 @@ from .home import get_home_dir, set_home_dir
 from .debug import is_debug_enabled, debug, set_debug
 from .experimental import (is_experimental_mode_enabled, experimental_mode,
                            set_experimental_mode)
+from .validate import (is_validation_enabled, optional_validation,
+                       set_validation)
 from .lazy_loader import LazyLoader
+
+
 
 graphgym = LazyLoader('graphgym', globals(), 'torch_geometric.graphgym')
 
@@ -29,6 +33,9 @@ __all__ = [
     'is_experimental_mode_enabled',
     'experimental_mode',
     'set_experimental_mode',
+    'is_validation_enabled',
+    'optional_validation',
+    'set_validation',
     'torch_geometric',
     '__version__',
 ]

--- a/torch_geometric/__init__.py
+++ b/torch_geometric/__init__.py
@@ -13,8 +13,7 @@ from .home import get_home_dir, set_home_dir
 from .debug import is_debug_enabled, debug, set_debug
 from .experimental import (is_experimental_mode_enabled, experimental_mode,
                            set_experimental_mode)
-from .validate import (is_validation_enabled, optional_validation,
-                       set_validation)
+from .validate import is_validation_enabled, set_validation, validate
 from .lazy_loader import LazyLoader
 
 graphgym = LazyLoader('graphgym', globals(), 'torch_geometric.graphgym')
@@ -32,8 +31,8 @@ __all__ = [
     'experimental_mode',
     'set_experimental_mode',
     'is_validation_enabled',
-    'optional_validation',
     'set_validation',
+    'validate',
     'torch_geometric',
     '__version__',
 ]

--- a/torch_geometric/nn/aggr/base.py
+++ b/torch_geometric/nn/aggr/base.py
@@ -1,4 +1,3 @@
-from contextlib import contextmanager
 from typing import Optional, Tuple
 
 import torch
@@ -59,7 +58,6 @@ class Aggregation(torch.nn.Module):
         - **output:** graph features :math:`(|\mathcal{G}|, F_{out})` or node
           features :math:`(|\mathcal{V}|, F_{out})`
     """
-    _validate = __debug__
 
     # @abstractmethod
     def forward(self, x: Tensor, index: Optional[Tensor] = None,
@@ -86,48 +84,9 @@ class Aggregation(torch.nn.Module):
     def reset_parameters(self):
         pass
 
-    @staticmethod
-    def validate() -> bool:
-        r"""Returns :obj:`True` if validation is enabled"""
-        return Aggregation._validate
-
-    @staticmethod
-    def set_validate_args(value: bool):
-        r"""Sets whether validation is enabled or disabled.
-
-        The default behavior mimics Python's :obj:`assert`` statement:
-        validation is on by default, but is disabled if Python is run in
-        optimized mode (via :obj:`python -O`).
-        Validation may be expensive, so you may want to disable it once a model
-        is working.
-
-        Args:
-            value (bool): Whether to enable validation.
-        """
-        Aggregation._validate = value
-
-    @staticmethod
-    @contextmanager
-    def validation_context(value: bool):
-        r"""Creates a context-manager for managing the validation of
-        Aggregation layers.
-
-        Example:
-
-            >>> with Aggregation.validate(False):
-            ...     out = model(data.x, data.edge_index)
-        """
-        try:
-            prev = Aggregation.validate()
-            Aggregation.set_validate_args(value)
-            yield
-        finally:
-            Aggregation.set_validate_args(prev)
-
     def __call__(self, x: Tensor, index: Optional[Tensor] = None,
                  ptr: Optional[Tensor] = None, dim_size: Optional[int] = None,
                  dim: int = -2, **kwargs) -> Tensor:
-
         if dim >= x.dim() or dim < -x.dim():
             raise ValueError(f"Encountered invalid dimension '{dim}' of "
                              f"source tensor with {x.dim()} dimensions")
@@ -146,7 +105,7 @@ class Aggregation(torch.nn.Module):
         if index is not None:
             if dim_size is None:
                 dim_size = int(index.max()) + 1 if index.numel() > 0 else 0
-            elif self._validate:
+            elif is_validation_enabled():
                 if index.numel() > 0 and dim_size <= int(index.max()):
                     raise ValueError(f"Encountered invalid 'dim_size' (got "
                                      f"'{dim_size}' but expected "
@@ -214,3 +173,9 @@ def expand_left(ptr: Tensor, dim: int, dims: int) -> Tensor:
     for _ in range(dims + dim if dim < 0 else dim):
         ptr = ptr.unsqueeze(0)
     return ptr
+
+
+def is_validation_enabled() -> bool:
+    from torch_geometric import is_validation_enabled
+
+    return is_validation_enabled()

--- a/torch_geometric/nn/aggr/base.py
+++ b/torch_geometric/nn/aggr/base.py
@@ -176,6 +176,7 @@ def expand_left(ptr: Tensor, dim: int, dims: int) -> Tensor:
 
 
 def is_validation_enabled() -> bool:
+    # Lazy-import to avoid circular reference
     from torch_geometric import is_validation_enabled
 
     return is_validation_enabled()

--- a/torch_geometric/nn/aggr/base.py
+++ b/torch_geometric/nn/aggr/base.py
@@ -1,3 +1,4 @@
+from contextlib import contextmanager
 from typing import Optional, Tuple
 
 import torch
@@ -86,6 +87,11 @@ class Aggregation(torch.nn.Module):
         pass
 
     @staticmethod
+    def validate() -> bool:
+        r"""Returns :obj:`True` if validation is enabled"""
+        return Aggregation._validate
+
+    @staticmethod
     def set_validate_args(value: bool):
         r"""Sets whether validation is enabled or disabled.
 
@@ -99,6 +105,24 @@ class Aggregation(torch.nn.Module):
             value (bool): Whether to enable validation.
         """
         Aggregation._validate = value
+
+    @staticmethod
+    @contextmanager
+    def validation_context(value: bool):
+        r"""Creates a context-manager for managing the validation of
+        Aggregation layers.
+
+        Example:
+
+            >>> with Aggregation.validate(False):
+            ...     out = model(data.x, data.edge_index)
+        """
+        try:
+            prev = Aggregation.validate()
+            Aggregation.set_validate_args(value)
+            yield
+        finally:
+            Aggregation.set_validate_args(prev)
 
     def __call__(self, x: Tensor, index: Optional[Tensor] = None,
                  ptr: Optional[Tensor] = None, dim_size: Optional[int] = None,

--- a/torch_geometric/nn/conv/message_passing.py
+++ b/torch_geometric/nn/conv/message_passing.py
@@ -196,9 +196,7 @@ class MessagePassing(torch.nn.Module):
             the_size[1] = edge_index.size(0)
             return the_size
         elif isinstance(edge_index, Tensor):
-            int_dtypes = (torch.uint8, torch.int8, torch.int32, torch.int64)
-
-            if edge_index.dtype not in int_dtypes:
+            if torch.is_floating_point(edge_index):
                 raise ValueError(f"Expected 'edge_index' to be of integer "
                                  f"type (got '{edge_index.dtype}')")
             if edge_index.dim() != 2:

--- a/torch_geometric/validate.py
+++ b/torch_geometric/validate.py
@@ -1,4 +1,5 @@
 from contextlib import contextmanager
+from typing import Generator
 
 __validation__ = {'enabled': __debug__}
 
@@ -24,7 +25,7 @@ def set_validation(value: bool):
 
 
 @contextmanager
-def validate(value: bool):
+def validate(value: bool) -> Generator:
     r"""Creates a context-manager for managing whether any optional validation
     is enabled or disabled within a scope.
 

--- a/torch_geometric/validate.py
+++ b/torch_geometric/validate.py
@@ -24,7 +24,7 @@ def set_validation(value: bool):
 
 
 @contextmanager
-def optional_validation(value: bool):
+def validate(value: bool):
     r"""Creates a context-manager for managing whether any optional validation
     is enabled or disabled within a scope.
 

--- a/torch_geometric/validate.py
+++ b/torch_geometric/validate.py
@@ -1,0 +1,41 @@
+from contextlib import contextmanager
+
+__validation__ = {'enabled': __debug__}
+
+
+def is_validation_enabled() -> bool:
+    r"""Returns :obj:`True` if validation is enabled"""
+    return __validation__['enabled']
+
+
+def set_validation(value: bool):
+    r"""Sets whether optional validation is enabled or disabled.
+
+    The default behavior mimics Python's :obj:`assert`` statement:
+    validation is on by default, but is disabled if Python is run in
+    optimized mode (via :obj:`python -O`).
+    Validation may be expensive, so you may want to disable it once a model
+    is working.
+
+    Args:
+        value (bool): Whether to enable optional validation.
+    """
+    __validation__['enabled'] = value
+
+
+@contextmanager
+def optional_validation(value: bool):
+    r"""Creates a context-manager for managing whether any optional validation
+    is enabled or disabled within a scope.
+
+    Example:
+
+        >>> with torch_geometric.validate(False):
+        ...     out = model(data.x, data.edge_index)
+    """
+    try:
+        prev = is_validation_enabled()
+        set_validation(value)
+        yield
+    finally:
+        set_validation(prev)


### PR DESCRIPTION
This patch extends the feature added in #5290 with:

* `torch_geometric.is_validation_enabled` for querying the current state of the optional validation
* `torch_geometric.set_validation` used to globally toggle the optional validation state
* `torch_geometric.optional_validation` that creates a context manager to toggle the validation state in a scoped manner