### PR TITLE
Automatic `n_id` and `e_id` attributes to mini-batches produced by `NodeLoader` and `LinkLoader`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- Keep node `__index__` in the minibatch for debug and customized model ([#6524](https://github.com/pyg-team/pytorch_geometric/pull/6524))
 - Added `PGMExplainer` to `torch_geometric.contrib` ([#6149](https://github.com/pyg-team/pytorch_geometric/pull/6149))
 - Added a `NumNeighbors` helper class for specifying the number of neighbors when sampling ([#6501](https://github.com/pyg-team/pytorch_geometric/pull/6501), [#6505](https://github.com/pyg-team/pytorch_geometric/pull/6505))
 - Added caching to `is_node_attr()` and `is_edge_attr()` calls ([#6492](https://github.com/pyg-team/pytorch_geometric/pull/6492))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
-- Keep node `__index__` in the minibatch for debug and customized model ([#6524](https://github.com/pyg-team/pytorch_geometric/pull/6524))
+- Added automatic `n_id` and `e_id` attributes to mini-batches produced by `NodeLoader` and `LinkLoader` ([#6524](https://github.com/pyg-team/pytorch_geometric/pull/6524))
 - Added `PGMExplainer` to `torch_geometric.contrib` ([#6149](https://github.com/pyg-team/pytorch_geometric/pull/6149))
 - Added a `NumNeighbors` helper class for specifying the number of neighbors when sampling ([#6501](https://github.com/pyg-team/pytorch_geometric/pull/6501), [#6505](https://github.com/pyg-team/pytorch_geometric/pull/6505))
 - Added caching to `is_node_attr()` and `is_edge_attr()` calls ([#6492](https://github.com/pyg-team/pytorch_geometric/pull/6492))

--- a/test/loader/test_hgt_loader.py
+++ b/test/loader/test_hgt_loader.py
@@ -60,13 +60,15 @@ def test_hgt_loader():
         assert set(batch.node_types) == {'paper', 'author'}
         assert set(batch.edge_types) == set(data.edge_types)
 
-        assert len(batch['paper']) == 3
+        assert len(batch['paper']) == 4
+        assert batch['paper'].n_id.size() == (batch['paper'].num_nodes, )
         assert batch['paper'].x.size() == (40, )  # 20 + 4 * 5
         assert batch['paper'].input_id.numel() == batch_size
         assert batch['paper'].batch_size == batch_size
         assert batch['paper'].x.min() >= 0 and batch['paper'].x.max() < 100
 
-        assert len(batch['author']) == 1
+        assert len(batch['author']) == 2
+        assert batch['author'].n_id.size() == (batch['author'].num_nodes, )
         assert batch['author'].x.size() == (20, )  # 4 * 5
         assert batch['author'].x.min() >= 100 and batch['author'].x.max() < 300
 
@@ -75,7 +77,9 @@ def test_hgt_loader():
                                          ('paper', 'to', 'author'),
                                          ('author', 'to', 'paper')}
 
-        assert len(batch['paper', 'paper']) == 2
+        assert len(batch['paper', 'paper']) == 3
+        num_edges = batch['paper', 'paper'].num_edges
+        assert batch['paper', 'paper'].e_id.size() == (num_edges, )
         row, col = batch['paper', 'paper'].edge_index
         value = batch['paper', 'paper'].edge_attr
         adj = full_adj[batch['paper'].x, batch['paper'].x]
@@ -91,7 +95,9 @@ def test_hgt_loader():
                          data['paper', 'paper'].edge_index, batch['paper'].x,
                          batch['paper'].x)
 
-        assert len(batch['paper', 'author']) == 2
+        assert len(batch['paper', 'author']) == 3
+        num_edges = batch['paper', 'author'].num_edges
+        assert batch['paper', 'author'].e_id.size() == (num_edges, )
         row, col = batch['paper', 'author'].edge_index
         value = batch['paper', 'author'].edge_attr
         adj = full_adj[batch['paper'].x, batch['author'].x]
@@ -107,7 +113,9 @@ def test_hgt_loader():
                          data['paper', 'author'].edge_index, batch['paper'].x,
                          batch['author'].x - 100)
 
-        assert len(batch['author', 'paper']) == 2
+        assert len(batch['author', 'paper']) == 3
+        num_edges = batch['author', 'paper'].num_edges
+        assert batch['author', 'paper'].e_id.size() == (num_edges, )
         row, col = batch['author', 'paper'].edge_index
         value = batch['author', 'paper'].edge_attr
         adj = full_adj[batch['author'].x, batch['paper'].x]

--- a/test/loader/test_link_neighbor_loader.py
+++ b/test/loader/test_link_neighbor_loader.py
@@ -49,7 +49,9 @@ def test_homo_link_neighbor_loader_basic(directed, neg_sampling_ratio):
     for batch in loader:
         assert isinstance(batch, Data)
 
-        assert len(batch) == 6
+        assert len(batch) == 8
+        assert batch.n_id.size() == (batch.num_nodes, )
+        assert batch.e_id.size() == (batch.num_edges, )
         assert batch.x.size(0) <= 100
         assert batch.x.min() >= 0 and batch.x.max() < 100
         assert batch.input_id.numel() == 20
@@ -109,7 +111,7 @@ def test_hetero_link_neighbor_loader_basic(directed, neg_sampling_ratio):
 
     for batch in loader:
         assert isinstance(batch, HeteroData)
-        assert len(batch) == 5 + (1 if neg_sampling_ratio is not None else 0)
+        assert len(batch) == 7 + (1 if neg_sampling_ratio is not None else 0)
         if neg_sampling_ratio is None:
             # Assert only positive samples are present in the original graph:
             edge_index = unique_edge_pairs(batch['paper', 'author'].edge_index)
@@ -295,7 +297,7 @@ def test_custom_hetero_link_neighbor_loader(FeatureStore, GraphStore):
             'author', 'to', 'paper'].edge_index.size())
 
 
-def test_homolink_neighbor_loader_no_edges():
+def test_homo_link_neighbor_loader_no_edges():
     loader = LinkNeighborLoader(
         Data(num_nodes=100),
         num_neighbors=[],
@@ -305,7 +307,7 @@ def test_homolink_neighbor_loader_no_edges():
 
     for batch in loader:
         assert isinstance(batch, Data)
-        assert len(batch) == 3
+        assert len(batch) == 5
         assert batch.input_id.numel() == 20
         assert batch.edge_label_index.size(1) == 20
         assert batch.num_nodes == batch.edge_label_index.unique().numel()
@@ -321,7 +323,7 @@ def test_hetero_link_neighbor_loader_no_edges():
 
     for batch in loader:
         assert isinstance(batch, HeteroData)
-        assert len(batch) == 3
+        assert len(batch) == 4
         assert batch['paper', 'paper'].input_id.numel() == 20
         assert batch['paper', 'paper'].edge_label_index.size(1) == 20
         assert batch['paper'].num_nodes == batch[
@@ -370,7 +372,7 @@ def test_homo_link_neighbor_loader_triplet(disjoint, temporal, amount):
 
     for batch in loader:
         assert isinstance(batch, Data)
-        num_elems = 7 + (1 if disjoint else 0) + (2 if temporal else 0)
+        num_elems = 9 + (1 if disjoint else 0) + (2 if temporal else 0)
         assert len(batch) == num_elems
 
         # Check that `src_index` and `dst_pos_index` point to valid edges:
@@ -464,7 +466,7 @@ def test_hetero_link_neighbor_loader_triplet(disjoint, temporal, amount):
 
     for batch in loader:
         assert isinstance(batch, HeteroData)
-        num_elems = 6 + (1 if disjoint else 0) + (2 if temporal else 0)
+        num_elems = 8 + (1 if disjoint else 0) + (2 if temporal else 0)
         assert len(batch) == num_elems
 
         node_store = batch['paper']

--- a/test/loader/test_neighbor_loader.py
+++ b/test/loader/test_neighbor_loader.py
@@ -402,8 +402,7 @@ def test_custom_neighbor_loader(FeatureStore, GraphStore):
     for batch1, batch2 in zip(loader1, loader2):
         # loader2 excplicitly adds `num_nodes` and `__index__` to the batch
         assert len(batch1) + 2 == len(batch2)
-        assert torch.allclose(batch2['paper'].x,
-                              batch2['paper'].x__index__)
+        assert torch.allclose(batch2['paper'].x, batch2['paper'].x__index__)
         assert batch1['paper'].batch_size == batch2['paper'].batch_size
 
         # Mapped indices of neighbors may be differently sorted:

--- a/test/loader/test_neighbor_loader.py
+++ b/test/loader/test_neighbor_loader.py
@@ -400,8 +400,10 @@ def test_custom_neighbor_loader(FeatureStore, GraphStore):
     assert len(loader1) == len(loader2)
 
     for batch1, batch2 in zip(loader1, loader2):
-        # loader2 excplicitly adds `num_nodes` to the batch
-        assert len(batch1) + 1 == len(batch2)
+        # loader2 excplicitly adds `num_nodes` and `__index__` to the batch
+        assert len(batch1) + 2 == len(batch2)
+        assert torch.allclose(batch2['paper'].x,
+                              batch2['paper'].x__index__)
         assert batch1['paper'].batch_size == batch2['paper'].batch_size
 
         # Mapped indices of neighbors may be differently sorted:

--- a/test/loader/test_neighbor_loader.py
+++ b/test/loader/test_neighbor_loader.py
@@ -58,8 +58,10 @@ def test_homo_neighbor_loader_basic(directed, dtype):
 
     for i, batch in enumerate(loader):
         assert isinstance(batch, Data)
-        assert len(batch) == 5
+        assert len(batch) == 7
         assert batch.x.size(0) <= 100
+        assert batch.n_id.size() == (batch.num_nodes, )
+        assert batch.e_id.size() == (batch.num_edges, )
         assert batch.input_id.numel() == batch.batch_size == 20
         assert batch.x.min() >= 0 and batch.x.max() < 100
         assert batch.edge_index.min() >= 0
@@ -142,13 +144,15 @@ def test_hetero_neighbor_loader_basic(directed, dtype):
         # Test node type selection:
         assert set(batch.node_types) == {'paper', 'author'}
 
-        assert len(batch['paper']) == 3
+        assert len(batch['paper']) == 4
+        assert batch['paper'].n_id.size() == (batch['paper'].num_nodes, )
         assert batch['paper'].x.size(0) <= 100
         assert batch['paper'].input_id.numel() == batch_size
         assert batch['paper'].batch_size == batch_size
         assert batch['paper'].x.min() >= 0 and batch['paper'].x.max() < 100
 
-        assert len(batch['author']) == 1
+        assert len(batch['author']) == 2
+        assert batch['author'].n_id.size() == (batch['author'].num_nodes, )
         assert batch['author'].x.size(0) <= 200
         assert batch['author'].x.min() >= 100 and batch['author'].x.max() < 300
 
@@ -157,7 +161,9 @@ def test_hetero_neighbor_loader_basic(directed, dtype):
                                          ('paper', 'to', 'author'),
                                          ('author', 'to', 'paper')}
 
-        assert len(batch['paper', 'paper']) == 2
+        assert len(batch['paper', 'paper']) == 3
+        num_edges = batch['paper', 'paper'].num_edges
+        assert batch['paper', 'paper'].e_id.size() == (num_edges, )
         row, col = batch['paper', 'paper'].edge_index
         value = batch['paper', 'paper'].edge_attr
         assert row.min() >= 0 and row.max() < batch['paper'].num_nodes
@@ -177,7 +183,9 @@ def test_hetero_neighbor_loader_basic(directed, dtype):
             batch['paper'].x,
         )
 
-        assert len(batch['paper', 'author']) == 2
+        assert len(batch['paper', 'author']) == 3
+        num_edges = batch['paper', 'author'].num_edges
+        assert batch['paper', 'author'].e_id.size() == (num_edges, )
         row, col = batch['paper', 'author'].edge_index
         value = batch['paper', 'author'].edge_attr
         assert row.min() >= 0 and row.max() < batch['paper'].num_nodes
@@ -197,7 +205,9 @@ def test_hetero_neighbor_loader_basic(directed, dtype):
             batch['author'].x - 100,
         )
 
-        assert len(batch['author', 'paper']) == 2
+        assert len(batch['author', 'paper']) == 3
+        num_edges = batch['author', 'paper'].num_edges
+        assert batch['author', 'paper'].e_id.size() == (num_edges, )
         row, col = batch['author', 'paper'].edge_index
         value = batch['author', 'paper'].edge_attr
         assert row.min() >= 0 and row.max() < batch['author'].num_nodes
@@ -400,9 +410,8 @@ def test_custom_neighbor_loader(FeatureStore, GraphStore):
     assert len(loader1) == len(loader2)
 
     for batch1, batch2 in zip(loader1, loader2):
-        # loader2 excplicitly adds `num_nodes` and `__index__` to the batch
-        assert len(batch1) + 2 == len(batch2)
-        assert torch.allclose(batch2['paper'].x, batch2['paper'].x__index__)
+        # loader2 explicitly adds `num_nodes` to the batch
+        assert len(batch1) + 1 == len(batch2)
         assert batch1['paper'].batch_size == batch2['paper'].batch_size
 
         # Mapped indices of neighbors may be differently sorted:

--- a/torch_geometric/data/storage.py
+++ b/torch_geometric/data/storage.py
@@ -29,8 +29,8 @@ from torch_geometric.utils import (
     is_undirected,
 )
 
-N_KEYS = {'x', 'feat', 'pos', 'batch', 'node_type'}
-E_KEYS = {'edge_index', 'edge_weight', 'edge_attr', 'edge_type'}
+N_KEYS = {'x', 'feat', 'pos', 'batch', 'node_type', 'n_id'}
+E_KEYS = {'edge_index', 'edge_weight', 'edge_attr', 'edge_type', 'e_id'}
 
 
 class AttrType(Enum):

--- a/torch_geometric/loader/link_loader.py
+++ b/torch_geometric/loader/link_loader.py
@@ -202,6 +202,11 @@ class LinkLoader(torch.utils.data.DataLoader):
             data = filter_data(self.data, out.node, out.row, out.col, out.edge,
                                self.link_sampler.edge_permutation)
 
+            if 'n_id' not in data:
+                data.n_id = out.node
+            if out.edge is not None and 'e_id' not in data:
+                data.e_id = out.edge
+
             data.batch = out.batch
             data.input_id = out.metadata[0]
 
@@ -228,8 +233,18 @@ class LinkLoader(torch.utils.data.DataLoader):
                 data = filter_custom_store(*self.data, out.node, out.row,
                                            out.col, out.edge, self.custom_cls)
 
-            for key, batch in (out.batch or {}).items():
-                data[key].batch = batch
+            for key, node in out.node.items():
+                if 'n_id' not in data[key]:
+                    data[key].n_id = node
+
+            if out.edge is not None:
+                for key, edge in out.edge.items():
+                    if 'e_id' not in data[key]:
+                        data[key].e_id = edge
+
+            if out.batch is not None:
+                for key, batch in out.batch.items():
+                    data[key].batch = batch
 
             input_type = self.input_data.input_type
             data[input_type].input_id = out.metadata[0]

--- a/torch_geometric/loader/neighbor_loader.py
+++ b/torch_geometric/loader/neighbor_loader.py
@@ -90,17 +90,15 @@ class NeighborLoader(NodeLoader):
     The :class:`~torch_geometric.loader.NeighborLoader` will return subgraphs
     where global node indices are mapped to local indices corresponding to this
     specific subgraph. However, often times it is desired to map the nodes of
-    the current subgraph back to the global node indices. A simple trick to
-    achieve this is to include this mapping as part of the :obj:`data` object:
+    the current subgraph back to the global node indices. The
+    :class:`~torch_geometric.loader.NeighborLoader` will include this mapping
+    as part of the :obj:`data` object:
 
     .. code-block:: python
 
-        # Assign each node its global node index:
-        data.n_id = torch.arange(data.num_nodes)
-
         loader = NeighborLoader(data, ...)
         sampled_data = next(iter(loader))
-        print(sampled_data.n_id)
+        print(sampled_data.n_id)  # Global node index of each node in batch.
 
     Args:
         data (Any): A :class:`~torch_geometric.data.Data`,

--- a/torch_geometric/loader/utils.py
+++ b/torch_geometric/loader/utils.py
@@ -191,6 +191,7 @@ def filter_custom_store(
     tensors = feature_store.multi_get_tensor(required_attrs)
     for i, attr in enumerate(required_attrs):
         data[attr.group_name][attr.attr_name] = tensors[i]
+        data[attr.group_name][f'{attr.attr_name}__index__'] = attr.index
 
     return data
 

--- a/torch_geometric/loader/utils.py
+++ b/torch_geometric/loader/utils.py
@@ -191,7 +191,6 @@ def filter_custom_store(
     tensors = feature_store.multi_get_tensor(required_attrs)
     for i, attr in enumerate(required_attrs):
         data[attr.group_name][attr.attr_name] = tensors[i]
-        data[attr.group_name][f'{attr.attr_name}__index__'] = attr.index
 
     return data
 


### PR DESCRIPTION
Keep the node index in the minibatch for more flexible model development and debug.