### PR TITLE
Enable `filter-per-worker` as argument in benchmarks

### DIFF
--- a/benchmark/inference/inference_benchmark.py
+++ b/benchmark/inference/inference_benchmark.py
@@ -273,7 +273,7 @@ if __name__ == '__main__':
         help='Use DataLoader affinitzation.')
     add('--loader-cores', nargs='+', default=[], type=int,
         help="List of CPU core IDs to use for DataLoader workers")
-    add('--filter-per-worker', action='store_true', 
+    add('--filter-per-worker', action='store_true',
         help='Enable filter-per-worker feature of the dataloader.')
     add('--measure-load-time', action='store_true')
     add('--full-batch', action='store_true', help='Use full batch mode')

--- a/benchmark/inference/inference_benchmark.py
+++ b/benchmark/inference/inference_benchmark.py
@@ -102,6 +102,7 @@ def run(args: argparse.ArgumentParser):
                         num_neighbors=[-1],  # layer-wise inference
                         input_nodes=mask,
                         sampler=sampler,
+                        filter_per_worker=args.filter_per_worker,
                         **kwargs,
                     ) if with_loader else None
                     if args.evaluate and not args.full_batch:
@@ -110,6 +111,7 @@ def run(args: argparse.ArgumentParser):
                             num_neighbors=[-1],  # layer-wise inference
                             input_nodes=test_mask,
                             sampler=None,
+                            filter_per_worker=args.filter_per_worker,
                             **kwargs,
                         )
 
@@ -122,6 +124,7 @@ def run(args: argparse.ArgumentParser):
                             num_neighbors=num_neighbors,
                             input_nodes=mask,
                             sampler=sampler,
+                            filter_per_worker=args.filter_per_worker,
                             **kwargs,
                         ) if with_loader else None
                         if args.evaluate and not args.full_batch:
@@ -130,6 +133,7 @@ def run(args: argparse.ArgumentParser):
                                 num_neighbors=num_neighbors,
                                 input_nodes=test_mask,
                                 sampler=None,
+                                filter_per_worker=args.filter_per_worker,
                                 **kwargs,
                             )
 
@@ -269,6 +273,8 @@ if __name__ == '__main__':
         help='Use DataLoader affinitzation.')
     add('--loader-cores', nargs='+', default=[], type=int,
         help="List of CPU core IDs to use for DataLoader workers")
+    add('--filter-per-worker', action='store_true', 
+        help='Enable filter-per-worker feature of the dataloader.')
     add('--measure-load-time', action='store_true')
     add('--full-batch', action='store_true', help='Use full batch mode')
     add('--evaluate', action='store_true')

--- a/benchmark/loader/neighbor_loader.py
+++ b/benchmark/loader/neighbor_loader.py
@@ -71,12 +71,11 @@ def run(args: argparse.ArgumentParser):
         if eval_batch_sizes is not None:
             print('Evaluation sampling with all neighbors')
             for batch_size in eval_batch_sizes:
-                subgraph_loader = NeighborLoader(data, num_neighbors=[-1],
-                                                 input_nodes=eval_idx,
-                                                 batch_size=batch_size,
-                                                 shuffle=False,
-                                                 num_workers=args.num_workers,
-                                                 filter_per_worker=args.filter_per_worker)
+                subgraph_loader = NeighborLoader(
+                    data, num_neighbors=[-1], input_nodes=eval_idx,
+                    batch_size=batch_size, shuffle=False,
+                    num_workers=args.num_workers,
+                    filter_per_worker=args.filter_per_worker)
                 cpu_affinity = subgraph_loader.enable_cpu_affinity(
                     args.loader_cores) if args.cpu_affinity else nullcontext()
                 runtimes = []

--- a/benchmark/loader/neighbor_loader.py
+++ b/benchmark/loader/neighbor_loader.py
@@ -47,7 +47,7 @@ def run(args: argparse.ArgumentParser):
                         data, num_neighbors=num_neighbors,
                         input_nodes=train_idx, batch_size=batch_size,
                         shuffle=True, num_workers=args.num_workers,
-                        filter_per_worker=args.filter)
+                        filter_per_worker=args.filter_per_worker)
                     cpu_affinity = train_loader.enable_cpu_affinity(
                         args.loader_cores
                     ) if args.cpu_affinity else nullcontext()
@@ -76,7 +76,7 @@ def run(args: argparse.ArgumentParser):
                                                  batch_size=batch_size,
                                                  shuffle=False,
                                                  num_workers=args.num_workers,
