### PR TITLE
Add new `cat` option to the `aggr` argument for `HeteroConv`

### DIFF
--- a/torch_geometric/nn/conv/hgt_conv.py
+++ b/torch_geometric/nn/conv/hgt_conv.py
@@ -22,6 +22,8 @@ def group(xs: List[Tensor], aggr: Optional[str]) -> Optional[Tensor]:
         return torch.stack(xs, dim=1)
     elif len(xs) == 1:
         return xs[0]
+    elif aggr == "cat":
+        return torch.cat(xs, dim=1)
     else:
         out = torch.stack(xs, dim=0)
         out = getattr(torch, aggr)(out, dim=0)


### PR DESCRIPTION
This new aggregation type will allow users to have the option of having the features from different edge types be concatenated together during the grouping stage of `HeteroConv`'s `forward` function.