### PR TITLE
Integrate `spmm_reduce()` API

### DIFF
--- a/benchmark/utils/utils.py
+++ b/benchmark/utils/utils.py
@@ -37,14 +37,15 @@ def get_dataset(name, root, use_sparse_tensor=False, bf16=False):
     transform = T.ToSparseTensor(
         remove_edge_index=False) if use_sparse_tensor else None
     if name == 'ogbn-mag':
-        if transform is None:
-            transform = T.ToUndirected(merge=True)
-        else:
+        if transform is not None:
             transform = T.Compose([T.ToUndirected(merge=True), transform])
+        else:
+            transform = T.ToUndirected(merge=True)          
         dataset = OGB_MAG(root=path, preprocess='metapath2vec',
                           transform=transform)
     elif name == 'ogbn-products':
-        transform = T.Compose([T.RemoveDuplicateSelfLoops(), transform])
+        if transform is not None: 
+            transform = T.Compose([T.RemoveDuplicateSelfLoops(), transform])
         dataset = PygNodePropPredDataset('ogbn-products', root=path,
                                          transform=transform)
     elif name == 'Reddit':

--- a/benchmark/utils/utils.py
+++ b/benchmark/utils/utils.py
@@ -44,6 +44,7 @@ def get_dataset(name, root, use_sparse_tensor=False, bf16=False):
         dataset = OGB_MAG(root=path, preprocess='metapath2vec',
                           transform=transform)
     elif name == 'ogbn-products':
+        transform = T.Compose([T.RemoveDuplicateSelfLoops(), transform])
         dataset = PygNodePropPredDataset('ogbn-products', root=path,
                                          transform=transform)
     elif name == 'Reddit':

--- a/docs/source/notes/sparse_tensor.rst
+++ b/docs/source/notes/sparse_tensor.rst
@@ -113,7 +113,7 @@ With it, the :class:`~torch_geometric.nn.conv.GINConv` layer can now be implemen
 
 .. code-block:: python
 
-    from torch.sparse.matmul import matmul
+    from torch_geometric.utils.matmul import matmul import matmul
 
     class GINConv(MessagePassing):
         def __init__(self):

--- a/docs/source/notes/sparse_tensor.rst
+++ b/docs/source/notes/sparse_tensor.rst
@@ -113,7 +113,7 @@ With it, the :class:`~torch_geometric.nn.conv.GINConv` layer can now be implemen
 
 .. code-block:: python
 
-    from torch_geometric.utils.matmul import matmul import matmul
+    from torch_geometric.utils.matmul import matmul
 
     class GINConv(MessagePassing):
         def __init__(self):

--- a/docs/source/notes/sparse_tensor.rst
+++ b/docs/source/notes/sparse_tensor.rst
@@ -113,7 +113,7 @@ With it, the :class:`~torch_geometric.nn.conv.GINConv` layer can now be implemen
 
 .. code-block:: python
 
-    from torch_sparse import matmul
+    from torch.sparse.matmul import matmul
 
     class GINConv(MessagePassing):
         def __init__(self):

--- a/test/nn/conv/test_gcn_conv.py
+++ b/test/nn/conv/test_gcn_conv.py
@@ -14,8 +14,8 @@ def test_gcn_conv():
     value = torch.rand(row.size(0))
     adj2 = SparseTensor(row=row, col=col, value=value, sparse_sizes=(4, 4))
     adj1 = adj2.set_value(None)
-    adj3 = adj1.to_torch_sparse_coo_tensor()
-    adj4 = adj2.to_torch_sparse_coo_tensor()
+    adj3 = adj1.to_torch_sparse_csr_tensor()
+    adj4 = adj2.to_torch_sparse_csr_tensor()
 
     conv = GCNConv(16, 32)
     assert conv.__repr__() == 'GCNConv(16, 32)'

--- a/test/nn/conv/test_message_passing.py
+++ b/test/nn/conv/test_message_passing.py
@@ -94,13 +94,6 @@ def test_my_conv():
     conv((x1, x2), torch_adj.t()).sum().backward()
     assert torch_adj.grad is not None
 
-    # Test backward compatibility for `torch.sparse` tensors:
-    conv.fuse = True
-    torch_adj = torch_adj.requires_grad_()
-    conv((x1, x2), torch_adj.t()).sum().backward()
-    assert torch_adj.grad is not None
-
-
 def test_my_conv_out_of_bounds():
     x = torch.randn(3, 8)
     value = torch.randn(4)

--- a/test/nn/conv/test_message_passing.py
+++ b/test/nn/conv/test_message_passing.py
@@ -7,7 +7,6 @@ from torch import Tensor
 from torch.nn import Linear
 from torch_scatter import scatter
 from torch_sparse import SparseTensor
-
 from torch_geometric.nn import MessagePassing, aggr
 from torch_geometric.typing import Adj, OptPairTensor, OptTensor, Size
 from torch_geometric.utils import spmm
@@ -87,6 +86,12 @@ def test_my_conv():
     assert torch.allclose(conv((x1, None), adj.t()), out2)
     assert torch.allclose(conv((x1, None), torch_adj.t()), out2)
     conv.fuse = True
+
+    # Test backward compatibility for `torch.sparse` tensors:
+    conv.fuse = True
+    torch_adj = torch_adj.requires_grad_()
+    conv((x1, x2), torch_adj.t()).sum().backward()
+    assert torch_adj.grad is not None
 
     # Test backward compatibility for `torch.sparse` tensors:
     conv.fuse = True

--- a/test/nn/conv/test_message_passing.py
+++ b/test/nn/conv/test_message_passing.py
@@ -55,7 +55,7 @@ def test_my_conv():
     row, col = edge_index
     value = torch.randn(row.size(0))
     adj = SparseTensor(row=row, col=col, value=value, sparse_sizes=(4, 4))
-    torch_adj = adj.to_torch_sparse_coo_tensor()
+    torch_adj = adj.to_torch_sparse_csr_tensor()
 
     conv = MyConv(8, 32)
     out = conv(x1, edge_index, value)
@@ -69,7 +69,7 @@ def test_my_conv():
     conv.fuse = True
 
     adj = adj.sparse_resize((4, 2))
-    torch_adj = adj.to_torch_sparse_coo_tensor()
+    torch_adj = adj.to_torch_sparse_csr_tensor()
 
     conv = MyConv((8, 16), 32)
     out1 = conv((x1, x2), edge_index, value)
@@ -212,7 +212,7 @@ def test_my_multiple_aggr_conv(multi_aggr_tuple):
     edge_index = torch.tensor([[0, 1, 2, 3], [0, 0, 1, 1]])
     row, col = edge_index
     adj = SparseTensor(row=row, col=col, sparse_sizes=(4, 4))
-    torch_adj = adj.to_torch_sparse_coo_tensor()
+    torch_adj = adj.to_torch_sparse_csr_tensor()
 
     conv = MyMultipleAggrConv(aggr_kwargs=aggr_kwargs)
     out = conv(x, edge_index)
@@ -281,7 +281,7 @@ def test_my_edge_conv():
     edge_index = torch.tensor([[0, 1, 2, 3], [0, 0, 1, 1]])
     row, col = edge_index
     adj = SparseTensor(row=row, col=col, sparse_sizes=(4, 4))
-    torch_adj = adj.to_torch_sparse_coo_tensor()
+    torch_adj = adj.to_torch_sparse_csr_tensor()
 
     expected = scatter(x[row] - x[col], col, dim=0, dim_size=4, reduce='add')
 
@@ -444,7 +444,7 @@ def test_my_default_arg_conv():
     edge_index = torch.tensor([[0, 1, 2, 3], [0, 0, 1, 1]])
     row, col = edge_index
     adj = SparseTensor(row=row, col=col, sparse_sizes=(4, 4))
-    torch_adj = adj.to_torch_sparse_coo_tensor()
+    torch_adj = adj.to_torch_sparse_csr_tensor()
 
     conv = MyDefaultArgConv()
     assert conv(x, edge_index).view(-1).tolist() == [0, 0, 0, 0]

--- a/test/nn/conv/test_message_passing.py
+++ b/test/nn/conv/test_message_passing.py
@@ -94,6 +94,7 @@ def test_my_conv():
     conv((x1, x2), torch_adj.t()).sum().backward()
     assert torch_adj.grad is not None
 
+
 def test_my_conv_out_of_bounds():
     x = torch.randn(3, 8)
     value = torch.randn(4)

--- a/test/nn/conv/test_message_passing.py
+++ b/test/nn/conv/test_message_passing.py
@@ -7,6 +7,7 @@ from torch import Tensor
 from torch.nn import Linear
 from torch_scatter import scatter
 from torch_sparse import SparseTensor
+
 from torch_geometric.nn import MessagePassing, aggr
 from torch_geometric.typing import Adj, OptPairTensor, OptTensor, Size
 from torch_geometric.utils import spmm

