### PR TITLE
Fix bugs in `PNAConv` and `DegreeScalerAggregation`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,7 +76,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
-- Fixed bugs in `PNAConv` and `DegreeScalerAggregation` ([#6609](https://github.com/pyg-team/pytorch_geometric/pull/6609))
+- Fixed a bug in `PNAConv` and `DegreeScalerAggregation` to correctly incorporate degree statistics of isolated nodes ([#6609](https://github.com/pyg-team/pytorch_geometric/pull/6609))
 - Improved code coverage ([#6523](https://github.com/pyg-team/pytorch_geometric/pull/6523), [#6538](https://github.com/pyg-team/pytorch_geometric/pull/6538), [#6555](https://github.com/pyg-team/pytorch_geometric/pull/6555), [#6558](https://github.com/pyg-team/pytorch_geometric/pull/6558), [#6568](https://github.com/pyg-team/pytorch_geometric/pull/6568), [#6573](https://github.com/pyg-team/pytorch_geometric/pull/6573), [#6578](https://github.com/pyg-team/pytorch_geometric/pull/6578), [#6597](https://github.com/pyg-team/pytorch_geometric/pull/6597))
 - Fixed a bug in which `data.to_heterogeneous()` filtered attributs in the wrong dimension ([#6522](https://github.com/pyg-team/pytorch_geometric/pull/6522))
 - Breaking Change: Temporal sampling will now also sample nodes with an equal timestamp to the seed time (requires `pyg-lib>0.1.0`) ([#6517](https://github.com/pyg-team/pytorch_geometric/pull/6517))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
+- Fixed bugs in `PNAConv` and `DegreeScalerAggregation` ([#6609](https://github.com/pyg-team/pytorch_geometric/pull/6609))
 - Improved code coverage ([#6523](https://github.com/pyg-team/pytorch_geometric/pull/6523), [#6538](https://github.com/pyg-team/pytorch_geometric/pull/6538), [#6555](https://github.com/pyg-team/pytorch_geometric/pull/6555), [#6558](https://github.com/pyg-team/pytorch_geometric/pull/6558), [#6568](https://github.com/pyg-team/pytorch_geometric/pull/6568), [#6573](https://github.com/pyg-team/pytorch_geometric/pull/6573), [#6578](https://github.com/pyg-team/pytorch_geometric/pull/6578))
 - Fixed a bug in which `data.to_heterogeneous()` filtered attributs in the wrong dimension ([#6522](https://github.com/pyg-team/pytorch_geometric/pull/6522))
 - Breaking Change: Temporal sampling will now also sample nodes with an equal timestamp to the seed time (requires `pyg-lib>0.1.0`) ([#6517](https://github.com/pyg-team/pytorch_geometric/pull/6517))

--- a/torch_geometric/nn/aggr/scaler.py
+++ b/torch_geometric/nn/aggr/scaler.py
@@ -25,7 +25,7 @@ class DegreeScalerAggregation(Aggregation):
             :obj:`"attenuation"`, :obj:`"linear"` and :obj:`"inverse_linear"`.
         deg (Tensor): Histogram of in-degrees of nodes in the training set,
             used by scalers to normalize.
-        train_norm (bool, optional) Whether normalization parameters
+        train_norm (bool, optional): Whether normalization parameters
             are trainable. (default: :obj:`False`)
         aggr_kwargs (Dict[str, Any], optional): Arguments passed to the
             respective aggregation function in case it gets automatically
@@ -82,7 +82,7 @@ class DegreeScalerAggregation(Aggregation):
         out = self.aggr(x, index, ptr, dim_size, dim)
 
         assert index is not None
-        deg = degree(index, num_nodes=dim_size, dtype=out.dtype).clamp_(1)
+        deg = degree(index, num_nodes=dim_size, dtype=out.dtype)
         size = [1] * len(out.size())
         size[dim] = -1
         deg = deg.view(size)
@@ -98,7 +98,8 @@ class DegreeScalerAggregation(Aggregation):
             elif scaler == 'linear':
                 out_scaler = out * (deg / self.avg_deg_lin)
             elif scaler == 'inverse_linear':
-                out_scaler = out * (self.avg_deg_lin / deg)
+                # Clamps minimum degree into one to avoid dividing by zero
+                out_scaler = out * (self.avg_deg_lin / deg.clamp(1))
             else:
                 raise ValueError(f"Unknown scaler '{scaler}'")
             outs.append(out_scaler)

--- a/torch_geometric/nn/conv/pna_conv.py
+++ b/torch_geometric/nn/conv/pna_conv.py
@@ -3,6 +3,7 @@ from typing import Any, Callable, Dict, List, Optional, Union
 import torch
 from torch import Tensor
 from torch.nn import ModuleList, Sequential
+from torch.utils.data import DataLoader
 
 from torch_geometric.nn.aggr import DegreeScalerAggregation
 from torch_geometric.nn.conv import MessagePassing
@@ -76,7 +77,7 @@ class PNAConv(MessagePassing):
         act_kwargs (Dict[str, Any], optional): Arguments passed to the
             respective activation function defined by :obj:`act`.
             (default: :obj:`None`)
-        train_norm (bool, optional) Whether normalization parameters
+        train_norm (bool, optional): Whether normalization parameters
             are trainable. (default: :obj:`False`)
         **kwargs (optional): Additional arguments of
             :class:`torch_geometric.nn.conv.MessagePassing`.
@@ -192,17 +193,16 @@ class PNAConv(MessagePassing):
                 f'edge_dim={self.edge_dim})')
 
     @staticmethod
-    def get_degree_histogram(loader) -> Tensor:
-        max_degree = 0
+    def get_degree_histogram(loader: DataLoader) -> Tensor:
+        deg_histogram = torch.zeros(1, dtype=torch.long)
         for data in loader:
             d = degree(data.edge_index[1], num_nodes=data.num_nodes,
                        dtype=torch.long)
-            max_degree = max(max_degree, int(d.max()))
-        # Compute the in-degree histogram tensor
-        deg_histogram = torch.zeros(max_degree + 1, dtype=torch.long)
-        for data in loader:
-            d = degree(data.edge_index[1], num_nodes=data.num_nodes,
-                       dtype=torch.long)
-            deg_histogram += torch.bincount(d, minlength=deg_histogram.numel())
+            d_bincount = torch.bincount(d, minlength=deg_histogram.numel())
+            if d_bincount.size(0) > deg_histogram.size(0):
+                d_bincount[:deg_histogram.size(0)] += deg_histogram
+                deg_histogram = d_bincount
+            else:
+                deg_histogram[:d_bincount.size(0)] += d_bincount
 
         return deg_histogram

--- a/torch_geometric/nn/conv/pna_conv.py
+++ b/torch_geometric/nn/conv/pna_conv.py
@@ -203,6 +203,7 @@ class PNAConv(MessagePassing):
                 d_bincount[:deg_histogram.size(0)] += deg_histogram
                 deg_histogram = d_bincount
             else:
-                deg_histogram[:d_bincount.size(0)] += d_bincount
+                assert d_bincount.size(0) == deg_histogram.size(0)
+                deg_histogram += d_bincount
 
         return deg_histogram


### PR DESCRIPTION
Some fixes, including bugs fixes and minor documentation fixes

### `torch_geometric/nn/aggr/scaler.py`
The `deg` tensor should be clamped during the `inverse_linear` computation and thus avoid division by zero (in case the `deg` tensor contains a zero degree value). Previous implementation will make the zero degree value equal to two in the `amplification` and `attenuation` cases where we also add one directly. Though I am not sure whether this way is correct and whether we also need to `clamp(1)` in the `linear` scaler.

### `torch_geometric/nn/conv/pna_conv.py`
The previous implementation utilized two for loops to compute the `deg_histogram` tensor. The first loop calculates the `max_degree`, while the second loop updates the `deg_histogram` by adding each `bincount`, with a `minlength` of `max_degree + 1`. However, for certain loaders (e.g. the `NeighborLoader`), the degree in the second loop may exceed the `max_degree` computed in the first loop and thus raise following error. Also, current implementation that replaces the two loops with one loop may potentially improve computation speed, although I don't verify this...
```
    deg_histogram += torch.bincount(d, minlength=deg_histogram.numel())
RuntimeError: The size of tensor a (17) must match the size of tensor b (19) at non-singleton dimension 0
```