### PR TITLE
Fix distributed batching example

### DIFF
--- a/examples/multi_gpu/distributed_batching.py
+++ b/examples/multi_gpu/distributed_batching.py
@@ -92,8 +92,8 @@ def run(rank, world_size: int, dataset_name: str, root: str):
             loss = criterion(logits, data.y.to(torch.float))
             loss.backward()
             optimizer.step()
-            total_loss[0] += loss.item() * logits.size(0)
-            total_loss[1] += len(data)
+            total_loss[0] += float(loss) * logits.size(0)
+            total_loss[1] += data.num_graphs
 
         dist.all_reduce(total_loss, op=dist.ReduceOp.SUM)
         loss = total_loss[0] / total_loss[1]

--- a/examples/multi_gpu/distributed_batching.py
+++ b/examples/multi_gpu/distributed_batching.py
@@ -96,7 +96,7 @@ def run(rank, world_size: int, dataset_name: str, root: str):
             total_loss[1] += data.num_graphs
 
         dist.all_reduce(total_loss, op=dist.ReduceOp.SUM)
-        loss = total_loss[0] / total_loss[1]
+        loss = float(total_loss[0] / total_loss[1])
 
         if rank == 0:  # We evaluate on a single GPU for now.
             model.eval()

--- a/examples/multi_gpu/distributed_batching.py
+++ b/examples/multi_gpu/distributed_batching.py
@@ -84,7 +84,7 @@ def run(rank, world_size: int, dataset_name: str, root: str):
     for epoch in range(1, 51):
         model.train()
 
-        total_loss = 0
+        total_loss = torch.zeros(2).to(rank)
         for data in train_loader:
             data = data.to(rank)
             optimizer.zero_grad()
@@ -92,10 +92,11 @@ def run(rank, world_size: int, dataset_name: str, root: str):
             loss = criterion(logits, data.y.to(torch.float))
             loss.backward()
             optimizer.step()
-            total_loss += float(loss) * logits.size(0)
-        loss = total_loss / len(train_loader.dataset)
+            total_loss[0] += loss.item() * logits.size(0)
+            total_loss[1] += len(data)
 
-        dist.barrier()
+        dist.all_reduce(total_loss, op=dist.ReduceOp.SUM)
+        loss = total_loss[0] / total_loss[1]
 
         if rank == 0:  # We evaluate on a single GPU for now.
             model.eval()


### PR DESCRIPTION
fix loss computation (output comes only from one task) in distributed batching example following [the tutorial](https://pytorch.org/tutorials/intermediate/FSDP_tutorial.html?utm_source=distr_landing&utm_medium=FSDP_getting_started)

Output before:
Let's use 1 GPUs!
.
Epoch: 050, **Loss: 0.0985**, Val: 0.7773, Test: 0.7450

Let's use 4 GPUs!
.
Epoch: 050, **Loss: 0.0249**, Val: 0.7242, Test: 0.7662

Output after fix:
Let's use 1 GPUs!
.
Epoch: 050, **Loss: 0.0977**, Val: 0.7751, Test: 0.7707

Let's use 4 GPUs!
.
Epoch: 050, **Loss: 0.1002**, Val: 0.7724, Test: 0.7507