--- a/test/utils/test_spmm.py
+++ b/test/utils/test_spmm.py
@@ -62,10 +62,17 @@ def compare_spmm(src: SparseTensor, other: torch.Tensor, reduce: str,
     if version == "torch.spmm":
         return spmm(src, other, reduce)
 
-
 @pytest.mark.parametrize('dtype,reduce', product(grad_dtypes, reductions))
 def test_spmm(dtype, reduce):
+    
+    @torch.jit.script
+    def jit_torch_sparse(src: SparseTensor, other: Tensor) -> Tensor:
+        return spmm(src, other)
 
+    @torch.jit.script
+    def jit_torch(src: Tensor, other: Tensor) -> Tensor:
+        return spmm(src, other, reduce='sum')
+    
     if reduce in ['mean', 'min', 'max']:
         src = torch.tensor([[1, 1], [0, 0]], dtype=dtype)
         other = torch.tensor([[1, -1], [99, -99]], dtype=dtype)
@@ -83,9 +90,9 @@ def test_spmm(dtype, reduce):
 
         out1 = src @ other
         src = SparseTensor.from_dense(src)
-        out2 = spmm(src, other, reduce=reduce)
+        out2 = jit_torch_sparse(src, other, reduce=reduce)
         src = src.to_torch_sparse_csr_tensor(dtype=other)
-        out3 = spmm(src, other, reduce=reduce)
+        out3 = jit_torch(src, other, reduce=reduce)
         assert out1.size() == (5, 8)
         assert torch.allclose(out1, out2)
         assert torch.allclose(out1, out3)

--- a/test/utils/test_spmm.py
+++ b/test/utils/test_spmm.py
@@ -5,7 +5,7 @@ import torch
 import torch_scatter
 from torch import Tensor
 from torch_sparse.matmul import spmm as sparse_spmm
-from torch_sparse.tensor import SparseTensor
+from torch_sparse import SparseTensor
 from utils import devices, grad_dtypes, reductions
 
 from torch_geometric.utils import spmm

--- a/test/utils/test_spmm.py
+++ b/test/utils/test_spmm.py
@@ -4,8 +4,8 @@ import pytest
 import torch
 import torch_scatter
 from torch import Tensor
-from torch_sparse.matmul import spmm as sparse_spmm
 from torch_sparse import SparseTensor
+from torch_sparse.matmul import spmm as sparse_spmm
 from utils import devices, grad_dtypes, reductions
 
 from torch_geometric.utils import spmm

--- a/test/utils/test_spmm.py
+++ b/test/utils/test_spmm.py
@@ -1,45 +1,95 @@
+from itertools import product
+
 import pytest
 import torch
+import torch_scatter
 from torch import Tensor
-from torch_sparse import SparseTensor
-
+from torch_sparse.matmul import spmm as sparse_spmm
 from torch_geometric.utils import spmm
+from torch_sparse.tensor import SparseTensor
+from utils import devices, grad_dtypes, reductions
 
+@pytest.mark.parametrize('dtype,device,reduce',
+                         product(grad_dtypes, ['cpu'], reductions))
 
-def test_spmm():
-    src = torch.randn(5, 4)
-    other = torch.randn(4, 8)
+def test_backward_compatibility_spmm(dtype, device, reduce):
+    m, n, k = 10, 8, 4
+    _src = torch.randn((m, n), dtype=dtype, device=device)
+    _src[2:4, :] = 0  # Remove multiple rows.
+    _src[:, 2:4] = 0  # Remove multiple columns.
+    
+    # sparse src
+    src = SparseTensor.from_dense(_src).requires_grad_()
+    src_ref = SparseTensor.from_dense(_src).requires_grad_()
 
-    out1 = src @ other
-    out2 = spmm(src.to_sparse(), other, reduce='sum')
-    out3 = spmm(SparseTensor.from_dense(src), other, reduce='sum')
-    assert out1.size() == (5, 8)
-    assert torch.allclose(out1, out2)
-    assert torch.allclose(out1, out3)
+    # dense other
+    other = torch.randn((n, k), dtype=dtype, device=device,
+                        requires_grad=True)
+    other_ref = other.clone().detach().requires_grad_()
+    other_csr = other.clone().detach().requires_grad_()
+    
+    row, col, value = src.coo()
+    _, _, value_ref = src_ref.coo()
+    
+    # Test with explicit conversion
+    csr = src.to_torch_sparse_csr_tensor(dtype=other).requires_grad_()
 
-    for reduce in ['mean', 'min', 'max']:
+    # Test against scatter reduce
+    src_col = other.index_select(-2, col) * value.unsqueeze(-1)
+    expected = torch_scatter.scatter(src_col, row, dim=-2, reduce=reduce)
+    grad_out = torch.randn_like(expected)
+    
+    # Test against implementation in pytorch_sparse
+    out_ref = compare_spmm(src_ref, other_ref, reduce, version="torch_sparse")
+    out_ref.backward(grad_out)
+    out = compare_spmm(src, other, reduce, version="torch.spmm")
+    out.backward(grad_out)
+    
+    out_csr = compare_spmm(csr, other_csr, reduce, version="torch.spmm")
+    out_csr.backward(grad_out)
+        
+    assert torch.allclose(out_ref, out)
+    assert torch.allclose(value_ref.grad, csr.grad.values(),
+                          atol=10-4) #? This passes
+    assert torch.allclose(other_ref.grad, other.grad)
+
+def compare_spmm(src: SparseTensor, other: torch.Tensor, reduce: str,
+             version: str) -> torch.Tensor:
+
+    if version == "torch_sparse":
+        return sparse_spmm(src, other, reduce)
+    if version == "torch.spmm":
+        return spmm(src, other, reduce)
+    
+@pytest.mark.parametrize('dtype,reduce',
+                         product(grad_dtypes, reductions))        
+def test_spmm(dtype, reduce):
+    
+    if reduce in ['mean','min','max']:
+        src = torch.tensor([[1, 1],
+                           [0, 0]], dtype = dtype)
+        other = torch.tensor([[1, -1],
+                             [99, -99]], dtype = dtype)
         out = spmm(SparseTensor.from_dense(src), other, reduce)
-        assert out.size() == (5, 8)
+        if reduce == 'mean':
+            assert out.sum() == 0
+        elif reduce == 'max':
+            assert out.sum() > 0
+        elif reduce == 'max':
+            assert out.sum() < 0
 
-        with pytest.raises(ValueError, match="not supported"):
-            spmm(src.to_sparse(), other, reduce)
+    elif reduce in ['sum', 'add']:
+        src = torch.randn(5, 4, dtype=dtype)
+        other = torch.randn(4, 8, dtype=dtype)
+
+        out1 = src @ other
+        src = SparseTensor.from_dense(src)
+        out2 = spmm(src, other, reduce=reduce)
+        src = src.to_torch_sparse_csr_tensor(dtype=other)
+        out3 = spmm(src, other, reduce=reduce)
+        assert out1.size() == (5, 8)
+        assert torch.allclose(out1, out2)
+        assert torch.allclose(out1, out3)
+        
 
 
-def test_spmm():
-    @torch.jit.script
-    def jit_torch_sparse(src: SparseTensor, other: Tensor) -> Tensor:
-        return spmm(src, other)
-
-    @torch.jit.script
-    def jit_torch(src: Tensor, other: Tensor) -> Tensor:
-        return spmm(src, other, reduce='sum')
-
-    src = torch.randn(5, 4)
-    other = torch.randn(4, 8)
-
-    out1 = src @ other
-    out2 = jit_torch_sparse(SparseTensor.from_dense(src), other)
-    out3 = jit_torch(src.to_sparse(), other)
-    assert out1.size() == (5, 8)
-    assert torch.allclose(out1, out2)
-    assert torch.allclose(out1, out3)

--- a/test/utils/test_spmm.py
+++ b/test/utils/test_spmm.py
@@ -5,32 +5,32 @@ import torch
 import torch_scatter
 from torch import Tensor
 from torch_sparse.matmul import spmm as sparse_spmm
-from torch_geometric.utils import spmm
 from torch_sparse.tensor import SparseTensor
 from utils import devices, grad_dtypes, reductions
 
+from torch_geometric.utils import spmm
+
+
 @pytest.mark.parametrize('dtype,device,reduce',
                          product(grad_dtypes, ['cpu'], reductions))
-
 def test_backward_compatibility_spmm(dtype, device, reduce):
     m, n, k = 10, 8, 4
     _src = torch.randn((m, n), dtype=dtype, device=device)
     _src[2:4, :] = 0  # Remove multiple rows.
     _src[:, 2:4] = 0  # Remove multiple columns.
-    
+
     # sparse src
     src = SparseTensor.from_dense(_src).requires_grad_()
     src_ref = SparseTensor.from_dense(_src).requires_grad_()
 
     # dense other
-    other = torch.randn((n, k), dtype=dtype, device=device,
-                        requires_grad=True)
+    other = torch.randn((n, k), dtype=dtype, device=device, requires_grad=True)
     other_ref = other.clone().detach().requires_grad_()
     other_csr = other.clone().detach().requires_grad_()
-    
+
     row, col, value = src.coo()
     _, _, value_ref = src_ref.coo()
-    
+
     # Test with explicit conversion
     csr = src.to_torch_sparse_csr_tensor(dtype=other).requires_grad_()
 
@@ -38,38 +38,37 @@ def test_backward_compatibility_spmm(dtype, device, reduce):
     src_col = other.index_select(-2, col) * value.unsqueeze(-1)
     expected = torch_scatter.scatter(src_col, row, dim=-2, reduce=reduce)
     grad_out = torch.randn_like(expected)
-    
+
     # Test against implementation in pytorch_sparse
     out_ref = compare_spmm(src_ref, other_ref, reduce, version="torch_sparse")
     out_ref.backward(grad_out)
     out = compare_spmm(src, other, reduce, version="torch.spmm")
     out.backward(grad_out)
-    
+
     out_csr = compare_spmm(csr, other_csr, reduce, version="torch.spmm")
     out_csr.backward(grad_out)
-        
+
     assert torch.allclose(out_ref, out)
     assert torch.allclose(value_ref.grad, csr.grad.values(),
-                          atol=10-4) #? This passes
+                          atol=10 - 4)  #? This passes
     assert torch.allclose(other_ref.grad, other.grad)
 
+
 def compare_spmm(src: SparseTensor, other: torch.Tensor, reduce: str,
-             version: str) -> torch.Tensor:
+                 version: str) -> torch.Tensor:
 
     if version == "torch_sparse":
         return sparse_spmm(src, other, reduce)
     if version == "torch.spmm":
         return spmm(src, other, reduce)
-    
-@pytest.mark.parametrize('dtype,reduce',
-                         product(grad_dtypes, reductions))        
+
+
+@pytest.mark.parametrize('dtype,reduce', product(grad_dtypes, reductions))
 def test_spmm(dtype, reduce):
-    
-    if reduce in ['mean','min','max']:
-        src = torch.tensor([[1, 1],
-                           [0, 0]], dtype = dtype)
-        other = torch.tensor([[1, -1],
-                             [99, -99]], dtype = dtype)
+
+    if reduce in ['mean', 'min', 'max']:
+        src = torch.tensor([[1, 1], [0, 0]], dtype=dtype)
+        other = torch.tensor([[1, -1], [99, -99]], dtype=dtype)
         out = spmm(SparseTensor.from_dense(src), other, reduce)
         if reduce == 'mean':
             assert out.sum() == 0
@@ -90,6 +89,3 @@ def test_spmm(dtype, reduce):
         assert out1.size() == (5, 8)
         assert torch.allclose(out1, out2)
         assert torch.allclose(out1, out3)
-        
-
-

--- a/test/utils/utils.py
+++ b/test/utils/utils.py
@@ -1,0 +1,20 @@
+import torch
+import torch_scatter
+from packaging import version
+
+reductions = ['sum', 'add', 'mean', 'min', 'max']
+
+dtypes = [torch.float, torch.double, torch.int, torch.long]
+grad_dtypes = [torch.float, torch.double]
+
+if version.parse(torch_scatter.__version__) > version.parse("2.0.9"):
+    dtypes.append(torch.bfloat16)
+    grad_dtypes.append(torch.bfloat16)
+
+devices = [torch.device('cpu')]
+if torch.cuda.is_available():
+    devices += [torch.device(f'cuda:{torch.cuda.current_device()}')]
+
+
+def tensor(x, dtype, device):
+    return None if x is None else torch.tensor(x, dtype=dtype, device=device)

--- a/torch_geometric/nn/conv/appnp.py
+++ b/torch_geometric/nn/conv/appnp.py
@@ -2,7 +2,7 @@ from typing import Optional, Tuple
 
 import torch.nn.functional as F
 from torch import Tensor
-from torch.sparse.matmul import matmul
+from torch_geometric.utils.matmul import matmul import matmul
 from torch_sparse import SparseTensor
 
 from torch_geometric.nn.conv import MessagePassing

--- a/torch_geometric/nn/conv/appnp.py
+++ b/torch_geometric/nn/conv/appnp.py
@@ -2,7 +2,7 @@ from typing import Optional, Tuple
 
 import torch.nn.functional as F
 from torch import Tensor
-from torch_geometric.utils.matmul import matmul import matmul
+from torch_geometric.utils.matmul import matmul
 from torch_sparse import SparseTensor
 
 from torch_geometric.nn.conv import MessagePassing

--- a/torch_geometric/nn/conv/appnp.py
+++ b/torch_geometric/nn/conv/appnp.py
@@ -2,8 +2,8 @@ from typing import Optional, Tuple
 
 import torch.nn.functional as F
 from torch import Tensor
-from torch_sparse import SparseTensor
 from torch.sparse.matmul import matmul
+from torch_sparse import SparseTensor
 
 from torch_geometric.nn.conv import MessagePassing
 from torch_geometric.nn.conv.gcn_conv import gcn_norm

--- a/torch_geometric/nn/conv/appnp.py
+++ b/torch_geometric/nn/conv/appnp.py
@@ -2,12 +2,12 @@ from typing import Optional, Tuple
 
 import torch.nn.functional as F
 from torch import Tensor
-from torch_geometric.utils.matmul import matmul
 from torch_sparse import SparseTensor
 
 from torch_geometric.nn.conv import MessagePassing
 from torch_geometric.nn.conv.gcn_conv import gcn_norm
 from torch_geometric.typing import Adj, OptTensor
+from torch_geometric.utils.matmul import matmul
 
 
 class APPNP(MessagePassing):

--- a/torch_geometric/nn/conv/appnp.py
+++ b/torch_geometric/nn/conv/appnp.py
@@ -2,7 +2,8 @@ from typing import Optional, Tuple
 
 import torch.nn.functional as F
 from torch import Tensor
