### PR TITLE
Change `DataLoader` workers with affinity to start at `cpu0` 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
+- Changed `DataLoader` workers with affinity to start at `cpu0` ([#6512](https://github.com/pyg-team/pytorch_geometric/pull/6512))
 - Allow 1D input to `global_*_pool` functions ([#6504](https://github.com/pyg-team/pytorch_geometric/pull/6504))
 - Add information about dynamic shapes in `RGCNConv` ([#6482](https://github.com/pyg-team/pytorch_geometric/pull/6482))
 - Fixed the use of types removed in `numpy 1.24.0` ([#6495](https://github.com/pyg-team/pytorch_geometric/pull/6495))

--- a/test/loader/test_neighbor_loader.py
+++ b/test/loader/test_neighbor_loader.py
@@ -603,7 +603,7 @@ def test_cpu_affinity_neighbor_loader(num_workers, loader_cores):
                 stdout=subprocess.PIPE)
             stdout = process.communicate()[0].decode('utf-8')
             out.append(int(stdout.split(':')[1].strip()))
-        if not loader_cores: 
+        if not loader_cores:
             assert out == list(range(0, num_workers))
         else:
             assert out == loader_cores

--- a/test/loader/test_neighbor_loader.py
+++ b/test/loader/test_neighbor_loader.py
@@ -603,4 +603,7 @@ def test_cpu_affinity_neighbor_loader(num_workers, loader_cores):
                 stdout=subprocess.PIPE)
             stdout = process.communicate()[0].decode('utf-8')
             out.append(int(stdout.split(':')[1].strip()))
-    assert out == list(range(1, num_workers + 1))
+        if not loader_cores: 
+            assert out == list(range(0, num_workers))
+        else:
+            assert out == loader_cores

--- a/torch_geometric/loader/node_loader.py
+++ b/torch_geometric/loader/node_loader.py
@@ -216,7 +216,7 @@ class NodeLoader(torch.utils.data.DataLoader):
         .. code-block:: python
 
             loader = NeigborLoader(data, num_workers=3)
-            with loader.enable_cpu_affinity(loader_cores=[1,2,3]):
+            with loader.enable_cpu_affinity(loader_cores=[0,1,2]):
                 for batch in loader:
                     pass
 
@@ -229,7 +229,7 @@ class NodeLoader(torch.utils.data.DataLoader):
                 By default, :obj:`cpu0` is reserved for all auxiliary threads
                 and ops.
                 The :class:`DataLoader` wil affinitize to cores starting at
-                :obj:`cpu1`. (default: :obj:`node0_cores[1:num_workers]`)
+                :obj:`cpu0`. (default: :obj:`node0_cores[:num_workers]`)
         """
         if not self.is_cuda_available:
             if not self.num_workers > 0:
@@ -266,13 +266,13 @@ class NodeLoader(torch.utils.data.DataLoader):
                 else:
                     node0_cores = list(range(psutil.cpu_count(logical=False)))
 
-                if len(node0_cores) - 1 < self.num_workers:
+                if len(node0_cores) < self.num_workers:
                     raise ValueError(
                         f"More workers (got {self.num_workers}) than "
-                        f"available cores (got {len(node0_cores) - 1})")
+                        f"available cores (got {len(node0_cores)})")
 
                 # Set default loader core IDs:
-                loader_cores = node0_cores[1:self.num_workers + 1]
+                loader_cores = node0_cores[:self.num_workers]
 
             try:
                 # Set CPU affinity for dataloader:

--- a/torch_geometric/loader/node_loader.py
+++ b/torch_geometric/loader/node_loader.py
@@ -216,7 +216,7 @@ class NodeLoader(torch.utils.data.DataLoader):
         .. code-block:: python
 
             loader = NeigborLoader(data, num_workers=3)
-            with loader.enable_cpu_affinity(loader_cores=[0,1,2]):
+            with loader.enable_cpu_affinity(loader_cores=[0, 1, 2]):
                 for batch in loader:
                     pass
 


### PR DESCRIPTION
Changing default range for DataLoader workers with affinity to start at cpu0 instead of cpu1.
Latest results proved that there's no need to always leave a single core free for main process. Therefore changing it to default range starting at 0, simplifying the code.