### PR TITLE
Update doc AirfRANS dataset

### DIFF
--- a/torch_geometric/datasets/airfrans.py
+++ b/torch_geometric/datasets/airfrans.py
@@ -37,7 +37,7 @@ class AirfRANS(InMemoryDataset):
     A library for manipulang simulations of the dataset is available `here
     <https://airfrans.readthedocs.io/en/latest/index.html>`_.
 
-    The dataset is under the `ODbL v1.0 License
+    The dataset is released under the `ODbL v1.0 License
     <https://opendatacommons.org/licenses/odbl/1-0/>`_.
 
     .. note::

--- a/torch_geometric/datasets/airfrans.py
+++ b/torch_geometric/datasets/airfrans.py
@@ -33,11 +33,11 @@ class AirfRANS(InMemoryDataset):
     per second).
     Finaly, a boolean is attached to each point to inform if this point lies on
     the airfoil or not.
-    
+
     A library for manipulang simulations of the dataset is available `here
     <https://airfrans.readthedocs.io/en/latest/index.html>`_.
-    
-    The dataset is under the `ODbL v1.0 License 
+
+    The dataset is under the `ODbL v1.0 License
     <https://opendatacommons.org/licenses/odbl/1-0/>`_.
 
     .. note::

--- a/torch_geometric/datasets/airfrans.py
+++ b/torch_geometric/datasets/airfrans.py
@@ -33,6 +33,12 @@ class AirfRANS(InMemoryDataset):
     per second).
     Finaly, a boolean is attached to each point to inform if this point lies on
     the airfoil or not.
+    
+    A library for manipulang simulations of the dataset is available `here
+    <https://airfrans.readthedocs.io/en/latest/index.html>`_.
+    
+    The dataset is under the `ODbL v1.0 License 
+    <https://opendatacommons.org/licenses/odbl/1-0/>`_.
 
     .. note::
 


### PR DESCRIPTION
Hi!
A short update on the documentation of the AirfRANS dataset to include the link toward a [library](https://airfrans.readthedocs.io/en/latest/index.html) for manipulating simulations and to mention the dataset license.

Best,
Florent