-from torch_sparse import SparseTensor, matmul
+from torch_sparse import SparseTensor
+from torch.sparse.matmul import matmul
 
 from torch_geometric.nn.conv import MessagePassing
 from torch_geometric.nn.conv.gcn_conv import gcn_norm

--- a/torch_geometric/nn/conv/arma_conv.py
+++ b/torch_geometric/nn/conv/arma_conv.py
@@ -4,7 +4,7 @@ import torch
 import torch.nn.functional as F
 from torch import Tensor, nn
 from torch.nn import Parameter, ReLU
-from torch.sparse.matmul import matmul
+from torch_geometric.utils.matmul import matmul import matmul
 from torch_sparse import SparseTensor
 
 from torch_geometric.nn.conv import MessagePassing

--- a/torch_geometric/nn/conv/arma_conv.py
+++ b/torch_geometric/nn/conv/arma_conv.py
@@ -4,12 +4,12 @@ import torch
 import torch.nn.functional as F
 from torch import Tensor, nn
 from torch.nn import Parameter, ReLU
-from torch_geometric.utils.matmul import matmul
 from torch_sparse import SparseTensor
 
 from torch_geometric.nn.conv import MessagePassing
 from torch_geometric.nn.conv.gcn_conv import gcn_norm
 from torch_geometric.typing import Adj, OptTensor
+from torch_geometric.utils.matmul import matmul
 
 from ..inits import glorot, zeros
 

--- a/torch_geometric/nn/conv/arma_conv.py
+++ b/torch_geometric/nn/conv/arma_conv.py
@@ -4,7 +4,8 @@ import torch
 import torch.nn.functional as F
 from torch import Tensor, nn
 from torch.nn import Parameter, ReLU
-from torch_sparse import SparseTensor, matmul
+from torch_sparse import SparseTensor
+from torch.sparse.matmul import matmul
 
 from torch_geometric.nn.conv import MessagePassing
 from torch_geometric.nn.conv.gcn_conv import gcn_norm

--- a/torch_geometric/nn/conv/arma_conv.py
+++ b/torch_geometric/nn/conv/arma_conv.py
@@ -4,7 +4,7 @@ import torch
 import torch.nn.functional as F
 from torch import Tensor, nn
 from torch.nn import Parameter, ReLU
-from torch_geometric.utils.matmul import matmul import matmul
+from torch_geometric.utils.matmul import matmul
 from torch_sparse import SparseTensor
 
 from torch_geometric.nn.conv import MessagePassing

--- a/torch_geometric/nn/conv/arma_conv.py
+++ b/torch_geometric/nn/conv/arma_conv.py
@@ -4,8 +4,8 @@ import torch
 import torch.nn.functional as F
 from torch import Tensor, nn
 from torch.nn import Parameter, ReLU
-from torch_sparse import SparseTensor
 from torch.sparse.matmul import matmul
+from torch_sparse import SparseTensor
 
 from torch_geometric.nn.conv import MessagePassing
 from torch_geometric.nn.conv.gcn_conv import gcn_norm

--- a/torch_geometric/nn/conv/cluster_gcn_conv.py
+++ b/torch_geometric/nn/conv/cluster_gcn_conv.py
@@ -1,5 +1,4 @@
 from torch import Tensor
-from torch_geometric.utils.matmul import matmul
 from torch_sparse import SparseTensor, set_diag
 from torch_sparse import sum as sparsesum
 
@@ -7,6 +6,7 @@ from torch_geometric.nn.conv import MessagePassing
 from torch_geometric.nn.dense.linear import Linear
 from torch_geometric.typing import Adj, OptTensor
 from torch_geometric.utils import add_self_loops, degree, remove_self_loops
+from torch_geometric.utils.matmul import matmul
 
 
 class ClusterGCNConv(MessagePassing):

--- a/torch_geometric/nn/conv/cluster_gcn_conv.py
+++ b/torch_geometric/nn/conv/cluster_gcn_conv.py
@@ -1,6 +1,6 @@
 from torch import Tensor
-from torch_sparse import SparseTensor, set_diag
 from torch.sparse.matmul import matmul
+from torch_sparse import SparseTensor, set_diag
 from torch_sparse import sum as sparsesum
 
 from torch_geometric.nn.conv import MessagePassing

--- a/torch_geometric/nn/conv/cluster_gcn_conv.py
+++ b/torch_geometric/nn/conv/cluster_gcn_conv.py
@@ -1,5 +1,5 @@
 from torch import Tensor
-from torch.sparse.matmul import matmul
+from torch_geometric.utils.matmul import matmul import matmul
 from torch_sparse import SparseTensor, set_diag
 from torch_sparse import sum as sparsesum
 

--- a/torch_geometric/nn/conv/cluster_gcn_conv.py
+++ b/torch_geometric/nn/conv/cluster_gcn_conv.py
@@ -1,5 +1,5 @@
 from torch import Tensor
-from torch_geometric.utils.matmul import matmul import matmul
+from torch_geometric.utils.matmul import matmul
 from torch_sparse import SparseTensor, set_diag
 from torch_sparse import sum as sparsesum
 

--- a/torch_geometric/nn/conv/cluster_gcn_conv.py
+++ b/torch_geometric/nn/conv/cluster_gcn_conv.py
@@ -1,5 +1,6 @@
 from torch import Tensor
-from torch_sparse import SparseTensor, matmul, set_diag
+from torch_sparse import SparseTensor, set_diag
+from torch.sparse.matmul import matmul
 from torch_sparse import sum as sparsesum
 
 from torch_geometric.nn.conv import MessagePassing

--- a/torch_geometric/nn/conv/eg_conv.py
+++ b/torch_geometric/nn/conv/eg_conv.py
@@ -3,7 +3,7 @@ from typing import List, Optional, Tuple
 import torch
 from torch import Tensor
 from torch.nn import Parameter
-from torch.sparse.matmul import matmul
+from torch_geometric.utils.matmul import matmul import matmul
 from torch_scatter import scatter
 from torch_sparse import SparseTensor, fill_diag
 

--- a/torch_geometric/nn/conv/eg_conv.py
+++ b/torch_geometric/nn/conv/eg_conv.py
@@ -3,9 +3,9 @@ from typing import List, Optional, Tuple
 import torch
 from torch import Tensor
 from torch.nn import Parameter
+from torch.sparse.matmul import matmul
 from torch_scatter import scatter
 from torch_sparse import SparseTensor, fill_diag
-from torch.sparse.matmul import matmul
 
 from torch_geometric.nn.conv import MessagePassing
 from torch_geometric.nn.conv.gcn_conv import gcn_norm

--- a/torch_geometric/nn/conv/eg_conv.py
+++ b/torch_geometric/nn/conv/eg_conv.py
@@ -3,7 +3,6 @@ from typing import List, Optional, Tuple
 import torch
 from torch import Tensor
 from torch.nn import Parameter
-from torch_geometric.utils.matmul import matmul
 from torch_scatter import scatter
 from torch_sparse import SparseTensor, fill_diag
 
@@ -13,6 +12,7 @@ from torch_geometric.nn.dense.linear import Linear
 from torch_geometric.nn.inits import zeros
 from torch_geometric.typing import Adj, OptTensor
 from torch_geometric.utils import add_remaining_self_loops
+from torch_geometric.utils.matmul import matmul
 
 
 class EGConv(MessagePassing):

--- a/torch_geometric/nn/conv/eg_conv.py
+++ b/torch_geometric/nn/conv/eg_conv.py
@@ -4,7 +4,8 @@ import torch
 from torch import Tensor
 from torch.nn import Parameter
 from torch_scatter import scatter
-from torch_sparse import SparseTensor, fill_diag, matmul
+from torch_sparse import SparseTensor, fill_diag
+from torch.sparse.matmul import matmul
 
 from torch_geometric.nn.conv import MessagePassing
 from torch_geometric.nn.conv.gcn_conv import gcn_norm

--- a/torch_geometric/nn/conv/eg_conv.py
+++ b/torch_geometric/nn/conv/eg_conv.py
@@ -3,7 +3,7 @@ from typing import List, Optional, Tuple
 import torch
 from torch import Tensor
 from torch.nn import Parameter
-from torch_geometric.utils.matmul import matmul import matmul
+from torch_geometric.utils.matmul import matmul
 from torch_scatter import scatter
 from torch_sparse import SparseTensor, fill_diag
 

--- a/torch_geometric/nn/conv/gated_graph_conv.py
+++ b/torch_geometric/nn/conv/gated_graph_conv.py
@@ -1,7 +1,8 @@
 import torch
 from torch import Tensor
 from torch.nn import Parameter as Param
-from torch_sparse import SparseTensor, matmul
+from torch_sparse import SparseTensor
+from torch.sparse.matmul import matmul
 
 from torch_geometric.nn.conv import MessagePassing
 from torch_geometric.typing import Adj, OptTensor

--- a/torch_geometric/nn/conv/gated_graph_conv.py
+++ b/torch_geometric/nn/conv/gated_graph_conv.py
@@ -1,7 +1,7 @@
 import torch
 from torch import Tensor
 from torch.nn import Parameter as Param
-from torch.sparse.matmul import matmul
+from torch_geometric.utils.matmul import matmul import matmul
 from torch_sparse import SparseTensor
 
 from torch_geometric.nn.conv import MessagePassing

--- a/torch_geometric/nn/conv/gated_graph_conv.py
+++ b/torch_geometric/nn/conv/gated_graph_conv.py
@@ -1,7 +1,7 @@
 import torch
 from torch import Tensor
 from torch.nn import Parameter as Param
-from torch_geometric.utils.matmul import matmul import matmul
+from torch_geometric.utils.matmul import matmul
 from torch_sparse import SparseTensor
 
 from torch_geometric.nn.conv import MessagePassing

--- a/torch_geometric/nn/conv/gated_graph_conv.py
+++ b/torch_geometric/nn/conv/gated_graph_conv.py
@@ -1,8 +1,8 @@
 import torch
 from torch import Tensor
 from torch.nn import Parameter as Param
-from torch_sparse import SparseTensor
 from torch.sparse.matmul import matmul
+from torch_sparse import SparseTensor
 
 from torch_geometric.nn.conv import MessagePassing
 from torch_geometric.typing import Adj, OptTensor

--- a/torch_geometric/nn/conv/gated_graph_conv.py
+++ b/torch_geometric/nn/conv/gated_graph_conv.py
@@ -1,11 +1,11 @@
 import torch
 from torch import Tensor
 from torch.nn import Parameter as Param
-from torch_geometric.utils.matmul import matmul
 from torch_sparse import SparseTensor
 
 from torch_geometric.nn.conv import MessagePassing
 from torch_geometric.typing import Adj, OptTensor
+from torch_geometric.utils.matmul import matmul
 
 from ..inits import uniform
 

--- a/torch_geometric/nn/conv/gcn2_conv.py
+++ b/torch_geometric/nn/conv/gcn2_conv.py
@@ -4,8 +4,8 @@ from typing import Optional, Tuple
 import torch
 from torch import Tensor
 from torch.nn import Parameter
-from torch_sparse import SparseTensor
 from torch.sparse.matmul import matmul
+from torch_sparse import SparseTensor
 
 from torch_geometric.nn.conv import MessagePassing
 from torch_geometric.nn.conv.gcn_conv import gcn_norm

--- a/torch_geometric/nn/conv/gcn2_conv.py
+++ b/torch_geometric/nn/conv/gcn2_conv.py
@@ -4,7 +4,8 @@ from typing import Optional, Tuple
 import torch
 from torch import Tensor
 from torch.nn import Parameter
-from torch_sparse import SparseTensor, matmul
+from torch_sparse import SparseTensor
+from torch.sparse.matmul import matmul
 
 from torch_geometric.nn.conv import MessagePassing
 from torch_geometric.nn.conv.gcn_conv import gcn_norm

