### PR TITLE
Enable `persistent_workers` in GraphGym dataloaders

### DIFF
--- a/torch_geometric/graphgym/loader.py
+++ b/torch_geometric/graphgym/loader.py
@@ -246,10 +246,11 @@ def create_dataset():
 
 
 def get_loader(dataset, sampler, batch_size, shuffle=True):
+    pw = cfg.num_workers > 0
     if sampler == "full_batch" or len(dataset) > 1:
         loader_train = DataLoader(dataset, batch_size=batch_size,
                                   shuffle=shuffle, num_workers=cfg.num_workers,
-                                  pin_memory=True)
+                                  pin_memory=True, persistent_workers=pw)
     elif sampler == "neighbor":
         loader_train = NeighborSampler(
             dataset[0], sizes=cfg.train.neighbor_sizes[:cfg.gnn.layers_mp],
@@ -260,7 +261,8 @@ def get_loader(dataset, sampler, batch_size, shuffle=True):
                                         num_parts=cfg.train.train_parts,
                                         shuffle=shuffle,
                                         num_workers=cfg.num_workers,
-                                        pin_memory=True)
+                                        pin_memory=True,
+                                        persistent_workers=pw)
     elif sampler == "saint_rw":
         loader_train = \
             GraphSAINTRandomWalkSampler(dataset[0],
@@ -270,21 +272,24 @@ def get_loader(dataset, sampler, batch_size, shuffle=True):
                                         sample_coverage=0,
                                         shuffle=shuffle,
                                         num_workers=cfg.num_workers,
-                                        pin_memory=True)
+                                        pin_memory=True,
+                                        persistent_workers=pw)
     elif sampler == "saint_node":
         loader_train = \
             GraphSAINTNodeSampler(dataset[0], batch_size=batch_size,
                                   num_steps=cfg.train.iter_per_epoch,
                                   sample_coverage=0, shuffle=shuffle,
                                   num_workers=cfg.num_workers,
-                                  pin_memory=True)
+                                  pin_memory=True,
+                                  persistent_workers=pw)
     elif sampler == "saint_edge":
         loader_train = \
             GraphSAINTEdgeSampler(dataset[0], batch_size=batch_size,
                                   num_steps=cfg.train.iter_per_epoch,
                                   sample_coverage=0, shuffle=shuffle,
                                   num_workers=cfg.num_workers,
-                                  pin_memory=True)
+                                  pin_memory=True,
+                                  persistent_workers=pw)
     elif sampler == "cluster":
         loader_train = \
             ClusterLoader(dataset[0],
@@ -294,7 +299,8 @@ def get_loader(dataset, sampler, batch_size, shuffle=True):
                                                       "-", "_")),
                           batch_size=batch_size, shuffle=shuffle,
                           num_workers=cfg.num_workers,
-                          pin_memory=True)
+                          pin_memory=True,
+                          persistent_workers=pw)
 
     else:
         raise NotImplementedError("%s sampler is not implemented!" % sampler)

--- a/torch_geometric/graphgym/loader.py
+++ b/torch_geometric/graphgym/loader.py
@@ -261,8 +261,7 @@ def get_loader(dataset, sampler, batch_size, shuffle=True):
                                         num_parts=cfg.train.train_parts,
                                         shuffle=shuffle,
                                         num_workers=cfg.num_workers,
-                                        pin_memory=True,
-                                        persistent_workers=pw)
+                                        pin_memory=True, persistent_workers=pw)
     elif sampler == "saint_rw":
         loader_train = \
             GraphSAINTRandomWalkSampler(dataset[0],


### PR DESCRIPTION
Enable `persistent_workers` in graphgym dataloader construction if multiple workers are used.

https://github.com/pyg-team/pytorch_geometric/issues/6842