### PR TITLE
chore: move flake8 args to pre-commit-config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -48,3 +48,4 @@ repos:
     hooks:
       - id: flake8
         name: Check PEP8
+        args: ["--ignore=F811, W503, W504"]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,9 +1,2 @@
 [aliases]
 test=pytest
-
-[flake8]
-ignore=
-    # ignore overload redefinition
-    F811,
-    # allow line breaks before/after binary operators
-    W503, W504,


### PR DESCRIPTION
Following the merge of #6431, I've been thinking about how to further minimize the number of configuration files. The only linter that was left in the `setup.cfg` file was `flake8`. Now while `flake8` doesn't support `pyproject.toml` yet (https://github.com/PyCQA/flake8/issues/234), based on a quick search `pytorch_geometric` only uses `flake8` in pre-commit.

This PR simply shifts the arguments to the `args` key of the flake8 hook. I checked if the hooks were placed appropriately by running 

```lang-bash
$ pre-commit run --all-files
```

---

Follow up questions:

- Maybe we should consider using the `https://github.com/asottile/yesqa` hook to check for redudant `# noqa` comments. I ran this hook on my local branch and several hits came up. (**Should I make a follow up PR ?**)
- Can we drop `setup.cfg` now ? It only contains a `aliases` section atm.