### PR TITLE
feat: Add `ComplEx` KGE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- Added the `ComplEx` KGE model ([#6898](https://github.com/pyg-team/pytorch_geometric/pull/6898))
 - Added option to write benchmark results to csv ([#6888](https://github.com/pyg-team/pytorch_geometric/pull/6888))
 - Added `HeteroLayerNorm` and `HeteroBatchNorm` layers ([#6838](https://github.com/pyg-team/pytorch_geometric/pull/6838))
 - Added the `HeterophilousGraphDataset` suite ([#6846](https://github.com/pyg-team/pytorch_geometric/pull/6846))

--- a/README.md
+++ b/README.md
@@ -300,7 +300,8 @@ Unlike simple stacking of GNN layers, these models could involve pre-processing,
 * **[LINKX](https://pytorch-geometric.readthedocs.io/en/latest/generated/torch_geometric.nn.models.LINKX.html)** from Lim *et al.*: [Large Scale Learning on Non-Homophilous Graphs:
 New Benchmarks and Strong Simple Methods](https://arxiv.org/abs/2110.14446) (NeurIPS 2021) [[**Example**](https://github.com/pyg-team/pytorch_geometric/blob/master/examples/linkx.py)]
 * **[RevGNN](https://pytorch-geometric.readthedocs.io/en/latest/generated/torch_geometric.nn.models.GroupAddRev.html)** from Li *et al.*: [Training Graph Neural with 1000 Layers](https://arxiv.org/abs/2106.07476) (ICML 2021) [[**Example**](https://github.com/pyg-team/pytorch_geometric/blob/master/examples/rev_gnn.py)]
-* **[TransE](https://pytorch-geometric.readthedocs.io/en/latest/generated/torch_geometric.nn.kge.TransE.html)** from Bordes *et al.*: [Translating Embeddings for Modeling Multi-Relational Data](https://proceedings.neurips.cc/paper/2013/file/1cecc7a77928ca8133fa24680a88d2f9-Paper.pdf) (NIPS 2013) [[**Example**](https://github.com/pyg-team/pytorch_geometric/blob/master/examples/transe_fb15k_237.py)]
+* **[TransE](https://pytorch-geometric.readthedocs.io/en/latest/generated/torch_geometric.nn.kge.TransE.html)** from Bordes *et al.*: [Translating Embeddings for Modeling Multi-Relational Data](https://proceedings.neurips.cc/paper/2013/file/1cecc7a77928ca8133fa24680a88d2f9-Paper.pdf) (NIPS 2013) [[**Example**](https://github.com/pyg-team/pytorch_geometric/blob/master/examples/kge_fb15k_237.py)]
+* **[ComplEx](https://pytorch-geometric.readthedocs.io/en/latest/generated/torch_geometric.nn.kge.ComplEx.html)** from Trouillon *et al.*: [Complex Embeddings for Simple Link Prediction](https://arxiv.org/pdf/1606.06357.pdf) (ICML 2016) [[**Example**](https://github.com/pyg-team/pytorch_geometric/blob/master/examples/kge_fb15k_237.py)]
 </details>
 
 **GNN operators and utilities:**

--- a/examples/kge_fb15k_237.py
+++ b/examples/kge_fb15k_237.py
@@ -8,10 +8,7 @@ from torch_geometric.datasets import FB15k_237
 from torch_geometric.nn import ComplEx, TransE
 
 available_models = ['transe', 'complex']
-model_map = {
-    'transe': TransE,
-    'complex': ComplEx
-}
+model_map = {'transe': TransE, 'complex': ComplEx}
 optimizer_map = {
     'transe': torch.optim.Adam(model.parameters(), lr=0.01),
     'complex': optim.Adagrad(model.parameters(), lr=0.001, weight_decay=1e-6)

--- a/examples/kge_fb15k_237.py
+++ b/examples/kge_fb15k_237.py
@@ -7,11 +7,10 @@ import torch.optim as optim
 from torch_geometric.datasets import FB15k_237
 from torch_geometric.nn import ComplEx, TransE
 
-available_models = ['transe', 'complex']
 model_map = {'transe': TransE, 'complex': ComplEx}
 
 parser = argparse.ArgumentParser()
-parser.add_argument('--model', choices=available_models, type=str.lower,
+parser.add_argument('--model', choices=model_map.keys(), type=str.lower,
                     required=True)
 args = parser.parse_args()
 

--- a/examples/kge_fb15k_237.py
+++ b/examples/kge_fb15k_237.py
@@ -1,9 +1,20 @@
 import os.path as osp
+import argparse
 
 import torch
 
 from torch_geometric.datasets import FB15k_237
-from torch_geometric.nn import TransE
+from torch_geometric.nn import TransE, ComplEx
+
+available_models = ['transe', 'complex']
+model_map = {
+    'transe': TransE,
+    'complex': ComplEx
+}
+
+parser = argparse.ArgumentParser()
+parser.add_argument('--model', choices=available_models, type=str.lower, required=True)
+args = parser.parse_args()
 
 device = 'cuda' if torch.cuda.is_available() else 'cpu'
 path = osp.join(osp.dirname(osp.realpath(__file__)), '..', 'data', 'FB15k')
@@ -12,7 +23,7 @@ train_data = FB15k_237(path, split='train')[0].to(device)
 val_data = FB15k_237(path, split='val')[0].to(device)
 test_data = FB15k_237(path, split='test')[0].to(device)
 
-model = TransE(
+model = model_map[args.model](
     num_nodes=train_data.num_nodes,
     num_relations=train_data.num_edge_types,
     hidden_channels=50,

--- a/examples/kge_fb15k_237.py
+++ b/examples/kge_fb15k_237.py
@@ -9,10 +9,6 @@ from torch_geometric.nn import ComplEx, TransE
 
 available_models = ['transe', 'complex']
 model_map = {'transe': TransE, 'complex': ComplEx}
-optimizer_map = {
-    'transe': torch.optim.Adam(model.parameters(), lr=0.01),
-    'complex': optim.Adagrad(model.parameters(), lr=0.001, weight_decay=1e-6)
-}
 
 parser = argparse.ArgumentParser()
 parser.add_argument('--model', choices=available_models, type=str.lower,
@@ -40,6 +36,10 @@ loader = model.loader(
     shuffle=True,
 )
 
+optimizer_map = {
+    'transe': torch.optim.Adam(model.parameters(), lr=0.01),
+    'complex': optim.Adagrad(model.parameters(), lr=0.001, weight_decay=1e-6)
+}
 optimizer = optimizer_map[args.model]
 
 

--- a/examples/kge_fb15k_237.py
+++ b/examples/kge_fb15k_237.py
@@ -2,12 +2,20 @@ import argparse
 import os.path as osp
 
 import torch
+import torch.optim as optim
 
 from torch_geometric.datasets import FB15k_237
 from torch_geometric.nn import ComplEx, TransE
 
 available_models = ['transe', 'complex']
-model_map = {'transe': TransE, 'complex': ComplEx}
+model_map = {
+    'transe': TransE,
+    'complex': ComplEx
+}
+optimizer_map = {
+    'transe': torch.optim.Adam(model.parameters(), lr=0.01),
+    'complex': optim.Adagrad(model.parameters(), lr=0.001, weight_decay=1e-6)
+}
 
 parser = argparse.ArgumentParser()
 parser.add_argument('--model', choices=available_models, type=str.lower,
@@ -31,11 +39,11 @@ loader = model.loader(
     head_index=train_data.edge_index[0],
     rel_type=train_data.edge_type,
     tail_index=train_data.edge_index[1],
-    batch_size=10000,
+    batch_size=1000,
     shuffle=True,
 )
 
-optimizer = torch.optim.Adam(model.parameters(), lr=0.01)
+optimizer = optimizer_map[args.model]
 
 
 def train():

--- a/examples/kge_fb15k_237.py
+++ b/examples/kge_fb15k_237.py
@@ -1,19 +1,17 @@
-import os.path as osp
 import argparse
+import os.path as osp
 
 import torch
 
 from torch_geometric.datasets import FB15k_237
-from torch_geometric.nn import TransE, ComplEx
+from torch_geometric.nn import ComplEx, TransE
 
 available_models = ['transe', 'complex']
-model_map = {
-    'transe': TransE,
-    'complex': ComplEx
-}
+model_map = {'transe': TransE, 'complex': ComplEx}
 
 parser = argparse.ArgumentParser()
-parser.add_argument('--model', choices=available_models, type=str.lower, required=True)
+parser.add_argument('--model', choices=available_models, type=str.lower,
+                    required=True)
 args = parser.parse_args()
 
 device = 'cuda' if torch.cuda.is_available() else 'cpu'

--- a/test/nn/kge/test_complex.py
+++ b/test/nn/kge/test_complex.py
@@ -1,0 +1,34 @@
+import torch
+
+from torch_geometric.nn import ComplEx
+
+def test_complex_scoring():
+  model = ComplEx(5, 2, 1)
+  model.node_emb.weight.data = torch.Tensor([[2.], [3.], [5.], [1.], [2.]])
+  model.node_emb_im.weight.data  = torch.Tensor([[4.], [1.], [3.], [1.], [2.]])
+  model.rel_emb.weight.data  = torch.Tensor([[2.], [3.]])
+  model.rel_emb_im.weight.data = torch.Tensor([[3.], [1.]])
+  
+  score = model(torch.IntTensor([1, 3]), torch.IntTensor([1, 0]), torch.IntTensor([2, 4]))
+  
+  assert torch.all(torch.eq(score, torch.tensor([58, 8])))
+  
+def test_complex():
+    model = ComplEx(num_nodes=10, num_relations=5, hidden_channels=32)
+    assert str(model) == 'ComplEx(10, num_relations=5, hidden_channels=32)'
+
+    head_index = torch.tensor([0, 2, 4, 6, 8])
+    rel_type = torch.tensor([0, 1, 2, 3, 4])
+    tail_index = torch.tensor([1, 3, 5, 7, 9])
+
+    loader = model.loader(head_index, rel_type, tail_index, batch_size=5)
+    for h, r, t in loader:
+        out = model(h, r, t)
+        assert out.size() == (5, )
+
+        loss = model.loss(h, r, t)
+        assert loss >= 0.
+
+        mean_rank, hits_at_10 = model.test(h, r, t, batch_size=5)
+        assert mean_rank <= 10
+        assert hits_at_10 == 1.0

--- a/test/nn/kge/test_complex.py
+++ b/test/nn/kge/test_complex.py
@@ -2,17 +2,21 @@ import torch
 
 from torch_geometric.nn import ComplEx
 
+
 def test_complex_scoring():
-  model = ComplEx(5, 2, 1)
-  model.node_emb.weight.data = torch.Tensor([[2.], [3.], [5.], [1.], [2.]])
-  model.node_emb_im.weight.data  = torch.Tensor([[4.], [1.], [3.], [1.], [2.]])
-  model.rel_emb.weight.data  = torch.Tensor([[2.], [3.]])
-  model.rel_emb_im.weight.data = torch.Tensor([[3.], [1.]])
-  
-  score = model(torch.IntTensor([1, 3]), torch.IntTensor([1, 0]), torch.IntTensor([2, 4]))
-  
-  assert torch.all(torch.eq(score, torch.tensor([58, 8])))
-  
+    model = ComplEx(5, 2, 1)
+    model.node_emb.weight.data = torch.Tensor([[2.], [3.], [5.], [1.], [2.]])
+    model.node_emb_im.weight.data = torch.Tensor([[4.], [1.], [3.], [1.],
+                                                  [2.]])
+    model.rel_emb.weight.data = torch.Tensor([[2.], [3.]])
+    model.rel_emb_im.weight.data = torch.Tensor([[3.], [1.]])
+
+    score = model(torch.IntTensor([1, 3]), torch.IntTensor([1, 0]),
+                  torch.IntTensor([2, 4]))
+
+    assert torch.all(torch.eq(score, torch.tensor([58, 8])))
+
+
 def test_complex():
     model = ComplEx(num_nodes=10, num_relations=5, hidden_channels=32)
     assert str(model) == 'ComplEx(10, num_relations=5, hidden_channels=32)'

--- a/test/nn/kge/test_complex.py
+++ b/test/nn/kge/test_complex.py
@@ -6,13 +6,13 @@ from torch_geometric.nn import ComplEx
 def test_complex_scoring():
     model = ComplEx(5, 2, 1)
     model.node_emb.weight.data = torch.Tensor([[2.], [3.], [5.], [1.], [2.]])
-    model.node_emb_im.weight.data = torch.Tensor([[4.], [1.], [3.], [1.],
-                                                  [2.]])
+    model.node_emb_im.weight.data = torch.Tensor(
+        [[4.], [1.], [3.], [1.], [2.]])
     model.rel_emb.weight.data = torch.Tensor([[2.], [3.]])
     model.rel_emb_im.weight.data = torch.Tensor([[3.], [1.]])
 
-    score = model(torch.IntTensor([1, 3]), torch.IntTensor([1, 0]),
-                  torch.IntTensor([2, 4]))
+    score = model(torch.IntTensor([1, 3]), torch.IntTensor(
+        [1, 0]), torch.IntTensor([2, 4]))
 
     assert torch.all(torch.eq(score, torch.tensor([58, 8])))
 

--- a/test/nn/kge/test_complex.py
+++ b/test/nn/kge/test_complex.py
@@ -6,13 +6,13 @@ from torch_geometric.nn import ComplEx
 def test_complex_scoring():
     model = ComplEx(5, 2, 1)
     model.node_emb.weight.data = torch.Tensor([[2.], [3.], [5.], [1.], [2.]])
-    model.node_emb_im.weight.data = torch.Tensor(
-        [[4.], [1.], [3.], [1.], [2.]])
+    model.node_emb_im.weight.data = torch.Tensor([[4.], [1.], [3.], [1.],
+                                                  [2.]])
     model.rel_emb.weight.data = torch.Tensor([[2.], [3.]])
     model.rel_emb_im.weight.data = torch.Tensor([[3.], [1.]])
 
-    score = model(torch.IntTensor([1, 3]), torch.IntTensor(
-        [1, 0]), torch.IntTensor([2, 4]))
+    score = model(torch.IntTensor([1, 3]), torch.IntTensor([1, 0]),
+                  torch.IntTensor([2, 4]))
 
     assert torch.all(torch.eq(score, torch.tensor([58, 8])))
 

--- a/test/nn/kge/test_complex.py
+++ b/test/nn/kge/test_complex.py
@@ -4,17 +4,37 @@ from torch_geometric.nn import ComplEx
 
 
 def test_complex_scoring():
-    model = ComplEx(5, 2, 1)
-    model.node_emb.weight.data = torch.Tensor([[2.], [3.], [5.], [1.], [2.]])
-    model.node_emb_im.weight.data = torch.Tensor([[4.], [1.], [3.], [1.],
-                                                  [2.]])
-    model.rel_emb.weight.data = torch.Tensor([[2.], [3.]])
-    model.rel_emb_im.weight.data = torch.Tensor([[3.], [1.]])
+    model = ComplEx(num_nodes=5, num_relations=2, hidden_channels=1)
 
-    score = model(torch.IntTensor([1, 3]), torch.IntTensor([1, 0]),
-                  torch.IntTensor([2, 4]))
+    model.node_emb.weight.data = torch.tensor([
+        [2.],
+        [3.],
+        [5.],
+        [1.],
+        [2.],
+    ])
+    model.node_emb_im.weight.data = torch.tensor([
+        [4.],
+        [1.],
+        [3.],
+        [1.],
+        [2.],
+    ])
+    model.rel_emb.weight.data = torch.tensor([
+        [2.],
+        [3.],
+    ])
+    model.rel_emb_im.weight.data = torch.tensor([
+        [3.],
+        [1.],
+    ])
 
-    assert torch.all(torch.eq(score, torch.tensor([58, 8])))
+    score = model(
+        head_index=torch.tensor([1, 3]),
+        rel_type=torch.tensor([1, 0]),
+        tail_index=torch.tensor([2, 4]),
+    )
+    assert score.tolist() == [58., 8.]
 
 
 def test_complex():

--- a/torch_geometric/nn/kge/__init__.py
+++ b/torch_geometric/nn/kge/__init__.py
@@ -2,8 +2,4 @@ from .base import KGEModel
 from .transe import TransE
 from .complex import ComplEx
 
-__all__ = classes = [
-    'KGEModel',
-    'TransE',
-    'ComplEx'
-]
+__all__ = classes = ['KGEModel', 'TransE', 'ComplEx']

--- a/torch_geometric/nn/kge/__init__.py
+++ b/torch_geometric/nn/kge/__init__.py
@@ -1,7 +1,9 @@
 from .base import KGEModel
 from .transe import TransE
+from .complex import ComplEx
 
 __all__ = classes = [
     'KGEModel',
     'TransE',
+    'ComplEx'
 ]

--- a/torch_geometric/nn/kge/__init__.py
+++ b/torch_geometric/nn/kge/__init__.py
@@ -2,4 +2,8 @@ from .base import KGEModel
 from .transe import TransE
 from .complex import ComplEx
 
-__all__ = classes = ['KGEModel', 'TransE', 'ComplEx']
+__all__ = classes = [
+    'KGEModel',
+    'TransE',
+    'ComplEx',
+]

--- a/torch_geometric/nn/kge/base.py
+++ b/torch_geometric/nn/kge/base.py
@@ -18,33 +18,26 @@ class KGEModel(torch.nn.Module):
         sparse (bool, optional): If set to :obj:`True`, gradients w.r.t. to the
             embedding matrices will be sparse. (default: :obj:`False`)
     """
-    def __init__(self, num_nodes: int, num_relations: int,
-                 hidden_channels: int, sparse: bool = False,
-                 uses_complex=False):
+    def __init__(
+        self,
+        num_nodes: int,
+        num_relations: int,
+        hidden_channels: int,
+        sparse: bool = False,
+    ):
         super().__init__()
 
         self.num_nodes = num_nodes
         self.num_relations = num_relations
         self.hidden_channels = hidden_channels
-        self.uses_complex = uses_complex
 
         self.node_emb = Embedding(num_nodes, hidden_channels, sparse=sparse)
         self.rel_emb = Embedding(num_relations, hidden_channels, sparse=sparse)
-        if uses_complex:
-            self.node_emb_im = Embedding(num_nodes, hidden_channels,
-                                         sparse=sparse)
-            self.rel_emb_im = Embedding(num_relations, hidden_channels,
-                                        sparse=sparse)
-
-        self.reset_parameters()
 
     def reset_parameters(self):
         r"""Resets all learnable parameters of the module."""
         self.node_emb.reset_parameters()
         self.rel_emb.reset_parameters()
-        if self.uses_complex:
-            self.node_emb_im.reset_parameters()
-            self.rel_emb_im.reset_parameters()
 
     def forward(self, head_index: Tensor, rel_type: Tensor,
                 tail_index: Tensor) -> Tensor:

--- a/torch_geometric/nn/kge/base.py
+++ b/torch_geometric/nn/kge/base.py
@@ -39,8 +39,12 @@ class KGEModel(torch.nn.Module):
         self.node_emb.reset_parameters()
         self.rel_emb.reset_parameters()
 
-    def forward(self, head_index: Tensor, rel_type: Tensor,
-                tail_index: Tensor) -> Tensor:
+    def forward(
+        self,
+        head_index: Tensor,
+        rel_type: Tensor,
+        tail_index: Tensor,
+    ) -> Tensor:
         r"""Returns the score for the given triplet.
 
         Args:
@@ -50,8 +54,12 @@ class KGEModel(torch.nn.Module):
         """
         raise NotImplementedError
 
-    def loss(self, head_index: Tensor, rel_type: Tensor,
-             tail_index: Tensor) -> Tensor:
+    def loss(
+        self,
+        head_index: Tensor,
+        rel_type: Tensor,
+        tail_index: Tensor,
+    ) -> Tensor:
         r"""Returns the loss value for the given triplet.
 
         Args:
@@ -61,8 +69,13 @@ class KGEModel(torch.nn.Module):
         """
         raise NotImplementedError
 
-    def loader(self, head_index: Tensor, rel_type: Tensor, tail_index: Tensor,
-               **kwargs) -> Tensor:
+    def loader(
+        self,
+        head_index: Tensor,
+        rel_type: Tensor,
+        tail_index: Tensor,
+        **kwargs,
+    ) -> Tensor:
         r"""Returns a mini-batch loader that samples a subset of triplets.
 
         Args:
@@ -121,8 +134,12 @@ class KGEModel(torch.nn.Module):
         return mean_rank, hits_at_k
 
     @torch.no_grad()
-    def random_sample(self, head_index: Tensor, rel_type: Tensor,
-                      tail_index: Tensor) -> Tuple[Tensor, Tensor, Tensor]:
+    def random_sample(
+        self,
+        head_index: Tensor,
+        rel_type: Tensor,
+        tail_index: Tensor,
+    ) -> Tuple[Tensor, Tensor, Tensor]:
         r"""Randomly samples negative triplets by either replacing the head or
         the tail (but not both).
 

--- a/torch_geometric/nn/kge/base.py
+++ b/torch_geometric/nn/kge/base.py
@@ -18,15 +18,9 @@ class KGEModel(torch.nn.Module):
         sparse (bool, optional): If set to :obj:`True`, gradients w.r.t. to the
             embedding matrices will be sparse. (default: :obj:`False`)
     """
-
-    def __init__(
-        self,
-        num_nodes: int,
-        num_relations: int,
-        hidden_channels: int,
-        sparse: bool = False,
-        uses_complex=False
-    ):
+    def __init__(self, num_nodes: int, num_relations: int,
+                 hidden_channels: int, sparse: bool = False,
+                 uses_complex=False):
         super().__init__()
 
         self.num_nodes = num_nodes
@@ -37,10 +31,10 @@ class KGEModel(torch.nn.Module):
         self.node_emb = Embedding(num_nodes, hidden_channels, sparse=sparse)
         self.rel_emb = Embedding(num_relations, hidden_channels, sparse=sparse)
         if uses_complex:
-            self.node_emb_im = Embedding(
-                num_nodes, hidden_channels, sparse=sparse)
-            self.rel_emb_im = Embedding(
-                num_relations, hidden_channels, sparse=sparse)
+            self.node_emb_im = Embedding(num_nodes, hidden_channels,
+                                         sparse=sparse)
+            self.rel_emb_im = Embedding(num_relations, hidden_channels,
+                                        sparse=sparse)
 
         self.reset_parameters()
 

--- a/torch_geometric/nn/kge/base.py
+++ b/torch_geometric/nn/kge/base.py
@@ -18,14 +18,9 @@ class KGEModel(torch.nn.Module):
         sparse (bool, optional): If set to :obj:`True`, gradients w.r.t. to the
             embedding matrices will be sparse. (default: :obj:`False`)
     """
-    def __init__(
-        self,
-        num_nodes: int,
-        num_relations: int,
-        hidden_channels: int,
-        sparse: bool = False,
-        uses_complex = False
-    ):
+    def __init__(self, num_nodes: int, num_relations: int,
+                 hidden_channels: int, sparse: bool = False,
+                 uses_complex=False):
         super().__init__()
 
         self.num_nodes = num_nodes
@@ -36,8 +31,10 @@ class KGEModel(torch.nn.Module):
         self.node_emb = Embedding(num_nodes, hidden_channels, sparse=sparse)
         self.rel_emb = Embedding(num_relations, hidden_channels, sparse=sparse)
         if uses_complex:
-            self.node_emb_im = Embedding(num_nodes, hidden_channels, sparse=sparse)
-            self.rel_emb_im = Embedding(num_relations, hidden_channels, sparse=sparse)
+            self.node_emb_im = Embedding(num_nodes, hidden_channels,
+                                         sparse=sparse)
+            self.rel_emb_im = Embedding(num_relations, hidden_channels,
+                                        sparse=sparse)
 
         self.reset_parameters()
 

--- a/torch_geometric/nn/kge/base.py
+++ b/torch_geometric/nn/kge/base.py
@@ -18,9 +18,15 @@ class KGEModel(torch.nn.Module):
         sparse (bool, optional): If set to :obj:`True`, gradients w.r.t. to the
             embedding matrices will be sparse. (default: :obj:`False`)
     """
-    def __init__(self, num_nodes: int, num_relations: int,
-                 hidden_channels: int, sparse: bool = False,
-                 uses_complex=False):
+
+    def __init__(
+        self,
+        num_nodes: int,
+        num_relations: int,
+        hidden_channels: int,
+        sparse: bool = False,
+        uses_complex=False
+    ):
         super().__init__()
 
         self.num_nodes = num_nodes
@@ -31,10 +37,10 @@ class KGEModel(torch.nn.Module):
         self.node_emb = Embedding(num_nodes, hidden_channels, sparse=sparse)
         self.rel_emb = Embedding(num_relations, hidden_channels, sparse=sparse)
         if uses_complex:
-            self.node_emb_im = Embedding(num_nodes, hidden_channels,
-                                         sparse=sparse)
-            self.rel_emb_im = Embedding(num_relations, hidden_channels,
-                                        sparse=sparse)
+            self.node_emb_im = Embedding(
+                num_nodes, hidden_channels, sparse=sparse)
+            self.rel_emb_im = Embedding(
+                num_relations, hidden_channels, sparse=sparse)
 
         self.reset_parameters()
 

--- a/torch_geometric/nn/kge/base.py
+++ b/torch_geometric/nn/kge/base.py
@@ -24,15 +24,20 @@ class KGEModel(torch.nn.Module):
         num_relations: int,
         hidden_channels: int,
         sparse: bool = False,
+        uses_complex = False
     ):
         super().__init__()
 
         self.num_nodes = num_nodes
         self.num_relations = num_relations
         self.hidden_channels = hidden_channels
+        self.uses_complex = uses_complex
 
         self.node_emb = Embedding(num_nodes, hidden_channels, sparse=sparse)
         self.rel_emb = Embedding(num_relations, hidden_channels, sparse=sparse)
+        if uses_complex:
+            self.node_emb_im = Embedding(num_nodes, hidden_channels, sparse=sparse)
+            self.rel_emb_im = Embedding(num_relations, hidden_channels, sparse=sparse)
 
         self.reset_parameters()
 
@@ -40,6 +45,9 @@ class KGEModel(torch.nn.Module):
         r"""Resets all learnable parameters of the module."""
         self.node_emb.reset_parameters()
         self.rel_emb.reset_parameters()
+        if self.uses_complex:
+            self.node_emb_im.reset_parameters()
+            self.rel_emb_im.reset_parameters()
 
     def forward(self, head_index: Tensor, rel_type: Tensor,
                 tail_index: Tensor) -> Tensor:

--- a/torch_geometric/nn/kge/complex.py
+++ b/torch_geometric/nn/kge/complex.py
@@ -40,6 +40,12 @@ class ComplEx(KGEModel):
     ):
         super().__init__(num_nodes, num_relations, hidden_channels, sparse,
                          uses_complex=True)
+        
+    def reset_parameters(self):
+        torch.nn.init.xavier_uniform_(self.node_emb.weight)
+        torch.nn.init.xavier_uniform_(self.node_emb_im.weight)
+        torch.nn.init.xavier_uniform_(self.rel_emb.weight)
+        torch.nn.init.xavier_uniform_(self.rel_emb_im.weight)
 
     def forward(self, head_index: Tensor, rel_type: Tensor,
                 tail_index: Tensor) -> Tensor:
@@ -57,13 +63,14 @@ class ComplEx(KGEModel):
             triple_dot(head_im, rel_re, tail_im) + \
             triple_dot(head_re, rel_im, tail_im) - \
             triple_dot(head_im, rel_im, tail_re)
+        
 
     def loss(self, head_index: Tensor, rel_type: Tensor,
              tail_index: Tensor) -> Tensor:
         pos_score = self(head_index, rel_type, tail_index)
         neg_score = self(*self.random_sample(head_index, rel_type, tail_index))
         input = torch.cat((pos_score, neg_score))
-        target = torch.cat((torch.ones_like(pos_score).long(),
-                            -torch.ones_like(neg_score).long()))
+        target = torch.cat((torch.ones_like(pos_score),
+                            torch.zeros_like(neg_score)))
 
-        return F.nll_loss(F.logsigmoid(input), target)
+        return F.binary_cross_entropy_with_logits(input, target, reduction='sum')

--- a/torch_geometric/nn/kge/complex.py
+++ b/torch_geometric/nn/kge/complex.py
@@ -16,7 +16,7 @@ class ComplEx(KGEModel):
 
     .. math::
         d(h, r, t) = Re(< \mathbf{e}_h,  \mathbf{w}_r, \mathbf{e}_t>)
-        
+
     .. note::
 
         For an example of using the :class:`ComplEx` model, see

--- a/torch_geometric/nn/kge/complex.py
+++ b/torch_geometric/nn/kge/complex.py
@@ -31,6 +31,7 @@ class ComplEx(KGEModel):
         sparse (bool, optional): If set to :obj:`True`, gradients w.r.t. to
             the embedding matrices will be sparse. (default: :obj:`False`)
     """
+
     def __init__(
         self,
         num_nodes: int,

--- a/torch_geometric/nn/kge/complex.py
+++ b/torch_geometric/nn/kge/complex.py
@@ -31,7 +31,6 @@ class ComplEx(KGEModel):
         sparse (bool, optional): If set to :obj:`True`, gradients w.r.t. to
             the embedding matrices will be sparse. (default: :obj:`False`)
     """
-
     def __init__(
         self,
         num_nodes: int,

--- a/torch_geometric/nn/kge/complex.py
+++ b/torch_geometric/nn/kge/complex.py
@@ -1,0 +1,57 @@
+import torch
+import torch.nn.functional as F
+from torch import Tensor
+
+from torch_geometric.nn.kge import KGEModel
+
+
+class ComplEx(KGEModel):
+    r"""The ComplEx model from the `"Complex Embeddings for Simple Link Prediction" 
+    <https://arxiv.org/pdf/1606.06357.pdf>
+
+    :class:`ComplEx` models relations as complex-valued bilinear mappings between head
+    and tail entities using the Hermetian dot product. The entities and relations are embedded
+    in different dimensional spaces, resulting in the scoring function:
+
+    .. math::
+        d(h, r, t) = Re(< \mathbf{e}_h,  \mathbf{w}_r, \mathbf{e}_t>)
+
+    Args:
+        num_nodes (int): The number of nodes/entities in the graph.
+        num_relations (int): The number of relations in the graph.
+        hidden_channels (int): The hidden embedding size.
+        sparse (bool, optional): If set to :obj:`True`, gradients w.r.t. to the
+            embedding matrices will be sparse. (default: :obj:`False`)
+    """
+    def __init__(
+        self,
+        num_nodes: int,
+        num_relations: int,
+        hidden_channels: int,
+        sparse: bool = False,
+    ):
+        super().__init__(num_nodes, num_relations, hidden_channels, sparse, uses_complex=True)
+
+    def forward(self, head_index: Tensor, rel_type: Tensor,
+                tail_index: Tensor) -> Tensor:
+        head_re = self.node_emb(head_index)     
+        head_im = self.node_emb_im(head_index)
+        rel_re = self.rel_emb(rel_type)
+        rel_im = self.rel_emb_im(rel_type)
+        tail_re = self.node_emb(tail_index)
+        tail_im = self.node_emb_im(tail_index)
+        
+        triple_dot = lambda x,y,z: torch.sum(x*y*z, dim=-1)
+        return triple_dot(head_re, rel_re, tail_re) + \
+            triple_dot(head_im, rel_re, tail_im) + \
+            triple_dot(head_re, rel_im, tail_im) - \
+            triple_dot(head_im, rel_im, tail_re) 
+            
+    def loss(self, head_index: Tensor, rel_type: Tensor,
+             tail_index: Tensor) -> Tensor:
+        pos_score = self(head_index, rel_type, tail_index)
+        neg_score = self(*self.random_sample(head_index, rel_type, tail_index))
+        input = torch.cat((pos_score, neg_score))
+        target = torch.cat((torch.ones_like(pos_score).long(), -torch.ones_like(neg_score).long()))
+        
+        return F.nll_loss(F.logsigmoid(input), target)

--- a/torch_geometric/nn/kge/complex.py
+++ b/torch_geometric/nn/kge/complex.py
@@ -16,7 +16,7 @@ class ComplEx(KGEModel):
     resulting in the scoring function:
 
     .. math::
-        d(h, r, t) = Re(< \mathbf{e}_h,  \mathbf{w}_r, \mathbf{e}_t>)
+        d(h, r, t) = Re(< \mathbf{e}_h,  \mathbf{e}_r, \mathbf{e}_t>)
 
     .. note::
 

--- a/torch_geometric/nn/kge/complex.py
+++ b/torch_geometric/nn/kge/complex.py
@@ -16,6 +16,13 @@ class ComplEx(KGEModel):
 
     .. math::
         d(h, r, t) = Re(< \mathbf{e}_h,  \mathbf{w}_r, \mathbf{e}_t>)
+        
+    .. note::
+
+        For an example of using the :class:`ComplEx` model, see
+        `examples/kge_fb15k_237.py
+        <https://github.com/pyg-team/pytorch_geometric/blob/master/examples/
+        kge_fb15k_237.py>`_.
 
     Args:
         num_nodes (int): The number of nodes/entities in the graph.
@@ -24,7 +31,6 @@ class ComplEx(KGEModel):
         sparse (bool, optional): If set to :obj:`True`, gradients w.r.t. to
             the embedding matrices will be sparse. (default: :obj:`False`)
     """
-
     def __init__(
         self,
         num_nodes: int,
@@ -32,13 +38,8 @@ class ComplEx(KGEModel):
         hidden_channels: int,
         sparse: bool = False,
     ):
-        super().__init__(
-            num_nodes,
-            num_relations,
-            hidden_channels,
-            sparse,
-            uses_complex=True
-        )
+        super().__init__(num_nodes, num_relations, hidden_channels, sparse,
+                         uses_complex=True)
 
     def forward(self, head_index: Tensor, rel_type: Tensor,
                 tail_index: Tensor) -> Tensor:
@@ -62,9 +63,7 @@ class ComplEx(KGEModel):
         pos_score = self(head_index, rel_type, tail_index)
         neg_score = self(*self.random_sample(head_index, rel_type, tail_index))
         input = torch.cat((pos_score, neg_score))
-        target = torch.cat((
-            torch.ones_like(pos_score).long(),
-            -torch.ones_like(neg_score).long()
-        ))
+        target = torch.cat((torch.ones_like(pos_score).long(),
+                            -torch.ones_like(neg_score).long()))
 
         return F.nll_loss(F.logsigmoid(input), target)

--- a/torch_geometric/nn/kge/complex.py
+++ b/torch_geometric/nn/kge/complex.py
@@ -6,7 +6,7 @@ from torch_geometric.nn.kge import KGEModel
 
 
 class ComplEx(KGEModel):
-    r"""The ComplEx model from the `"Complex Embeddings for Simple Link Prediction" 
+    r"""The ComplEx model from the `"Complex Embeddings for Simple Link Prediction"
     <https://arxiv.org/pdf/1606.06357.pdf>
 
     :class:`ComplEx` models relations as complex-valued bilinear mappings between head
@@ -30,28 +30,30 @@ class ComplEx(KGEModel):
         hidden_channels: int,
         sparse: bool = False,
     ):
-        super().__init__(num_nodes, num_relations, hidden_channels, sparse, uses_complex=True)
+        super().__init__(num_nodes, num_relations, hidden_channels, sparse,
+                         uses_complex=True)
 
     def forward(self, head_index: Tensor, rel_type: Tensor,
                 tail_index: Tensor) -> Tensor:
-        head_re = self.node_emb(head_index)     
+        head_re = self.node_emb(head_index)
         head_im = self.node_emb_im(head_index)
         rel_re = self.rel_emb(rel_type)
         rel_im = self.rel_emb_im(rel_type)
         tail_re = self.node_emb(tail_index)
         tail_im = self.node_emb_im(tail_index)
-        
-        triple_dot = lambda x,y,z: torch.sum(x*y*z, dim=-1)
+
+        triple_dot = lambda x, y, z: torch.sum(x * y * z, dim=-1)
         return triple_dot(head_re, rel_re, tail_re) + \
             triple_dot(head_im, rel_re, tail_im) + \
             triple_dot(head_re, rel_im, tail_im) - \
-            triple_dot(head_im, rel_im, tail_re) 
-            
+            triple_dot(head_im, rel_im, tail_re)
+
     def loss(self, head_index: Tensor, rel_type: Tensor,
              tail_index: Tensor) -> Tensor:
         pos_score = self(head_index, rel_type, tail_index)
         neg_score = self(*self.random_sample(head_index, rel_type, tail_index))
         input = torch.cat((pos_score, neg_score))
-        target = torch.cat((torch.ones_like(pos_score).long(), -torch.ones_like(neg_score).long()))
-        
+        target = torch.cat((torch.ones_like(pos_score).long(),
+                            -torch.ones_like(neg_score).long()))
+
         return F.nll_loss(F.logsigmoid(input), target)

--- a/torch_geometric/nn/kge/complex.py
+++ b/torch_geometric/nn/kge/complex.py
@@ -1,6 +1,7 @@
 import torch
 import torch.nn.functional as F
 from torch import Tensor
+from torch.nn import Embedding
 
 from torch_geometric.nn.kge import KGEModel
 
@@ -38,8 +39,13 @@ class ComplEx(KGEModel):
         hidden_channels: int,
         sparse: bool = False,
     ):
-        super().__init__(num_nodes, num_relations, hidden_channels, sparse,
-                         uses_complex=True)
+        super().__init__(num_nodes, num_relations, hidden_channels, sparse)
+
+        self.node_emb_im = Embedding(num_nodes, hidden_channels, sparse=sparse)
+        self.rel_emb_im = Embedding(num_relations, hidden_channels,
+                                    sparse=sparse)
+
+        self.reset_parameters()
 
     def reset_parameters(self):
         torch.nn.init.xavier_uniform_(self.node_emb.weight)

--- a/torch_geometric/nn/kge/complex.py
+++ b/torch_geometric/nn/kge/complex.py
@@ -40,7 +40,7 @@ class ComplEx(KGEModel):
     ):
         super().__init__(num_nodes, num_relations, hidden_channels, sparse,
                          uses_complex=True)
-        
+
     def reset_parameters(self):
         torch.nn.init.xavier_uniform_(self.node_emb.weight)
         torch.nn.init.xavier_uniform_(self.node_emb_im.weight)
@@ -63,14 +63,14 @@ class ComplEx(KGEModel):
             triple_dot(head_im, rel_re, tail_im) + \
             triple_dot(head_re, rel_im, tail_im) - \
             triple_dot(head_im, rel_im, tail_re)
-        
 
     def loss(self, head_index: Tensor, rel_type: Tensor,
              tail_index: Tensor) -> Tensor:
         pos_score = self(head_index, rel_type, tail_index)
         neg_score = self(*self.random_sample(head_index, rel_type, tail_index))
         input = torch.cat((pos_score, neg_score))
-        target = torch.cat((torch.ones_like(pos_score),
-                            torch.zeros_like(neg_score)))
+        target = torch.cat(
+            (torch.ones_like(pos_score), torch.zeros_like(neg_score)))
 
-        return F.binary_cross_entropy_with_logits(input, target, reduction='sum')
+        return F.binary_cross_entropy_with_logits(input, target,
+                                                  reduction='sum')

--- a/torch_geometric/nn/kge/complex.py
+++ b/torch_geometric/nn/kge/complex.py
@@ -6,12 +6,13 @@ from torch_geometric.nn.kge import KGEModel
 
 
 class ComplEx(KGEModel):
-    r"""The ComplEx model from the `"Complex Embeddings for Simple Link Prediction"
-    <https://arxiv.org/pdf/1606.06357.pdf>
+    r"""The ComplEx model from the `"Complex Embeddings for Simple Link
+    Prediction" <https://arxiv.org/pdf/1606.06357.pdf>`_ paper.
 
-    :class:`ComplEx` models relations as complex-valued bilinear mappings between head
-    and tail entities using the Hermetian dot product. The entities and relations are embedded
-    in different dimensional spaces, resulting in the scoring function:
+    :class:`ComplEx` models relations as complex-valued bilinear mappings
+    between head and tail entities using the Hermetian dot product. The
+    entities and relations are embedded in different dimensional spaces,
+    resulting in the scoring function:
 
     .. math::
         d(h, r, t) = Re(< \mathbf{e}_h,  \mathbf{w}_r, \mathbf{e}_t>)
@@ -20,9 +21,10 @@ class ComplEx(KGEModel):
         num_nodes (int): The number of nodes/entities in the graph.
         num_relations (int): The number of relations in the graph.
         hidden_channels (int): The hidden embedding size.
-        sparse (bool, optional): If set to :obj:`True`, gradients w.r.t. to the
-            embedding matrices will be sparse. (default: :obj:`False`)
+        sparse (bool, optional): If set to :obj:`True`, gradients w.r.t. to
+            the embedding matrices will be sparse. (default: :obj:`False`)
     """
+
     def __init__(
         self,
         num_nodes: int,
@@ -30,8 +32,13 @@ class ComplEx(KGEModel):
         hidden_channels: int,
         sparse: bool = False,
     ):
-        super().__init__(num_nodes, num_relations, hidden_channels, sparse,
-                         uses_complex=True)
+        super().__init__(
+            num_nodes,
+            num_relations,
+            hidden_channels,
+            sparse,
+            uses_complex=True
+        )
 
     def forward(self, head_index: Tensor, rel_type: Tensor,
                 tail_index: Tensor) -> Tensor:
@@ -42,7 +49,9 @@ class ComplEx(KGEModel):
         tail_re = self.node_emb(tail_index)
         tail_im = self.node_emb_im(tail_index)
 
-        triple_dot = lambda x, y, z: torch.sum(x * y * z, dim=-1)
+        def triple_dot(x, y, z):
+            return torch.sum(x * y * z, dim=-1)
+
         return triple_dot(head_re, rel_re, tail_re) + \
             triple_dot(head_im, rel_re, tail_im) + \
             triple_dot(head_re, rel_im, tail_im) - \
@@ -53,7 +62,9 @@ class ComplEx(KGEModel):
         pos_score = self(head_index, rel_type, tail_index)
         neg_score = self(*self.random_sample(head_index, rel_type, tail_index))
         input = torch.cat((pos_score, neg_score))
-        target = torch.cat((torch.ones_like(pos_score).long(),
-                            -torch.ones_like(neg_score).long()))
+        target = torch.cat((
+            torch.ones_like(pos_score).long(),
+            -torch.ones_like(neg_score).long()
+        ))
 
         return F.nll_loss(F.logsigmoid(input), target)

--- a/torch_geometric/nn/kge/transe.py
+++ b/torch_geometric/nn/kge/transe.py
@@ -54,6 +54,8 @@ class TransE(KGEModel):
         self.margin = margin
         super().__init__(num_nodes, num_relations, hidden_channels, sparse)
 
+        self.reset_parameters()
+
     def reset_parameters(self):
         bound = 6. / math.sqrt(self.hidden_channels)
         torch.nn.init.uniform_(self.node_emb.weight, -bound, bound)

--- a/torch_geometric/nn/kge/transe.py
+++ b/torch_geometric/nn/kge/transe.py
@@ -63,8 +63,13 @@ class TransE(KGEModel):
         F.normalize(self.rel_emb.weight.data, p=self.p_norm, dim=-1,
                     out=self.rel_emb.weight.data)
 
-    def forward(self, head_index: Tensor, rel_type: Tensor,
-                tail_index: Tensor) -> Tensor:
+    def forward(
+        self,
+        head_index: Tensor,
+        rel_type: Tensor,
+        tail_index: Tensor,
+    ) -> Tensor:
+
         head = self.node_emb(head_index)
         rel = self.rel_emb(rel_type)
         tail = self.node_emb(tail_index)
@@ -75,8 +80,13 @@ class TransE(KGEModel):
         # Calculate *negative* TransE norm:
         return -((head + rel) - tail).norm(p=self.p_norm, dim=-1)
 
-    def loss(self, head_index: Tensor, rel_type: Tensor,
-             tail_index: Tensor) -> Tensor:
+    def loss(
+        self,
+        head_index: Tensor,
+        rel_type: Tensor,
+        tail_index: Tensor,
+    ) -> Tensor:
+
         pos_score = self(head_index, rel_type, tail_index)
         neg_score = self(*self.random_sample(head_index, rel_type, tail_index))
 

--- a/torch_geometric/nn/kge/transe.py
+++ b/torch_geometric/nn/kge/transe.py
@@ -26,9 +26,9 @@ class TransE(KGEModel):
     .. note::
 
         For an example of using the :class:`TransE` model, see
-        `examples/transe_fb15k_237.py
+        `examples/kge_fb15k_237.py
         <https://github.com/pyg-team/pytorch_geometric/blob/master/examples/
-        transe_fb15k_237.py>`_.
+        kge_fb15k_237.py>`_.
 
     Args:
         num_nodes (int): The number of nodes/entities in the graph.


### PR DESCRIPTION
Hello! we are hoping to add the ComplEx knowledge graph embedding to PyG as part of our CS224W final project at Stanford.

Our implementation largely follows that of TransE. We implemented complex vectors by breaking the real and imaginary components into separate vectors, but are open to other approaches.

We'd also like to seek input on whether an example is necessary like for TransE [here](https://github.com/pyg-team/pytorch_geometric/blob/master/examples/transe_fb15k_237.py), and if so, whether it would be preferred to be in the same file or a new one.