--- a/torch_geometric/nn/conv/gcn2_conv.py
+++ b/torch_geometric/nn/conv/gcn2_conv.py
@@ -4,12 +4,12 @@ from typing import Optional, Tuple
 import torch
 from torch import Tensor
 from torch.nn import Parameter
-from torch_geometric.utils.matmul import matmul
 from torch_sparse import SparseTensor
 
 from torch_geometric.nn.conv import MessagePassing
 from torch_geometric.nn.conv.gcn_conv import gcn_norm
 from torch_geometric.typing import Adj, OptTensor
+from torch_geometric.utils.matmul import matmul
 
 from ..inits import glorot
 

--- a/torch_geometric/nn/conv/gcn2_conv.py
+++ b/torch_geometric/nn/conv/gcn2_conv.py
@@ -4,7 +4,7 @@ from typing import Optional, Tuple
 import torch
 from torch import Tensor
 from torch.nn import Parameter
-from torch_geometric.utils.matmul import matmul import matmul
+from torch_geometric.utils.matmul import matmul
 from torch_sparse import SparseTensor
 
 from torch_geometric.nn.conv import MessagePassing

--- a/torch_geometric/nn/conv/gcn2_conv.py
+++ b/torch_geometric/nn/conv/gcn2_conv.py
@@ -4,7 +4,7 @@ from typing import Optional, Tuple
 import torch
 from torch import Tensor
 from torch.nn import Parameter
-from torch.sparse.matmul import matmul
+from torch_geometric.utils.matmul import matmul import matmul
 from torch_sparse import SparseTensor
 
 from torch_geometric.nn.conv import MessagePassing

--- a/torch_geometric/nn/conv/gcn_conv.py
+++ b/torch_geometric/nn/conv/gcn_conv.py
@@ -3,7 +3,6 @@ from typing import Optional
 import torch
 from torch import Tensor
 from torch.nn import Parameter
-from torch_geometric.utils.matmul import matmul
 from torch_scatter import scatter_add
 from torch_sparse import SparseTensor, fill_diag, mul
 from torch_sparse import sum as sparsesum
@@ -19,6 +18,7 @@ from torch_geometric.utils import (
     spmm,
     to_torch_coo_tensor,
 )
+from torch_geometric.utils.matmul import matmul
 from torch_geometric.utils.num_nodes import maybe_num_nodes
 
 

--- a/torch_geometric/nn/conv/gcn_conv.py
+++ b/torch_geometric/nn/conv/gcn_conv.py
@@ -3,7 +3,7 @@ from typing import Optional
 import torch
 from torch import Tensor
 from torch.nn import Parameter
-from torch.sparse.matmul import matmul
+from torch_geometric.utils.matmul import matmul import matmul
 from torch_scatter import scatter_add
 from torch_sparse import SparseTensor, fill_diag, mul
 from torch_sparse import sum as sparsesum

--- a/torch_geometric/nn/conv/gcn_conv.py
+++ b/torch_geometric/nn/conv/gcn_conv.py
@@ -3,7 +3,7 @@ from typing import Optional
 import torch
 from torch import Tensor
 from torch.nn import Parameter
-from torch_geometric.utils.matmul import matmul import matmul
+from torch_geometric.utils.matmul import matmul
 from torch_scatter import scatter_add
 from torch_sparse import SparseTensor, fill_diag, mul
 from torch_sparse import sum as sparsesum

--- a/torch_geometric/nn/conv/gcn_conv.py
+++ b/torch_geometric/nn/conv/gcn_conv.py
@@ -3,7 +3,9 @@ from typing import Optional
 import torch
 from torch import Tensor
 from torch.nn import Parameter
+from torch_scatter import scatter_add
 from torch_sparse import SparseTensor, fill_diag, mul
+from torch.sparse.matmul import matmul
 from torch_sparse import sum as sparsesum
 
 from torch_geometric.nn.conv import MessagePassing

--- a/torch_geometric/nn/conv/gcn_conv.py
+++ b/torch_geometric/nn/conv/gcn_conv.py
@@ -3,9 +3,9 @@ from typing import Optional
 import torch
 from torch import Tensor
 from torch.nn import Parameter
+from torch.sparse.matmul import matmul
 from torch_scatter import scatter_add
 from torch_sparse import SparseTensor, fill_diag, mul
-from torch.sparse.matmul import matmul
 from torch_sparse import sum as sparsesum
 
 from torch_geometric.nn.conv import MessagePassing

--- a/torch_geometric/nn/conv/gin_conv.py
+++ b/torch_geometric/nn/conv/gin_conv.py
@@ -2,7 +2,7 @@ from typing import Callable, Optional, Union
 
 import torch
 from torch import Tensor
-from torch_geometric.utils.matmul import matmul import matmul
+from torch_geometric.utils.matmul import matmul
 from torch_sparse import SparseTensor
 
 from torch_geometric.nn.conv import MessagePassing

--- a/torch_geometric/nn/conv/gin_conv.py
+++ b/torch_geometric/nn/conv/gin_conv.py
@@ -2,8 +2,8 @@ from typing import Callable, Optional, Union
 
 import torch
 from torch import Tensor
-from torch_sparse import SparseTensor
 from torch.sparse.matmul import matmul
+from torch_sparse import SparseTensor
 
 from torch_geometric.nn.conv import MessagePassing
 from torch_geometric.nn.dense.linear import Linear

--- a/torch_geometric/nn/conv/gin_conv.py
+++ b/torch_geometric/nn/conv/gin_conv.py
@@ -2,7 +2,8 @@ from typing import Callable, Optional, Union
 
 import torch
 from torch import Tensor
-from torch_sparse import SparseTensor, matmul
+from torch_sparse import SparseTensor
+from torch.sparse.matmul import matmul
 
 from torch_geometric.nn.conv import MessagePassing
 from torch_geometric.nn.dense.linear import Linear

--- a/torch_geometric/nn/conv/gin_conv.py
+++ b/torch_geometric/nn/conv/gin_conv.py
@@ -2,12 +2,12 @@ from typing import Callable, Optional, Union
 
 import torch
 from torch import Tensor
-from torch_geometric.utils.matmul import matmul
 from torch_sparse import SparseTensor
 
 from torch_geometric.nn.conv import MessagePassing
 from torch_geometric.nn.dense.linear import Linear
 from torch_geometric.typing import Adj, OptPairTensor, OptTensor, Size
+from torch_geometric.utils.matmul import matmul
 
 from ..inits import reset
 

--- a/torch_geometric/nn/conv/gin_conv.py
+++ b/torch_geometric/nn/conv/gin_conv.py
@@ -2,7 +2,7 @@ from typing import Callable, Optional, Union
 
 import torch
 from torch import Tensor
-from torch.sparse.matmul import matmul
+from torch_geometric.utils.matmul import matmul import matmul
 from torch_sparse import SparseTensor
 
 from torch_geometric.nn.conv import MessagePassing

--- a/torch_geometric/nn/conv/graph_conv.py
+++ b/torch_geometric/nn/conv/graph_conv.py
@@ -1,7 +1,7 @@
 from typing import Tuple, Union
 
 from torch import Tensor
-from torch_geometric.utils.matmul import matmul import matmul
+from torch_geometric.utils.matmul import matmul
 from torch_sparse import SparseTensor
 
 from torch_geometric.nn.conv import MessagePassing

--- a/torch_geometric/nn/conv/graph_conv.py
+++ b/torch_geometric/nn/conv/graph_conv.py
@@ -1,7 +1,7 @@
 from typing import Tuple, Union
 
 from torch import Tensor
-from torch.sparse.matmul import matmul
+from torch_geometric.utils.matmul import matmul import matmul
 from torch_sparse import SparseTensor
 
 from torch_geometric.nn.conv import MessagePassing

--- a/torch_geometric/nn/conv/graph_conv.py
+++ b/torch_geometric/nn/conv/graph_conv.py
@@ -1,8 +1,8 @@
 from typing import Tuple, Union
 
 from torch import Tensor
-from torch_sparse import SparseTensor
 from torch.sparse.matmul import matmul
+from torch_sparse import SparseTensor
 
 from torch_geometric.nn.conv import MessagePassing
 from torch_geometric.nn.dense.linear import Linear

--- a/torch_geometric/nn/conv/graph_conv.py
+++ b/torch_geometric/nn/conv/graph_conv.py
@@ -1,7 +1,8 @@
 from typing import Tuple, Union
 
 from torch import Tensor
-from torch_sparse import SparseTensor, matmul
+from torch_sparse import SparseTensor
+from torch.sparse.matmul import matmul
 
 from torch_geometric.nn.conv import MessagePassing
 from torch_geometric.nn.dense.linear import Linear

--- a/torch_geometric/nn/conv/graph_conv.py
+++ b/torch_geometric/nn/conv/graph_conv.py
@@ -1,12 +1,12 @@
 from typing import Tuple, Union
 
 from torch import Tensor
-from torch_geometric.utils.matmul import matmul
 from torch_sparse import SparseTensor
 
 from torch_geometric.nn.conv import MessagePassing
 from torch_geometric.nn.dense.linear import Linear
 from torch_geometric.typing import Adj, OptPairTensor, OptTensor, Size
+from torch_geometric.utils.matmul import matmul
 
 
 class GraphConv(MessagePassing):

--- a/torch_geometric/nn/conv/lg_conv.py
+++ b/torch_geometric/nn/conv/lg_conv.py
@@ -1,5 +1,6 @@
 from torch import Tensor
-from torch_sparse import SparseTensor, matmul
+from torch_sparse import SparseTensor
+from torch.sparse.matmul import matmul
 
 from torch_geometric.nn.conv import MessagePassing
 from torch_geometric.nn.conv.gcn_conv import gcn_norm

--- a/torch_geometric/nn/conv/lg_conv.py
+++ b/torch_geometric/nn/conv/lg_conv.py
@@ -1,10 +1,10 @@
 from torch import Tensor
-from torch_geometric.utils.matmul import matmul
 from torch_sparse import SparseTensor
 
 from torch_geometric.nn.conv import MessagePassing
 from torch_geometric.nn.conv.gcn_conv import gcn_norm
 from torch_geometric.typing import Adj, OptTensor
+from torch_geometric.utils.matmul import matmul
 
 
 class LGConv(MessagePassing):

--- a/torch_geometric/nn/conv/lg_conv.py
+++ b/torch_geometric/nn/conv/lg_conv.py
@@ -1,6 +1,6 @@
 from torch import Tensor
-from torch_sparse import SparseTensor
 from torch.sparse.matmul import matmul
+from torch_sparse import SparseTensor
 
 from torch_geometric.nn.conv import MessagePassing
 from torch_geometric.nn.conv.gcn_conv import gcn_norm

--- a/torch_geometric/nn/conv/lg_conv.py
+++ b/torch_geometric/nn/conv/lg_conv.py
@@ -1,5 +1,5 @@
 from torch import Tensor
-from torch_geometric.utils.matmul import matmul import matmul
+from torch_geometric.utils.matmul import matmul
 from torch_sparse import SparseTensor
 
 from torch_geometric.nn.conv import MessagePassing

--- a/torch_geometric/nn/conv/lg_conv.py
+++ b/torch_geometric/nn/conv/lg_conv.py
@@ -1,5 +1,5 @@
 from torch import Tensor
-from torch.sparse.matmul import matmul
+from torch_geometric.utils.matmul import matmul import matmul
 from torch_sparse import SparseTensor
 
 from torch_geometric.nn.conv import MessagePassing

--- a/torch_geometric/nn/conv/mf_conv.py
+++ b/torch_geometric/nn/conv/mf_conv.py
@@ -3,7 +3,7 @@ from typing import Tuple, Union
 import torch
 from torch import Tensor
 from torch.nn import ModuleList
