### PR TITLE
Fix `eval_loader_kwargs` in lightning modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
-- Added option to customize loader arguments for evaluation in `LightningNodeData` and `LightningLinkData` ([#6450](https://github.com/pyg-team/pytorch_geometric/pull/6450))
+- Added option to customize loader arguments for evaluation in `LightningNodeData` and `LightningLinkData` ([#6450](https://github.com/pyg-team/pytorch_geometric/pull/6450), [#6456](https://github.com/pyg-team/pytorch_geometric/pull/6456))
 - Added option to customize `num_neighbors` in `NeighborSampler` after instantiation ([#6446](https://github.com/pyg-team/pytorch_geometric/pull/6446))
 - Added the `Taobao` dataset and a corresponding example for it ([#6144](https://github.com/pyg-team/pytorch_geometric/pull/6144))
 - Added `pyproject.toml` ([#6431](https://github.com/pyg-team/pytorch_geometric/pull/6431))

--- a/torch_geometric/data/lightning/datamodule.py
+++ b/torch_geometric/data/lightning/datamodule.py
@@ -372,13 +372,12 @@ class LightningNodeData(LightningDataModule):
 
         # Determine validation sampler and loader arguments ###################
 
+        self.eval_loader_kwargs = copy.copy(self.loader_kwargs)
         if eval_loader_kwargs is not None:
-            # The user wants to override certain values during evaluation, so
+            # If the user wants to override certain values during evaluation,
             # we shallow-copy the sampler and update its attributes.
-
             if hasattr(self, 'neighbor_sampler'):
                 self.eval_neighbor_sampler = copy.copy(self.neighbor_sampler)
-                self.eval_loader_kwargs = copy.copy(self.loader_kwargs)
 
                 eval_sampler_kwargs, eval_loader_kwargs = split_kwargs(
                     eval_loader_kwargs,
@@ -386,15 +385,11 @@ class LightningNodeData(LightningDataModule):
                 )
                 for key, value in eval_sampler_kwargs.items():
                     setattr(self.eval_neighbor_sampler, key, value)
-                self.eval_loader_kwargs.update(eval_loader_kwargs)
-            else:
-                self.eval_loader_kwargs = copy.copy(self.loader_kwargs)
-                self.eval_loader_kwargs.update(eval_loader_kwargs)
-        else:
-            if hasattr(self, 'neighbor_sampler'):
-                self.eval_neighbor_sampler = self.neighbor_sampler
 
-            self.eval_loader_kwargs = self.loader_kwargs
+            self.eval_loader_kwargs.update(eval_loader_kwargs)
+
+        elif hasattr(self, 'neighbor_sampler'):
+            self.eval_neighbor_sampler = self.neighbor_sampler
 
         self.eval_loader_kwargs.pop('sampler', None)
         self.eval_loader_kwargs.pop('batch_sampler', None)
@@ -689,13 +684,12 @@ class LightningLinkData(LightningDataModule):
 
         # Determine validation sampler and loader arguments ###################
 
+        self.eval_loader_kwargs = copy.copy(self.loader_kwargs)
         if eval_loader_kwargs is not None:
             # The user wants to override certain values during evaluation, so
             # we shallow-copy the sampler and update its attributes.
-
             if hasattr(self, 'neighbor_sampler'):
                 self.eval_neighbor_sampler = copy.copy(self.neighbor_sampler)
-                self.eval_loader_kwargs = copy.copy(self.loader_kwargs)
 
                 eval_sampler_kwargs, eval_loader_kwargs = split_kwargs(
                     eval_loader_kwargs,
@@ -703,15 +697,11 @@ class LightningLinkData(LightningDataModule):
                 )
                 for key, value in eval_sampler_kwargs.items():
                     setattr(self.eval_neighbor_sampler, key, value)
-                self.eval_loader_kwargs.update(eval_loader_kwargs)
-            else:
-                self.eval_loader_kwargs = copy.copy(self.loader_kwargs)
-                self.eval_loader_kwargs.update(eval_loader_kwargs)
-        else:
-            if hasattr(self, 'neighbor_sampler'):
-                self.eval_neighbor_sampler = self.neighbor_sampler
 
-            self.eval_loader_kwargs = self.loader_kwargs
+            self.eval_loader_kwargs.update(eval_loader_kwargs)
+
+        elif hasattr(self, 'neighbor_sampler'):
+            self.eval_neighbor_sampler = self.neighbor_sampler
 
         self.eval_loader_kwargs.pop('sampler', None)
         self.eval_loader_kwargs.pop('batch_sampler', None)

--- a/torch_geometric/data/lightning/datamodule.py
+++ b/torch_geometric/data/lightning/datamodule.py
@@ -686,7 +686,7 @@ class LightningLinkData(LightningDataModule):
 
         self.eval_loader_kwargs = copy.copy(self.loader_kwargs)
         if eval_loader_kwargs is not None:
-            # The user wants to override certain values during evaluation, so
+            # If the user wants to override certain values during evaluation,
             # we shallow-copy the sampler and update its attributes.
             if hasattr(self, 'neighbor_sampler'):
                 self.eval_neighbor_sampler = copy.copy(self.neighbor_sampler)


### PR DESCRIPTION
Need to `copy` the dictionary before modifying it.