### PR TITLE
Re-factor variable names

### DIFF
--- a/benchmark/citation/train_eval.py
+++ b/benchmark/citation/train_eval.py
@@ -150,13 +150,13 @@ def evaluate(model, data):
     model.eval()
 
     with torch.no_grad():
-        logits = model(data)
+        out = model(data)
 
     outs = {}
     for key in ['train', 'val', 'test']:
         mask = data[f'{key}_mask']
-        loss = F.nll_loss(logits[mask], data.y[mask]).item()
-        pred = logits[mask].max(1)[1]
+        loss = F.nll_loss(out[mask], data.y[mask]).item()
+        pred = out[mask].max(1)[1]
         acc = pred.eq(data.y[mask]).sum().item() / mask.sum().item()
 
         outs[f'{key}_loss'] = loss

--- a/benchmark/citation/train_eval.py
+++ b/benchmark/citation/train_eval.py
@@ -146,17 +146,17 @@ def train(model, optimizer, data):
     optimizer.step()
 
 
+@torch.no_grad()
 def evaluate(model, data):
     model.eval()
 
-    with torch.no_grad():
-        out = model(data)
+    out = model(data)
 
     outs = {}
     for key in ['train', 'val', 'test']:
         mask = data[f'{key}_mask']
-        loss = F.nll_loss(out[mask], data.y[mask]).item()
-        pred = out[mask].max(1)[1]
+        loss = float(F.nll_loss(out[mask], data.y[mask]))
+        pred = out[mask].argmax(1)
         acc = pred.eq(data.y[mask]).sum().item() / mask.sum().item()
 
         outs[f'{key}_loss'] = loss

--- a/examples/agnn.py
+++ b/examples/agnn.py
@@ -43,11 +43,12 @@ def train():
     optimizer.step()
 
 
+@torch.no_grad()
 def test():
     model.eval()
-    logits, accs = model(), []
+    out, accs = model(), []
     for _, mask in data('train_mask', 'val_mask', 'test_mask'):
-        pred = logits[mask].max(1)[1]
+        pred = out[mask].argmax(1)
         acc = pred.eq(data.y[mask]).sum().item() / mask.sum().item()
         accs.append(acc)
     return accs

--- a/examples/arma.py
+++ b/examples/arma.py
@@ -49,9 +49,9 @@ def train():
 
 def test():
     model.eval()
-    logits, accs = model(data.x, data.edge_index), []
+    out, accs = model(data.x, data.edge_index), []
     for _, mask in data('train_mask', 'val_mask', 'test_mask'):
-        pred = logits[mask].max(1)[1]
+        pred = out[mask].argmax(1)
         acc = pred.eq(data.y[mask]).sum().item() / mask.sum().item()
         accs.append(acc)
     return accs

--- a/examples/captum_explainability.py
+++ b/examples/captum_explainability.py
@@ -36,8 +36,8 @@ optimizer = torch.optim.Adam(model.parameters(), lr=0.01, weight_decay=5e-4)
 for epoch in range(1, 201):
     model.train()
     optimizer.zero_grad()
-    log_logits = model(data.x, data.edge_index)
-    loss = F.nll_loss(log_logits[data.train_mask], data.y[data.train_mask])
+    out = model(data.x, data.edge_index)
+    loss = F.nll_loss(out[data.train_mask], data.y[data.train_mask])
     loss.backward()
     optimizer.step()
 

--- a/examples/dna.py
+++ b/examples/dna.py
@@ -75,11 +75,12 @@ def train():
     optimizer.step()
 
 
+@torch.no_grad()
 def test():
     model.eval()
-    logits, accs = model(data.x, data.edge_index), []
+    out, accs = model(data.x, data.edge_index), []
     for _, idx in data('train_idx', 'val_idx', 'test_idx'):
-        pred = logits[idx].max(1)[1]
+        pred = out[idx].argmax(1)
         acc = pred.eq(data.y[idx]).sum().item() / idx.numel()
         accs.append(acc)
     return accs

--- a/examples/gnn_explainer.py
+++ b/examples/gnn_explainer.py
@@ -34,8 +34,8 @@ optimizer = torch.optim.Adam(model.parameters(), lr=0.01, weight_decay=5e-4)
 for epoch in range(1, 201):
     model.train()
     optimizer.zero_grad()
-    log_logits = model(data.x, data.edge_index)
-    loss = F.nll_loss(log_logits[data.train_mask], data.y[data.train_mask])
+    out = model(data.x, data.edge_index)
+    loss = F.nll_loss(out[data.train_mask], data.y[data.train_mask])
     loss.backward()
     optimizer.step()
 

--- a/examples/graph_unet.py
+++ b/examples/graph_unet.py
@@ -42,11 +42,12 @@ def train():
     optimizer.step()
 
 
+@torch.no_grad()
 def test():
     model.eval()
-    logits, accs = model(), []
+    out, accs = model(), []
     for _, mask in data('train_mask', 'val_mask', 'test_mask'):
