### PR TITLE
Respect tuple of `data` objects in `Dataset.num_classes`

### DIFF
--- a/test/data/test_dataset.py
+++ b/test/data/test_dataset.py
@@ -1,3 +1,5 @@
+import copy
+
 import pytest
 import torch
 from torch_sparse import SparseTensor
@@ -6,8 +8,8 @@ from torch_geometric.data import Data, HeteroData, InMemoryDataset
 
 
 class MyTestDataset(InMemoryDataset):
-    def __init__(self, data_list):
-        super().__init__('/tmp/MyTestDataset')
+    def __init__(self, data_list, transform=None):
+        super().__init__('/tmp/MyTestDataset', transform=transform)
         self.data, self.slices = self.collate(data_list)
 
 
@@ -70,6 +72,15 @@ def test_in_memory_num_classes():
         Data(y=torch.tensor([[0, 0, 1, 0]])),
     ])
     assert dataset.num_classes == 4
+
+    # Test when `__getitem__` returns a tuple of data objects.
+    def transform(data):
+        copied_data = copy.copy(data)
+        copied_data.y += 1
+        return data, copied_data, 'foo'
+
+    dataset = MyTestDataset([Data(y=0), Data(y=1)], transform=transform)
+    assert dataset.num_classes == 3
 
 
 def test_in_memory_dataset_copy():

--- a/torch_geometric/data/dataset.py
+++ b/torch_geometric/data/dataset.py
@@ -152,7 +152,14 @@ class Dataset(torch.utils.data.Dataset, ABC):
     @property
     def num_classes(self) -> int:
         r"""Returns the number of classes in the dataset."""
-        y = torch.cat([data.y for data in self], dim=0)
+        data_list = []
+        for data in self:
+            if isinstance(data, tuple):
+                for data_i in data:
+                    data_list.append(data_i.y)
+            else:
+                data_list.append(data.y)
+        y = torch.cat(data_list, dim=0)
         # Do not fill cache for `InMemoryDataset`:
         if hasattr(self, '_data_list') and self._data_list is not None:
             self._data_list = self.len() * [None]

--- a/torch_geometric/data/dataset.py
+++ b/torch_geometric/data/dataset.py
@@ -11,7 +11,7 @@ import numpy as np
 import torch.utils.data
 from torch import Tensor
 
-from torch_geometric.data import Data
+from torch_geometric.data.data import BaseData
 from torch_geometric.data.makedirs import makedirs
 
 IndexType = Union[slice, Tensor, np.ndarray, Sequence]
@@ -66,7 +66,7 @@ class Dataset(torch.utils.data.Dataset, ABC):
         raise NotImplementedError
 
     @abstractmethod
-    def get(self, idx: int) -> Data:
+    def get(self, idx: int) -> BaseData:
         r"""Gets the data object at index :obj:`idx`."""
         raise NotImplementedError
 
@@ -152,14 +152,13 @@ class Dataset(torch.utils.data.Dataset, ABC):
     @property
     def num_classes(self) -> int:
         r"""Returns the number of classes in the dataset."""
-        data_list = []
-        for data in self:
-            if isinstance(data, tuple):
-                for data_i in data:
-                    data_list.append(data_i.y)
-            else:
-                data_list.append(data.y)
-        y = torch.cat(data_list, dim=0)
+        # We iterate over the dataset and collect all labels to determine the
+        # maximum number of classes. Importantly, in rare cases, `__getitem__`
+        # may produce a tuple of data objects (e.g., when used in combination
+        # with `RandomLinkSplit`, so we take care of this case here as well:
+        data_list = _get_flattened_data_list([data for data in self])
+        y = torch.cat([data.y for data in data_list if 'y' in data], dim=0)
+
         # Do not fill cache for `InMemoryDataset`:
         if hasattr(self, '_data_list') and self._data_list is not None:
             self._data_list = self.len() * [None]
@@ -245,7 +244,7 @@ class Dataset(torch.utils.data.Dataset, ABC):
     def __getitem__(
         self,
         idx: Union[int, np.integer, IndexType],
-    ) -> Union['Dataset', Data]:
+    ) -> Union['Dataset', BaseData]:
         r"""In case :obj:`idx` is of type integer, will return the data object
         at index :obj:`idx` (and transforms it in case :obj:`transform` is
         present).
@@ -383,3 +382,15 @@ def _repr(obj: Any) -> str:
     if obj is None:
         return 'None'
     return re.sub('(<.*?)\\s.*(>)', r'\1\2', str(obj))
+
+
+def _get_flattened_data_list(data_list: List[Any]) -> List[BaseData]:
+    outs: List[BaseData] = []
+    for data in data_list:
+        if isinstance(data, BaseData):
+            outs.append(data)
+        elif isinstance(data, (tuple, list)):
+            outs.extend(_get_flattened_data_list(data))
+        elif isinstance(data, dict):
+            outs.extend(_get_flattened_data_list(data.values()))
+    return outs

--- a/torch_geometric/datasets/planetoid.py
+++ b/torch_geometric/datasets/planetoid.py
@@ -91,7 +91,7 @@ class Planetoid(InMemoryDataset):
 
         super().__init__(root, transform, pre_transform)
         self.data, self.slices = torch.load(self.processed_paths[0])
-
+    
         if split == 'full':
             data = self.get(0)
             data.train_mask.fill_(True)
@@ -116,7 +116,6 @@ class Planetoid(InMemoryDataset):
             data.test_mask[remaining[num_val:num_val + num_test]] = True
 
             self.data, self.slices = self.collate([data])
-        self.data.num_classes = self.num_classes
 
     @property
     def raw_dir(self) -> str:

--- a/torch_geometric/datasets/planetoid.py
+++ b/torch_geometric/datasets/planetoid.py
@@ -116,6 +116,7 @@ class Planetoid(InMemoryDataset):
             data.test_mask[remaining[num_val:num_val + num_test]] = True
 
             self.data, self.slices = self.collate([data])
+        self.data.num_classes = self.num_classes
 
     @property
     def raw_dir(self) -> str:

--- a/torch_geometric/datasets/planetoid.py
+++ b/torch_geometric/datasets/planetoid.py
@@ -91,7 +91,7 @@ class Planetoid(InMemoryDataset):
 
         super().__init__(root, transform, pre_transform)
         self.data, self.slices = torch.load(self.processed_paths[0])
-    
+
         if split == 'full':
             data = self.get(0)
             data.train_mask.fill_(True)


### PR DESCRIPTION
https://github.com/pyg-team/pytorch_geometric/issues/6782#issuecomment-1460485546

> Traceback (most recent call last):
>   File "argva_node_clustering.py", line 130, in <module>
>     plot_points(test_data, colors)
>   File "/usr/local/lib/python3.8/dist-packages/torch/utils/_contextlib.py", line 115, in decorate_context
>     return func(*args, **kwargs)
>   File "argva_node_clustering.py", line 121, in plot_points
>     for i in range(dataset.num_classes):
>   File "/usr/local/lib/python3.8/dist-packages/torch_geometric-2.3.0-py3.8.egg/torch_geometric/data/in_memory_dataset.py", line 175, in __getattr__
>     raise AttributeError(f"'{self.__class__.__name__}' object has no "
> AttributeError: 'Planetoid' object has no attribute 'num_classes'