### PR TITLE
Add HeteroLayerNorm and HeteroBatchNorm

### DIFF
--- a/test/nn/norm/test_batch_norm.py
+++ b/test/nn/norm/test_batch_norm.py
@@ -1,6 +1,6 @@
 import pytest
 import torch
-from torch_scatter import scatter_mean  # , scatter_std
+from torch_scatter import scatter_mean, scatter_std
 
 from torch_geometric.nn import BatchNorm, HeteroBatchNorm
 from torch_geometric.testing import is_full_test
@@ -54,7 +54,7 @@ def test_hetero_batch_norm(conf, device):
         hetero_out = hetero_norm(x, types)
 
         assert hetero_out.size() == (100, 16)
-        assert torch.allclose(hetero_out, real_out, atol=1e-6)
+        assert torch.allclose(hetero_out, real_out, atol=1e-5)
 
         # test hetero case
         num_types = 5
@@ -66,10 +66,10 @@ def test_hetero_batch_norm(conf, device):
 
         # check if means are zero and vars are 1 across all types
         means = scatter_mean(hetero_out, types, dim=0)
-        # stds = scatter_std(hetero_out, types, dim=0)
+        stds = scatter_std(hetero_out, types, dim=0, unbiased=False)
 
-        assert torch.allclose(means, torch.zeros_like(means), atol=1e-6)
-        # assert torch.allclose(stds, torch.ones_like(stds), atol=1e-6)
+        assert torch.allclose(means, torch.zeros_like(means), atol=1e-5)
+        assert torch.allclose(stds, torch.ones_like(stds), atol=1e-5)
 
     else:
         # test hetero case

--- a/test/nn/norm/test_batch_norm.py
+++ b/test/nn/norm/test_batch_norm.py
@@ -1,7 +1,8 @@
 import pytest
 import torch
+from torch_scatter import scatter_mean  # , scatter_std
 
-from torch_geometric.nn import BatchNorm
+from torch_geometric.nn import BatchNorm, HeteroBatchNorm
 from torch_geometric.testing import is_full_test
 
 
@@ -33,3 +34,50 @@ def test_batch_norm_single_element():
     norm = BatchNorm(16, track_running_stats=True, allow_single_element=True)
     out = norm(x)
     assert torch.allclose(out, x)
+
+
+@pytest.mark.parametrize('conf', [True, False])
+@pytest.mark.parametrize('device', ['cpu', 'cuda'])
+def test_hetero_batch_norm(conf, device):
+    x = torch.randn((100, 16), device=device)
+
+    norm = torch.nn.BatchNorm1d(16, device=device)
+    real_out = norm(x)
+
+    if not conf:
+        # test homogeneous case
+        num_types = 1
+        types = torch.randint(num_types, (100, ), device=device)
+        hetero_norm = HeteroBatchNorm(16, num_types=num_types,
+                                      elementwise_affine=conf,
+                                      track_running_stats=conf, device=device)
+        hetero_out = hetero_norm(x, types)
+
+        assert hetero_out.size() == (100, 16)
+        assert torch.allclose(hetero_out, real_out, atol=1e-6)
+
+        # test hetero case
+        num_types = 5
+        types = torch.randint(num_types, (100, ), device=device)
+        hetero_norm = HeteroBatchNorm(16, num_types=num_types,
+                                      elementwise_affine=conf,
+                                      track_running_stats=conf, device=device)
+        hetero_out = hetero_norm(x, types)
+
+        # check if means are zero and vars are 1 across all types
+        means = scatter_mean(hetero_out, types, dim=0)
+        # stds = scatter_std(hetero_out, types, dim=0)
+
+        assert torch.allclose(means, torch.zeros_like(means), atol=1e-6)
+        # assert torch.allclose(stds, torch.ones_like(stds), atol=1e-6)
+
+    else:
+        # test hetero case
+        num_types = 5
+        types = torch.randint(num_types, (100, ), device=device)
+        hetero_norm = HeteroBatchNorm(16, num_types=num_types,
+                                      elementwise_affine=conf,
+                                      track_running_stats=conf, device=device)
+
+        assert hetero_norm.running_mean.size() == (num_types, 16)
+        assert hetero_norm.running_var.size() == (num_types, 16)

--- a/test/nn/norm/test_layer_norm.py
+++ b/test/nn/norm/test_layer_norm.py
@@ -41,13 +41,12 @@ def test_hetero_layer_norm(affine, device):
     hetero_out = hetero_norm(x, types)
 
     if affine:
