### PR TITLE
Fixing Subgraph Methods

### DIFF
--- a/test/data/test_data.py
+++ b/test/data/test_data.py
@@ -208,6 +208,15 @@ def test_data_subgraph():
     assert torch.equal(out.edge_weight, edge_weight[torch.arange(2, 6)])
     assert out.num_nodes == 3
 
+    # test for unordered selection
+    out = data.subgraph(torch.tensor([3, 1, 2]))
+    assert len(out) == 5
+    assert torch.equal(out.x, torch.tensor([3, 1, 2]))
+    assert torch.equal(out.y, data.y)
+    assert out.edge_index.tolist() == [[1, 2, 2, 0], [2, 1, 0, 2]]
+    assert torch.equal(out.edge_weight, torch.tensor([2, 3, 4, 5]))
+    assert out.num_nodes == 3
+
     out = data.subgraph(torch.tensor([False, False, False, True, True]))
     assert len(out) == 5
     assert torch.equal(out.x, torch.arange(3, 5))

--- a/test/data/test_hetero_data.py
+++ b/test/data/test_hetero_data.py
@@ -211,6 +211,47 @@ def test_hetero_data_subgraph():
     assert torch.allclose(out['conf'].x, data['conf'].x[subset['conf']])
     assert out['conf'].num_nodes == 2
 
+    # construct correct edge index manually
+    paper_mask = torch.zeros((x_paper.size(0),), dtype=torch.bool)
+    paper_node_map = torch.zeros((x_paper.size(0),), dtype=torch.long)
+    paper_mask[subset['paper']] = True
+    paper_node_map[subset['paper']] = torch.arange(subset['paper'].size(0))
+
+    author_mask = torch.zeros((x_author.size(0),), dtype=torch.bool)
+    author_node_map = torch.zeros((x_author.size(0),), dtype=torch.long)
+    author_mask[subset['author']] = True
+    author_node_map[subset['author']] = torch.arange(subset['author'].size(0))
+
+    conf_mask = torch.zeros((x_conference.size(0),), dtype=torch.bool)
+    conf_node_map = torch.zeros((x_conference.size(0),), dtype=torch.long)
+    conf_mask[subset['conf']] = True
+    conf_node_map[subset['conf']] = torch.arange(subset['conf'].size(0))
+
+    edge_mask_paper_paper = paper_mask[edge_index_paper_paper[0]] \
+                            & paper_mask[edge_index_paper_paper[1]]
+    sub_edge_index_paper_paper = edge_index_paper_paper[:, edge_mask_paper_paper]
+    sub_edge_index_paper_paper[0] = paper_node_map[sub_edge_index_paper_paper[0]]
+    sub_edge_index_paper_paper[1] = paper_node_map[sub_edge_index_paper_paper[1]]
+    sub_edge_attr_paper_paper = edge_attr_paper_paper[edge_mask_paper_paper]
+
+    edge_mask_paper_author = paper_mask[edge_index_paper_author[0]] \
+                           & author_mask[edge_index_paper_author[1]]
+    sub_edge_index_paper_author = edge_index_paper_author[:, edge_mask_paper_author]
+    sub_edge_index_paper_author[0] = paper_node_map[sub_edge_index_paper_author[0]]
+    sub_edge_index_paper_author[1] = author_node_map[sub_edge_index_paper_author[1]]
+
+    edge_mask_author_paper = author_mask[edge_index_author_paper[0]] \
+                           & paper_mask[edge_index_author_paper[1]]
+    sub_edge_index_author_paper = edge_index_author_paper[:, edge_mask_author_paper]
+    sub_edge_index_author_paper[0] = author_node_map[sub_edge_index_author_paper[0]]
+    sub_edge_index_author_paper[1] = paper_node_map[sub_edge_index_author_paper[1]]
+
+    edge_mask_paper_conf = paper_mask[edge_index_paper_conference[0]] \
+                           & conf_mask[edge_index_paper_conference[1]]
+    sub_edge_index_paper_conf = edge_index_paper_conference[:, edge_mask_paper_conf]
+    sub_edge_index_paper_conf[0] = paper_node_map[sub_edge_index_paper_conf[0]]
+    sub_edge_index_paper_conf[1] = conf_node_map[sub_edge_index_paper_conf[1]]
+
     assert out.edge_types == [
         ('paper', 'to', 'paper'),
         ('author', 'to', 'paper'),
@@ -219,13 +260,14 @@ def test_hetero_data_subgraph():
     ]
 
     assert len(out['paper', 'paper']) == 3
