### PR TITLE
Fix `deprecated` decorator for classes

### DIFF
--- a/torch_geometric/deprecation.py
+++ b/torch_geometric/deprecation.py
@@ -6,15 +6,18 @@ from typing import Optional
 
 def deprecated(details: Optional[str] = None, func_name: Optional[str] = None):
     def decorator(func):
+        name = func_name or func.__name__
+
         if inspect.isclass(func):
-            cls_name = func_name or func.__name__
-            func.__init__ = deprecated(details, cls_name)(func.__init__)
+            func = type(func.__name__, (func, ), {})
+            func.__init__ = deprecated(details, name)(func.__init__)
             return func
 
         @functools.wraps(func)
         def wrapper(*args, **kwargs):
-            out = f"'{func_name or func.__name__}' is deprecated" + (
-                f', {details}' if details is not None else '')
+            out = f"'{name}' is deprecated"
+            if details is not None:
+                out += f", {details}"
             warnings.warn(out)
             return func(*args, **kwargs)
 


### PR DESCRIPTION
We need to copy/inherit the class before modifying `__init__`.