### PR TITLE
Fix typo in `AddRandomWalkPE` documentation

### DIFF
--- a/torch_geometric/transforms/add_positional_encoding.py
+++ b/torch_geometric/transforms/add_positional_encoding.py
@@ -105,7 +105,7 @@ class AddRandomWalkPE(BaseTransform):
         attr_name (str, optional): The attribute name of the data object to add
             positional encodings to. If set to :obj:`None`, will be
             concatenated to :obj:`data.x`.
-            (default: :obj:`"laplacian_eigenvector_pe"`)
+            (default: :obj:`"random_walk_pe"`)
     """
     def __init__(
         self,

--- a/torch_geometric/transforms/add_positional_encoding.py
+++ b/torch_geometric/transforms/add_positional_encoding.py
@@ -122,7 +122,7 @@ class AddRandomWalkPE(BaseTransform):
         adj = SparseTensor.from_edge_index(edge_index, edge_weight,
                                            sparse_sizes=(num_nodes, num_nodes))
 
-        # Compute D^{-1} A:
+        # Compute A D^{-1} :
         deg_inv = 1.0 / adj.sum(dim=1)
         deg_inv[deg_inv == float('inf')] = 0
         adj = adj * deg_inv.view(-1, 1)

--- a/torch_geometric/transforms/add_positional_encoding.py
+++ b/torch_geometric/transforms/add_positional_encoding.py
@@ -122,7 +122,7 @@ class AddRandomWalkPE(BaseTransform):
         adj = SparseTensor.from_edge_index(edge_index, edge_weight,
                                            sparse_sizes=(num_nodes, num_nodes))
 
-        # Compute A D^{-1} :
+        # Compute D^{-1} A:
         deg_inv = 1.0 / adj.sum(dim=1)
         deg_inv[deg_inv == float('inf')] = 0
         adj = adj * deg_inv.view(-1, 1)


### PR DESCRIPTION
This PR fix the documentation of `AddRandomWalkPE` where it was written that the default attribute was `"laplacian_eigenvector_pe"` which is the one of `AddLaplacianEigenvectorPE`.