### PR TITLE
Removed `Aggregation.set_validate_args` option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Optimized `utils.softmax` implementation ([#6113](https://github.com/pyg-team/pytorch_geometric/pull/6113), [#6155](https://github.com/pyg-team/pytorch_geometric/pull/6155))
 - Optimized `topk` implementation for large enough graphs ([#6123](https://github.com/pyg-team/pytorch_geometric/pull/6123))
 ### Removed
-- Removed `Aggregation.set_validate_args` option  ([]())
+- Removed `Aggregation.set_validate_args` option  ([#6175](https://github.com/pyg-team/pytorch_geometric/pull/6175))
 
 ## [2.2.0] - 2022-12-01
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Optimized `utils.softmax` implementation ([#6113](https://github.com/pyg-team/pytorch_geometric/pull/6113), [#6155](https://github.com/pyg-team/pytorch_geometric/pull/6155))
 - Optimized `topk` implementation for large enough graphs ([#6123](https://github.com/pyg-team/pytorch_geometric/pull/6123))
 ### Removed
+- Removed `Aggregation.set_validate_args` option  ([]())
 
 ## [2.2.0] - 2022-12-01
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Optimized `utils.softmax` implementation ([#6113](https://github.com/pyg-team/pytorch_geometric/pull/6113), [#6155](https://github.com/pyg-team/pytorch_geometric/pull/6155))
 - Optimized `topk` implementation for large enough graphs ([#6123](https://github.com/pyg-team/pytorch_geometric/pull/6123))
 ### Removed
-- Removed `Aggregation.set_validate_args` option  ([#6175](https://github.com/pyg-team/pytorch_geometric/pull/6175))
+- Removed `Aggregation.set_validate_args` option ([#6175](https://github.com/pyg-team/pytorch_geometric/pull/6175))
 
 ## [2.2.0] - 2022-12-01
 ### Added

--- a/test/nn/aggr/test_basic.py
+++ b/test/nn/aggr/test_basic.py
@@ -30,10 +30,6 @@ def test_validate():
     with pytest.raises(ValueError, match="invalid 'dim_size'"):
         aggr(x, index, dim_size=2)
 
-    aggr.set_validate_args(False)
-    with pytest.raises(RuntimeError, match="out of bounds"):
-        aggr(x, index, dim_size=2)
-
 
 @pytest.mark.parametrize('Aggregation', [
     MeanAggregation,

--- a/torch_geometric/nn/aggr/base.py
+++ b/torch_geometric/nn/aggr/base.py
@@ -109,11 +109,11 @@ class Aggregation(torch.nn.Module):
         try:
             return super().__call__(x, index, ptr, dim_size, dim, **kwargs)
         except (IndexError, RuntimeError) as e:
-            if index is not None and index.numel() > 0 and dim_size <= int(
-                    index.max()):
-                raise ValueError(f"Encountered invalid 'dim_size' (got "
-                                 f"'{dim_size}' but expected "
-                                 f">= '{int(index.max()) + 1}')")
+            if index is not None:
+                if index.numel() > 0 and dim_size <= int(index.max()):
+                    raise ValueError(f"Encountered invalid 'dim_size' (got "
+                                     f"'{dim_size}' but expected "
+                                     f">= '{int(index.max()) + 1}')")
             raise e
 
     def __repr__(self) -> str:

--- a/torch_geometric/nn/aggr/base.py
+++ b/torch_geometric/nn/aggr/base.py
@@ -58,7 +58,6 @@ class Aggregation(torch.nn.Module):
         - **output:** graph features :math:`(|\mathcal{G}|, F_{out})` or node
           features :math:`(|\mathcal{V}|, F_{out})`
     """
-    _validate = __debug__
 
     # @abstractmethod
     def forward(self, x: Tensor, index: Optional[Tensor] = None,
@@ -85,21 +84,6 @@ class Aggregation(torch.nn.Module):
     def reset_parameters(self):
         pass
 
-    @staticmethod
-    def set_validate_args(value: bool):
-        r"""Sets whether validation is enabled or disabled.
-
-        The default behavior mimics Python's :obj:`assert`` statement:
-        validation is on by default, but is disabled if Python is run in
-        optimized mode (via :obj:`python -O`).
-        Validation may be expensive, so you may want to disable it once a model
-        is working.
-
-        Args:
-            value (bool): Whether to enable validation.
-        """
-        Aggregation._validate = value
-
     def __call__(self, x: Tensor, index: Optional[Tensor] = None,
                  ptr: Optional[Tensor] = None, dim_size: Optional[int] = None,
                  dim: int = -2, **kwargs) -> Tensor:
@@ -119,16 +103,18 @@ class Aggregation(torch.nn.Module):
                                  f"'{dim_size}' but expected "
                                  f"'{ptr.numel() - 1}')")
 
-        if index is not None:
-            if dim_size is None:
-                dim_size = int(index.max()) + 1 if index.numel() > 0 else 0
-            elif self._validate:
-                if index.numel() > 0 and dim_size <= int(index.max()):
-                    raise ValueError(f"Encountered invalid 'dim_size' (got "
-                                     f"'{dim_size}' but expected "
-                                     f">= '{int(index.max()) + 1}')")
+        if index is not None and dim_size is None:
+            dim_size = int(index.max()) + 1 if index.numel() > 0 else 0
 
-        return super().__call__(x, index, ptr, dim_size, dim, **kwargs)
+        try:
+            return super().__call__(x, index, ptr, dim_size, dim, **kwargs)
+        except (IndexError, RuntimeError) as e:
+            if index is not None and index.numel() > 0 and dim_size <= int(
+                    index.max()):
+                raise ValueError(f"Encountered invalid 'dim_size' (got "
+                                 f"'{dim_size}' but expected "
+                                 f">= '{int(index.max()) + 1}')")
+            raise e
 
     def __repr__(self) -> str:
         return f'{self.__class__.__name__}()'


### PR DESCRIPTION
This patch removes `Aggregation.set_validate_args` that was added in #5290 and instead defers the checking of the index values when an exception is thrown by the aggregation.  This works in both the standard eager-PyTorch mode as well in a compiled context.