### PR TITLE
Drop `target_index` argument in `Explainer`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Optimized `utils.softmax` implementation ([#6113](https://github.com/pyg-team/pytorch_geometric/pull/6113), [#6155](https://github.com/pyg-team/pytorch_geometric/pull/6155))
 - Optimized `topk` implementation for large enough graphs ([#6123](https://github.com/pyg-team/pytorch_geometric/pull/6123))
 ### Removed
+- Removed `target_index` argument in the `Explainer` interface ([#6270](https://github.com/pyg-team/pytorch_geometric/pull/6270))
 - Removed `Aggregation.set_validate_args` option ([#6175](https://github.com/pyg-team/pytorch_geometric/pull/6175))
 
 ## [2.2.0] - 2022-12-01

--- a/test/explain/algorithm/test_gnn_explainer.py
+++ b/test/explain/algorithm/test_gnn_explainer.py
@@ -13,10 +13,9 @@ from torch_geometric.nn import GCNConv, global_add_pool
 
 
 class GCN(torch.nn.Module):
-    def __init__(self, model_config: ModelConfig, multi_output: bool = False):
+    def __init__(self, model_config: ModelConfig):
         super().__init__()
         self.model_config = model_config
-        self.multi_output = multi_output
 
         if model_config.mode == ModelMode.multiclass_classification:
             out_channels = 7
@@ -45,7 +44,7 @@ class GCN(torch.nn.Module):
             elif self.model_config.return_type == ModelReturnType.log_probs:
                 x = x.log_softmax(dim=-1)
 
-        return torch.stack([x, x], dim=0) if self.multi_output else x
+        return x
 
 
 def check_explanation(
@@ -97,7 +96,6 @@ edge_label_index = torch.tensor([[0, 1, 2], [3, 4, 5]])
 @pytest.mark.parametrize('task_level', ['node', 'edge', 'graph'])
 @pytest.mark.parametrize('return_type', ['probs', 'raw'])
 @pytest.mark.parametrize('index', [None, 2, torch.arange(3)])
-@pytest.mark.parametrize('multi_output', [False])
 def test_gnn_explainer_binary_classification(
     edge_mask_type,
     node_mask_type,
@@ -105,7 +103,6 @@ def test_gnn_explainer_binary_classification(
     task_level,
     return_type,
     index,
-    multi_output,
 ):
     model_config = ModelConfig(
         mode='binary_classification',
@@ -113,7 +110,7 @@ def test_gnn_explainer_binary_classification(
         return_type=return_type,
     )
 
-    model = GCN(model_config, multi_output)
+    model = GCN(model_config)
 
     target = None
     if explanation_type == 'phenomenon':
@@ -138,7 +135,6 @@ def test_gnn_explainer_binary_classification(
         edge_index,
         target=target,
         index=index,
-        target_index=0 if multi_output else None,
         batch=batch,
         edge_label_index=edge_label_index,
     )
@@ -152,7 +148,6 @@ def test_gnn_explainer_binary_classification(
 @pytest.mark.parametrize('task_level', ['node', 'edge', 'graph'])
 @pytest.mark.parametrize('return_type', ['log_probs', 'probs', 'raw'])
 @pytest.mark.parametrize('index', [None, 2, torch.arange(3)])
-@pytest.mark.parametrize('multi_output', [False, True])
 def test_gnn_explainer_multiclass_classification(
     edge_mask_type,
     node_mask_type,
@@ -160,7 +155,6 @@ def test_gnn_explainer_multiclass_classification(
     task_level,
     return_type,
     index,
-    multi_output,
 ):
     model_config = ModelConfig(
         mode='multiclass_classification',
@@ -168,7 +162,7 @@ def test_gnn_explainer_multiclass_classification(
         return_type=return_type,
     )
 
-    model = GCN(model_config, multi_output)
+    model = GCN(model_config)
 
     target = None
     if explanation_type == 'phenomenon':
@@ -189,7 +183,6 @@ def test_gnn_explainer_multiclass_classification(
         edge_index,
         target=target,
         index=index,
-        target_index=0 if multi_output else None,
         batch=batch,
         edge_label_index=edge_label_index,
     )
@@ -202,21 +195,19 @@ def test_gnn_explainer_multiclass_classification(
 @pytest.mark.parametrize('explanation_type', ['model', 'phenomenon'])
 @pytest.mark.parametrize('task_level', ['node', 'edge', 'graph'])
 @pytest.mark.parametrize('index', [None, 2, torch.arange(3)])
-@pytest.mark.parametrize('multi_output', [False, True])
 def test_gnn_explainer_regression(
     edge_mask_type,
     node_mask_type,
     explanation_type,
     task_level,
     index,
-    multi_output,
 ):
     model_config = ModelConfig(
         mode='regression',
         task_level=task_level,
     )
 
-    model = GCN(model_config, multi_output)
+    model = GCN(model_config)
 
     target = None
     if explanation_type == 'phenomenon':
@@ -237,7 +228,6 @@ def test_gnn_explainer_regression(
         edge_index,
         target=target,
         index=index,
-        target_index=0 if multi_output else None,
         batch=batch,
         edge_label_index=edge_label_index,
     )

--- a/torch_geometric/explain/algorithm/base.py
+++ b/torch_geometric/explain/algorithm/base.py
@@ -22,7 +22,6 @@ class ExplainerAlgorithm(torch.nn.Module):
         *,
         target: Tensor,
         index: Optional[Union[int, Tensor]] = None,
-        target_index: Optional[int] = None,
         **kwargs,
     ) -> Explanation:
         r"""Computes the explanation.
@@ -37,11 +36,6 @@ class ExplainerAlgorithm(torch.nn.Module):
             index (Union[int, Tensor], optional): The index of the model
                 output to explain. Can be a single index or a tensor of
                 indices. (default: :obj:`None`)
-            target_index (int, optional): The index of the model outputs to
-                reference in case the model returns a list of tensors, *e.g.*,
-                in a multi-task learning scenario. Should be kept to
-                :obj:`None` in case the model only returns a single output
-                tensor. (default: :obj:`None`)
             **kwargs (optional): Additional keyword arguments passed to
                 :obj:`model`.
         """

--- a/torch_geometric/explain/algorithm/gnn_explainer.py
+++ b/torch_geometric/explain/algorithm/gnn_explainer.py
@@ -85,7 +85,6 @@ class GNNExplainer(ExplainerAlgorithm):
         *,
         target: Tensor,
         index: Optional[Union[int, Tensor]] = None,
-        target_index: Optional[int] = None,
         **kwargs,
     ) -> Explanation:
         hard_node_mask = hard_edge_mask = None
@@ -95,8 +94,7 @@ class GNNExplainer(ExplainerAlgorithm):
             hard_node_mask, hard_edge_mask = self._get_hard_masks(
                 model, index, edge_index, num_nodes=x.size(0))
 
-        self._train(model, x, edge_index, target=target, index=index,
-                    target_index=target_index, **kwargs)
+        self._train(model, x, edge_index, target=target, index=index, **kwargs)
 
         node_mask = self._post_process_mask(self.node_mask, x.size(0),
                                             hard_node_mask, apply_sigmoid=True)
@@ -115,7 +113,6 @@ class GNNExplainer(ExplainerAlgorithm):
         *,
         target: Tensor,
         index: Optional[Union[int, Tensor]] = None,
-        target_index: Optional[int] = None,
         **kwargs,
     ):
         if isinstance(x, dict) or isinstance(edge_index, dict):
@@ -137,8 +134,6 @@ class GNNExplainer(ExplainerAlgorithm):
             h = x * self.node_mask.sigmoid()
             y_hat, y = model(h, edge_index, **kwargs), target
 
-            if target_index is not None:
-                y_hat, y = y_hat[target_index], y[target_index]
             if index is not None:
                 y_hat, y = y_hat[index], y[index]
 

--- a/torch_geometric/explain/explainer.py
+++ b/torch_geometric/explain/explainer.py
@@ -150,7 +150,6 @@ class Explainer:
         *,
         target: Optional[Tensor] = None,
         index: Optional[Union[int, Tensor]] = None,
-        target_index: Optional[int] = None,
         **kwargs,
     ) -> Union[Explanation, HeteroExplanation]:
         r"""Computes the explanation of the GNN for the given inputs and
@@ -176,11 +175,6 @@ class Explainer:
             index (Union[int, Tensor], optional): The index of the model
                 output to explain. Can be a single index or a tensor of
                 indices. (default: :obj:`None`)
-            target_index (int, optional): The index of the model outputs to
-                reference in case the model returns a list of tensors, *e.g.*,
-                in a multi-task learning scenario. Should be kept to
-                :obj:`None` in case the model only returns a single output
-                tensor. (default: :obj:`None`)
             **kwargs: additional arguments to pass to the GNN.
         """
         # Choose the `target` depending on the explanation type:
@@ -207,7 +201,6 @@ class Explainer:
             edge_index,
             target=target,
             index=index,
-            target_index=target_index,
             **kwargs,
         )
 
@@ -218,7 +211,6 @@ class Explainer:
         explanation.prediction = prediction
         explanation.target = target
         explanation.index = index
-        explanation.target_index = target_index
 
         # Add model inputs to the `Explanation` object:
         if isinstance(explanation, Explanation):


### PR DESCRIPTION
I feel this is a very special argument that over-complicates a lot of design decisions in the `Explainer` code, e.g., it needs to be passed to `get_prediction` or `get_masked_prediction` as well. I am in favor of dropping this argument. If the user wants to explain a model with multiple outputs, she can use hooks to only return the desired output.