-                                                 filter_per_worker=args.filter)
+                                                 filter_per_worker=args.filter_per_worker)
                 cpu_affinity = subgraph_loader.enable_cpu_affinity(
                     args.loader_cores) if args.cpu_affinity else nullcontext()
                 runtimes = []
@@ -120,7 +120,7 @@ if __name__ == '__main__':
         help="Number of iterations for each test setting.")
     add('--profile', default=False, action='store_true',
         help="Run torch.profiler.")
-    add('--filter', default=False, action='store_true',
+    add('--filter-per-worker', default=False, action='store_true',
         help="Use filter per worker.")
     add('--cpu-affinity', default=False, action='store_true',
         help="Use DataLoader affinitzation.")

--- a/benchmark/loader/neighbor_loader.py
+++ b/benchmark/loader/neighbor_loader.py
@@ -72,10 +72,14 @@ def run(args: argparse.ArgumentParser):
             print('Evaluation sampling with all neighbors')
             for batch_size in eval_batch_sizes:
                 subgraph_loader = NeighborLoader(
-                    data, num_neighbors=[-1], input_nodes=eval_idx,
-                    batch_size=batch_size, shuffle=False,
+                    data,
+                    num_neighbors=[-1],
+                    input_nodes=eval_idx,
+                    batch_size=batch_size,
+                    shuffle=False,
                     num_workers=args.num_workers,
-                    filter_per_worker=args.filter_per_worker, )
+                    filter_per_worker=args.filter_per_worker,
+                )
                 cpu_affinity = subgraph_loader.enable_cpu_affinity(
                     args.loader_cores) if args.cpu_affinity else nullcontext()
                 runtimes = []

--- a/benchmark/loader/neighbor_loader.py
+++ b/benchmark/loader/neighbor_loader.py
@@ -75,7 +75,7 @@ def run(args: argparse.ArgumentParser):
                     data, num_neighbors=[-1], input_nodes=eval_idx,
                     batch_size=batch_size, shuffle=False,
                     num_workers=args.num_workers,
-                    filter_per_worker=args.filter_per_worker)
+                    filter_per_worker=args.filter_per_worker, )
                 cpu_affinity = subgraph_loader.enable_cpu_affinity(
                     args.loader_cores) if args.cpu_affinity else nullcontext()
                 runtimes = []

--- a/benchmark/training/training_benchmark.py
+++ b/benchmark/training/training_benchmark.py
@@ -162,15 +162,27 @@ def run(args: argparse.ArgumentParser):
                         'num_workers': args.num_workers,
                     }
                     subgraph_loader = NeighborLoader(
-                        data, input_nodes=mask, sampler=sampler,
-                        filter_per_worker=args.filter_per_worker, **kwargs, )
+                        data,
+                        input_nodes=mask,
+                        sampler=sampler,
+                        filter_per_worker=args.filter_per_worker,
+                        **kwargs,
+                    )
                     if args.evaluate:
                         val_loader = NeighborLoader(
-                            data, input_nodes=val_mask, sampler=None,
-                            filter_per_worker=args.filter_per_worker, **kwargs,)
+                            data,
+                            input_nodes=val_mask,
+                            sampler=None,
+                            filter_per_worker=args.filter_per_worker,
+                            **kwargs,
+                        )
                         test_loader = NeighborLoader(
-                            data, input_nodes=test_mask, sampler=None,
-                            filter_per_worker=args.filter_per_worker, **kwargs,)
+                            data,
+                            input_nodes=test_mask,
+                            sampler=None,
+                            filter_per_worker=args.filter_per_worker,
+                            **kwargs,
+                        )
                     for hidden_channels in args.num_hidden_channels:
                         print('----------------------------------------------')
                         print(f'Batch size={batch_size}, '

--- a/benchmark/training/training_benchmark.py
+++ b/benchmark/training/training_benchmark.py
@@ -167,10 +167,10 @@ def run(args: argparse.ArgumentParser):
                     if args.evaluate:
                         val_loader = NeighborLoader(
                             data, input_nodes=val_mask, sampler=None,
-                            filter_per_worker=args.filter_per_worker, **kwargs)
+                            filter_per_worker=args.filter_per_worker, **kwargs,)
                         test_loader = NeighborLoader(
                             data, input_nodes=test_mask, sampler=None,
-                            filter_per_worker=args.filter_per_worker, **kwargs)
+                            filter_per_worker=args.filter_per_worker, **kwargs,)
                     for hidden_channels in args.num_hidden_channels:
                         print('----------------------------------------------')
                         print(f'Batch size={batch_size}, '

--- a/benchmark/training/training_benchmark.py
+++ b/benchmark/training/training_benchmark.py
@@ -163,7 +163,7 @@ def run(args: argparse.ArgumentParser):
                     }
                     subgraph_loader = NeighborLoader(
                         data, input_nodes=mask, sampler=sampler,
-                        filter_per_worker=args.filter_per_worker, **kwargs)
+                        filter_per_worker=args.filter_per_worker, **kwargs, )
                     if args.evaluate:
                         val_loader = NeighborLoader(
                             data, input_nodes=val_mask, sampler=None,

--- a/benchmark/training/training_benchmark.py
+++ b/benchmark/training/training_benchmark.py
@@ -162,13 +162,19 @@ def run(args: argparse.ArgumentParser):
                         'num_workers': args.num_workers,
                     }
                     subgraph_loader = NeighborLoader(data, input_nodes=mask,
-                                                     sampler=sampler, **kwargs)
+                                                     sampler=sampler, 
+                                                     filter_per_worker=args.filter_per_worker,
+                                                     **kwargs)
                     if args.evaluate:
                         val_loader = NeighborLoader(data, input_nodes=val_mask,
-                                                    sampler=None, **kwargs)
+                                                    sampler=None, 
+                                                    filter_per_worker=args.filter_per_worker,
+                                                    **kwargs)
                         test_loader = NeighborLoader(data,
                                                      input_nodes=test_mask,
-                                                     sampler=None, **kwargs)
+                                                     sampler=None,
+                                                     filter_per_worker=args.filter_per_worker,
+                                                     **kwargs)
                     for hidden_channels in args.num_hidden_channels:
                         print('----------------------------------------------')
                         print(f'Batch size={batch_size}, '
@@ -301,6 +307,8 @@ if __name__ == '__main__':
         help="Use DataLoader affinitzation.")
     add('--loader-cores', nargs='+', default=[], type=int,
         help="List of CPU core IDs to use for DataLoader workers.")
