### PR TITLE
Fix pyg-nightly workflow

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -32,7 +32,7 @@ jobs:
           sed -i "s/$VERSION/$VERSION.dev$TODAY/" setup.py
           sed -i "s/$VERSION/$VERSION.dev$TODAY/" torch_geometric/__init__.py
           sed -i 's/name="torch_geometric"/name="pyg-nightly"/' pyproject.toml
-          sed -i 's/version="$VERSION"/version="$VERSION.dev$TODAY"/' pyproject.toml
+          sed -i "s/version=\"$VERSION\"/version=\"$VERSION.dev$TODAY\"/" pyproject.toml
 
       - name: Build package
         run: python setup.py sdist


### PR DESCRIPTION
The following error shows up when trying to install pyg-nightly:
`Requested pyg-nightly==2.3.0.dev20230130  has inconsistent version: expected '2.3.0.dev20230130', but metadata has '2.3.0'`

This change should solve the problem.