### PR TITLE
Move `ExplainerConfig` arguments to `Explainer` class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,10 +11,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Added support for dropping nodes in `utils.to_dense_batch` in case `max_num_nodes` is smaller than the number of nodes  ([#6124](https://github.com/pyg-team/pytorch_geometric/pull/6124))
 - Added the RandLA-Net architecture as an example ([#5117](https://github.com/pyg-team/pytorch_geometric/pull/5117))
 ### Changed
-- Refactoed `NeighborSampler` to be input-type agnostic ([#7247](https://github.com/pyg-team/pytorch_geometric/pull/7247))
+- Breaking Change: Move `ExplainerConfig` arguments to the `Explainer` class  ([#6176](https://github.com/pyg-team/pytorch_geometric/pull/6176))
+- Refactored `NeighborSampler` to be input-type agnostic ([#6173](https://github.com/pyg-team/pytorch_geometric/pull/6173))
 - Infer correct CUDA device ID in `profileit` decorator ([#6164](https://github.com/pyg-team/pytorch_geometric/pull/6164))
 - Correctly use edge weights in `GDC` example ([#6159](https://github.com/pyg-team/pytorch_geometric/pull/6159))
-- [Breaking Change] Moved PyTorch Lightning data modules to `torch_geometric.data.lightning` ([#6140](https://github.com/pyg-team/pytorch_geometric/pull/6140))
+- Breaking Change: Moved PyTorch Lightning data modules to `torch_geometric.data.lightning` ([#6140](https://github.com/pyg-team/pytorch_geometric/pull/6140))
 - Make `torch_sparse` an optional dependency ([#6132](https://github.com/pyg-team/pytorch_geometric/pull/6132), [#6134](https://github.com/pyg-team/pytorch_geometric/pull/6134), [#6138](https://github.com/pyg-team/pytorch_geometric/pull/6138), [#6139](https://github.com/pyg-team/pytorch_geometric/pull/6139))
 - Optimized `utils.softmax` implementation ([#6113](https://github.com/pyg-team/pytorch_geometric/pull/6113), [#6155](https://github.com/pyg-team/pytorch_geometric/pull/6155))
 - Optimized `topk` implementation for large enough graphs ([#6123](https://github.com/pyg-team/pytorch_geometric/pull/6123))

--- a/examples/gnn_explainer.py
+++ b/examples/gnn_explainer.py
@@ -42,11 +42,9 @@ for epoch in range(1, 201):
 explainer = Explainer(
     model=model,
     algorithm=GNNExplainer(epochs=200),
-    explainer_config=dict(
-        explanation_type='model',
-        node_mask_type='attributes',
-        edge_mask_type='object',
-    ),
+    explanation_type='model',
+    node_mask_type='attributes',
+    edge_mask_type='object',
     model_config=dict(
         mode='classification',
         task_level='node',

--- a/examples/gnn_explainer_ba_shapes.py
+++ b/examples/gnn_explainer_ba_shapes.py
@@ -62,11 +62,9 @@ for explanation_type in ['phenomenon', 'model']:
     explainer = Explainer(
         model=model,
         algorithm=GNNExplainer(epochs=300),
-        explainer_config=dict(
-            explanation_type=explanation_type,
-            node_mask_type='attributes',
-            edge_mask_type='object',
-        ),
+        explanation_type=explanation_type,
+        node_mask_type='attributes',
+        edge_mask_type='object',
         model_config=dict(
             mode='classification',
             task_level='node',

--- a/test/explain/algorithm/test_gnn_explainer.py
+++ b/test/explain/algorithm/test_gnn_explainer.py
@@ -2,11 +2,7 @@ import pytest
 import torch
 
 from torch_geometric.explain import Explainer, Explanation, GNNExplainer
-from torch_geometric.explain.config import (
-    ExplainerConfig,
-    MaskType,
-    ModelConfig,
-)
+from torch_geometric.explain.config import MaskType, ModelConfig
 from torch_geometric.nn import GCNConv, global_add_pool
 
 
@@ -106,12 +102,6 @@ def test_gnn_explainer_classification(
         return_type=return_type,
     )
 
-    explainer_config = ExplainerConfig(
-        explanation_type=explanation_type,
-        node_mask_type=node_mask_type,
-        edge_mask_type=edge_mask_type,
-    )
-
     model = GCN(model_config, multi_output)
 
     target = None
@@ -122,7 +112,9 @@ def test_gnn_explainer_classification(
     explainer = Explainer(
         model=model,
         algorithm=GNNExplainer(epochs=2),
-        explainer_config=explainer_config,
+        explanation_type=explanation_type,
+        node_mask_type=node_mask_type,
+        edge_mask_type=edge_mask_type,
         model_config=model_config,
     )
 
@@ -158,12 +150,6 @@ def test_gnn_explainer_regression(
         task_level=task_level,
     )
 
-    explainer_config = ExplainerConfig(
-        explanation_type=explanation_type,
-        node_mask_type=node_mask_type,
-        edge_mask_type=edge_mask_type,
-    )
-
     model = GCN(model_config, multi_output)
 
     target = None
@@ -174,7 +160,9 @@ def test_gnn_explainer_regression(
     explainer = Explainer(
         model=model,
         algorithm=GNNExplainer(epochs=2),
-        explainer_config=explainer_config,
+        explanation_type=explanation_type,
+        node_mask_type=node_mask_type,
+        edge_mask_type=edge_mask_type,
         model_config=model_config,
     )
 

--- a/test/explain/test_explainer.py
+++ b/test/explain/test_explainer.py
@@ -35,10 +35,8 @@ def test_get_prediction(data, model):
     explainer = Explainer(
         model,
         algorithm=DummyExplainer(),
-        explainer_config=dict(
-            explanation_type='phenomenon',
-            node_mask_type='object',
-        ),
+        explanation_type='phenomenon',
+        node_mask_type='object',
         model_config=dict(
             mode='regression',
             task_level='graph',
@@ -58,10 +56,8 @@ def test_forward(data, target, explanation_type):
     explainer = Explainer(
         model,
         algorithm=DummyExplainer(),
-        explainer_config=dict(
-            explanation_type=explanation_type,
-            node_mask_type='attributes',
-        ),
+        explanation_type=explanation_type,
+        node_mask_type='attributes',
         model_config=dict(
             mode='regression',
             task_level='graph',
@@ -84,11 +80,9 @@ def test_hard_threshold(data, threshold_value, node_mask_type):
     explainer = Explainer(
         DummyModel(out_dim=2),
         algorithm=DummyExplainer(),
-        explainer_config=dict(
-            explanation_type='model',
-            node_mask_type=node_mask_type,
-            edge_mask_type='object',
-        ),
+        explanation_type='model',
+        node_mask_type=node_mask_type,
+        edge_mask_type='object',
         model_config=dict(
             mode='regression',
             task_level='graph',
@@ -113,11 +107,9 @@ def test_topk_threshold(data, threshold_value, node_mask_type):
     explainer = Explainer(
         DummyModel(out_dim=2),
         algorithm=DummyExplainer(),
-        explainer_config=dict(
-            explanation_type='model',
-            node_mask_type=node_mask_type,
-            edge_mask_type='object',
-        ),
+        explanation_type='model',
+        node_mask_type=node_mask_type,
+        edge_mask_type='object',
         model_config=dict(
             mode='regression',
             task_level='graph',
@@ -145,11 +137,9 @@ def test_topk_hard_threshold(data, threshold_value, node_mask_type):
     explainer = Explainer(
         DummyModel(out_dim=2),
         algorithm=DummyExplainer(),
-        explainer_config=dict(
-            explanation_type='model',
-            node_mask_type=node_mask_type,
-            edge_mask_type='object',
-        ),
+        explanation_type='model',
+        node_mask_type=node_mask_type,
+        edge_mask_type='object',
         model_config=dict(
             mode='regression',
             task_level='graph',

--- a/torch_geometric/explain/config.py
+++ b/torch_geometric/explain/config.py
@@ -61,8 +61,8 @@ class ExplainerConfig(CastMixin):
                   is trying to predict.
 
             In practice, this means that the explanation algorithm will either
-            compute their losses with respect to the model output or the target
-            output.
+            compute their losses with respect to the model output
+            (:obj:`"model"`) or the target output (:obj:`"phenomenon"`).
 
         node_mask_type (MaskType or str, optional): The type of mask to apply
             on nodes. The possible values are (default: :obj:`None`):
@@ -76,7 +76,7 @@ class ExplainerConfig(CastMixin):
                 - :obj:`"attributes"`: Will mask each feature across all nodes.
 
         edge_mask_type (MaskType or str, optional): The type of mask to apply
-            on edges. Same types as :obj:`node_mask_type`.
+            on edges. Has the sample possible values as :obj:`node_mask_type`.
             (default: :obj:`None`)
     """
     explanation_type: ExplanationType

--- a/torch_geometric/explain/explainer.py
+++ b/torch_geometric/explain/explainer.py
@@ -25,22 +25,37 @@ class Explainer:
         model (torch.nn.Module): The model to explain.
         algorithm (ExplainerAlgorithm): The explanation algorithm.
         explanation_type (ExplanationType or str): The type of explanation to
-            compute (:obj:`"model"` or :obj:`"phenomenon"`).
-            See :class:`~torch_geometric.explain.ExplainerConfig` for more
-            information.
+            compute. The possible values are:
+
+                - :obj:`"model"`: Explains the model prediction.
+
+                - :obj:`"phenomenon"`: Explains the phenomenon that the model
+                  is trying to predict.
+
+            In practice, this means that the explanation algorithm will either
+            compute their losses with respect to the model output
+            (:obj:`"model"`) or the target output (:obj:`"phenomenon"`).
         model_config (ModelConfig): The model configuration.
+            See :class:`~torch_geometric.explain.ModelConfig` for available
+            options. (default: :obj:`None`)
         node_mask_type (MaskType or str, optional): The type of mask to apply
-            on nodes (:obj:`None`, :obj:`"object"`, :obj:`"common_attributes"`
-            or :obj:`"attributes"`).
-            See :class:`~torch_geometric.explain.ExplainerConfig` for more
-            information. (default: :obj:`None`)
+            on nodes. The possible values are (default: :obj:`None`):
+
+                - :obj:`None`: Will not apply any mask on nodes.
+
+                - :obj:`"object"`: Will mask each node.
+
+                - :obj:`"common_attributes"`: Will mask each feature.
+
+                - :obj:`"attributes"`: Will mask each feature across all nodes.
+
         edge_mask_type (MaskType or str, optional): The type of mask to apply
-            on edges (:obj:`None`, :obj:`"object"`, :obj:`"common_attributes"`
-            or :obj:`"attributes"`).
-            See :class:`~torch_geometric.explain.ExplainerConfig` for more
-            information. (default: :obj:`None`)
+            on edges. Has the sample possible values as :obj:`node_mask_type`.
+            (default: :obj:`None`)
         threshold_config (ThresholdConfig, optional): The threshold
-            configuration. (default: :obj:`None`)
+            configuration.
+            See :class:`~torch_geometric.explain.ThresholdConfig` for available
+            options. (default: :obj:`None`)
     """
     def __init__(
         self,

--- a/torch_geometric/explain/explainer.py
+++ b/torch_geometric/explain/explainer.py
@@ -36,8 +36,8 @@ class Explainer:
             compute their losses with respect to the model output
             (:obj:`"model"`) or the target output (:obj:`"phenomenon"`).
         model_config (ModelConfig): The model configuration.
-            See :class:`~torch_geometric.explain.ModelConfig` for available
-            options. (default: :obj:`None`)
+            See :class:`~torch_geometric.explain.config.ModelConfig` for
+            available options. (default: :obj:`None`)
         node_mask_type (MaskType or str, optional): The type of mask to apply
             on nodes. The possible values are (default: :obj:`None`):
 
@@ -54,8 +54,8 @@ class Explainer:
             (default: :obj:`None`)
         threshold_config (ThresholdConfig, optional): The threshold
             configuration.
-            See :class:`~torch_geometric.explain.ThresholdConfig` for available
-            options. (default: :obj:`None`)
+            See :class:`~torch_geometric.explain.config.ThresholdConfig` for
+            available options. (default: :obj:`None`)
     """
     def __init__(
         self,

--- a/torch_geometric/explain/explainer.py
+++ b/torch_geometric/explain/explainer.py
@@ -53,9 +53,9 @@ class Explainer:
         threshold_config: Optional[ThresholdConfig] = None,
     ):
         explainer_config = ExplainerConfig(
-            self.explanation_type,
-            self.node_mask_type,
-            self.edge_mask_type,
+            explanation_type=explanation_type,
+            node_mask_type=node_mask_type,
+            edge_mask_type=edge_mask_type,
         )
 
         self.model = model

--- a/torch_geometric/explain/explainer.py
+++ b/torch_geometric/explain/explainer.py
@@ -1,6 +1,6 @@
 import copy
 import warnings
-from typing import Optional, Union
+from typing import Any, Dict, Optional, Union
 
 import torch
 from torch import Tensor
@@ -9,6 +9,7 @@ from torch_geometric.explain import ExplainerAlgorithm, Explanation
 from torch_geometric.explain.config import (
     ExplainerConfig,
     ExplanationType,
+    MaskType,
     ModelConfig,
     ModelMode,
     ThresholdConfig,
@@ -23,8 +24,21 @@ class Explainer:
     Args:
         model (torch.nn.Module): The model to explain.
         algorithm (ExplainerAlgorithm): The explanation algorithm.
-        explainer_config (ExplainerConfig): The explainer configuration.
+        explanation_type (ExplanationType or str): The type of explanation to
+            compute (:obj:`"model"` or :obj:`"phenomenon"`).
+            See :class:`~torch_geometric.explain.ExplainerConfig` for more
+            information.
         model_config (ModelConfig): The model configuration.
+        node_mask_type (MaskType or str, optional): The type of mask to apply
+            on nodes (:obj:`None`, :obj:`"object"`, :obj:`"common_attributes"`
+            or :obj:`"attributes"`).
+            See :class:`~torch_geometric.explain.ExplainerConfig` for more
+            information. (default: :obj:`None`)
+        edge_mask_type (MaskType or str, optional): The type of mask to apply
+            on edges (:obj:`None`, :obj:`"object"`, :obj:`"common_attributes"`
+            or :obj:`"attributes"`).
+            See :class:`~torch_geometric.explain.ExplainerConfig` for more
+            information. (default: :obj:`None`)
         threshold_config (ThresholdConfig, optional): The threshold
             configuration. (default: :obj:`None`)
     """
@@ -32,18 +46,27 @@ class Explainer:
         self,
         model: torch.nn.Module,
         algorithm: ExplainerAlgorithm,
-        explainer_config: ExplainerConfig,
-        model_config: ModelConfig,
+        explanation_type: Union[ExplanationType, str],
+        model_config: Union[ModelConfig, Dict[str, Any]],
+        node_mask_type: Optional[Union[MaskType, str]] = None,
+        edge_mask_type: Optional[Union[MaskType, str]] = None,
         threshold_config: Optional[ThresholdConfig] = None,
     ):
+        explainer_config = ExplainerConfig(
+            self.explanation_type,
+            self.node_mask_type,
+            self.edge_mask_type,
+        )
+
         self.model = model
         self.algorithm = algorithm
-
-        self.explainer_config = ExplainerConfig.cast(explainer_config)
+        self.explanation_type = explainer_config.explanation_type
         self.model_config = ModelConfig.cast(model_config)
+        self.node_mask_type = explainer_config.node_mask_type
+        self.edge_mask_type = explainer_config.edge_mask_type
         self.threshold_config = ThresholdConfig.cast(threshold_config)
 
-        self.algorithm.connect(self.explainer_config, self.model_config)
+        self.algorithm.connect(explainer_config, self.model_config)
 
     @torch.no_grad()
     def get_prediction(self, *args, **kwargs) -> torch.Tensor:
@@ -110,17 +133,16 @@ class Explainer:
             **kwargs: additional arguments to pass to the GNN.
         """
         # Choose the `target` depending on the explanation type:
-        explanation_type = self.explainer_config.explanation_type
-        if explanation_type == ExplanationType.phenomenon:
+        if self.explanation_type == ExplanationType.phenomenon:
             if target is None:
                 raise ValueError(
                     f"The 'target' has to be provided for the explanation "
-                    f"type '{explanation_type.value}'")
-        elif explanation_type == ExplanationType.model:
+                    f"type '{self.explanation_type.value}'")
+        elif self.explanation_type == ExplanationType.model:
             if target is not None:
                 warnings.warn(
                     f"The 'target' should not be provided for the explanation "
-                    f"type '{explanation_type.value}'")
+                    f"type '{self.explanation_type.value}'")
             target = self.get_prediction(x=x, edge_index=edge_index, **kwargs)
 
         training = self.model.training


### PR DESCRIPTION
The `Explainer` should take the `ExplainerConfig` arguments as top-level arguments.