### PR TITLE
Implemented an approximate variant of heat kernel diffusion for the GDC transform

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ## [2.3.0] - 2023-MM-DD
 ### Added
+- Added an approximate variant of heat kernel diffusion for the GDC transform ([#6246](https://github.com/pyg-team/pytorch_geometric/pull/6246))
 - Added `get_messagepassing_embeddings` ([#6201](https://github.com/pyg-team/pytorch_geometric/pull/6201))
 - Added the `PointGNNConv` layer ([#6194](https://github.com/pyg-team/pytorch_geometric/pull/6194)))
 - Added `GridGraph` graph generator to generate grid graphs ([#6220](https://github.com/pyg-team/pytorch_geometric/pull/6220)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Added support for dropping nodes in `utils.to_dense_batch` in case `max_num_nodes` is smaller than the number of nodes  ([#6124](https://github.com/pyg-team/pytorch_geometric/pull/6124))
 - Added the RandLA-Net architecture as an example ([#5117](https://github.com/pyg-team/pytorch_geometric/pull/5117))
 ### Changed
+- Fixed approximate PPR variant in the GDC transform crashing on graphs with isolated nodes ([#6242](https://github.com/pyg-team/pytorch_geometric/pull/6242))
 - Moved thresholding config of the `Explainer` to `Explanation` ([#6215](https://github.com/pyg-team/pytorch_geometric/pull/6215))
 - Fixed a bug in the output order in `HeteroLinear` for un-sorted type vectors ([#6198](https://github.com/pyg-team/pytorch_geometric/pull/6198))
 - Breaking Change: Move `ExplainerConfig` arguments to the `Explainer` class  ([#6176](https://github.com/pyg-team/pytorch_geometric/pull/6176))

--- a/test/transforms/test_gdc.py
+++ b/test/transforms/test_gdc.py
@@ -90,3 +90,13 @@ def test_gdc():
     assert torch.all(
         torch.isclose(col_sum, torch.tensor(1.0))
         | torch.isclose(col_sum, torch.tensor(0.0)))
+
+    data = Data(edge_index=edge_index, num_nodes=5)
+    gdc = GDC(self_loop_weight=1, normalization_in='sym',
+              normalization_out='sym',
+              diffusion_kwargs=dict(method='heat', t=10, eps=1e-10),
+              sparsification_kwargs=dict(method='threshold',
+                                         avg_degree=2), exact=False)
+    data = gdc(data)
+    mat = to_dense_adj(data.edge_index, edge_attr=data.edge_attr).squeeze()
+    assert torch.all(mat >= -1e-8)

--- a/torch_geometric/transforms/gdc.py
+++ b/torch_geometric/transforms/gdc.py
@@ -304,7 +304,7 @@ class GDC(BaseTransform):
 
             edge_index_np = edge_index.cpu().numpy()
             # Assumes coalesced edge_index.
-            indptr = np.empty(edge_index_np[0, -1] + 2, dtype = np.int64)
+            indptr = np.empty(edge_index_np[0, -1] + 2, dtype=np.int64)
             indptr[0] = 0
             indptr[-1] = len(edge_index_np[0])
             prev = 0

--- a/torch_geometric/transforms/gdc.py
+++ b/torch_geometric/transforms/gdc.py
@@ -304,10 +304,20 @@ class GDC(BaseTransform):
 
             edge_index_np = edge_index.cpu().numpy()
             # Assumes coalesced edge_index.
-            _, indptr, out_degree = np.unique(edge_index_np[0],
-                                              return_index=True,
-                                              return_counts=True)
-            indptr = np.append(indptr, len(edge_index_np[0]))
+            indptr = np.empty(edge_index_np[0, -1] + 2, dtype = np.int64)
+            indptr[0] = 0
+            indptr[-1] = len(edge_index_np[0])
+            prev = 0
+            j = 1
+            for i in range(len(edge_index_np[0])):
+                val = edge_index_np[0, i]
+                if val == prev:
+                    continue
+                for _ in range(val - prev):
+                    indptr[j] = i
+                    j += 1
+                prev = val
+            out_degree = np.bincount(edge_index_np[0])
 
             neighbors, neighbor_weights = self.__calc_ppr__(
                 indptr, edge_index_np[1], out_degree, kwargs['alpha'],

--- a/torch_geometric/transforms/gdc.py
+++ b/torch_geometric/transforms/gdc.py
@@ -630,9 +630,10 @@ def get_calc_heat():
     from numba.typed import Dict
 
     @numba.jit(nopython=True)
-    def calc_heat(indptr: np.ndarray, indices: np.ndarray,
-                  out_degree: np.ndarray, t: int,
-                  eps: float) -> Tuple[List[List[int]], List[List[float]]]:
+    def calc_heat(
+        indptr: np.ndarray, indices: np.ndarray, out_degree: np.ndarray,
+        t: int, eps: float
+    ) -> Tuple[List[List[int]], List[List[float]]]:  # pragma: no cover
         r"""Calculate the heat kernel diffusion vector for all nodes using a
         variant of the Kloster-Gleich algorithm (see Kloster and Gleich: Heat
         kernel based community detection (KDD 2014).)

--- a/torch_geometric/transforms/gdc.py
+++ b/torch_geometric/transforms/gdc.py
@@ -1,4 +1,3 @@
-import math
 from typing import Any, Dict, List, Tuple
 
 import numpy as np
@@ -624,6 +623,8 @@ def get_calc_ppr():
 
 
 def get_calc_heat():
+    import math
+
     import numba
     from numba.core import types
     from numba.typed import Dict

--- a/torch_geometric/transforms/gdc.py
+++ b/torch_geometric/transforms/gdc.py
@@ -702,7 +702,8 @@ def get_calc_heat():
                     if neighbour not in solution[v]:
                         solution[v][neighbour] = 0.
                     solution[v][neighbour] += residuals[v][neighbour]
-                mass = (t * total_residual / (float(j) + 1.)) / out_degree[v]
+                mass = (t * total_residual / (float(j) + 1.)
+                        ) / out_degree[v] if out_degree[v] != 0 else 0
                 # For neighbours of v
                 for u in indices[indptr[v]:indptr[v + 1]]:
                     next_residuals[u][v] = mass


### PR DESCRIPTION
Depends on #6242 being merged first.

Previously, heat kernel diffusion was only implemented in the exact variant of GDC with just a note pointing to a paper by Kloster & Gleich for anybody who'd want an approximate version. I implemented the approximate variant based on that paper. The code started from the pseudo-code in the paper, but was heavily modified to preserve edge weight instead of just node weights an in order to enable numba. I'd be happy to walk any potential reviewers through the code.

The value of `N` can be computed in a more efficient way, however, this is just fine for the time being...