-from torch.sparse.matmul import matmul
+from torch_geometric.utils.matmul import matmul import matmul
 from torch_sparse import SparseTensor
 
 from torch_geometric.nn.conv import MessagePassing

--- a/torch_geometric/nn/conv/mf_conv.py
+++ b/torch_geometric/nn/conv/mf_conv.py
@@ -3,13 +3,13 @@ from typing import Tuple, Union
 import torch
 from torch import Tensor
 from torch.nn import ModuleList
-from torch_geometric.utils.matmul import matmul
 from torch_sparse import SparseTensor
 
 from torch_geometric.nn.conv import MessagePassing
 from torch_geometric.nn.dense.linear import Linear
 from torch_geometric.typing import Adj, OptPairTensor, Size
 from torch_geometric.utils import degree
+from torch_geometric.utils.matmul import matmul
 
 
 class MFConv(MessagePassing):

--- a/torch_geometric/nn/conv/mf_conv.py
+++ b/torch_geometric/nn/conv/mf_conv.py
@@ -3,7 +3,8 @@ from typing import Tuple, Union
 import torch
 from torch import Tensor
 from torch.nn import ModuleList
-from torch_sparse import SparseTensor, matmul
+from torch_sparse import SparseTensor
+from torch.sparse.matmul import matmul
 
 from torch_geometric.nn.conv import MessagePassing
 from torch_geometric.nn.dense.linear import Linear

--- a/torch_geometric/nn/conv/mf_conv.py
+++ b/torch_geometric/nn/conv/mf_conv.py
@@ -3,8 +3,8 @@ from typing import Tuple, Union
 import torch
 from torch import Tensor
 from torch.nn import ModuleList
-from torch_sparse import SparseTensor
 from torch.sparse.matmul import matmul
+from torch_sparse import SparseTensor
 
 from torch_geometric.nn.conv import MessagePassing
 from torch_geometric.nn.dense.linear import Linear

--- a/torch_geometric/nn/conv/mf_conv.py
+++ b/torch_geometric/nn/conv/mf_conv.py
@@ -3,7 +3,7 @@ from typing import Tuple, Union
 import torch
 from torch import Tensor
 from torch.nn import ModuleList
-from torch_geometric.utils.matmul import matmul import matmul
+from torch_geometric.utils.matmul import matmul
 from torch_sparse import SparseTensor
 
 from torch_geometric.nn.conv import MessagePassing

--- a/torch_geometric/nn/conv/pan_conv.py
+++ b/torch_geometric/nn/conv/pan_conv.py
@@ -3,8 +3,8 @@ from typing import Optional, Tuple
 import torch
 from torch import Tensor
 from torch.nn import Parameter
-from torch_sparse import SparseTensor
 from torch.sparse.matmul import matmul
+from torch_sparse import SparseTensor
 
 from torch_geometric.nn.conv import MessagePassing
 from torch_geometric.nn.dense.linear import Linear

--- a/torch_geometric/nn/conv/pan_conv.py
+++ b/torch_geometric/nn/conv/pan_conv.py
@@ -3,7 +3,8 @@ from typing import Optional, Tuple
 import torch
 from torch import Tensor
 from torch.nn import Parameter
-from torch_sparse import SparseTensor, matmul
+from torch_sparse import SparseTensor
+from torch.sparse.matmul import matmul
 
 from torch_geometric.nn.conv import MessagePassing
 from torch_geometric.nn.dense.linear import Linear

--- a/torch_geometric/nn/conv/pan_conv.py
+++ b/torch_geometric/nn/conv/pan_conv.py
@@ -3,12 +3,12 @@ from typing import Optional, Tuple
 import torch
 from torch import Tensor
 from torch.nn import Parameter
-from torch_geometric.utils.matmul import matmul
 from torch_sparse import SparseTensor
 
 from torch_geometric.nn.conv import MessagePassing
 from torch_geometric.nn.dense.linear import Linear
 from torch_geometric.typing import Adj
+from torch_geometric.utils.matmul import matmul
 
 
 class PANConv(MessagePassing):

--- a/torch_geometric/nn/conv/pan_conv.py
+++ b/torch_geometric/nn/conv/pan_conv.py
@@ -3,7 +3,7 @@ from typing import Optional, Tuple
 import torch
 from torch import Tensor
 from torch.nn import Parameter
-from torch.sparse.matmul import matmul
+from torch_geometric.utils.matmul import matmul import matmul
 from torch_sparse import SparseTensor
 
 from torch_geometric.nn.conv import MessagePassing

--- a/torch_geometric/nn/conv/pan_conv.py
+++ b/torch_geometric/nn/conv/pan_conv.py
@@ -3,7 +3,7 @@ from typing import Optional, Tuple
 import torch
 from torch import Tensor
 from torch.nn import Parameter
-from torch_geometric.utils.matmul import matmul import matmul
+from torch_geometric.utils.matmul import matmul
 from torch_sparse import SparseTensor
 
 from torch_geometric.nn.conv import MessagePassing

--- a/torch_geometric/nn/conv/pdn_conv.py
+++ b/torch_geometric/nn/conv/pdn_conv.py
@@ -1,12 +1,12 @@
 import torch
 from torch import Tensor
 from torch.nn import Linear, Parameter, ReLU, Sequential, Sigmoid
-from torch_geometric.utils.matmul import matmul
 from torch_sparse import SparseTensor
 
 from torch_geometric.nn.conv import MessagePassing
 from torch_geometric.nn.conv.gcn_conv import gcn_norm
 from torch_geometric.typing import Adj, OptTensor
+from torch_geometric.utils.matmul import matmul
 
 from ..inits import glorot, zeros
 

--- a/torch_geometric/nn/conv/pdn_conv.py
+++ b/torch_geometric/nn/conv/pdn_conv.py
@@ -1,8 +1,8 @@
 import torch
 from torch import Tensor
 from torch.nn import Linear, Parameter, ReLU, Sequential, Sigmoid
-from torch_sparse import SparseTensor
 from torch.sparse.matmul import matmul
+from torch_sparse import SparseTensor
 
 from torch_geometric.nn.conv import MessagePassing
 from torch_geometric.nn.conv.gcn_conv import gcn_norm

--- a/torch_geometric/nn/conv/pdn_conv.py
+++ b/torch_geometric/nn/conv/pdn_conv.py
@@ -1,7 +1,7 @@
 import torch
 from torch import Tensor
 from torch.nn import Linear, Parameter, ReLU, Sequential, Sigmoid
-from torch.sparse.matmul import matmul
+from torch_geometric.utils.matmul import matmul import matmul
 from torch_sparse import SparseTensor
 
 from torch_geometric.nn.conv import MessagePassing

--- a/torch_geometric/nn/conv/pdn_conv.py
+++ b/torch_geometric/nn/conv/pdn_conv.py
@@ -1,7 +1,8 @@
 import torch
 from torch import Tensor
 from torch.nn import Linear, Parameter, ReLU, Sequential, Sigmoid
-from torch_sparse import SparseTensor, matmul
+from torch_sparse import SparseTensor
+from torch.sparse.matmul import matmul
 
 from torch_geometric.nn.conv import MessagePassing
 from torch_geometric.nn.conv.gcn_conv import gcn_norm

--- a/torch_geometric/nn/conv/pdn_conv.py
+++ b/torch_geometric/nn/conv/pdn_conv.py
@@ -1,7 +1,7 @@
 import torch
 from torch import Tensor
 from torch.nn import Linear, Parameter, ReLU, Sequential, Sigmoid
-from torch_geometric.utils.matmul import matmul import matmul
+from torch_geometric.utils.matmul import matmul
 from torch_sparse import SparseTensor
 
 from torch_geometric.nn.conv import MessagePassing

--- a/torch_geometric/nn/conv/rgcn_conv.py
+++ b/torch_geometric/nn/conv/rgcn_conv.py
@@ -5,7 +5,7 @@ import torch.nn.functional as F
 from torch import Tensor
 from torch.nn import Parameter
 from torch.nn import Parameter as Param
-from torch_geometric.utils.matmul import matmul import matmul
+from torch_geometric.utils.matmul import matmul
 from torch_scatter import scatter
 from torch_sparse import SparseTensor, masked_select_nnz
 

--- a/torch_geometric/nn/conv/rgcn_conv.py
+++ b/torch_geometric/nn/conv/rgcn_conv.py
@@ -6,7 +6,8 @@ from torch import Tensor
 from torch.nn import Parameter
 from torch.nn import Parameter as Param
 from torch_scatter import scatter
-from torch_sparse import SparseTensor, masked_select_nnz, matmul
+from torch_sparse import SparseTensor, masked_select_nnz
+from torch.sparse.matmul import matmul
 
 import torch_geometric.typing
 from torch_geometric.nn.conv import MessagePassing

--- a/torch_geometric/nn/conv/rgcn_conv.py
+++ b/torch_geometric/nn/conv/rgcn_conv.py
@@ -5,9 +5,9 @@ import torch.nn.functional as F
 from torch import Tensor
 from torch.nn import Parameter
 from torch.nn import Parameter as Param
+from torch.sparse.matmul import matmul
 from torch_scatter import scatter
 from torch_sparse import SparseTensor, masked_select_nnz
-from torch.sparse.matmul import matmul
 
 import torch_geometric.typing
 from torch_geometric.nn.conv import MessagePassing

--- a/torch_geometric/nn/conv/rgcn_conv.py
+++ b/torch_geometric/nn/conv/rgcn_conv.py
@@ -5,13 +5,13 @@ import torch.nn.functional as F
 from torch import Tensor
 from torch.nn import Parameter
 from torch.nn import Parameter as Param
-from torch_geometric.utils.matmul import matmul
 from torch_scatter import scatter
 from torch_sparse import SparseTensor, masked_select_nnz
 
 import torch_geometric.typing
 from torch_geometric.nn.conv import MessagePassing
 from torch_geometric.typing import Adj, OptTensor, pyg_lib
+from torch_geometric.utils.matmul import matmul
 
 from ..inits import glorot, zeros
 

--- a/torch_geometric/nn/conv/rgcn_conv.py
+++ b/torch_geometric/nn/conv/rgcn_conv.py
@@ -5,7 +5,7 @@ import torch.nn.functional as F
 from torch import Tensor
 from torch.nn import Parameter
 from torch.nn import Parameter as Param
-from torch.sparse.matmul import matmul
+from torch_geometric.utils.matmul import matmul import matmul
 from torch_scatter import scatter
 from torch_sparse import SparseTensor, masked_select_nnz
 

--- a/torch_geometric/nn/conv/sage_conv.py
+++ b/torch_geometric/nn/conv/sage_conv.py
@@ -3,7 +3,7 @@ from typing import List, Optional, Tuple, Union
 import torch.nn.functional as F
 from torch import Tensor
 from torch.nn import LSTM
-from torch.sparse.matmul import matmul
+from torch_geometric.utils.matmul import matmul import matmul
 from torch_sparse import SparseTensor  # , matmul
 
 from torch_geometric.nn.aggr import Aggregation, MultiAggregation

--- a/torch_geometric/nn/conv/sage_conv.py
+++ b/torch_geometric/nn/conv/sage_conv.py
@@ -3,7 +3,8 @@ from typing import List, Optional, Tuple, Union
 import torch.nn.functional as F
 from torch import Tensor
 from torch.nn import LSTM
-from torch_sparse import SparseTensor, matmul
+from torch_sparse import SparseTensor #, matmul
+from torch.sparse.matmul import matmul
 
 from torch_geometric.nn.aggr import Aggregation, MultiAggregation
 from torch_geometric.nn.conv import MessagePassing