+    add('--filter-per-worker', action='store_true', 
+        help='Enable filter-per-worker feature of the dataloader.')
     add('--measure-load-time', action='store_true')
     add('--evaluate', action='store_true')
     add('--write-csv', action='store_true', help='Write benchmark data to csv')

--- a/benchmark/training/training_benchmark.py
+++ b/benchmark/training/training_benchmark.py
@@ -161,20 +161,16 @@ def run(args: argparse.ArgumentParser):
                         'shuffle': shuffle,
                         'num_workers': args.num_workers,
                     }
-                    subgraph_loader = NeighborLoader(data, input_nodes=mask,
-                                                     sampler=sampler, 
-                                                     filter_per_worker=args.filter_per_worker,
-                                                     **kwargs)
+                    subgraph_loader = NeighborLoader(
+                        data, input_nodes=mask, sampler=sampler,
+                        filter_per_worker=args.filter_per_worker, **kwargs)
                     if args.evaluate:
-                        val_loader = NeighborLoader(data, input_nodes=val_mask,
-                                                    sampler=None, 
-                                                    filter_per_worker=args.filter_per_worker,
-                                                    **kwargs)
-                        test_loader = NeighborLoader(data,
-                                                     input_nodes=test_mask,
-                                                     sampler=None,
-                                                     filter_per_worker=args.filter_per_worker,
-                                                     **kwargs)
+                        val_loader = NeighborLoader(
+                            data, input_nodes=val_mask, sampler=None,
+                            filter_per_worker=args.filter_per_worker, **kwargs)
+                        test_loader = NeighborLoader(
+                            data, input_nodes=test_mask, sampler=None,
+                            filter_per_worker=args.filter_per_worker, **kwargs)
                     for hidden_channels in args.num_hidden_channels:
                         print('----------------------------------------------')
                         print(f'Batch size={batch_size}, '
@@ -307,7 +303,7 @@ if __name__ == '__main__':
         help="Use DataLoader affinitzation.")
     add('--loader-cores', nargs='+', default=[], type=int,
         help="List of CPU core IDs to use for DataLoader workers.")
-    add('--filter-per-worker', action='store_true', 
+    add('--filter-per-worker', action='store_true',
         help='Enable filter-per-worker feature of the dataloader.')
     add('--measure-load-time', action='store_true')
     add('--evaluate', action='store_true')


### PR DESCRIPTION
This feature is useful when running multi-process Dataloader. When 'filter_fn' isn't delegated to workers' sub-processes, the main process gets quickly overcrowded and delays execution, waiting for data batches to be pre-processed. The workloads scale better with increasing number of workers with this DL flag enabled.