### PR TITLE
GraphGym incompatible with custom PyG `torch_geometric.data.Dataset` datasets

### DIFF
--- a/torch_geometric/graphgym/loader.py
+++ b/torch_geometric/graphgym/loader.py
@@ -291,6 +291,7 @@ def get_loader(dataset, sampler, batch_size, shuffle=True):
 
     else:
         raise NotImplementedError("%s sampler is not implemented!" % sampler)
+   
     return loader_train
 
 
@@ -313,11 +314,11 @@ def create_loader():
     if cfg.dataset.split_mode == "random":
         dataset.shuffle()
 
-    # Split indexes accrding to porportions in `cfg.dataset.split`
+    # Split indexes according to porportions in `cfg.dataset.split`
     ratios = np.array(cfg.dataset.split)
-    split_indexs = ratios.cumsum() * dataset.len()
-    split_indexs = split_indexs.astype(int)
+    split_indexs = (ratios.cumsum() * dataset.len()).astype(int)
     splits = np.split(range(dataset.len()), split_indexs)
+    splits.pop() # Remove last split which is empty. 
 
     # For every split build and append loader
     for i, split in enumerate(splits):

--- a/torch_geometric/graphgym/loader.py
+++ b/torch_geometric/graphgym/loader.py
@@ -1,6 +1,7 @@
 from typing import Callable
 
 import torch
+import numpy as np
 
 import torch_geometric.graphgym.register as register
 import torch_geometric.transforms as T
@@ -209,27 +210,19 @@ def set_dataset_info(dataset):
 
     # get dim_in and dim_out
     try:
-        cfg.share.dim_in = dataset._data.x.shape[1]
+        cfg.share.dim_in = dataset.num_node_features
     except Exception:
         cfg.share.dim_in = 1
     try:
         if cfg.dataset.task_type == 'classification':
-            cfg.share.dim_out = torch.unique(dataset._data.y).shape[0]
+            cfg.share.dim_out = dataset.num_classes
         else:
-            cfg.share.dim_out = dataset._data.y.shape[1]
+            cfg.share.dim_out = dataset.len()
     except Exception:
         cfg.share.dim_out = 1
 
-    # count number of dataset splits
-    cfg.share.num_splits = 1
-    for key in dataset._data.keys:
-        if 'val' in key:
-            cfg.share.num_splits += 1
-            break
-    for key in dataset._data.keys:
-        if 'test' in key:
-            cfg.share.num_splits += 1
-            break
+    # count number of dataset splits. 
+    cfg.share.num_splits = len(cfg.dataset.split)
 
 
 def create_dataset():