-        out = hetero_norm(x, types)
         weight = hetero_norm.weight
         bias = hetero_norm.bias
         node = 5
         node_type = types[node]
 
         assert torch.allclose(
-            out[5], real_out[5] * weight[node_type] + bias[node_type])
+            hetero_out[5], real_out[5] * weight[node_type] + bias[node_type])
     else:
-        assert torch.allclose(out, hetero_out, atol=1e-6)
+        assert torch.allclose(real_out, hetero_out, atol=1e-6)

--- a/test/nn/norm/test_layer_norm.py
+++ b/test/nn/norm/test_layer_norm.py
@@ -1,7 +1,7 @@
 import pytest
 import torch
 
-from torch_geometric.nn import LayerNorm
+from torch_geometric.nn import HeteroLayerNorm, LayerNorm
 from torch_geometric.testing import is_full_test
 
 
@@ -24,3 +24,28 @@ def test_layer_norm(affine, mode):
     out2 = norm(torch.cat([x, x], dim=0), torch.cat([batch, batch + 1], dim=0))
     assert torch.allclose(out1, out2[:100], atol=1e-6)
     assert torch.allclose(out1, out2[100:], atol=1e-6)
+
+
+@pytest.mark.parametrize('affine', [False, True])
+def test_hetero_layer_norm(affine):
+    num_types = 5
+    x = torch.randn(100, 16)
+    types = torch.randint(num_types, (100, ))
+
+    hetero_norm = HeteroLayerNorm(16, num_types=num_types,
+                                  elementwise_affine=affine)
+    norm = torch.nn.LayerNorm(16, elementwise_affine=False)
+
+    real_norm = hetero_norm(x, types)
+
+    if affine:
+        out = hetero_norm(x, types)
+        weight = hetero_norm.weight
+        bias = hetero_norm.bias
+        node = 5
+        node_type = types[node]
+        assert torch.allclose(
+            out[5], real_norm[5] * weight[node_type] + bias[node_type])
+    else:
+        out = norm(x)
+        assert torch.allclose(out, real_norm, atol=1e-6)

--- a/torch_geometric/nn/norm/__init__.py
+++ b/torch_geometric/nn/norm/__init__.py
@@ -1,4 +1,4 @@
-from .batch_norm import BatchNorm
+from .batch_norm import BatchNorm, HeteroBatchNorm
 from .instance_norm import InstanceNorm
 from .layer_norm import LayerNorm, HeteroLayerNorm
 from .graph_norm import GraphNorm
