### PR TITLE
Fix the use of removed numpy types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
+- Fixed the use of types removed in `numpy 1.24.0` ([#6495](https://github.com/pyg-team/pytorch_geometric/pull/6495))
 - Fixed keyword parameters in `examples/mnist_voxel_grid.py` ([#6478](https://github.com/pyg-team/pytorch_geometric/pull/6478))
 - Unified `LightningNodeData` and `LightningLinkData` code paths ([#6473](https://github.com/pyg-team/pytorch_geometric/pull/6473))
 - Allow indices with any integer type in `RGCNConv` ([#6463](https://github.com/pyg-team/pytorch_geometric/pull/6463))

--- a/torch_geometric/data/dataset.py
+++ b/torch_geometric/data/dataset.py
@@ -263,7 +263,7 @@ class Dataset(torch.utils.data.Dataset):
         elif isinstance(idx, np.ndarray) and idx.dtype == np.int64:
             return self.index_select(idx.flatten().tolist())
 
-        elif isinstance(idx, np.ndarray) and idx.dtype == np.bool:
+        elif isinstance(idx, np.ndarray) and idx.dtype == bool:
             idx = idx.flatten().nonzero()[0]
             return self.index_select(idx.flatten().tolist())
 

--- a/torch_geometric/datasets/entities.py
+++ b/torch_geometric/datasets/entities.py
@@ -4,7 +4,6 @@ import os.path as osp
 from collections import Counter
 from typing import Callable, List, Optional
 
-import numpy as np
 import torch
 
 from torch_geometric.data import (
@@ -169,7 +168,7 @@ class Entities(InMemoryDataset):
         labels_df = pd.read_csv(task_file, sep='\t')
         labels_set = set(labels_df[label_header].values.tolist())
         labels_dict = {lab: i for i, lab in enumerate(list(labels_set))}
-        nodes_dict = {np.unicode(key): val for key, val in nodes_dict.items()}
+        nodes_dict = {str(key): val for key, val in nodes_dict.items()}
 
         train_labels_df = pd.read_csv(train_file, sep='\t')
         train_indices, train_labels = [], []


### PR DESCRIPTION
Both `np.bool` and `np.unicode` were [deprecated in numpy 1.20.0](https://numpy.org/doc/stable/release/1.20.0-notes.html#:~:text=Deprecations-,Using%20the%20aliases%20of%20builtin%20types,-like%20np.int%20is%20deprecated%23) and [removed in numpy 1.24.0](https://numpy.org/doc/stable/release/1.24.0-notes.html#:~:text=The-,deprecation,-for%20the%20aliases).
Since [release notes of 1.20.0](https://numpy.org/doc/stable/release/1.20.0-notes.html#:~:text=Deprecations-,Using%20the%20aliases%20of%20builtin%20types,-like%20np.int%20is%20deprecated%23) say that `np.bool` is identical to `bool` and `np.unicode` is identical to `str`, I changed them that way.

Confirmed using numpy 1.23.5:
```
>>> np.__version__
'1.23.5'
>>> np.unicode is str
<stdin>:1: DeprecationWarning: `np.unicode` is a deprecated alias for `np.compat.unicode`. To silence this warning, use `np.compat.unicode` by itself. In the likely event your code does not need to work on Python 2 you can use the builtin `str` for which `np.compat.unicode` is itself an alias. Doing this will not modify any behaviour and is safe. If you specifically wanted the numpy scalar type, use `np.str_` here.
Deprecated in NumPy 1.20; for more details and guidance: https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations
True
>>> np.bool is bool
<stdin>:1: DeprecationWarning: `np.bool` is a deprecated alias for the builtin `bool`. To silence this warning, use `bool` by itself. Doing this will not modify any behavior and is safe. If you specifically wanted the numpy scalar type, use `np.bool_` here.
Deprecated in NumPy 1.20; for more details and guidance: https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations
True
```
In numpy 1.24.0 both types don't exist anymore:
```
>>> np.__version__
'1.24.0'
>>> np.unicode       
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "[...]/python3.8/site-packages/numpy/__init__.py", line 284, in __getattr__
    raise AttributeError("module {!r} has no attribute "
AttributeError: module 'numpy' has no attribute 'unicode'
>>> np.bool
<stdin>:1: FutureWarning: In the future `np.bool` will be defined as the corresponding NumPy scalar.  (This may have returned Python scalars in past versions.
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "[...]/python3.8/site-packages/numpy/__init__.py", line 284, in __getattr__
    raise AttributeError("module {!r} has no attribute "
AttributeError: module 'numpy' has no attribute 'bool'
```