@@ -309,32 +302,45 @@ def create_loader():
 
     """
     dataset = create_dataset()
-    # train loader
-    if cfg.dataset.task == 'graph':
-        id = dataset.data['train_graph_index']
-        loaders = [
-            get_loader(dataset[id], cfg.train.sampler, cfg.train.batch_size,
-                       shuffle=True)
-        ]
-        delattr(dataset.data, 'train_graph_index')
-    else:
-        loaders = [
-            get_loader(dataset, cfg.train.sampler, cfg.train.batch_size,
-                       shuffle=True)
-        ]
 
-    # val and test loaders
-    for i in range(cfg.share.num_splits - 1):
+    # Create empty list of loaders
+    loaders = []
+
+    # Creat list of split names
+    split_names = ['train_graph_index', 'val_graph_index', 'test_graph_index']
+
+    # Shuffle sataset
+    if cfg.dataset.split_mode == "random":
+        dataset.shuffle()
+
+    # Split indexes accrding to porportions in `cfg.dataset.split`
+    ratios = np.array(cfg.dataset.split)
+    split_indexs = ratios.cumsum() * dataset.len()
+    split_indexs = split_indexs.astype(int)
+    splits = np.split(range(dataset.len()), split_indexs)
+
+    # For every split build and append loader
+    for i, split in enumerate(splits):
+        if i == 0:
+            sampler = cfg.train.sampler
+            shuffle = True
+        else:
+            sampler = cfg.val.sampler
+            shuffle = False
+
         if cfg.dataset.task == 'graph':
-            split_names = ['val_graph_index', 'test_graph_index']
-            id = dataset.data[split_names[i]]
+            try:
+                id = dataset.data[split_names[i]]
+                delattr(dataset.data, split_names[i])
+            except AttributeError:
+                id = split
+
             loaders.append(
-                get_loader(dataset[id], cfg.val.sampler, cfg.train.batch_size,
-                           shuffle=False))
-            delattr(dataset.data, split_names[i])
+                get_loader(dataset[id], sampler, cfg.train.batch_size, shuffle=shuffle)
+                )
         else:
             loaders.append(
-                get_loader(dataset, cfg.val.sampler, cfg.train.batch_size,
-                           shuffle=False))
+                get_loader(dataset, sampler, cfg.train.batch_size, shuffle=shuffle)
+                )
 
     return loaders

--- a/torch_geometric/graphgym/loader.py
+++ b/torch_geometric/graphgym/loader.py
@@ -1,7 +1,7 @@
 from typing import Callable
 
-import torch
 import numpy as np
+import torch
 
 import torch_geometric.graphgym.register as register
 import torch_geometric.transforms as T
@@ -221,7 +221,7 @@ def set_dataset_info(dataset):
     except Exception:
         cfg.share.dim_out = 1
 
-    # count number of dataset splits. 
+    # count number of dataset splits.
     cfg.share.num_splits = len(cfg.dataset.split)
 
 
@@ -291,7 +291,7 @@ def get_loader(dataset, sampler, batch_size, shuffle=True):
 
     else:
         raise NotImplementedError("%s sampler is not implemented!" % sampler)
-   
+
     return loader_train
 
 
@@ -318,7 +318,7 @@ def create_loader():
     ratios = np.array(cfg.dataset.split)
     split_indexs = (ratios.cumsum() * dataset.len()).astype(int)
     splits = np.split(range(dataset.len()), split_indexs)
-    splits.pop() # Remove last split which is empty. 
+    splits.pop()  # Remove last split which is empty.
 
     # For every split build and append loader
     for i, split in enumerate(splits):
@@ -337,11 +337,11 @@ def create_loader():
                 id = split
 
             loaders.append(
-                get_loader(dataset[id], sampler, cfg.train.batch_size, shuffle=shuffle)
-                )
+                get_loader(dataset[id], sampler, cfg.train.batch_size,
+                           shuffle=shuffle))
         else:
             loaders.append(
-                get_loader(dataset, sampler, cfg.train.batch_size, shuffle=shuffle)
-                )
+                get_loader(dataset, sampler, cfg.train.batch_size,
+                           shuffle=shuffle))
 
     return loaders


### PR DESCRIPTION
GraphGym assumes that if you use a PyG dataset it is a `torch_geometric.data.InMemoryDataset` dataset. This is problematic because if you are a user like me that would like to do model selection for your custom-made `torch_geometric.data.Dataset` dataset, well you can't, at least out of the box. 

Specifically, the issue comes from `torch_geometric/graphgym/loader.py` where on several occasions the `dataset._data` attribute is accessed, and `torch_geometric.data.Dataset` datasets have no such attribute. I replaced these with`dataset.<a method>()` to access information about the dataset. 

Additionally, since the data-loader calling strategy depended on `dataset._data` attribute, I designed a new one. With these changes, one can use both types of PyG datasets. I'm then able to run GraphGym both on my own dataset and on the ones used in the examples. I tried to retain as much as possible from the original code, to avoid unforeseen issues. Please let me know if anything needs explanation. 

Cheers!

How to reproduce the error:

1. Clone PyG, or make a new branch. 
2. Add a `torch_geometric.data.Dataset` dataset register to `/pytorch_geometric/graphgym/custom_graphgym/loader`
3. Place your data wherever you please.
4. Adjust the path in your config to the location of the data.
5. Run `pytorch_geometric/graphgym/main.py`.

Here are my examples of some data, a register, and the config I used. 
[example_files 2.zip](https://github.com/pyg-team/pytorch_geometric/files/10460761/example_files.2.zip)
