### PR TITLE
Fix to save best models instead of worst

### DIFF
--- a/examples/pytorch_lightning/gin.py
+++ b/examples/pytorch_lightning/gin.py
@@ -75,7 +75,8 @@ def main():
 
     devices = torch.cuda.device_count()
     strategy = pl.strategies.DDPSpawnStrategy(find_unused_parameters=False)
-    checkpoint = pl.callbacks.ModelCheckpoint(monitor='val_acc', save_top_k=1)
+    checkpoint = pl.callbacks.ModelCheckpoint(monitor='val_acc', save_top_k=1,
+                                              mode='max')
     trainer = pl.Trainer(strategy=strategy, accelerator='gpu', devices=devices,
                          max_epochs=50, log_every_n_steps=5,
                          callbacks=[checkpoint])

--- a/examples/pytorch_lightning/graph_sage.py
+++ b/examples/pytorch_lightning/graph_sage.py
@@ -76,7 +76,8 @@ def main():
 
     devices = torch.cuda.device_count()
     strategy = pl.strategies.DDPSpawnStrategy(find_unused_parameters=False)
-    checkpoint = pl.callbacks.ModelCheckpoint(monitor='val_acc', save_top_k=1)
+    checkpoint = pl.callbacks.ModelCheckpoint(monitor='val_acc', save_top_k=1,
+                                              mode='max')
     trainer = pl.Trainer(strategy=strategy, accelerator='gpu', devices=devices,
                          max_epochs=20, callbacks=[checkpoint])
 

--- a/examples/pytorch_lightning/relational_gnn.py
+++ b/examples/pytorch_lightning/relational_gnn.py
@@ -141,7 +141,8 @@ def main():
     datamodule = DataModule('../../data/OGB')
     model = RelationalGNN(datamodule.metadata(), hidden_channels=64,
                           out_channels=349, dropout=0.0)
-    checkpoint_callback = ModelCheckpoint(monitor='val_acc', save_top_k=1)
+    checkpoint_callback = ModelCheckpoint(monitor='val_acc', save_top_k=1,
+                                          mode='max')
     trainer = Trainer(accelerator='gpu', devices=1, max_epochs=20,
                       callbacks=[checkpoint_callback])
 


### PR DESCRIPTION
This PR Fixes a minor bug in PyTorchLightning examples. Currently, the worst models are saved instead of the best ones. See the [documentation of `pl.callbacks.ModelCheckpoint`](https://pytorch-lightning.readthedocs.io/en/stable/api/pytorch_lightning.callbacks.ModelCheckpoint.html#pytorch_lightning.callbacks.ModelCheckpoint.params.mode)