### PR TITLE
Update pycodestyle link in `CONTRIBUTING.md`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,6 +104,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Optimized `utils.softmax` implementation ([#6113](https://github.com/pyg-team/pytorch_geometric/pull/6113), [#6155](https://github.com/pyg-team/pytorch_geometric/pull/6155))
 - Optimized `topk` implementation for large enough graphs ([#6123](https://github.com/pyg-team/pytorch_geometric/pull/6123))
 
+- Fixed `CONTRIBUTING.md` typo error ([#6557](https://github.com/pyg-team/pytorch_geometric/pull/6557))
+
 ### Removed
 
 - Removed most of the `torch-scatter` dependencies ([#6394](https://github.com/pyg-team/pytorch_geometric/pull/6394), [#6395](https://github.com/pyg-team/pytorch_geometric/pull/6395), [#6399](https://github.com/pyg-team/pytorch_geometric/pull/6399), [#6400](https://github.com/pyg-team/pytorch_geometric/pull/6400))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,8 +104,6 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Optimized `utils.softmax` implementation ([#6113](https://github.com/pyg-team/pytorch_geometric/pull/6113), [#6155](https://github.com/pyg-team/pytorch_geometric/pull/6155))
 - Optimized `topk` implementation for large enough graphs ([#6123](https://github.com/pyg-team/pytorch_geometric/pull/6123))
 
-- Fixed `CONTRIBUTING.md` typo error ([#6557](https://github.com/pyg-team/pytorch_geometric/pull/6557))
-
 ### Removed
 
 - Removed most of the `torch-scatter` dependencies ([#6394](https://github.com/pyg-team/pytorch_geometric/pull/6394), [#6395](https://github.com/pyg-team/pytorch_geometric/pull/6395), [#6399](https://github.com/pyg-team/pytorch_geometric/pull/6399), [#6400](https://github.com/pyg-team/pytorch_geometric/pull/6400))

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -90,7 +90,7 @@ PyG uses [GitHub Actions](https://github.com/pyg-team/pytorch_geometric/actions)
 
 Everytime you send a Pull Request, your commit will be built and checked against the PyG guidelines:
 
-1. Ensure that your code is formatted correctly by testing against the styleguide of [`flake8`](https://github.com/PyCQA/flake8)://github.com/PyCQA/pycodestyle):
+1. Ensure that your code is formatted correctly by testing against the styleguide of [`flake8`](https://github.com/PyCQA/flake8) and [`pycodestyle`](https://github.com/PyCQA/pycodestyle):
 
    ```bash
    flake8 .

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -90,7 +90,7 @@ PyG uses [GitHub Actions](https://github.com/pyg-team/pytorch_geometric/actions)
 
 Everytime you send a Pull Request, your commit will be built and checked against the PyG guidelines:
 
-1. Ensure that your code is formatted correctly by testing against the styleguide of [`flake8`](https://github.com/PyCQA/flake8) and [`pycodestyle`](https://github.com/PyCQA/pycodestyle):
+1. Ensure that your code is formatted correctly by testing against the styleguide of [`flake8`](https://github.com/PyCQA/flake8):
 
    ```bash
    flake8 .


### PR DESCRIPTION
Hi pyg team, 
I am a student from CS 224W and noticed there is a typo error in `CONTRIBUTING.md`. Not sure if that was intended, if it was, just ignore my PR.
The new readme link https://github.com/JinL0/pytorch_geometric/blob/jinl/fix_contribution_readme/CONTRIBUTING.md
