### PR TITLE
Fix `to_hetero` when using an uninitialized submodule without implementing `reset_parameters`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,6 +98,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
+- Fixed a bug in `to_hetero` when using an uninitialized submodule without implementing `reset_parameters` ([#6863](https://github.com/pyg-team/pytorch_geometric/issues/6790))
 - Fixed a bug in `get_mesh_laplacian` ([#6790](https://github.com/pyg-team/pytorch_geometric/issues/6790))
 - Fixed a bug in which masks were not properly masked in `GNNExplainer` on link prediction tasks ([#6787](https://github.com/pyg-team/pytorch_geometric/pull/6787))
 - Allow the usage of `ChebConv` within `GNNExplainer` ([#6778](https://github.com/pyg-team/pytorch_geometric/pull/6778))

--- a/test/nn/test_to_hetero_transformer.py
+++ b/test/nn/test_to_hetero_transformer.py
@@ -157,6 +157,15 @@ class Net11(torch.nn.Module):
         return torch.cat(xs, dim=-1)
 
 
+class Net12(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.conv = Net8()
+
+    def forward(self, x: Tensor) -> Tensor:
+        return self.conv(x)
+
+
 def test_to_hetero_basic():
     x_dict = {
         'paper': torch.randn(100, 16),
@@ -272,6 +281,13 @@ def test_to_hetero_basic():
     assert isinstance(out, dict) and len(out) == 2
     assert out['paper'].size() == (100, 64)
     assert out['author'].size() == (100, 64)
+
+    model = Net12()
+    model = to_hetero(model, metadata, debug=False)
+    out = model({'paper': torch.randn(4, 8), 'author': torch.randn(8, 16)})
+    assert isinstance(out, dict) and len(out) == 2
+    assert out['paper'].size() == (4, 32)
+    assert out['author'].size() == (8, 32)
 
 
 class GCN(torch.nn.Module):

--- a/torch_geometric/nn/to_hetero_transformer.py
+++ b/torch_geometric/nn/to_hetero_transformer.py
@@ -6,6 +6,7 @@ from typing import Any, Dict, Optional, Tuple, Union
 import torch
 from torch.nn import Module
 
+from torch_geometric.nn.dense.linear import is_uninitialized_parameter
 from torch_geometric.nn.fx import Transformer, get_submodule
 from torch_geometric.typing import EdgeType, Metadata, NodeType
 from torch_geometric.utils.hetero import (
@@ -371,7 +372,10 @@ class ToHeteroTransformer(Transformer):
                 continue
             if hasattr(module, 'reset_parameters'):
                 module_dict[key2str(key)].reset_parameters()
-            elif sum([p.numel() for p in module.parameters()]) > 0:
+            elif sum([
+                    is_uninitialized_parameter(p) or p.numel()
+                    for p in module.parameters()
+            ]) > 0:
                 warnings.warn(
                     f"'{target}' will be duplicated, but its parameters "
                     f"cannot be reset. To suppress this warning, add a "


### PR DESCRIPTION
Fix https://github.com/pyg-team/pytorch_geometric/issues/6862.