### PR TITLE
`EquilibriumAggregation`: Padding tensor was not created on correct device

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- Fix incorrect device in `EquilibriumAggregration` ([#6560](https://github.com/pyg-team/pytorch_geometric/pull/6560))
 - Added bipartite graph support in `dense_to_sparse()` ([#6546](https://github.com/pyg-team/pytorch_geometric/pull/6546))
 - Add CPU affinity support for more data loaders ([#6534](https://github.com/pyg-team/pytorch_geometric/pull/6534))
 - Added the `BAMultiShapesDataset` ([#6541](https://github.com/pyg-team/pytorch_geometric/pull/6541))
@@ -103,7 +104,6 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Make `torch_sparse` an optional dependency ([#6132](https://github.com/pyg-team/pytorch_geometric/pull/6132), [#6134](https://github.com/pyg-team/pytorch_geometric/pull/6134), [#6138](https://github.com/pyg-team/pytorch_geometric/pull/6138), [#6139](https://github.com/pyg-team/pytorch_geometric/pull/6139))
 - Optimized `utils.softmax` implementation ([#6113](https://github.com/pyg-team/pytorch_geometric/pull/6113), [#6155](https://github.com/pyg-team/pytorch_geometric/pull/6155))
 - Optimized `topk` implementation for large enough graphs ([#6123](https://github.com/pyg-team/pytorch_geometric/pull/6123))
-- Create temporary tensor on correct device in `EquilibriumAggregration.forward` ([#6560](https://github.com/pyg-team/pytorch_geometric/pull/6560))
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,6 +103,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Make `torch_sparse` an optional dependency ([#6132](https://github.com/pyg-team/pytorch_geometric/pull/6132), [#6134](https://github.com/pyg-team/pytorch_geometric/pull/6134), [#6138](https://github.com/pyg-team/pytorch_geometric/pull/6138), [#6139](https://github.com/pyg-team/pytorch_geometric/pull/6139))
 - Optimized `utils.softmax` implementation ([#6113](https://github.com/pyg-team/pytorch_geometric/pull/6113), [#6155](https://github.com/pyg-team/pytorch_geometric/pull/6155))
 - Optimized `topk` implementation for large enough graphs ([#6123](https://github.com/pyg-team/pytorch_geometric/pull/6123))
+- Create temporary tensor on correct device in `EquilibriumAggregration.forward` ([#6560](https://github.com/pyg-team/pytorch_geometric/pull/6560))
 
 ### Removed
 

--- a/torch_geometric/nn/aggr/equilibrium.py
+++ b/torch_geometric/nn/aggr/equilibrium.py
@@ -175,8 +175,7 @@ class EquilibriumAggregation(Aggregation):
                                iterations=self.grad_iter)
 
         if dim_size > index_size:
-            zero = torch.zeros(dim_size - index_size,
-                               *y.size()[1:], device=self.lamb.device)
+            zero = y.new_zeros(dim_size - index_size, *y.size()[1:])
             y = torch.cat([y, zero])
 
         return y

--- a/torch_geometric/nn/aggr/equilibrium.py
+++ b/torch_geometric/nn/aggr/equilibrium.py
@@ -175,7 +175,7 @@ class EquilibriumAggregation(Aggregation):
                                iterations=self.grad_iter)
 
         if dim_size > index_size:
-            zero = torch.zeros(dim_size - index_size, *y.size()[1:])
+            zero = torch.zeros(dim_size - index_size, *y.size()[1:], device=self.lamb.device)
             y = torch.cat([y, zero])
 
         return y

--- a/torch_geometric/nn/aggr/equilibrium.py
+++ b/torch_geometric/nn/aggr/equilibrium.py
@@ -175,7 +175,8 @@ class EquilibriumAggregation(Aggregation):
                                iterations=self.grad_iter)
 
         if dim_size > index_size:
-            zero = torch.zeros(dim_size - index_size, *y.size()[1:], device=self.lamb.device)
+            zero = torch.zeros(dim_size - index_size,
+                               *y.size()[1:], device=self.lamb.device)
             y = torch.cat([y, zero])
 
         return y


### PR DESCRIPTION
In the `forward` method of the equilibrium aggregation, if `dim_size > index_size` a new tensor is created for padding, but without specification of the target device.
I added the device to be the same as `self.lamb.device` like it is done in the `init_output` method.

Example to reproduce:

```
import torch
from torch_geometric.nn.aggr import EquilibriumAggregation

print("Has cuda:", torch.cuda.is_available())

x = torch.rand(8, 4)
index = torch.tensor([0, 0, 0, 0, 2, 2, 2, 2])

aggr = EquilibriumAggregation(4, 4, [8])

print(
    "This works",
    aggr(x.to(torch.device("cpu")), index=index, dim_size=3).shape
    == torch.Size([3, 4]),
)
print(
    "This crashes",
    aggr(x.to(torch.device("cuda")), index=index, dim_size=3).shape
    == torch.Size([3, 4]),
)
```

Error message:
```
torch_geometric/nn/aggr/equilibrium.py", line 39, in forward
    inp = torch.cat([x, y[index]], dim=1)
RuntimeError: Expected all tensors to be on the same device, but found at least two devices, cuda:0 and cpu! (when checking argument for argument tensors in method wrapper_cat)
```