### PR TITLE
Fix `download` and `process` in `torch_geometric.data.Dataset` when using a duplicated class name `Dataset`

### DIFF
--- a/test/data/test_dataset.py
+++ b/test/data/test_dataset.py
@@ -164,8 +164,8 @@ def test_hetero_in_memory_dataset():
         'paper', 'paper'].edge_index.tolist())
 
 
-def test_override_behaviour():
-    class DS(Dataset):
+def test_override_behavior():
+    class DS1(Dataset):
         def __init__(self):
             self.enter_download = False
             self.enter_process = False
@@ -210,7 +210,10 @@ def test_override_behaviour():
         def _process(self):
             self.enter_process = True
 
-    ds = DS()
+    class DS4(DS1):
+        pass
+
+    ds = DS1()
     assert ds.enter_download
     assert ds.enter_process
 
@@ -221,6 +224,10 @@ def test_override_behaviour():
     ds = DS3()
     assert not ds.enter_download
     assert not ds.enter_process
+
+    ds = DS4()
+    assert ds.enter_download
+    assert ds.enter_process
 
 
 def test_lists_of_tensors_in_memory_dataset():

--- a/torch_geometric/data/dataset.py
+++ b/torch_geometric/data/dataset.py
@@ -87,12 +87,10 @@ class Dataset(torch.utils.data.Dataset):
         self.log = log
         self._indices: Optional[Sequence] = None
 
-        flag = self.__class__.__name__ == 'Dataset' and has_parent(
-            self.__class__.__bases__, Dataset)
-        if self.download.__qualname__.split('.')[0] != 'Dataset' or flag:
+        if 'download' in self.__class__.__dict__:
             self._download()
 
-        if self.process.__qualname__.split('.')[0] != 'Dataset' or flag:
+        if 'process' in self.__class__.__dict__:
             self._process()
 
     def indices(self) -> Sequence:

--- a/torch_geometric/data/dataset.py
+++ b/torch_geometric/data/dataset.py
@@ -333,16 +333,6 @@ class Dataset(torch.utils.data.Dataset):
         return DatasetAdapter(self)
 
 
-def has_parent(classes, cls) -> bool:
-    """Check if a set of classes has a parent class `cls`."""
-    for c in classes:
-        if c is cls:
-            return True
-        else:
-            return has_parent(c.__bases__, cls)
-    return False
-
-
 def to_list(value: Any) -> Sequence:
     if isinstance(value, Sequence) and not isinstance(value, str):
         return value

--- a/torch_geometric/data/dataset.py
+++ b/torch_geometric/data/dataset.py
@@ -87,10 +87,10 @@ class Dataset(torch.utils.data.Dataset):
         self.log = log
         self._indices: Optional[Sequence] = None
 
-        if 'download' in self.__class__.__dict__:
+        if self.has_download:
             self._download()
 
-        if 'process' in self.__class__.__dict__:
+        if self.has_process:
             self._process()
 
     def indices(self) -> Sequence:
@@ -177,12 +177,22 @@ class Dataset(torch.utils.data.Dataset):
             files = files()
         return [osp.join(self.processed_dir, f) for f in to_list(files)]
 
+    @property
+    def has_download(self) -> bool:
+        r"""Checks whether the dataset defines a :meth:`download` method."""
+        return overrides_method(self.__class__, 'download')
+
     def _download(self):
         if files_exist(self.raw_paths):  # pragma: no cover
             return
 
         makedirs(self.raw_dir)
         self.download()
+
+    @property
+    def has_process(self) -> bool:
+        r"""Checks whether the dataset defines a :meth:`process` method."""
+        return overrides_method(self.__class__, 'process')
 
     def _process(self):
         f = osp.join(self.processed_dir, 'pre_transform.pt')
@@ -331,6 +341,19 @@ class Dataset(torch.utils.data.Dataset):
         from torch_geometric.data.datapipes import DatasetAdapter
 
         return DatasetAdapter(self)
+
+
+def overrides_method(cls, method_name: str):
+    from torch_geometric.data import InMemoryDataset
+
+    if method_name in cls.__dict__:
+        return True
+
+    out = False
+    for base in cls.__bases__:
+        if base != Dataset and base != InMemoryDataset:
+            out |= overrides_method(base, method_name)
+    return out
 
 
 def to_list(value: Any) -> Sequence:

--- a/torch_geometric/data/dataset.py
+++ b/torch_geometric/data/dataset.py
@@ -87,10 +87,12 @@ class Dataset(torch.utils.data.Dataset):
         self.log = log
         self._indices: Optional[Sequence] = None
 
-        if self.download.__qualname__.split('.')[0] != 'Dataset':
+        flag = self.__class__.__name__ == 'Dataset' and has_parent(
+            self.__class__.__bases__, Dataset)
+        if self.download.__qualname__.split('.')[0] != 'Dataset' or flag:
             self._download()
 
-        if self.process.__qualname__.split('.')[0] != 'Dataset':
+        if self.process.__qualname__.split('.')[0] != 'Dataset' or flag:
             self._process()
 
     def indices(self) -> Sequence:
@@ -331,6 +333,16 @@ class Dataset(torch.utils.data.Dataset):
         from torch_geometric.data.datapipes import DatasetAdapter
 
         return DatasetAdapter(self)
+
+
+def has_parent(classes, cls) -> bool:
+    """Check if a set of classes has a parent class `cls`."""
+    for c in classes:
+        if c is cls:
+            return True
+        else:
+            return has_parent(c.__bases__, cls)
+    return False
 
 
 def to_list(value: Any) -> Sequence:


### PR DESCRIPTION
To fix https://github.com/pyg-team/pytorch_geometric/issues/6582. Not sure if it is a "bug" and should be fixed.


### test example
```python
import torch_geometric
class Dataset(torch_geometric.data.Dataset):
    def __init__(self):
        self.enter_download = False
        self.enter_process = False
        super().__init__()

    def _download(self):
        self.enter_download = True

    def _process(self):
        self.enter_process = True

    def download(self):
        pass

    def process(self):
        pass

ds = Dataset()
assert ds.enter_download
assert ds.enter_process
```