### PR TITLE
Fix a typo in comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - [Breaking Change] Moved PyTorch Lightning data modules to `torch_geometric.data.lightning` ([#6140](https://github.com/pyg-team/pytorch_geometric/pull/6140))
 - Make `torch_sparse` an optional dependency ([#6132](https://github.com/pyg-team/pytorch_geometric/pull/6132), [#6134](https://github.com/pyg-team/pytorch_geometric/pull/6134), [#6138](https://github.com/pyg-team/pytorch_geometric/pull/6138), [#6139](https://github.com/pyg-team/pytorch_geometric/pull/6139))
 - Optimized `utils.softmax` implementation ([#6113](https://github.com/pyg-team/pytorch_geometric/pull/6113))
-- Optimized `topk` implementation for large enough graphs ([#6123](https://github.com/pyg-team/pytorch_geometric/pull/6123/))
-- Fixed a typo in the documentation ([#6143](https://github.com/pyg-team/pytorch_geometric/pull/6143/))
+- Optimized `topk` implementation for large enough graphs ([#6123](https://github.com/pyg-team/pytorch_geometric/pull/6123))
 ### Removed
 
 ## [2.2.0] - 2022-12-01

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Make `torch_sparse` an optional dependency ([#6132](https://github.com/pyg-team/pytorch_geometric/pull/6132), [#6134](https://github.com/pyg-team/pytorch_geometric/pull/6134), [#6138](https://github.com/pyg-team/pytorch_geometric/pull/6138), [#6139](https://github.com/pyg-team/pytorch_geometric/pull/6139))
 - Optimized `utils.softmax` implementation ([#6113](https://github.com/pyg-team/pytorch_geometric/pull/6113))
 - Optimized `topk` implementation for large enough graphs ([#6123](https://github.com/pyg-team/pytorch_geometric/pull/6123/))
+- Fixed a typo in the documentation ([#6143](https://github.com/pyg-team/pytorch_geometric/pull/6143/))
 ### Removed
 
 ## [2.2.0] - 2022-12-01

--- a/torch_geometric/explain/config.py
+++ b/torch_geometric/explain/config.py
@@ -175,7 +175,7 @@ class ThresholdConfig(CastMixin):
                   The top obj:`value` elements of each mask are kept, the
                   others are set to :obj:`0`.
 
-                - :obj:`"topk_hard"`: Aame as :obj:`"topk"` but values are set
+                - :obj:`"topk_hard"`: Same as :obj:`"topk"` but values are set
                   to :obj:`1` for all elements which are kept.
 
         value (int or float, optional): The value to use when thresholding.


### PR DESCRIPTION
Fix a typo in comments(will also affect the document) of `ThresholdConfig`  in `torch_geometric/explain/config.py`