--- a/torch_geometric/nn/conv/sage_conv.py
+++ b/torch_geometric/nn/conv/sage_conv.py
@@ -3,13 +3,13 @@ from typing import List, Optional, Tuple, Union
 import torch.nn.functional as F
 from torch import Tensor
 from torch.nn import LSTM
-from torch_geometric.utils.matmul import matmul
 from torch_sparse import SparseTensor  # , matmul
 
 from torch_geometric.nn.aggr import Aggregation, MultiAggregation
 from torch_geometric.nn.conv import MessagePassing
 from torch_geometric.nn.dense.linear import Linear
 from torch_geometric.typing import Adj, OptPairTensor, Size
+from torch_geometric.utils.matmul import matmul
 
 
 class SAGEConv(MessagePassing):

--- a/torch_geometric/nn/conv/sage_conv.py
+++ b/torch_geometric/nn/conv/sage_conv.py
@@ -3,7 +3,7 @@ from typing import List, Optional, Tuple, Union
 import torch.nn.functional as F
 from torch import Tensor
 from torch.nn import LSTM
-from torch_geometric.utils.matmul import matmul import matmul
+from torch_geometric.utils.matmul import matmul
 from torch_sparse import SparseTensor  # , matmul
 
 from torch_geometric.nn.aggr import Aggregation, MultiAggregation

--- a/torch_geometric/nn/conv/sage_conv.py
+++ b/torch_geometric/nn/conv/sage_conv.py
@@ -3,8 +3,8 @@ from typing import List, Optional, Tuple, Union
 import torch.nn.functional as F
 from torch import Tensor
 from torch.nn import LSTM
-from torch_sparse import SparseTensor #, matmul
 from torch.sparse.matmul import matmul
+from torch_sparse import SparseTensor  # , matmul
 
 from torch_geometric.nn.aggr import Aggregation, MultiAggregation
 from torch_geometric.nn.conv import MessagePassing

--- a/torch_geometric/nn/conv/sg_conv.py
+++ b/torch_geometric/nn/conv/sg_conv.py
@@ -1,7 +1,8 @@
 from typing import Optional
 
 from torch import Tensor
-from torch_sparse import SparseTensor, matmul
+from torch_sparse import SparseTensor
+from torch.sparse.matmul import matmul
 
 from torch_geometric.nn.conv import MessagePassing
 from torch_geometric.nn.conv.gcn_conv import gcn_norm

--- a/torch_geometric/nn/conv/sg_conv.py
+++ b/torch_geometric/nn/conv/sg_conv.py
@@ -1,13 +1,13 @@
 from typing import Optional
 
 from torch import Tensor
-from torch_geometric.utils.matmul import matmul
 from torch_sparse import SparseTensor
 
 from torch_geometric.nn.conv import MessagePassing
 from torch_geometric.nn.conv.gcn_conv import gcn_norm
 from torch_geometric.nn.dense.linear import Linear
 from torch_geometric.typing import Adj, OptTensor
+from torch_geometric.utils.matmul import matmul
 
 
 class SGConv(MessagePassing):

--- a/torch_geometric/nn/conv/sg_conv.py
+++ b/torch_geometric/nn/conv/sg_conv.py
@@ -1,7 +1,7 @@
 from typing import Optional
 
 from torch import Tensor
-from torch.sparse.matmul import matmul
+from torch_geometric.utils.matmul import matmul import matmul
 from torch_sparse import SparseTensor
 
 from torch_geometric.nn.conv import MessagePassing

--- a/torch_geometric/nn/conv/sg_conv.py
+++ b/torch_geometric/nn/conv/sg_conv.py
@@ -1,7 +1,7 @@
 from typing import Optional
 
 from torch import Tensor
-from torch_geometric.utils.matmul import matmul import matmul
+from torch_geometric.utils.matmul import matmul
 from torch_sparse import SparseTensor
 
 from torch_geometric.nn.conv import MessagePassing

--- a/torch_geometric/nn/conv/sg_conv.py
+++ b/torch_geometric/nn/conv/sg_conv.py
@@ -1,8 +1,8 @@
 from typing import Optional
 
 from torch import Tensor
-from torch_sparse import SparseTensor
 from torch.sparse.matmul import matmul
+from torch_sparse import SparseTensor
 
 from torch_geometric.nn.conv import MessagePassing
 from torch_geometric.nn.conv.gcn_conv import gcn_norm

--- a/torch_geometric/nn/conv/signed_conv.py
+++ b/torch_geometric/nn/conv/signed_conv.py
@@ -2,7 +2,7 @@ from typing import Union
 
 import torch
 from torch import Tensor
-from torch.sparse.matmul import matmul
+from torch_geometric.utils.matmul import matmul import matmul
 from torch_sparse import SparseTensor
 
 from torch_geometric.nn.conv import MessagePassing

--- a/torch_geometric/nn/conv/signed_conv.py
+++ b/torch_geometric/nn/conv/signed_conv.py
@@ -2,7 +2,7 @@ from typing import Union
 
 import torch
 from torch import Tensor
-from torch_geometric.utils.matmul import matmul import matmul
+from torch_geometric.utils.matmul import matmul
 from torch_sparse import SparseTensor
 
 from torch_geometric.nn.conv import MessagePassing

--- a/torch_geometric/nn/conv/signed_conv.py
+++ b/torch_geometric/nn/conv/signed_conv.py
@@ -2,8 +2,8 @@ from typing import Union
 
 import torch
 from torch import Tensor
-from torch_sparse import SparseTensor
 from torch.sparse.matmul import matmul
+from torch_sparse import SparseTensor
 
 from torch_geometric.nn.conv import MessagePassing
 from torch_geometric.nn.dense.linear import Linear

--- a/torch_geometric/nn/conv/signed_conv.py
+++ b/torch_geometric/nn/conv/signed_conv.py
@@ -2,12 +2,12 @@ from typing import Union
 
 import torch
 from torch import Tensor
-from torch_geometric.utils.matmul import matmul
 from torch_sparse import SparseTensor
 
 from torch_geometric.nn.conv import MessagePassing
 from torch_geometric.nn.dense.linear import Linear
 from torch_geometric.typing import Adj, PairTensor
+from torch_geometric.utils.matmul import matmul
 
 
 class SignedConv(MessagePassing):

--- a/torch_geometric/nn/conv/signed_conv.py
+++ b/torch_geometric/nn/conv/signed_conv.py
@@ -2,7 +2,8 @@ from typing import Union
 
 import torch
 from torch import Tensor
-from torch_sparse import SparseTensor, matmul
+from torch_sparse import SparseTensor
+from torch.sparse.matmul import matmul
 
 from torch_geometric.nn.conv import MessagePassing
 from torch_geometric.nn.dense.linear import Linear

--- a/torch_geometric/nn/conv/ssg_conv.py
+++ b/torch_geometric/nn/conv/ssg_conv.py
@@ -1,7 +1,8 @@
 from typing import Optional
 
 from torch import Tensor
-from torch_sparse import SparseTensor, matmul
+from torch_sparse import SparseTensor
+from torch.sparse.matmul import matmul
 
 from torch_geometric.nn.conv import MessagePassing
 from torch_geometric.nn.conv.gcn_conv import gcn_norm

--- a/torch_geometric/nn/conv/ssg_conv.py
+++ b/torch_geometric/nn/conv/ssg_conv.py
@@ -1,13 +1,13 @@
 from typing import Optional
 
 from torch import Tensor
-from torch_geometric.utils.matmul import matmul
 from torch_sparse import SparseTensor
 
 from torch_geometric.nn.conv import MessagePassing
 from torch_geometric.nn.conv.gcn_conv import gcn_norm
 from torch_geometric.nn.dense.linear import Linear
 from torch_geometric.typing import Adj, OptTensor
+from torch_geometric.utils.matmul import matmul
 
 
 class SSGConv(MessagePassing):

--- a/torch_geometric/nn/conv/ssg_conv.py
+++ b/torch_geometric/nn/conv/ssg_conv.py
@@ -1,7 +1,7 @@
 from typing import Optional
 
 from torch import Tensor
-from torch.sparse.matmul import matmul
+from torch_geometric.utils.matmul import matmul import matmul
 from torch_sparse import SparseTensor
 
 from torch_geometric.nn.conv import MessagePassing

--- a/torch_geometric/nn/conv/ssg_conv.py
+++ b/torch_geometric/nn/conv/ssg_conv.py
@@ -1,7 +1,7 @@
 from typing import Optional
 
 from torch import Tensor
-from torch_geometric.utils.matmul import matmul import matmul
+from torch_geometric.utils.matmul import matmul
 from torch_sparse import SparseTensor
 
 from torch_geometric.nn.conv import MessagePassing

--- a/torch_geometric/nn/conv/ssg_conv.py
+++ b/torch_geometric/nn/conv/ssg_conv.py
@@ -1,8 +1,8 @@
 from typing import Optional
 
 from torch import Tensor
-from torch_sparse import SparseTensor
 from torch.sparse.matmul import matmul
+from torch_sparse import SparseTensor
 
 from torch_geometric.nn.conv import MessagePassing
 from torch_geometric.nn.conv.gcn_conv import gcn_norm

--- a/torch_geometric/nn/conv/tag_conv.py
+++ b/torch_geometric/nn/conv/tag_conv.py
@@ -1,6 +1,6 @@
 import torch
 from torch import Tensor
-from torch_geometric.utils.matmul import matmul import matmul
+from torch_geometric.utils.matmul import matmul
 from torch_sparse import SparseTensor
 
 from torch_geometric.nn.conv import MessagePassing

--- a/torch_geometric/nn/conv/tag_conv.py
+++ b/torch_geometric/nn/conv/tag_conv.py
@@ -1,6 +1,5 @@
 import torch
 from torch import Tensor
-from torch_geometric.utils.matmul import matmul
 from torch_sparse import SparseTensor
 
 from torch_geometric.nn.conv import MessagePassing
@@ -8,6 +7,7 @@ from torch_geometric.nn.conv.gcn_conv import gcn_norm
 from torch_geometric.nn.dense.linear import Linear
 from torch_geometric.nn.inits import zeros
 from torch_geometric.typing import Adj, OptTensor
+from torch_geometric.utils.matmul import matmul
 
 
 class TAGConv(MessagePassing):

--- a/torch_geometric/nn/conv/tag_conv.py
+++ b/torch_geometric/nn/conv/tag_conv.py
@@ -1,7 +1,7 @@
 import torch
 from torch import Tensor
-from torch_sparse import SparseTensor
 from torch.sparse.matmul import matmul
+from torch_sparse import SparseTensor
 
 from torch_geometric.nn.conv import MessagePassing
 from torch_geometric.nn.conv.gcn_conv import gcn_norm

--- a/torch_geometric/nn/conv/tag_conv.py
+++ b/torch_geometric/nn/conv/tag_conv.py
@@ -1,6 +1,6 @@
 import torch
 from torch import Tensor
-from torch.sparse.matmul import matmul
+from torch_geometric.utils.matmul import matmul import matmul
 from torch_sparse import SparseTensor
 
 from torch_geometric.nn.conv import MessagePassing

--- a/torch_geometric/nn/conv/tag_conv.py
+++ b/torch_geometric/nn/conv/tag_conv.py
@@ -1,6 +1,7 @@
 import torch
 from torch import Tensor
-from torch_sparse import SparseTensor, matmul
+from torch_sparse import SparseTensor
+from torch.sparse.matmul import matmul
 
 from torch_geometric.nn.conv import MessagePassing
 from torch_geometric.nn.conv.gcn_conv import gcn_norm

--- a/torch_geometric/nn/models/basic_gnn.py
+++ b/torch_geometric/nn/models/basic_gnn.py
@@ -220,13 +220,14 @@ class BasicGNN(torch.nn.Module):
 
         for i in range(self.num_layers):
             xs: List[Tensor] = []
