### PR TITLE
Remove adding `num_edges` directly to store in the `Pad` transform

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Added a `RemoveDuplicatedEdges` transform ([#6709](https://github.com/pyg-team/pytorch_geometric/pull/6709))
 - Added TorchScript support to the `LINKX` model ([#6712](https://github.com/pyg-team/pytorch_geometric/pull/6712))
 - Added `torch.jit` examples for `example/film.py` and `example/gcn.py`([#6602](https://github.com/pyg-team/pytorch_geometric/pull/6692))
-- Added `Pad` transform ([#5940](https://github.com/pyg-team/pytorch_geometric/pull/5940), [#6697](https://github.com/pyg-team/pytorch_geometric/pull/6697), [#6731](https://github.com/pyg-team/pytorch_geometric/pull/6731))
+- Added `Pad` transform ([#5940](https://github.com/pyg-team/pytorch_geometric/pull/5940), [#6697](https://github.com/pyg-team/pytorch_geometric/pull/6697), [#6731](https://github.com/pyg-team/pytorch_geometric/pull/6731), [#6758](https://github.com/pyg-team/pytorch_geometric/pull/6758))
 - Added full batch mode to the inference benchmark ([#6631](https://github.com/pyg-team/pytorch_geometric/pull/6631))
 - Added `cat` aggregation type to the `HeteroConv` class so that features can be concatenated during grouping ([#6634](https://github.com/pyg-team/pytorch_geometric/pull/6634))
 - Added `torch.compile` support and benchmark study ([#6610](https://github.com/pyg-team/pytorch_geometric/pull/6610))

--- a/torch_geometric/transforms/pad.py
+++ b/torch_geometric/transforms/pad.py
@@ -405,7 +405,6 @@ class Pad(BaseTransform):
                     del store[key]
                 self.__pad_edge_store(store, data.__cat_dim__, data.num_nodes)
                 self.__pad_node_store(store, data.__cat_dim__)
-            data.num_edges = self.max_num_edges.get_value()
             data.num_nodes = self.max_num_nodes.get_value()
         else:
             assert isinstance(
@@ -424,8 +423,6 @@ class Pad(BaseTransform):
                                       (data[src_node_type].num_nodes,
                                        data[dst_node_type].num_nodes),
                                       edge_type)
-                data[edge_type].num_edges = self.max_num_edges.get_value(
-                    edge_type)
 
             for node_type, store in data.node_items():
                 for key in self.exclude_keys:


### PR DESCRIPTION
Handling `num_edges` as an attribute requires couple more changes and doesn't work well with the current implementation. For example, when `num_edges` is set on the `Data` objects and those objects are merged into a `Batch` the `num_edges` attribute is a tensor with values from all the objects. It works well when implemented as a property of `EdgeStorage` and not as a direct attribute, so removing it for now.