-    assert out['paper', 'paper'].edge_index is not None
-    assert out['paper', 'paper'].edge_attr is not None
+    assert torch.equal(out['paper', 'paper'].edge_index, sub_edge_index_paper_paper)
+    assert torch.allclose(out['paper', 'paper'].edge_attr, sub_edge_attr_paper_paper)
     assert out['paper', 'paper'].name == 'cites'
     assert len(out['paper', 'author']) == 1
-    assert out['paper', 'author'].edge_index is not None
+    assert torch.equal(out['paper', 'author'].edge_index, sub_edge_index_paper_author)
     assert len(out['author', 'paper']) == 1
-    assert out['author', 'paper'].edge_index is not None
+    assert torch.equal(out['author', 'paper'].edge_index, sub_edge_index_author_paper)
+    assert torch.equal(out['paper', 'conf'].edge_index, sub_edge_index_paper_conf)
 
     out = data.node_type_subgraph(['paper', 'author'])
     assert out.node_types == ['paper', 'author']

--- a/torch_geometric/data/data.py
+++ b/torch_geometric/data/data.py
@@ -598,6 +598,11 @@ class Data(BaseData, FeatureStore, GraphStore):
         else:
             num_nodes = subset.size(0)
 
+            # check if selection is unordered and re-map edge_index if necessary
+            if (subset[:-1] > subset[1:]).any():
+                node_idx = torch.argsort(subset)
+                edge_index = node_idx[edge_index]
+
         data = copy.copy(self)
 
         for key, value in self:

--- a/torch_geometric/data/hetero_data.py
+++ b/torch_geometric/data/hetero_data.py
@@ -615,6 +615,16 @@ class HeteroData(BaseData, FeatureStore, GraphStore):
                 return_edge_mask=True,
             )
 
+            # reorder source nodes if needed
+            if src_subset.dtype == torch.long and (src_subset[:-1] > src_subset[1:]).any():
+                src_node_idx = torch.argsort(src_subset)
+                edge_index[0] = src_node_idx[edge_index[0]]
+
+            # reorder destination nodes if needed
+            if dst_subset.dtype == torch.long and (dst_subset[:-1] > dst_subset[1:]).any():
+                dst_node_idx = torch.argsort(dst_subset)
+                edge_index[1] = dst_node_idx[edge_index[1]]
+
             for key, value in self[edge_type].items():
                 if key == 'edge_index':
                     data[edge_type].edge_index = edge_index


### PR DESCRIPTION
This pull request addresses a bug in both ```Data.subgraph``` and ```HeteroData.subgraph```,  which yield incorrect results when an unsorted list of integers is used to select a subgraph. In this case, the attributes of nodes are reordered according to the given list of integers, but the ids used in ```edge_index``` are *not*. Therefore, the node features will be distributed incorrectly in the output subgraph.
Note that ```Data.subgraph``` does use the ```utils.subgraph``` method with the ```relabel_nodes=True``` option to compute the reduced edge list. However, this is insufficient to ensure a correct output, as this only shifts node ids downward to ensure consecutive ids. It has no effect on the actual order of nodes, which causes this problem.

Consider the following example:
```python
import torch
from torch_geometric.data import Data

data = Data(x=torch.tensor([0, 0, 1, 1]), edge_index=torch.tensor([[0, 2], [1, 3]]))
sub = data.subgraph(torch.tensor([0, 2, 1]))
print(sub.x)
print(sub.edge_index)
```
With torch_geometric==2.3.0 (current nightly) we obtain the following output:
```
x: [0 1 0]
Edge Idx:
 [[0]
 [1]]
```
Note that in the original graph each edge has a source and destination with the same node label. In the subgraph, the remaining edge has a source with label 0 and a destination with label 1. This is therefore not a valid subgraph.

I have addressed this bug by re-mapping the node ids in ```edge_index``` to their correct new index if the input is indeed an unsorted integer list. ```HeteroData.subgraph``` had the same issue with an analog solution. I also extended the tests to cover these issues.

Beyond this, I was wondering what the behaviour of ```Data.subgraph``` should be if the argument is a list of  integers with duplicate entries. Should the method raise an Exception, ignore duplicates or create duplicate vertices? I have not implemented anything in this regard yet, but I do think this should be specified.