-            for batch in loader:
+            for idx, batch in enumerate(loader):
                 x = x_all[batch.n_id].to(device)
                 if hasattr(batch, 'adj_t'):
                     edge_index = batch.adj_t.to(device)
                 else:
                     edge_index = batch.edge_index.to(device)
                 x = self.convs[i](x, edge_index)[:batch.batch_size]
+                
                 if i == self.num_layers - 1 and self.jk_mode is None:
                     xs.append(x.cpu())
                     if progress_bar:

--- a/torch_geometric/nn/models/basic_gnn.py
+++ b/torch_geometric/nn/models/basic_gnn.py
@@ -227,7 +227,7 @@ class BasicGNN(torch.nn.Module):
                 else:
                     edge_index = batch.edge_index.to(device)
                 x = self.convs[i](x, edge_index)[:batch.batch_size]
-                
+
                 if i == self.num_layers - 1 and self.jk_mode is None:
                     xs.append(x.cpu())
                     if progress_bar:

--- a/torch_geometric/nn/models/basic_gnn.py
+++ b/torch_geometric/nn/models/basic_gnn.py
@@ -220,7 +220,7 @@ class BasicGNN(torch.nn.Module):
 
         for i in range(self.num_layers):
             xs: List[Tensor] = []
-            for idx, batch in enumerate(loader):
+            for batch in loader:
                 x = x_all[batch.n_id].to(device)
                 if hasattr(batch, 'adj_t'):
                     edge_index = batch.adj_t.to(device)

--- a/torch_geometric/nn/models/label_prop.py
+++ b/torch_geometric/nn/models/label_prop.py
@@ -3,8 +3,8 @@ from typing import Callable, Optional
 import torch
 import torch.nn.functional as F
 from torch import Tensor
-from torch_sparse import SparseTensor
 from torch.sparse.matmul import matmul
+from torch_sparse import SparseTensor
 
 from torch_geometric.nn.conv import MessagePassing
 from torch_geometric.nn.conv.gcn_conv import gcn_norm

--- a/torch_geometric/nn/models/label_prop.py
+++ b/torch_geometric/nn/models/label_prop.py
@@ -3,7 +3,7 @@ from typing import Callable, Optional
 import torch
 import torch.nn.functional as F
 from torch import Tensor
-from torch.sparse.matmul import matmul
+from torch_geometric.utils.matmul import matmul import matmul
 from torch_sparse import SparseTensor
 
 from torch_geometric.nn.conv import MessagePassing

--- a/torch_geometric/nn/models/label_prop.py
+++ b/torch_geometric/nn/models/label_prop.py
@@ -3,7 +3,8 @@ from typing import Callable, Optional
 import torch
 import torch.nn.functional as F
 from torch import Tensor
-from torch_sparse import SparseTensor, matmul
+from torch_sparse import SparseTensor
+from torch.sparse.matmul import matmul
 
 from torch_geometric.nn.conv import MessagePassing
 from torch_geometric.nn.conv.gcn_conv import gcn_norm

--- a/torch_geometric/nn/models/label_prop.py
+++ b/torch_geometric/nn/models/label_prop.py
@@ -3,7 +3,7 @@ from typing import Callable, Optional
 import torch
 import torch.nn.functional as F
 from torch import Tensor
-from torch_geometric.utils.matmul import matmul import matmul
+from torch_geometric.utils.matmul import matmul
 from torch_sparse import SparseTensor
 
 from torch_geometric.nn.conv import MessagePassing

--- a/torch_geometric/nn/models/linkx.py
+++ b/torch_geometric/nn/models/linkx.py
@@ -3,8 +3,8 @@ import math
 import torch
 from torch import Tensor
 from torch.nn import BatchNorm1d, Parameter
-from torch_sparse import SparseTensor
 from torch.sparse.matmul import matmul
+from torch_sparse import SparseTensor
 
 from torch_geometric.nn import inits
 from torch_geometric.nn.conv import MessagePassing

--- a/torch_geometric/nn/models/linkx.py
+++ b/torch_geometric/nn/models/linkx.py
@@ -3,7 +3,8 @@ import math
 import torch
 from torch import Tensor
 from torch.nn import BatchNorm1d, Parameter
-from torch_sparse import SparseTensor, matmul
+from torch_sparse import SparseTensor
+from torch.sparse.matmul import matmul
 
 from torch_geometric.nn import inits
 from torch_geometric.nn.conv import MessagePassing

--- a/torch_geometric/nn/models/linkx.py
+++ b/torch_geometric/nn/models/linkx.py
@@ -3,7 +3,7 @@ import math
 import torch
 from torch import Tensor
 from torch.nn import BatchNorm1d, Parameter
-from torch.sparse.matmul import matmul
+from torch_geometric.utils.matmul import matmul import matmul
 from torch_sparse import SparseTensor
 
 from torch_geometric.nn import inits

--- a/torch_geometric/nn/models/linkx.py
+++ b/torch_geometric/nn/models/linkx.py
@@ -3,7 +3,7 @@ import math
 import torch
 from torch import Tensor
 from torch.nn import BatchNorm1d, Parameter
-from torch_geometric.utils.matmul import matmul import matmul
+from torch_geometric.utils.matmul import matmul
 from torch_sparse import SparseTensor
 
 from torch_geometric.nn import inits

--- a/torch_geometric/nn/pool/asap.py
+++ b/torch_geometric/nn/pool/asap.py
@@ -10,10 +10,11 @@ from torch_sparse import (
     SparseTensor,
     fill_diag,
     index_select,
-    matmul,
     remove_diag,
 )
 from torch_sparse import t as transpose
+
+from torch.sparse.matmul import matmul
 
 from torch_geometric.nn import LEConv
 from torch_geometric.nn.pool.topk_pool import topk

--- a/torch_geometric/nn/pool/asap.py
+++ b/torch_geometric/nn/pool/asap.py
@@ -5,7 +5,7 @@ import torch
 import torch.nn.functional as F
 from torch import Tensor
 from torch.nn import Linear
-from torch_geometric.utils.matmul import matmul import matmul
+from torch_geometric.utils.matmul import matmul
 from torch_scatter import scatter
 from torch_sparse import SparseTensor, fill_diag, index_select, remove_diag
 from torch_sparse import t as transpose

--- a/torch_geometric/nn/pool/asap.py
+++ b/torch_geometric/nn/pool/asap.py
@@ -5,7 +5,7 @@ import torch
 import torch.nn.functional as F
 from torch import Tensor
 from torch.nn import Linear
-from torch.sparse.matmul import matmul
+from torch_geometric.utils.matmul import matmul import matmul
 from torch_scatter import scatter
 from torch_sparse import SparseTensor, fill_diag, index_select, remove_diag
 from torch_sparse import t as transpose

--- a/torch_geometric/nn/pool/asap.py
+++ b/torch_geometric/nn/pool/asap.py
@@ -5,16 +5,10 @@ import torch
 import torch.nn.functional as F
 from torch import Tensor
 from torch.nn import Linear
-from torch_scatter import scatter
-from torch_sparse import (
-    SparseTensor,
-    fill_diag,
-    index_select,
-    remove_diag,
-)
-from torch_sparse import t as transpose
-
 from torch.sparse.matmul import matmul
+from torch_scatter import scatter
+from torch_sparse import SparseTensor, fill_diag, index_select, remove_diag
+from torch_sparse import t as transpose
 
 from torch_geometric.nn import LEConv
 from torch_geometric.nn.pool.topk_pool import topk

--- a/torch_geometric/nn/pool/asap.py
+++ b/torch_geometric/nn/pool/asap.py
@@ -5,7 +5,6 @@ import torch
 import torch.nn.functional as F
 from torch import Tensor
 from torch.nn import Linear
-from torch_geometric.utils.matmul import matmul
 from torch_scatter import scatter
 from torch_sparse import SparseTensor, fill_diag, index_select, remove_diag
 from torch_sparse import t as transpose
@@ -13,6 +12,7 @@ from torch_sparse import t as transpose
 from torch_geometric.nn import LEConv
 from torch_geometric.nn.pool.topk_pool import topk
 from torch_geometric.utils import add_remaining_self_loops, softmax
+from torch_geometric.utils.matmul import matmul
 
 
 class ASAPooling(torch.nn.Module):

--- a/torch_geometric/transforms/__init__.py
+++ b/torch_geometric/transforms/__init__.py
@@ -24,6 +24,7 @@ from .random_rotate import RandomRotate
 from .random_shear import RandomShear
 from .normalize_features import NormalizeFeatures
 from .add_self_loops import AddSelfLoops
+from .remove_duplicate_self_loops import RemoveDuplicateSelfLoops
 from .remove_isolated_nodes import RemoveIsolatedNodes
 from .knn_graph import KNNGraph
 from .radius_graph import RadiusGraph
