### PR TITLE
chore: drop redundant `.style.yapf`

### DIFF
--- a/.style.yapf
+++ b/.style.yapf
@@ -1,4 +1,0 @@
-[style]
-based_on_style=pep8
-split_before_named_assigns=False
-blank_line_before_nested_class_or_def=False

--- a/torch_geometric/nn/conv/sage_conv.py
+++ b/torch_geometric/nn/conv/sage_conv.py
@@ -13,7 +13,7 @@ from torch_geometric.typing import Adj, OptPairTensor, Size
 
 class SAGEConv(MessagePassing):
     r"""The GraphSAGE operator from the `"Inductive Representation Learning on
-    Large Graphs" <https://arxiv.org/abs/1706.02216>`_ paper
+    Large Graphs" <https://arxiv.org/abs/1706.02216>`_ paper:
 
     .. math::
         \mathbf{x}^{\prime}_i = \mathbf{W}_1 \mathbf{x}_i + \mathbf{W}_2 \cdot
@@ -64,6 +64,7 @@ class SAGEConv(MessagePassing):
         - **outputs:** node features :math:`(|\mathcal{V}|, F_{out})` or
           :math:`(|\mathcal{V_t}|, F_{out})` if bipartite
     """
+
     def __init__(
         self,
         in_channels: Union[int, Tuple[int, int]],

--- a/torch_geometric/nn/conv/sage_conv.py
+++ b/torch_geometric/nn/conv/sage_conv.py
@@ -13,7 +13,7 @@ from torch_geometric.typing import Adj, OptPairTensor, Size
 
 class SAGEConv(MessagePassing):
     r"""The GraphSAGE operator from the `"Inductive Representation Learning on
-    Large Graphs" <https://arxiv.org/abs/1706.02216>`_ paper:
+    Large Graphs" <https://arxiv.org/abs/1706.02216>`_ paper
 
     .. math::
         \mathbf{x}^{\prime}_i = \mathbf{W}_1 \mathbf{x}_i + \mathbf{W}_2 \cdot

--- a/torch_geometric/nn/conv/sage_conv.py
+++ b/torch_geometric/nn/conv/sage_conv.py
@@ -64,7 +64,6 @@ class SAGEConv(MessagePassing):
         - **outputs:** node features :math:`(|\mathcal{V}|, F_{out})` or
           :math:`(|\mathcal{V_t}|, F_{out})` if bipartite
     """
-
     def __init__(
         self,
         in_channels: Union[int, Tuple[int, int]],


### PR DESCRIPTION
#6431 created a `pyproject.toml` which aimed to create a single configuration file for `yapf`, `isort`, `coverage`, `pyright` among others. All the configuration for `yapf` now lies within the `pyproject.toml` file. 

This PR aims to delete the redundant `.style.yapf` possibly added back after (#6144).