@@ -10,6 +10,7 @@ from .diff_group_norm import DiffGroupNorm
 
 __all__ = [
     'BatchNorm',
+    'HeteroBatchNorm',
     'InstanceNorm',
     'LayerNorm',
     'HeteroLayerNorm',

--- a/torch_geometric/nn/norm/__init__.py
+++ b/torch_geometric/nn/norm/__init__.py
@@ -1,6 +1,6 @@
 from .batch_norm import BatchNorm
 from .instance_norm import InstanceNorm
-from .layer_norm import LayerNorm
+from .layer_norm import LayerNorm, HeteroLayerNorm
 from .graph_norm import GraphNorm
 from .graph_size_norm import GraphSizeNorm
 from .pair_norm import PairNorm
@@ -12,6 +12,7 @@ __all__ = [
     'BatchNorm',
     'InstanceNorm',
     'LayerNorm',
+    'HeteroLayerNorm',
     'GraphNorm',
     'GraphSizeNorm',
     'PairNorm',

--- a/torch_geometric/nn/norm/batch_norm.py
+++ b/torch_geometric/nn/norm/batch_norm.py
@@ -89,12 +89,13 @@ class HeteroBatchNorm(torch.nn.Module):
     .. math::
         \mathbf{x}^{\prime}_i = \frac{\mathbf{x} -
         \textrm{E}[\mathbf{x}]}{\sqrt{\textrm{Var}[\mathbf{x}] + \epsilon}}
-        \odot \gamma + \beta
+        \odot \gamma_{\tau} + \beta_{\tau}
 
     The mean and standard-deviation are calculated per-dimension individually
     for each node type inside the mini-batch.
-    \gamma and \beta earnable affine transform parameters of 
-    shape (num_types, in_channels).
+    \gamma_{\tau} and \beta_{\tau} are learnable affine transform parameters,
+    where {\tau} is the type of the node. There is a distint \gamma and \beta for 
+    each type.
 
     Args:
         in_channels (int): Size of each input sample.

--- a/torch_geometric/nn/norm/batch_norm.py
+++ b/torch_geometric/nn/norm/batch_norm.py
@@ -1,5 +1,9 @@
+from typing import Optional
+
 import torch
 from torch import Tensor
+from torch.nn import Parameter, init
+from torch_scatter import scatter_add
 
 
 class BatchNorm(torch.nn.Module):
@@ -74,3 +78,117 @@ class BatchNorm(torch.nn.Module):
 
     def __repr__(self):
         return f'{self.__class__.__name__}({self.module.num_features})'
+
+
+class HeteroBatchNorm(torch.nn.Module):
+    def __init__(self, in_channels: int, num_types: int,
+                 elementwise_affine: bool = True,
+                 track_running_stats: bool = True, eps: float = 1e-5,
+                 momentum: float = 0.1, device=None, dtype=None):
+        factory_kwargs = {'device': device, 'dtype': dtype}
+        super(HeteroBatchNorm, self).__init__()
+        self.device = device
+        self.elementwise_affine = elementwise_affine
+        self.track_running_stats = track_running_stats
+        self.in_channels = in_channels
+        self.num_types = num_types
+        self.eps = eps
+        self.momentum = momentum
+
+        if self.elementwise_affine:
+            self.weight = Parameter(
+                torch.empty((self.num_types, self.in_channels),
+                            **factory_kwargs))
+            self.bias = Parameter(
+                torch.empty((self.num_types, self.in_channels),
+                            **factory_kwargs))
+        else:
+            self.register_parameter('weight', None)
+            self.register_parameter('bias', None)
+
+        if self.training and self.track_running_stats:
+            self.register_buffer(
+                'running_mean',
+                torch.zeros((self.num_types, self.in_channels),
+                            **factory_kwargs))
+            self.register_buffer(
+                'running_var',
+                torch.ones((self.num_types, self.in_channels),
+                           **factory_kwargs))
+            self.running_mean: Optional[Tensor]
+            self.running_var: Optional[Tensor]
+            self.register_buffer(
+                'num_batches_tracked',
+                torch.tensor(
+                    0, dtype=torch.long, **{
+                        k: v
+                        for k, v in factory_kwargs.items() if k != 'dtype'
+                    }))
+            self.num_batches_tracked: Optional[Tensor]
+        else:
+            self.register_buffer("running_mean", None)
+            self.register_buffer("running_var", None)
+            self.register_buffer("num_batches_tracked", None)
+
+        # initialize parameters
+        self.reset_parameters()
+
+    def reset_parameters(self):
+        self.reset_running_stats()
+        if self.elementwise_affine:
+            init.ones_(self.weight)
+            init.zeros_(self.bias)
+
+    def reset_running_stats(self):
+        if self.track_running_stats:
+            self.running_mean.zero_()
+            self.running_var.fill_(1)
+            self.num_batches_tracked.zero_()
+
+    def compute_mean_var(self, x, types):
+        tmp = scatter_add(src=x, index=types, dim=0)
+        count = scatter_add(torch.ones((x.shape[0], ), device=self.device),
+                            types, dim=0).view(-1, 1)
+        mean = tmp.div_(count.clamp(min=1))
+        var = x - mean[types]
+        var = var.mul_(var)
+        var = scatter_add(src=var, index=types, dim=0)
+        var = var.div_(count.clamp(min=1))
+
+        return mean, var
+
+    def forward(self, x, types):
+        if self.track_running_stats:
+            # if track running stats calculate mean and var in nograd env
+            with torch.no_grad():
+                mean, var = self.compute_mean_var(x, types)
+            if self.training:
+                if self.momentum is None:
+                    self.num_batches_tracked.add_(1)
+                    exponential_average_factor = 1.0 / float(
+                        self.num_batches_tracked)
+                else:
+                    exponential_average_factor = self.momentum
+
+                # update running mean and var
+                with torch.no_grad():
+                    present_types = torch.unique(types)
+                    self.running_mean[present_types] = (
+                        1 - exponential_average_factor) * self.running_mean[
+                            present_types] + exponential_average_factor * mean
+                    self.running_var[present_types] = (
+                        1 - exponential_average_factor) * self.running_var[
+                            present_types] + exponential_average_factor * var
+            mean = self.running_mean
+            var = self.running_var
+
+        else:
+            mean, var = self.compute_mean_var(x, types)
+
+        # compute out
+        out = (x - mean[types]).div_(torch.sqrt(var + self.eps)[types])
+
+        if self.elementwise_affine:
+            out = out.mul_(self.weight[types]).add_(self.bias[types])
+
+        return out

--- a/torch_geometric/nn/norm/batch_norm.py
+++ b/torch_geometric/nn/norm/batch_norm.py
@@ -81,6 +81,37 @@ class BatchNorm(torch.nn.Module):
 
 
 class HeteroBatchNorm(torch.nn.Module):
+    r"""Applies batch normalization over a batch of node features as described
+    in the `"Batch Normalization: Accelerating Deep Network Training by
+    Reducing Internal Covariate Shift" <https://arxiv.org/abs/1502.03167>`_
+    paper
+
+    .. math::
+        \mathbf{x}^{\prime}_i = \frac{\mathbf{x} -
+        \textrm{E}[\mathbf{x}]}{\sqrt{\textrm{Var}[\mathbf{x}] + \epsilon}}
+        \odot \gamma + \beta
+
+    The mean and standard-deviation are calculated per-dimension individually
+    for each node type inside the mini-batch.
+    \gamma and \beta earnable affine transform parameters of 
+    shape (num_types, in_channels).
+
+    Args:
+        in_channels (int): Size of each input sample.
+        num_types (torch.Tensor): Number of node types.
+        eps (float, optional): A value added to the denominator for numerical
+            stability. (default: :obj:`1e-5`)
+        momentum (float, optional): The value used for the running mean and
+            running variance computation. (default: :obj:`0.1`)
+        elementwise_affine (bool, optional): If set to :obj:`True`, this module has
+            learnable affine parameters :math:`\gamma` and :math:`\beta`.
+            (default: :obj:`True`)
+        track_running_stats (bool, optional): If set to :obj:`True`, this
+            module tracks the running mean and variance, and when set to
+            :obj:`False`, this module does not track such statistics and always
+            uses batch statistics in both training and eval modes.
+            (default: :obj:`True`)
+    """
     def __init__(self, in_channels: int, num_types: int,
                  elementwise_affine: bool = True,
                  track_running_stats: bool = True, eps: float = 1e-5,

--- a/torch_geometric/nn/norm/layer_norm.py
+++ b/torch_geometric/nn/norm/layer_norm.py
@@ -112,12 +112,13 @@ class HeteroLayerNorm(torch.nn.Module):
     .. math::
         \mathbf{x}^{\prime}_i = \frac{\mathbf{x} -
         \textrm{E}[\mathbf{x}]}{\sqrt{\textrm{Var}[\mathbf{x}] + \epsilon}}
-        \odot \gamma + \gamma
+        \odot \gamma_{\tau} + \beta_{\tau}
 
     The mean and standard-deviation are calculated across all nodes and all
     node channels separately for each object in a mini-batch.
-    \gamma and \beta earnable affine transform parameters of 
-    shape (num_types, in_channels).
+    \gamma_{\tau} and \beta_{\tau} are learnable affine transform parameters,
+    where {\tau} is the type of the node. There is a distint \gamma and \beta for 
+    each type.
 
     Args:
         in_channels (int): Size of each input sample.

--- a/torch_geometric/nn/norm/layer_norm.py
+++ b/torch_geometric/nn/norm/layer_norm.py
@@ -105,6 +105,29 @@ class LayerNorm(torch.nn.Module):
 
 
 class HeteroLayerNorm(torch.nn.Module):
+    r"""Applies layer normalization over each individual example in a batch
+    of node features as described in the `"Layer Normalization"
+    <https://arxiv.org/abs/1607.06450>`_ paper
+
+    .. math::
+        \mathbf{x}^{\prime}_i = \frac{\mathbf{x} -
+        \textrm{E}[\mathbf{x}]}{\sqrt{\textrm{Var}[\mathbf{x}] + \epsilon}}
+        \odot \gamma + \gamma
+
+    The mean and standard-deviation are calculated across all nodes and all
+    node channels separately for each object in a mini-batch.
+    \gamma and \beta earnable affine transform parameters of 
+    shape (num_types, in_channels).
+
+    Args:
+        in_channels (int): Size of each input sample.
+        num_types (torch.Tensor): Number of node types.
+        eps (float, optional): A value added to the denominator for numerical
+            stability. (default: :obj:`1e-5`)
+        elementwise_affine (bool, optional): If set to :obj:`True`, this module has
+            learnable affine parameters :math:`\gamma` and :math:`\beta`.
+            (default: :obj:`True`)
+    """
     def __init__(self, in_channels: int, num_types: int,
                  elementwise_affine: bool = True, eps: float = 1e-5,
                  device=None, dtype=None):


### PR DESCRIPTION
-HeteroLayerNorm is the same as LayerNorm but we train separate affine transformation parameters for each type.

-At HeteroBatchNorm,  the mean and standard-deviation are calculated per-dimension individually for each node type inside the mini-batch. We also train a separate affine transformation parameters for each type.
   