### PR TITLE
Add missing `=None` to `: Optional[T]`-annotated pooling functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
+
 ## [2.3.0] - 2023-MM-DD
 
 ### Added

--- a/torch_geometric/nn/pool/glob.py
+++ b/torch_geometric/nn/pool/glob.py
@@ -5,7 +5,7 @@ from torch import Tensor
 from torch_geometric.utils import scatter
 
 
-def global_add_pool(x: Tensor, batch: Optional[Tensor],
+def global_add_pool(x: Tensor, batch: Optional[Tensor] = None,
                     size: Optional[int] = None) -> Tensor:
     r"""Returns batch-wise graph-level-outputs by adding node features
     across the node dimension, so that for a single graph
@@ -34,7 +34,7 @@ def global_add_pool(x: Tensor, batch: Optional[Tensor],
     return scatter(x, batch, dim=dim, dim_size=size, reduce='sum')
 
 
-def global_mean_pool(x: Tensor, batch: Optional[Tensor],
+def global_mean_pool(x: Tensor, batch: Optional[Tensor] = None,
                      size: Optional[int] = None) -> Tensor:
     r"""Returns batch-wise graph-level-outputs by averaging node features
     across the node dimension, so that for a single graph
@@ -63,7 +63,7 @@ def global_mean_pool(x: Tensor, batch: Optional[Tensor],
     return scatter(x, batch, dim=dim, dim_size=size, reduce='mean')
 
 
-def global_max_pool(x: Tensor, batch: Optional[Tensor],
+def global_max_pool(x: Tensor, batch: Optional[Tensor] = None,
                     size: Optional[int] = None) -> Tensor:
     r"""Returns batch-wise graph-level-outputs by taking the channel-wise
     maximum across the node dimension, so that for a single graph


### PR DESCRIPTION
This PR adds the missing default values for `Optional`-annotated arguments in nn.pool.glob pooling functions.

Without this change, for example the following error is raised:
```python3
> nn.pool.global_max_pool(x)
...
TypeError: global_max_pool() missing 1 required positional argument: 'batch'
```

The code for these functions already accommodates the case in which `batch is None`, so this little fix to the default args is sufficient to rectify the discrepancy between the type annotation semantics (`Optional`) and the function signature (requires a positional arg).