### PR TITLE
Update `filter_*_store_()` returns in loader utils

### DIFF
--- a/torch_geometric/loader/utils.py
+++ b/torch_geometric/loader/utils.py
@@ -54,7 +54,7 @@ def index_select(value: FeatureTensorType, index: Tensor,
 
 
 def filter_node_store_(store: NodeStorage, out_store: NodeStorage,
-                       index: Tensor) -> NodeStorage:
+                       index: Tensor) -> None:
     # Filters a node storage object to only hold the nodes in `index`:
     for key, value in store.items():
         if key == 'num_nodes':
@@ -68,12 +68,10 @@ def filter_node_store_(store: NodeStorage, out_store: NodeStorage,
             dim = store._parent().__cat_dim__(key, value, store)
             out_store[key] = index_select(value, index, dim=dim)
 
-    return store
-
 
 def filter_edge_store_(store: EdgeStorage, out_store: EdgeStorage, row: Tensor,
                        col: Tensor, index: Tensor,
-                       perm: OptTensor = None) -> EdgeStorage:
+                       perm: OptTensor = None) -> None:
     # Filters a edge storage object to only hold the edges in `index`,
     # which represents the new graph as denoted by `(row, col)`:
     for key, value in store.items():
@@ -114,8 +112,6 @@ def filter_edge_store_(store: EdgeStorage, out_store: EdgeStorage, row: Tensor,
                     perm[index.to(torch.int64)],
                     dim=dim,
                 )
-
-    return store
 
 
 def filter_data(data: Data, node: Tensor, row: Tensor, col: Tensor,


### PR DESCRIPTION
Remove `return store` from `filter_node_store_` and `filter_edge_store_` as these values are not modified by the function, so the return can be `None`.