### PR TITLE
Fix xlabel issue in `Explanation.visualize_feature_importance` for pandas>=1.5

### DIFF
--- a/torch_geometric/explain/explanation.py
+++ b/torch_geometric/explain/explanation.py
@@ -250,7 +250,7 @@ class Explanation(Data, ExplanationMixin):
             kind='barh',
             figsize=(10, 7),
             title=title,
-            xlabel='Feature label',
+            ylabel='Feature label',
             xlim=[0, float(feat_importance.max()) + 0.3],
             legend=False,
         )


### PR DESCRIPTION
This bug was caused by pandas and has been fixed in pandas>=1.5. It works fine with an older pandas version specifying `xlabel` or `ylabel`.