### PR TITLE
Added `utils.to_edge_index` to convert sparse tensors to edge indices and edge attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
-- Added `to_edge_index` to convert PyTorch Sparse Tensor to edge indices and edge attributes ([#6728](https://github.com/pyg-team/pytorch_geometric/issues/6728))
+- Added `utils.to_edge_index` to convert sparse tensors to edge indices and edge attributes ([#6728](https://github.com/pyg-team/pytorch_geometric/issues/6728))
 - Fixed expected data format in `PolBlogs` dataset ([#6714](https://github.com/pyg-team/pytorch_geometric/issues/6714))
 - Added `SimpleConv` to perform non-trainable propagation ([#6718](https://github.com/pyg-team/pytorch_geometric/pull/6718))
 - Added a `RemoveDuplicatedEdges` transform ([#6709](https://github.com/pyg-team/pytorch_geometric/pull/6709))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- Added `to_edge_index` to convert PyTorch Sparse Tensor to edge indices and edge attributes ([#6728](https://github.com/pyg-team/pytorch_geometric/issues/6728))
 - Fixed expected data format in `PolBlogs` dataset ([#6714](https://github.com/pyg-team/pytorch_geometric/issues/6714))
 - Added `SimpleConv` to perform non-trainable propagation ([#6718](https://github.com/pyg-team/pytorch_geometric/pull/6718))
 - Added a `RemoveDuplicatedEdges` transform ([#6709](https://github.com/pyg-team/pytorch_geometric/pull/6709))

--- a/test/utils/test_sparse.py
+++ b/test/utils/test_sparse.py
@@ -6,6 +6,7 @@ from torch_geometric.utils import (
     dense_to_sparse,
     is_sparse,
     is_torch_sparse_tensor,
+    to_edge_index,
     to_torch_coo_tensor,
 )
 
@@ -95,3 +96,20 @@ def test_to_torch_coo_tensor():
         assert adj.layout == torch.sparse_coo
         assert torch.allclose(adj.indices(), edge_index)
         assert torch.allclose(adj.values(), edge_attr)
+
+
+def test_to_edge_index():
+    adj = torch.tensor([[0., 1., 0., 0.], [1., 0., 1., 0.], [0., 1., 0., 1.],
+                        [0., 0., 1., 0.]]).to_sparse()
+
+    edge_index, edge_attr = to_edge_index(adj)
+    assert torch.allclose(adj.indices(), edge_index)
+    assert edge_index.tolist() == [[0, 1, 1, 2, 2, 3], [1, 0, 2, 1, 3, 2]]
+    assert edge_attr.tolist() == [1., 1., 1., 1., 1., 1.]
+
+    if is_full_test():
+        jit = torch.jit.script(to_edge_index)
+        edge_index, edge_attr = jit(adj)
+        assert torch.allclose(adj.indices(), edge_index)
+        assert edge_index.tolist() == [[0, 1, 1, 2, 2, 3], [1, 0, 2, 1, 3, 2]]
+        assert edge_attr.tolist() == [1., 1., 1., 1., 1., 1.]

--- a/test/utils/test_sparse.py
+++ b/test/utils/test_sparse.py
@@ -99,17 +99,19 @@ def test_to_torch_coo_tensor():
 
 
 def test_to_edge_index():
-    adj = torch.tensor([[0., 1., 0., 0.], [1., 0., 1., 0.], [0., 1., 0., 1.],
-                        [0., 0., 1., 0.]]).to_sparse()
+    adj = torch.tensor([
+        [0., 1., 0., 0.],
+        [1., 0., 1., 0.],
+        [0., 1., 0., 1.],
+        [0., 0., 1., 0.],
+    ]).to_sparse()
 
     edge_index, edge_attr = to_edge_index(adj)
-    assert torch.allclose(adj.indices(), edge_index)
     assert edge_index.tolist() == [[0, 1, 1, 2, 2, 3], [1, 0, 2, 1, 3, 2]]
     assert edge_attr.tolist() == [1., 1., 1., 1., 1., 1.]
 
     if is_full_test():
         jit = torch.jit.script(to_edge_index)
         edge_index, edge_attr = jit(adj)
-        assert torch.allclose(adj.indices(), edge_index)
         assert edge_index.tolist() == [[0, 1, 1, 2, 2, 3], [1, 0, 2, 1, 3, 2]]
         assert edge_attr.tolist() == [1., 1., 1., 1., 1., 1.]

--- a/torch_geometric/nn/conv/gcn_conv.py
+++ b/torch_geometric/nn/conv/gcn_conv.py
@@ -19,6 +19,7 @@ from torch_geometric.utils import (
     is_torch_sparse_tensor,
     scatter,
     spmm,
+    to_edge_index,
     to_torch_coo_tensor,
 )
 from torch_geometric.utils.num_nodes import maybe_num_nodes
@@ -66,15 +67,7 @@ def gcn_norm(edge_index, edge_weight=None, num_nodes=None, improved=False,
         flow = 'target_to_source'
         adj_t = edge_index
         num_nodes = adj_t.size(0)
-        if adj_t.requires_grad:
-            # Calling adj_t._values() will return a detached tensor.
-            # Use `adj_t.coalesce().values()` instead to track gradients.
-            adj_t = adj_t.coalesce()
-            edge_index = adj_t.indices()
-            edge_weight = adj_t.values()
-        else:
-            edge_index = adj_t._indices()
-            edge_weight = adj_t._values()
+        edge_index, edge_weight = to_edge_index(adj_t)
     else:
         assert flow in ["source_to_target", "target_to_source"]
         num_nodes = maybe_num_nodes(edge_index, num_nodes)

--- a/torch_geometric/nn/conv/message_passing.py
+++ b/torch_geometric/nn/conv/message_passing.py
@@ -24,7 +24,11 @@ from torch.utils.hooks import RemovableHandle
 from torch_geometric.nn.aggr import Aggregation, MultiAggregation
 from torch_geometric.nn.resolver import aggregation_resolver as aggr_resolver
 from torch_geometric.typing import Adj, Size, SparseTensor
-from torch_geometric.utils import is_sparse, is_torch_sparse_tensor
+from torch_geometric.utils import (
+    is_sparse,
+    is_torch_sparse_tensor,
+    to_edge_index,
+)
 
 from .utils.inspector import Inspector, func_body_repr, func_header_repr
 from .utils.jit import class_from_module_repr
@@ -307,13 +311,7 @@ class MessagePassing(torch.nn.Module):
                 out[arg] = data
 
         if is_torch_sparse_tensor(edge_index):
-            if edge_index.requires_grad:
-                edge_index = edge_index.coalesce()
-                indices = edge_index.indices()
-                values = edge_index.values()
-            else:
-                indices = edge_index._indices()
-                values = edge_index._values()
+            indices, values = to_edge_index(edge_index)
             out['adj_t'] = edge_index
             out['edge_index'] = None
             out['edge_index_i'] = indices[0]

--- a/torch_geometric/utils/__init__.py
+++ b/torch_geometric/utils/__init__.py
@@ -23,7 +23,7 @@ from .to_dense_batch import to_dense_batch
 from .to_dense_adj import to_dense_adj
 from .nested import to_nested_tensor, from_nested_tensor
 from .sparse import (dense_to_sparse, is_sparse, is_torch_sparse_tensor,
-                     to_torch_coo_tensor)
+                     to_torch_coo_tensor, to_edge_index)
 from .spmm import spmm
 from .unbatch import unbatch, unbatch_edge_index
 from .normalized_cut import normalized_cut
@@ -88,6 +88,7 @@ __all__ = [
     'is_torch_sparse_tensor',
     'is_sparse',
     'to_torch_coo_tensor',
+    'to_edge_index',
     'spmm',
     'unbatch',
     'unbatch_edge_index',

--- a/torch_geometric/utils/sparse.py
+++ b/torch_geometric/utils/sparse.py
@@ -54,7 +54,7 @@ def dense_to_sparse(adj: Tensor) -> Tuple[Tensor, Tensor]:
 
 
 def is_torch_sparse_tensor(src: Any) -> bool:
-    """Returns :obj:`True` if the input :obj:`src` is a
+    r"""Returns :obj:`True` if the input :obj:`src` is a
     :class:`torch.sparse.Tensor` (in any sparse layout).
 
     Args:
@@ -64,7 +64,7 @@ def is_torch_sparse_tensor(src: Any) -> bool:
 
 
 def is_sparse(src: Any) -> bool:
-    """Returns :obj:`True` if the input :obj:`src` is of type
+    r"""Returns :obj:`True` if the input :obj:`src` is of type
     :class:`torch.sparse.Tensor` (in any sparse layout) or of type
     :class:`torch_sparse.SparseTensor`.
 
@@ -79,9 +79,9 @@ def to_torch_coo_tensor(
     edge_attr: Optional[Tensor] = None,
     size: Optional[Union[int, Tuple[int, int]]] = None,
 ) -> Tensor:
-    """Converts a sparse adjacency matrix defined by edge indices and edge
+    r"""Converts a sparse adjacency matrix defined by edge indices and edge
     attributes to a :class:`torch.sparse.Tensor`.
-    See also :class:`torch_geometric.utils.to_edge_index`.
+    See :meth:`~torch_geometric.utils.to_edge_index` for the reverse operation.
 
     Args:
         edge_index (LongTensor): The edge indices.
@@ -120,14 +120,12 @@ def to_torch_coo_tensor(
     return out
 
 
-def to_edge_index(adj: Tensor) -> Tuple[Tensor, Tensor]:
-    """Converts a :class:`torch.sparse.Tensor` to a sparse adjacency matrix
-    defined by edge indices and edge attributes
-    (:class:`LongTensor`, :class:`Tensor`).
-    See also :class:`torch_geometric.utils.to_torch_coo_tensor`.
+def to_edge_index(adj: Union[Tensor, SparseTensor]) -> Tuple[Tensor, Tensor]:
+    r"""Converts a :class:`torch.sparse.Tensor` or a
+    :class:`torch_sparse.SparseTensor` to edge indices and edge attributes.
 
     Args:
-        adj (torch.sparse.FloatTensor): The adjacency matrix.
+        adj (torch.sparse.Tensor or SparseTensor): The adjacency matrix.
 
     :rtype: (:class:`LongTensor`, :class:`Tensor`)
 
@@ -141,13 +139,16 @@ def to_edge_index(adj: Tensor) -> Tuple[Tensor, Tensor]:
                 [1, 0, 2, 1, 3, 2]]),
         tensor([1., 1., 1., 1., 1., 1.]))
     """
+    if isinstance(adj, SparseTensor):
+        row, col, value = adj.coo()
+        if value is None:
+            value = torch.ones(row.size(0), device=row.device)
+        return torch.stack([row, col], dim=0), value
+
     if adj.requires_grad:
-        # Calling adj_t._values() will return a detached tensor.
-        # Use `adj_t.coalesce().values()` instead to track gradients.
+        # Calling adj._values() will return a detached tensor.
+        # Use `adj.coalesce().values()` instead to track gradients.
         adj = adj.coalesce()
-        edge_index = adj.indices()
-        edge_attr = adj.values()
-    else:
-        edge_index = adj._indices()
-        edge_attr = adj._values()
-    return edge_index, edge_attr
+        return adj.indices(), adj.values()
+
+    return adj._indices(), adj._values()


### PR DESCRIPTION
This PR implements `to_edge_index` to simplify the conversion between PyTorch Sparse Tensor and edge indices. Perhaps there is a better name than `to_edge_index`?