### PR TITLE
`RGCNConv`: Allow indices with any integer type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
+- Allow indices with any integer type in `RGCNConv` ([#](https://github.com/pyg-team/pytorch_geometric/pull/))
 - Re-structured the documentation ([#6420](https://github.com/pyg-team/pytorch_geometric/pull/6420), [#6423](https://github.com/pyg-team/pytorch_geometric/pull/6423), [#6429](https://github.com/pyg-team/pytorch_geometric/pull/6429), [#6440](https://github.com/pyg-team/pytorch_geometric/pull/6440), [#6443](https://github.com/pyg-team/pytorch_geometric/pull/6443), [#6445](https://github.com/pyg-team/pytorch_geometric/pull/6445), [#6452](https://github.com/pyg-team/pytorch_geometric/pull/6452), [#6453](https://github.com/pyg-team/pytorch_geometric/pull/6453), [#6458](https://github.com/pyg-team/pytorch_geometric/pull/6458), [#6459](https://github.com/pyg-team/pytorch_geometric/pull/6459), [#6460](https://github.com/pyg-team/pytorch_geometric/pull/6460))
 - Fix the default arguments of `DataParallel` class ([#6376](https://github.com/pyg-team/pytorch_geometric/pull/6376))
 - Fix `ImbalancedSampler` on sliced `InMemoryDataset` ([#6374](https://github.com/pyg-team/pytorch_geometric/pull/6374))

--- a/torch_geometric/nn/conv/rgcn_conv.py
+++ b/torch_geometric/nn/conv/rgcn_conv.py
@@ -204,7 +204,7 @@ class RGCNConv(MessagePassing):
 
         if self.num_blocks is not None:  # Block-diagonal-decomposition =====
 
-            if x_l.dtype == torch.long and self.num_blocks is not None:
+            if not torch.is_floating_point(x_r) and self.num_blocks is not None:
                 raise ValueError('Block-diagonal decomposition not supported '
                                  'for non-continuous input features.')
 
@@ -231,7 +231,7 @@ class RGCNConv(MessagePassing):
                 for i in range(self.num_relations):
                     tmp = masked_edge_index(edge_index, edge_type == i)
 
-                    if x_l.dtype == torch.long:
+                    if not torch.is_floating_point(x_r):
                         out = out + self.propagate(
                             tmp,
                             x=weight[i, x_l],
@@ -245,7 +245,8 @@ class RGCNConv(MessagePassing):
 
         root = self.root
         if root is not None:
-            out = out + (root[x_r] if x_r.dtype == torch.long else x_r @ root)
+            out = out + \
+                (root[x_r] if not torch.is_floating_point(x_r) else x_r @ root)
 
         if self.bias is not None:
             out = out + self.bias
@@ -270,6 +271,7 @@ class RGCNConv(MessagePassing):
 
 class FastRGCNConv(RGCNConv):
     r"""See :class:`RGCNConv`."""
+
     def forward(self, x: Union[OptTensor, Tuple[OptTensor, Tensor]],
                 edge_index: Adj, edge_type: OptTensor = None):
         """"""
@@ -296,7 +298,8 @@ class FastRGCNConv(RGCNConv):
 
         root = self.root
         if root is not None:
-            out = out + (root[x_r] if x_r.dtype == torch.long else x_r @ root)
+            out = out + \
+                (root[x_r] if not torch.is_floating_point(x_r) else x_r @ root)
 
         if self.bias is not None:
             out = out + self.bias
@@ -311,7 +314,7 @@ class FastRGCNConv(RGCNConv):
                 self.num_relations, self.in_channels_l, self.out_channels)
 
         if self.num_blocks is not None:  # Block-diagonal-decomposition =======
-            if x_j.dtype == torch.long:
+            if not torch.is_floating_point(x_j):
                 raise ValueError('Block-diagonal decomposition not supported '
                                  'for non-continuous input features.')
 
@@ -320,7 +323,7 @@ class FastRGCNConv(RGCNConv):
             return torch.bmm(x_j, weight).view(-1, self.out_channels)
 
         else:  # No regularization/Basis-decomposition ========================
-            if x_j.dtype == torch.long:
+            if not torch.is_floating_point(x_j):
                 weight_index = edge_type * weight.size(1) + edge_index_j
                 return weight.view(-1, self.out_channels)[weight_index]
 

--- a/torch_geometric/nn/conv/rgcn_conv.py
+++ b/torch_geometric/nn/conv/rgcn_conv.py
@@ -204,7 +204,8 @@ class RGCNConv(MessagePassing):
 
         if self.num_blocks is not None:  # Block-diagonal-decomposition =====
 
-            if not torch.is_floating_point(x_r) and self.num_blocks is not None:
+            if not torch.is_floating_point(
+                    x_r) and self.num_blocks is not None:
                 raise ValueError('Block-diagonal decomposition not supported '
                                  'for non-continuous input features.')
 
@@ -245,8 +246,10 @@ class RGCNConv(MessagePassing):
 
         root = self.root
         if root is not None:
-            out = out + \
-                (root[x_r] if not torch.is_floating_point(x_r) else x_r @ root)
+            if not torch.is_floating_point(x_r):
+                out = out + root[x_r]
+            else:
+                out = out + x_r @ root
 
         if self.bias is not None:
             out = out + self.bias
@@ -271,7 +274,6 @@ class RGCNConv(MessagePassing):
 
 class FastRGCNConv(RGCNConv):
     r"""See :class:`RGCNConv`."""
-
     def forward(self, x: Union[OptTensor, Tuple[OptTensor, Tensor]],
                 edge_index: Adj, edge_type: OptTensor = None):
         """"""
@@ -298,8 +300,10 @@ class FastRGCNConv(RGCNConv):
 
         root = self.root
         if root is not None:
-            out = out + \
-                (root[x_r] if not torch.is_floating_point(x_r) else x_r @ root)
+            if not torch.is_floating_point(x_r):
+                out = out + root[x_r]
+            else:
+                out = out + x_r @ root
 
         if self.bias is not None:
             out = out + self.bias


### PR DESCRIPTION
This PR update conditionals to replace the long datatype comparison to int with any size (including int32). This will allow to use other data format of indices for other backends.