@@ -80,6 +81,7 @@ __all__ = [
     'RandomShear',
     'NormalizeFeatures',
     'AddSelfLoops',
+    'RemoveDuplicateSelfLoops',
     'RemoveIsolatedNodes',
     'KNNGraph',
     'RadiusGraph',

--- a/torch_geometric/transforms/remove_duplicate_self_loops.py
+++ b/torch_geometric/transforms/remove_duplicate_self_loops.py
@@ -14,7 +14,6 @@ class RemoveDuplicateSelfLoops(BaseTransform):
     <https://ogb.stanford.edu/docs/nodeprop/#:~:text=Note%3A%20A%20very%20small%20number%20of%20self%2Dconnecting%20edges%20are%20repeated%20(see%20here)%3B%20you%20may%20remove%20them%20if%20necessary>
     (functional name: :obj:`remove_duplicate_self_loops`).
     """
-
     def __call__(
         self,
         data: Union[Data, HeteroData],
@@ -23,18 +22,22 @@ class RemoveDuplicateSelfLoops(BaseTransform):
             if store.is_bipartite() or 'edge_index' not in store:
                 continue
 
-            (edge_index, edge_weight, loop_edge_index, loop_edge_attr) = segregate_self_loops(store.edge_index, getattr(store, 'edge_weight', None))
-            
+            (edge_index, edge_weight, loop_edge_index,
+             loop_edge_attr) = segregate_self_loops(
+                 store.edge_index, getattr(store, 'edge_weight', None))
+
             loop_edge_index = torch.unique(loop_edge_index[0])
-            loop_edge_index = torch.stack((loop_edge_index, loop_edge_index), dim=0)
+            loop_edge_index = torch.stack((loop_edge_index, loop_edge_index),
+                                          dim=0)
 
             edge_index = torch.cat((edge_index, loop_edge_index), dim=1)
             setattr(store, 'edge_index', edge_index)
-            
+
             if edge_weight is not None:
                 loop_edge_attr = torch.unique(loop_edge_attr[0])
-                loop_edge_attr = torch.stack((loop_edge_attr, loop_edge_attr), dim=0) 
+                loop_edge_attr = torch.stack((loop_edge_attr, loop_edge_attr),
+                                             dim=0)
                 torch.cat((edge_weight, loop_edge_attr), dim=1)
                 setattr(store, 'edge_weight', edge_weight)
-        
+
         return data

--- a/torch_geometric/transforms/remove_duplicate_self_loops.py
+++ b/torch_geometric/transforms/remove_duplicate_self_loops.py
@@ -1,0 +1,40 @@
+from typing import Optional, Union
+
+import torch
+
+from torch_geometric.data import Data, HeteroData
+from torch_geometric.data.datapipes import functional_transform
+from torch_geometric.transforms import BaseTransform
+from torch_geometric.utils import segregate_self_loops
+
+
+@functional_transform('remove_duplicate_self_loops')
+class RemoveDuplicateSelfLoops(BaseTransform):
+    r"""Removes duplicate self-loops to the given homogeneous or heterogeneous graph. It will change the original order of dataset by concatenating unique self-looping edges at the end of the dataset. It can be used to clean up known issue with ogbn-products dataset:
+    <https://ogb.stanford.edu/docs/nodeprop/#:~:text=Note%3A%20A%20very%20small%20number%20of%20self%2Dconnecting%20edges%20are%20repeated%20(see%20here)%3B%20you%20may%20remove%20them%20if%20necessary>
+    (functional name: :obj:`remove_duplicate_self_loops`).
+    """
+
+    def __call__(
+        self,
+        data: Union[Data, HeteroData],
+    ) -> Union[Data, HeteroData]:
+        for store in data.edge_stores:
+            if store.is_bipartite() or 'edge_index' not in store:
+                continue
+
+            (edge_index, edge_weight, loop_edge_index, loop_edge_attr) = segregate_self_loops(store.edge_index, getattr(store, 'edge_weight', None))
+            
+            loop_edge_index = torch.unique(loop_edge_index[0])
+            loop_edge_index = torch.stack((loop_edge_index, loop_edge_index), dim=0)
+
+            edge_index = torch.cat((edge_index, loop_edge_index), dim=1)
+            setattr(store, 'edge_index', edge_index)
+            
+            if edge_weight is not None:
+                loop_edge_attr = torch.unique(loop_edge_attr[0])
+                loop_edge_attr = torch.stack((loop_edge_attr, loop_edge_attr), dim=0) 
+                torch.cat((edge_weight, loop_edge_attr), dim=1)
+                setattr(store, 'edge_weight', edge_weight)
+        
+        return data

--- a/torch_geometric/transforms/remove_duplicate_self_loops.py
+++ b/torch_geometric/transforms/remove_duplicate_self_loops.py
@@ -11,7 +11,7 @@ from torch_geometric.utils import segregate_self_loops
 @functional_transform('remove_duplicate_self_loops')
 class RemoveDuplicateSelfLoops(BaseTransform):
     r"""Removes duplicate self-loops to the given homogeneous or heterogeneous graph. It will change the original order of dataset by concatenating unique self-looping edges at the end of the dataset. It can be used to clean up known issue with ogbn-products dataset:
-    <https://ogb.stanford.edu/docs/nodeprop/#:~:text=Note%3A%20A%20very%20small%20number%20of%20self%2Dconnecting%20edges%20are%20repeated%20(see%20here)%3B%20you%20may%20remove%20them%20if%20necessary>
+    <https://tinyurl.com/ogbdocs>
     (functional name: :obj:`remove_duplicate_self_loops`).
     """
     def __call__(

--- a/torch_geometric/utils/__init__.py
+++ b/torch_geometric/utils/__init__.py
@@ -21,6 +21,7 @@ from .to_dense_batch import to_dense_batch
 from .to_dense_adj import to_dense_adj
 from .sparse import (dense_to_sparse, is_sparse, is_torch_sparse_tensor,
                      to_torch_coo_tensor)
+from .matmul import matmul
 from .spmm import spmm
 from .unbatch import unbatch, unbatch_edge_index
 from .normalized_cut import normalized_cut

--- a/torch_geometric/utils/matmul.py
+++ b/torch_geometric/utils/matmul.py
@@ -1,7 +1,9 @@
 import torch
 from torch_sparse import SparseTensor
 from torch_sparse.matmul import spspmm
+
 from .spmm import spmm
+
 
 @torch.jit._overload  # noqa: F811
 def matmul(src, other, reduce):  # noqa: F811
@@ -21,6 +23,7 @@ def matmul(src, other, reduce="sum"):  # noqa: F811
     elif isinstance(other, SparseTensor):
         return spspmm(src, other, reduce)
     raise ValueError
+
 
 SparseTensor.matmul = lambda self, other, reduce="sum": matmul(
     self, other, reduce)

--- a/torch_geometric/utils/matmul.py
+++ b/torch_geometric/utils/matmul.py
@@ -1,0 +1,27 @@
+import torch
+from torch_sparse import SparseTensor
+from torch_sparse.matmul import spspmm
+from .spmm import spmm
+
+@torch.jit._overload  # noqa: F811
+def matmul(src, other, reduce):  # noqa: F811
+    # type: (SparseTensor, torch.Tensor, str) -> torch.Tensor
+    pass
+
+
+@torch.jit._overload  # noqa: F811
+def matmul(src, other, reduce):  # noqa: F811
+    # type: (SparseTensor, SparseTensor, str) -> SparseTensor
+    pass
+
+
+def matmul(src, other, reduce="sum"):  # noqa: F811
+    if isinstance(other, torch.Tensor):
+        return spmm(src, other, reduce)
+    elif isinstance(other, SparseTensor):
+        return spspmm(src, other, reduce)
+    raise ValueError
+
+SparseTensor.matmul = lambda self, other, reduce="sum": matmul(
+    self, other, reduce)
+SparseTensor.__matmul__ = lambda self, other: matmul(self, other, 'sum')

--- a/torch_geometric/utils/matmul.py
+++ b/torch_geometric/utils/matmul.py
@@ -1,8 +1,13 @@
 import torch
 from torch_sparse import SparseTensor
 from torch_sparse.matmul import spspmm
+from packaging import version
 
-from .spmm import spmm
+if version.parse(torch.__version__) <= version.parse('1.13'):
+    from torch_sparse.matmul import spmm
+else:
+    from .spmm import spmm
+    
 
 
 @torch.jit._overload  # noqa: F811

--- a/torch_geometric/utils/spmm.py
+++ b/torch_geometric/utils/spmm.py
@@ -3,6 +3,7 @@ from torch import Tensor
 
 from torch_geometric.typing import Adj, SparseTensor
 from torch_geometric.utils import is_torch_sparse_tensor
+from torch_sparse.matmul import spmm as sparse_spmm
 
 
 @torch.jit._overload
@@ -36,6 +37,9 @@ def spmm(src: Adj, other: Tensor, reduce: str = "sum") -> Tensor:
         'sum', 'add', 'mean', 'min', 'max'
     ], f"Uknown reduction type {reduce}. Supported: ['sum','add', 'mean','max','min']"
     reduce = 'sum' if reduce == 'add' else reduce
+    
+    if len(other.size()) > 2:
+        return sparse_spmm(src, other, reduce)
 
     # TODO: When torch.sparse.Tensor is available and use more strict        is_torch_sparse_tensor(src)
     # if not is_torch_sparse_tensor(src):

--- a/torch_geometric/utils/spmm.py
+++ b/torch_geometric/utils/spmm.py
@@ -1,8 +1,8 @@
 import torch
 from torch import Tensor
-
 from torch_sparse import SparseTensor
-from .sparse import is_torch_sparse_tensor, is_sparse
+
+from .sparse import is_sparse, is_torch_sparse_tensor
 
 
 @torch.jit._overload
@@ -32,35 +32,40 @@ def spmm(src: Adj, other: Tensor, reduce: str = "sum") -> Tensor:
     :rtype: :class:`Tensor`
     """
 
-    assert reduce in ['sum', 'add', 'mean', 'min', 'max'], f"Uknown reduction type {reduce}. Supported: ['sum','mean','max','min']"
+    assert reduce in [
+        'sum', 'add', 'mean', 'min', 'max'
+    ], f"Uknown reduction type {reduce}. Supported: ['sum','mean','max','min']"
     reduce = 'sum' if reduce == 'add' else reduce
-    
+
     # TODO: When torch.sparse.Tensor is available and use more strict        is_torch_sparse_tensor(src)
     # if not is_sparse(src):
-    # 
+    #
     #     raise ValueError("`src` must be a `torch_sparse.SparseTensor` "
     #                      f"or a `torch.sparse.Tensor` (got {type(src)}).")
-    
+
     if isinstance(src, SparseTensor):
         if other.requires_grad:
             row = src.storage.row()
             csr2csc = src.storage.csr2csc()
             ccol_indices = src.storage.colptr()
         csr = src.to_torch_sparse_csr_tensor(dtype=other.dtype)
-    
+
     else:
         csr = src
         row = None
         csr2csc = None
         ccol_indices = None
-        
+
     if not csr.layout == torch.sparse_csr:
-        raise ValueError(f"src must be a `torch.Tensor` with `torch.sparse_csr` layout {csr.layout}")
-    
+        raise ValueError(
+            f"src must be a `torch.Tensor` with `torch.sparse_csr` layout {csr.layout}"
+        )
+
     if other.requires_grad:
-        return torch.sparse.spmm_reduce(csr, other, reduce, row, ccol_indices, csr2csc)
+        return torch.sparse.spmm_reduce(csr, other, reduce, row, ccol_indices,
+                                        csr2csc)
     else:
         return torch.sparse.spmm_reduce(csr, other, reduce)
 
-    
+
 SparseTensor.spmm = lambda self, other, reduce="sum": spmm(self, other, reduce)

--- a/torch_geometric/utils/spmm.py
+++ b/torch_geometric/utils/spmm.py
@@ -1,9 +1,9 @@
 import torch
 from torch import Tensor
+from torch_sparse.matmul import spmm as sparse_spmm
 
 from torch_geometric.typing import Adj, SparseTensor
 from torch_geometric.utils import is_torch_sparse_tensor
-from torch_sparse.matmul import spmm as sparse_spmm
 
 
 @torch.jit._overload
@@ -37,7 +37,7 @@ def spmm(src: Adj, other: Tensor, reduce: str = "sum") -> Tensor:
         'sum', 'add', 'mean', 'min', 'max'
     ], f"Uknown reduction type {reduce}. Supported: ['sum','add', 'mean','max','min']"
     reduce = 'sum' if reduce == 'add' else reduce
-    
+
     if len(other.size()) > 2:
         return sparse_spmm(src, other, reduce)
 

--- a/torch_geometric/utils/spmm.py
+++ b/torch_geometric/utils/spmm.py
@@ -2,8 +2,6 @@ import torch
 from torch import Tensor
 from torch_sparse import SparseTensor
 
-from .sparse import is_sparse, is_torch_sparse_tensor
-
 
 @torch.jit._overload
 def spmm(src, other, reduce):
@@ -17,7 +15,7 @@ def spmm(src, other, reduce):
     pass
 
 
-def spmm(src: Adj, other: Tensor, reduce: str = "sum") -> Tensor:
+def spmm(src: SparseTensor, other: Tensor, reduce: str = "sum") -> Tensor:
     """Matrix product of sparse matrix with dense matrix.
 
     Args:


### PR DESCRIPTION
Relates to PR in pytorch repo: https://github.com/pytorch/pytorch/pull/83727
Implements new `spmm_reduce()` kernel into PyG.

I've opened this Draft to have an overview of changes needed to integrate the new `spmm_reduce()` I'm open for your suggestions if there're changes that need to be done. 

Summary of changes:
- [torch_geometric/utils/spmm.py](https://github.com/pyg-team/pytorch_geometric/pull/6172/files#diff-cd82640198bf2c9a228baa9609100b7a2667ac3ce05003e9419f82d5ab5e0ac6) performs type checks and conversions from SparseTensor to torch.Tensor with CSR layout. It assumes that there's `torch.sparse.spmm_reduce()` available.
- in `torch_geometric/nn/...` the imports have been replaced according to the schema:
    :heavy_minus_sign: from torch_sparse import SparseTensor, matmul
    :heavy_plus_sign: from torch.sparse.matmul import matmul
    :heavy_plus_sign: from torch_sparse import SparseTensor
- added a new dataset transformation `RemoveDuplicateSelfLoops()` that cleans duplicate self-loops as a workaround for `to_torch_sparse_csr_tensor()` not supporting multi-graph Adj
- added [backwards compatibility test for spmm](https://github.com/pyg-team/pytorch_geometric/pull/6172/files#diff-1735e4bea9217783aab25502cb1c87999220f2a3ba56019a564ac6c9e9bc5cd1), that compares spmm of `torch-sparse` with the new kernel 