-        pred = logits[mask].max(1)[1]
+        pred = out[mask].argmax(1)
         acc = pred.eq(data.y[mask]).sum().item() / mask.sum().item()
         accs.append(acc)
     return accs

--- a/examples/jit/gat.py
+++ b/examples/jit/gat.py
@@ -49,9 +49,9 @@ def train():
 @torch.no_grad()
 def test():
     model.eval()
-    logits, accs = model(data.x, data.edge_index), []
+    out, accs = model(data.x, data.edge_index), []
     for _, mask in data('train_mask', 'val_mask', 'test_mask'):
-        pred = logits[mask].max(1)[1]
+        pred = out[mask].argmax(1)
         acc = pred.eq(data.y[mask]).sum().item() / mask.sum().item()
         accs.append(acc)
     return accs

--- a/examples/randlanet_classification.py
+++ b/examples/randlanet_classification.py
@@ -142,6 +142,7 @@ class Net(torch.nn.Module):
     ):
         super().__init__()
         self.decimation = decimation
+        # An option to return logits instead of log probabilities:
         self.return_logits = return_logits
         self.fc0 = Linear(in_features=num_features, out_features=8)
         # 2 DilatedResidualBlock converges better than 4 on ModelNet.

--- a/examples/randlanet_segmentation.py
+++ b/examples/randlanet_segmentation.py
@@ -74,7 +74,7 @@ class Net(torch.nn.Module):
         super().__init__()
 
         self.decimation = decimation
-        # An option to return logits instead of probas
+        # An option to return logits instead of log probabilities:
         self.return_logits = return_logits
 
         # Authors use 8, which is a bottleneck

--- a/examples/sgc.py
+++ b/examples/sgc.py
@@ -36,11 +36,12 @@ def train():
     optimizer.step()
 
 
+@torch.no_grad()
 def test():
     model.eval()
-    logits, accs = model(), []
+    out, accs = model(), []
     for _, mask in data('train_mask', 'val_mask', 'test_mask'):
-        pred = logits[mask].max(1)[1]
+        pred = out[mask].argmax(1)
         acc = pred.eq(data.y[mask]).sum().item() / mask.sum().item()
         accs.append(acc)
     return accs

--- a/examples/super_gat.py
+++ b/examples/super_gat.py
@@ -50,11 +50,12 @@ def train(data):
     optimizer.step()
 
 
+@torch.no_grad()
 def test(data):
     model.eval()
-    logits, accs = model(data.x, data.edge_index)[0], []
+    out, accs = model(data.x, data.edge_index)[0], []
     for _, mask in data('train_mask', 'val_mask', 'test_mask'):
-        pred = logits[mask].max(1)[1]
+        pred = out[mask].argmax(1)
         acc = pred.eq(data.y[mask]).sum().item() / mask.sum().item()
         accs.append(acc)
     return accs

--- a/examples/tagcn.py
+++ b/examples/tagcn.py
@@ -39,11 +39,12 @@ def train():
     optimizer.step()
 
 
+@torch.no_grad()
 def test():
     model.eval()
-    logits, accs = model(), []
+    out, accs = model(), []
     for _, mask in data('train_mask', 'val_mask', 'test_mask'):
-        pred = logits[mask].max(1)[1]
+        pred = out[mask].argmax(1)
         acc = pred.eq(data.y[mask]).sum().item() / mask.sum().item()
         accs.append(acc)
     return accs

--- a/examples/tensorboard_logging.py
+++ b/examples/tensorboard_logging.py
@@ -35,8 +35,8 @@ optimizer = torch.optim.Adam(model.parameters(), lr=0.01, weight_decay=5e-4)
 def train():
     model.train()
     optimizer.zero_grad()
-    logits = model(data.x, data.edge_index)
-    loss = F.nll_loss(logits[data.train_mask], data.y[data.train_mask])
+    out = model(data.x, data.edge_index)
+    loss = F.nll_loss(out[data.train_mask], data.y[data.train_mask])
     loss.backward()
     optimizer.step()
     return loss.item()
@@ -45,9 +45,9 @@ def train():
 @torch.no_grad()
 def test():
     model.eval()
-    logits, accs = model(data.x, data.edge_index), []
+    out, accs = model(data.x, data.edge_index), []
     for _, mask in data('train_mask', 'val_mask', 'test_mask'):
-        pred = logits[mask].max(1)[1]
+        pred = out[mask].max(1)[1]
         acc = pred.eq(data.y[mask]).sum().item() / mask.sum().item()
         accs.append(acc)
     return accs

--- a/examples/tensorboard_logging.py
+++ b/examples/tensorboard_logging.py
@@ -47,7 +47,7 @@ def test():
     model.eval()
     out, accs = model(data.x, data.edge_index), []
     for _, mask in data('train_mask', 'val_mask', 'test_mask'):
-        pred = out[mask].max(1)[1]
+        pred = out[mask].argmax(1)
         acc = pred.eq(data.y[mask]).sum().item() / mask.sum().item()
         accs.append(acc)
     return accs


### PR DESCRIPTION
In some places, `logits` were accidentally used to described "log probabilities".