### PR TITLE
Explainability Dataset Task: `GridGraph`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ## [2.3.0] - 2023-MM-DD
 ### Added
+- Added `GridGraph` graph generator to generate Grid graphs ([#6220](https://github.com/pyg-team/pytorch_geometric/pull/6220)
 - Added `visualize_feature_importance` to support node feature visualizations ([#6094](https://github.com/pyg-team/pytorch_geometric/pull/6094))
 - Added heterogeneous graph support to `Explanation` framework ([#6091](https://github.com/pyg-team/pytorch_geometric/pull/6091), [#6218](https://github.com/pyg-team/pytorch_geometric/pull/6218))
 - Added a `CustomMotif` motif generator ([#6179](https://github.com/pyg-team/pytorch_geometric/pull/6179))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ## [2.3.0] - 2023-MM-DD
 ### Added
-- Added `GridGraph` graph generator to generate Grid graphs ([#6220](https://github.com/pyg-team/pytorch_geometric/pull/6220)
+- Added `GridGraph` graph generator to generate grid graphs ([#6220](https://github.com/pyg-team/pytorch_geometric/pull/6220)
 - Added `visualize_feature_importance` to support node feature visualizations ([#6094](https://github.com/pyg-team/pytorch_geometric/pull/6094))
 - Added heterogeneous graph support to `Explanation` framework ([#6091](https://github.com/pyg-team/pytorch_geometric/pull/6091), [#6218](https://github.com/pyg-team/pytorch_geometric/pull/6218))
 - Added a `CustomMotif` motif generator ([#6179](https://github.com/pyg-team/pytorch_geometric/pull/6179))

--- a/test/datasets/graph_generator/test_grid_graph.py
+++ b/test/datasets/graph_generator/test_grid_graph.py
@@ -1,0 +1,11 @@
+from torch_geometric.datasets.graph_generator import GridGraph
+
+
+def test_grid_graph():
+    graph_generator = GridGraph(height=10, width=10)
+    assert str(graph_generator) == 'GridGraph(height=10, width=10)'
+
+    data = graph_generator()
+    assert len(data) == 2
+    assert data.num_nodes == 100
+    assert data.num_edges == 784

--- a/torch_geometric/datasets/graph_generator/__init__.py
+++ b/torch_geometric/datasets/graph_generator/__init__.py
@@ -3,4 +3,4 @@ from .ba_graph import BAGraph
 from .er_graph import ERGraph
 from .grid_graph import GridGraph
 
-__all__ = classes = ['GraphGenerator', 'BAGraph', 'ERGraph', 'GridGraph']
+__all__ = classes = ['GraphGenerator', 'BAGraph', 'ERGraph', 'GridGraph', ]

--- a/torch_geometric/datasets/graph_generator/__init__.py
+++ b/torch_geometric/datasets/graph_generator/__init__.py
@@ -1,9 +1,11 @@
 from .base import GraphGenerator
 from .ba_graph import BAGraph
 from .er_graph import ERGraph
+from .grid_graph import GridGraph
 
 __all__ = classes = [
     'GraphGenerator',
     'BAGraph',
     'ERGraph',
+    'GridGraph'
 ]

--- a/torch_geometric/datasets/graph_generator/__init__.py
+++ b/torch_geometric/datasets/graph_generator/__init__.py
@@ -3,9 +3,4 @@ from .ba_graph import BAGraph
 from .er_graph import ERGraph
 from .grid_graph import GridGraph
 
-__all__ = classes = [
-    'GraphGenerator',
-    'BAGraph',
-    'ERGraph',
-    'GridGraph'
-]
+__all__ = classes = ['GraphGenerator', 'BAGraph', 'ERGraph', 'GridGraph']

--- a/torch_geometric/datasets/graph_generator/__init__.py
+++ b/torch_geometric/datasets/graph_generator/__init__.py
@@ -3,4 +3,9 @@ from .ba_graph import BAGraph
 from .er_graph import ERGraph
 from .grid_graph import GridGraph
 
-__all__ = classes = ['GraphGenerator', 'BAGraph', 'ERGraph', 'GridGraph', ]
+__all__ = classes = [
+    'GraphGenerator',
+    'BAGraph',
+    'ERGraph',
+    'GridGraph',
+]

--- a/torch_geometric/datasets/graph_generator/grid_graph.py
+++ b/torch_geometric/datasets/graph_generator/grid_graph.py
@@ -15,7 +15,7 @@ class GridGraph(GraphGenerator):
         height (int): The height of the grid.
         width (int): The width of the grid.
         dtype (:obj:`torch.dtype`, optional): The desired data type of the
-            returned position tensor.
+            returned position tensor. (default: :obj:`None`)
     """
     def __init__(
         self,

--- a/torch_geometric/datasets/graph_generator/grid_graph.py
+++ b/torch_geometric/datasets/graph_generator/grid_graph.py
@@ -1,0 +1,37 @@
+from typing import Optional
+
+import torch
+
+from torch_geometric.data import Data
+from torch_geometric.datasets.graph_generator import GraphGenerator
+from torch_geometric.utils import grid
+
+
+class GridGraph(GraphGenerator):
+    r"""Generates Grid Graphs.
+    See :meth:`~torch_geometric.utils.grid` for more information.
+
+    Args:
+        height (int): The height of the grid.
+        width (int): The width of the grid.
+        dtype (:obj:`torch.dtype`, optional): The desired data type of the
+            returned position tensor.
+    """
+    def __init__(
+        self, 
+        height: int,
+        width: int,
+        dtype: Optional[torch.dtype] = None,
+    ):
+        super().__init__()
+        self.height = height
+        self.width = width
+        self.dtype = dtype
+
+    def __call__(self) -> Data:
+        edge_index, pos = grid(height=self.height, width=self.width, dtype=self.dtype)
+        return Data(edge_index=edge_index, pos=pos)
+
+    def __repr__(self) -> str:
+        return (f'{self.__class__.__name__}(height={self.height}, '
+                f'width={self.width})')

--- a/torch_geometric/datasets/graph_generator/grid_graph.py
+++ b/torch_geometric/datasets/graph_generator/grid_graph.py
@@ -18,7 +18,7 @@ class GridGraph(GraphGenerator):
             returned position tensor.
     """
     def __init__(
-        self, 
+        self,
         height: int,
         width: int,
         dtype: Optional[torch.dtype] = None,
@@ -29,7 +29,8 @@ class GridGraph(GraphGenerator):
         self.dtype = dtype
 
     def __call__(self) -> Data:
-        edge_index, pos = grid(height=self.height, width=self.width, dtype=self.dtype)
+        edge_index, pos = grid(height=self.height, width=self.width,
+                               dtype=self.dtype)
         return Data(edge_index=edge_index, pos=pos)
 
     def __repr__(self) -> str:

--- a/torch_geometric/datasets/graph_generator/grid_graph.py
+++ b/torch_geometric/datasets/graph_generator/grid_graph.py
@@ -8,7 +8,7 @@ from torch_geometric.utils import grid
 
 
 class GridGraph(GraphGenerator):
-    r"""Generates Grid Graphs.
+    r"""Generates two-dimensional grid graphs.
     See :meth:`~torch_geometric.utils.grid` for more information.
 
     Args:


### PR DESCRIPTION
Adds GridGraph. Fixes task https://github.com/pyg-team/pytorch_geometric/issues/5817.

```python
from torch_geometric.datasets.generators import GridGraph

motif = Motif(structure='house')
generator = GridGraph(height=10, width=10, dtype=torch.float)
dataset = ExplainerDataset(generator=generator)
```

TODO
- [x] Tests
- [x] ChangeLog