### PR TITLE
Refactor `EdgeUpdater`

### DIFF
--- a/test/nn/conv/test_message_passing.py
+++ b/test/nn/conv/test_message_passing.py
@@ -261,15 +261,12 @@ class MyEdgeConv(MessagePassing):
         super().__init__(aggr='add')
 
     def forward(self, x: Tensor, edge_index: Adj) -> Tensor:
-        # edge_updater_type: (x: Tensor)
-        edge_attr = self.edge_updater(edge_index, x=x)
-
         # propagate_type: (edge_attr: Tensor)
-        return self.propagate(edge_index, edge_attr=edge_attr,
+        return self.propagate(edge_index, x=x,
                               size=(x.size(0), x.size(0)))
 
-    def edge_update(self, x_j: Tensor, x_i: Tensor) -> Tensor:
-        return x_j - x_i
+    def edge_update(self, x_j: Tensor, x_i: Tensor) -> dict:
+        return {'edge_attr': x_j - x_i}
 
     def message(self, edge_attr: Tensor) -> Tensor:
         return edge_attr

--- a/test/nn/edge_updater/test_basics.py
+++ b/test/nn/edge_updater/test_basics.py
@@ -1,0 +1,65 @@
+import torch
+
+from torch_geometric.nn.conv.gcn_conv import gcn_norm
+from torch_geometric.nn.edge_updater import (
+    Compose, GCNNorm, AddRemainingSelfLoops
+)
+
+
+def test_gcn_norm():
+    torch.manual_seed(2)
+    edge_index = torch.tensor([[0, 0, 0, 1, 2, 3], [1, 2, 3, 0, 0, 0]])
+    row, col = edge_index
+    value = torch.rand(row.size(0))
+
+    updater = GCNNorm()
+    assert str(updater) == 'GCNNorm()'
+    out1 = updater(edge_index[1], edge_index[0], value,
+                   dim_size=4)['edge_weight']
+    out2 = gcn_norm(edge_index, value, 4,
+                    improved=False, add_self_loops=False)[1]
+    assert out1.size() == out2.size()
+    assert torch.allclose(out1, out2, atol=1e-6)
+
+    updater = Compose((
+        AddRemainingSelfLoops(),
+        GCNNorm()
+    ))
+    assert str(updater) == 'Compose([' \
+                           'AddRemainingSelfLoops(), ' \
+                           'GCNNorm()' \
+                           '])'
+    out1 = updater(
+        edge_index_i=edge_index[1],
+        edge_index_j=edge_index[0],
+        edge_weight=value,
+        edge_attr=None, edge_type=None,
+        num_nodes=4, dim_size=4
+    )['edge_weight']
+    out2 = gcn_norm(edge_index, value, 4,
+                    improved=False, add_self_loops=True)[1]
+    assert out1.size() == out2.size()
+    assert torch.allclose(out1, out2, atol=1e-6)
+
+    updater = Compose((
+        AddRemainingSelfLoops(2),
+        GCNNorm()
+    ))
+    assert str(updater) == 'Compose([' \
+                           'AddRemainingSelfLoops(), ' \
+                           'GCNNorm()' \
+                           '])'
+    out1 = updater(
+        edge_index_i=edge_index[1],
+        edge_index_j=edge_index[0],
+        edge_weight=value,
+        edge_attr=None, edge_type=None,
+        num_nodes=4, dim_size=4
+    )['edge_weight']
+    out2 = gcn_norm(edge_index, value, 4,
+                    improved=True, add_self_loops=True)[1]
+    assert out1.size() == out2.size()
+    assert torch.allclose(out1, out2, atol=1e-6)
+
+
+# TODO test fill

--- a/torch_geometric/nn/conv/cluster_gcn_conv.py
+++ b/torch_geometric/nn/conv/cluster_gcn_conv.py
@@ -90,6 +90,7 @@ class ClusterGCNConv(MessagePassing):
             if is_sparse_tensor:
                 edge_index = to_torch_coo_tensor(edge_index.flip(0),
                                                  edge_weight, size=num_nodes)
+                edge_weight = None
 
         elif isinstance(edge_index, SparseTensor):
             if self.add_self_loops:
@@ -101,6 +102,7 @@ class ClusterGCNConv(MessagePassing):
             edge_weight = deg_inv[col]
             edge_weight[row == col] += self.diag_lambda * deg_inv
             edge_index = edge_index.set_value(edge_weight, layout='coo')
+            edge_weight = None
 
         # propagate_type: (x: Tensor, edge_weight: OptTensor)
         out = self.propagate(edge_index, x=x, edge_weight=edge_weight,

--- a/torch_geometric/nn/conv/message_passing.py
+++ b/torch_geometric/nn/conv/message_passing.py
@@ -301,7 +301,7 @@ class MessagePassing(torch.nn.Module):
 
             edge_index_i = get_and_sort('edge_index_i', indices[0])
             edge_index_j = get_and_sort('edge_index_j', indices[1])
-            perm = torch.argsort(edge_index_i * size[1] + edge_index_j)
+            perm = torch.argsort(edge_index_i * size[0] + edge_index_j)
 
             out['edge_index_i'] = edge_index_i[perm]
             out['edge_index_j'] = edge_index_j[perm]
@@ -311,7 +311,7 @@ class MessagePassing(torch.nn.Module):
                                             None if values.dim() == 1 else values,
                                             perm)
 
-            out['ptr'] = torch.ops.torch_sparse.ind2ptr(out['edge_index_i'], size[0])
+            out['ptr'] = torch.ops.torch_sparse.ind2ptr(out['edge_index_i'], size[1])
             out['edge_index'] = None
 
             # TODO add adj_t with edge_weight, edge_type or edge_attr, and making sure that,

--- a/torch_geometric/nn/conv/pdn_conv.py
+++ b/torch_geometric/nn/conv/pdn_conv.py
@@ -106,6 +106,7 @@ class PDNConv(MessagePassing):
                 edge_index = gcn_norm(edge_index, None, x.size(self.node_dim),
                                       False, self.add_self_loops, self.flow,
                                       x.dtype)
+                edge_attr = edge_index.storage.value()
 
         x = self.lin(x)
 

--- a/torch_geometric/nn/conv/utils/inspector.py
+++ b/torch_geometric/nn/conv/utils/inspector.py
@@ -14,6 +14,13 @@ class Inspector(object):
     def inspect(self, func: Callable,
                 pop_first: bool = False) -> Dict[str, Any]:
         params = inspect.signature(func).parameters
+        params = filter(
+            lambda x: x[1].kind not in [
+                inspect.Parameter.VAR_KEYWORD,
+                inspect.Parameter.VAR_POSITIONAL,
+            ],
+            params.items()
+        )
         params = OrderedDict(params)
         if pop_first:
             params.popitem(last=False)

--- a/torch_geometric/nn/edge_updater/__init__.py
+++ b/torch_geometric/nn/edge_updater/__init__.py
@@ -4,10 +4,12 @@ from .basics import (
     Cache,
     GCNNorm
 )
+from .compose import Compose
 
 __all__ = classes = [
     'EdgeUpdater',
     'Fill',
     'Cache',
     'GCNNorm',
+    'Compose',
 ]

--- a/torch_geometric/nn/edge_updater/__init__.py
+++ b/torch_geometric/nn/edge_updater/__init__.py
@@ -4,6 +4,10 @@ from .basics import (
     Cache,
     GCNNorm
 )
+from .loop import (
+    MaskEdges, RemoveSelfLoops, SegregateSelfLoops,
+    AddMaskedSelfLoops, AddSelfLoops, AddRemainingSelfLoops
+)
 from .compose import Compose
 
 __all__ = classes = [
@@ -12,4 +16,10 @@ __all__ = classes = [
     'Cache',
     'GCNNorm',
     'Compose',
+    'MaskEdges',
+    'RemoveSelfLoops',
+    'SegregateSelfLoops',
+    'AddMaskedSelfLoops',
+    'AddSelfLoops',
+    'AddRemainingSelfLoops'
 ]

--- a/torch_geometric/nn/edge_updater/__init__.py
+++ b/torch_geometric/nn/edge_updater/__init__.py
@@ -1,0 +1,13 @@
+from .base import EdgeUpdater
+from .basics import (
+    Fill,
+    Cache,
+    GCNNorm
+)
+
+__all__ = classes = [
+    'EdgeUpdater',
+    'Fill',
+    'Cache',
+    'GCNNorm',
+]

--- a/torch_geometric/nn/edge_updater/base.py
+++ b/torch_geometric/nn/edge_updater/base.py
@@ -22,7 +22,7 @@ class EdgeUpdater(torch.nn.Module):
         """
         raise NotImplementedError
 
-    def reset_parameters(self):
+    def reset_parameters(self) -> None:
         r"""Resets all learnable parameters of the module."""
         pass
 

--- a/torch_geometric/nn/edge_updater/base.py
+++ b/torch_geometric/nn/edge_updater/base.py
@@ -1,0 +1,31 @@
+from typing import Dict
+
+import torch
+
+
+class EdgeUpdater(torch.nn.Module):
+    r"""An abstract base class for implementing custom edge update operators.
+    TODO
+    """
+    def __init__(self):
+        super().__init__()
+
+    def forward(self, *args, **kwargs) -> Dict:
+        r"""
+        Args: TODO
+            index (torch.Tensor or SparseTensor): The indices of the edges on the graph.
+            weight (torch.Tensor, optional): The weight values associated with each of the
+                edges in :obj:`index`. If missing, then it is filled with ones.
+            attr (torch.Tensor, optional): The attributes associated with each of the
+                edges in :obj:`index`, unless :obj:`index` is a
+                :class:`torch_sparse.SparseTensor`, in which case it should not be used.
+        """
+        raise NotImplementedError
+
+    def reset_parameters(self):
+        r"""Resets all learnable parameters of the module."""
+        pass
+
+    def __repr__(self) -> str:
+        return f'{self.__class__.__name__}()'
+

--- a/torch_geometric/nn/edge_updater/basics.py
+++ b/torch_geometric/nn/edge_updater/basics.py
@@ -52,10 +52,7 @@ class Cache(EdgeUpdater):
 class GCNNorm(EdgeUpdater):
     r"""TODO
     """
-    def __init__(self):
-        super().__init__()
-
-    def forward(self, edge_index_i: LongTensor, edge_index_j: LongTensor,
+    def forward(self, edge_index_i: LongTensor, edge_index_j: LongTensor,  # TODO I might have mixed _i and _j
                 edge_weight: Tensor, dim_size: int) -> Dict:
         deg = scatter(edge_weight, edge_index_i, dim=0, dim_size=dim_size, reduce='sum')
         deg_inv_sqrt = deg.pow_(-0.5)

--- a/torch_geometric/nn/edge_updater/basics.py
+++ b/torch_geometric/nn/edge_updater/basics.py
@@ -1,0 +1,83 @@
+import inspect
+from typing import Dict, Union
+
+import torch
+from torch import LongTensor, Tensor
+
+from torch_geometric.nn.edge_updater import EdgeUpdater
+from torch_geometric.utils import scatter
+
+
+def copy_signature(frm, to):
+    def wrapper(*args, **kwargs):
+        return to(*args, **kwargs)
+    wrapper.__signature__ = inspect.signature(frm)
+    return wrapper
+
+
+class Fill(EdgeUpdater):
+    def __init__(self, value: Union[float, int]):
+        super().__init__()
+        self.value = value
+
+    def forward(self, edge_weight) -> Dict:
+        print('called')
+        return {
+            'edge_weight': torch.fill(edge_weight, self.value)
+        }
+
+
+class Cache(EdgeUpdater):
+    def __init__(self, edge_updater: EdgeUpdater):
+        super().__init__()
+        self.edge_updater = edge_updater
+        self._cached = None
+
+    def reset_parameters(self):
+        self.edge_updater.reset_parameters()
+        self._cached = None
+
+    def forward(self, *args, **kwargs) -> Dict:
+        if self._cached is None:
+            self._cached = self.edge_updater(*args, **kwargs)
+
+        return self._cached
+
+    def __getattribute__(self, item):
+        value = object.__getattribute__(self, item)
+        if item == 'forward':
+            value = copy_signature(frm=self.edge_updater.forward, to=value)
+        return value
+
+
+class GCNNorm(EdgeUpdater):
+    r"""TODO
+    """
+    def __init__(self):
+        super().__init__()
+
+    def forward(self, edge_index_i: LongTensor, edge_index_j: LongTensor,
+                edge_weight: Tensor, dim_size: int) -> Dict:
+        deg = scatter(edge_weight, edge_index_i, dim=0, dim_size=dim_size, reduce='sum')
+        deg_inv_sqrt = deg.pow_(-0.5)
+        deg_inv_sqrt.masked_fill_(deg_inv_sqrt == float('inf'), 0)
+        edge_weight = deg_inv_sqrt[edge_index_i] * edge_weight * deg_inv_sqrt[edge_index_j]
+
+        return {
+            'edge_weight': edge_weight
+        }
+
+
+if __name__ == '__main__':
+    # TODO REMOVE
+    edge_weight = torch.randn(5)
+    print(edge_weight)
+
+    updater = Cache(Fill(2.))
+    x = updater(edge_weight)
+    print(x)
+    x['edge_weight'][0] = 3
+    print(updater(edge_weight))
+
+    print(inspect.signature(updater.forward))
+

--- a/torch_geometric/nn/edge_updater/basics.py
+++ b/torch_geometric/nn/edge_updater/basics.py
@@ -21,7 +21,6 @@ class Fill(EdgeUpdater):
         self.value = value
 
     def forward(self, edge_weight) -> Dict:
-        print('called')
         return {
             'edge_weight': torch.fill(edge_weight, self.value)
         }
@@ -33,7 +32,7 @@ class Cache(EdgeUpdater):
         self.edge_updater = edge_updater
         self._cached = None
 
-    def reset_parameters(self):
+    def reset_parameters(self) -> None:
         self.edge_updater.reset_parameters()
         self._cached = None
 

--- a/torch_geometric/nn/edge_updater/compose.py
+++ b/torch_geometric/nn/edge_updater/compose.py
@@ -1,4 +1,4 @@
-from inspect import Signature
+from inspect import Parameter, Signature
 from typing import Iterable, Dict
 
 import torch
@@ -15,7 +15,8 @@ def merge_signatures(srcs):
         assert signature.return_annotation in [dict, Dict]
         parameters.update(signature.parameters)
 
-    return Signature(list(parameters.values()), return_annotation=Dict)
+    parameters = sorted(parameters.values(), key=lambda x: x.default != Parameter.empty)
+    return Signature(parameters, return_annotation=Dict)
 
 
 def copy_signature(signature, to):

--- a/torch_geometric/nn/edge_updater/compose.py
+++ b/torch_geometric/nn/edge_updater/compose.py
@@ -1,0 +1,79 @@
+from inspect import Signature
+from typing import Iterable, Dict
+
+import torch
+
+from torch_geometric.nn.conv.utils.inspector import Inspector
+from torch_geometric.nn.edge_updater import EdgeUpdater
+
+
+def merge_signatures(srcs):
+    parameters = {}
+    for src in srcs:
+        signature = Signature.from_callable(src, follow_wrapped=True)
+
+        assert signature.return_annotation in [dict, Dict]
+        parameters.update(signature.parameters)
+
+    return Signature(list(parameters.values()), return_annotation=Dict)
+
+
+def copy_signature(signature, to):
+    def wrapper(*args, **kwargs):
+        return to(*args, **kwargs)
+    wrapper.__signature__ = signature
+    return wrapper
+
+
+class Compose(EdgeUpdater):
+    r"""TODO
+    """
+
+    def __init__(self, updaters: Iterable[EdgeUpdater]):
+        r"""TODO
+        """
+        super().__init__()
+
+        self.updaters = torch.nn.ModuleList(updaters)
+        self.inspectors = [Inspector(u) for u in self.updaters]
+        for module, inspector in zip(self.updaters, self.inspectors):
+            inspector.inspect(module.forward)
+
+        self._signature = merge_signatures(
+            [u.forward for u in self.updaters]
+        )
+
+    def reset_parameters(self) -> None:
+        for module in self.updaters:
+            module.reset_parameters()
+
+    def forward(self, **kwargs) -> Dict:
+        output = {}
+
+        for updater, inspector in zip(self.updaters, self.inspectors):
+            updater_kwargs = inspector.distribute('forward', kwargs)
+            updater_ouptut = updater(**updater_kwargs)
+            output.update(updater_ouptut)
+
+        return output
+
+    def __getattribute__(self, item):
+        value = object.__getattribute__(self, item)
+        if item == 'forward':
+            value = copy_signature(signature=self._signature, to=value)
+        return value
+
+
+if __name__ == '__main__':  # TODO REMOVE
+    from torch_geometric.nn.edge_updater import Fill, GCNNorm
+    import inspect
+
+    edge_weight = torch.randn(5)
+    print(edge_weight)
+    updater = Compose([
+        Fill(2.), Fill(3), GCNNorm()
+    ])
+    print(inspect.signature(updater.forward))
+
+    # x = updater(edge_weight=edge_weight)
+    # print(x)

--- a/torch_geometric/nn/edge_updater/compose.py
+++ b/torch_geometric/nn/edge_updater/compose.py
@@ -65,6 +65,10 @@ class Compose(EdgeUpdater):
             value = copy_signature(signature=self._signature, to=value)
         return value
 
+    def __repr__(self):
+        upd_names = ', '.join([x.__repr__() for x in self.updaters])
+        return f'{self.__class__.__name__}([{upd_names}])'
+
 
 if __name__ == '__main__':  # TODO REMOVE
     from torch_geometric.nn.edge_updater import Fill, GCNNorm

--- a/torch_geometric/nn/edge_updater/compose.py
+++ b/torch_geometric/nn/edge_updater/compose.py
@@ -55,6 +55,7 @@ class Compose(EdgeUpdater):
             updater_kwargs = inspector.distribute('forward', kwargs)
             updater_ouptut = updater(**updater_kwargs)
             output.update(updater_ouptut)
+            kwargs.update(updater_ouptut)
 
         return output
 

--- a/torch_geometric/nn/edge_updater/loop.py
+++ b/torch_geometric/nn/edge_updater/loop.py
@@ -1,0 +1,222 @@
+import inspect
+from typing import Optional, Union, Dict, Callable
+
+import torch
+from torch import Tensor, LongTensor, BoolTensor
+from torch_scatter import scatter
+
+from torch_geometric.nn.edge_updater import EdgeUpdater
+from torch_geometric.typing import OptTensor
+
+
+def generate_mask(
+        callback: Callable[..., BoolTensor],
+        edge_index_i: LongTensor,
+        edge_index_j: LongTensor,
+        edge_weight: Tensor,
+        edge_attr: OptTensor,
+        edge_type: Tensor,
+        **kwargs
+) -> BoolTensor:
+    kwargs['edge_index_i'] = edge_index_i
+    kwargs['edge_index_j'] = edge_index_j
+    kwargs['edge_weight'] = edge_weight
+    kwargs['edge_attr'] = edge_attr
+    kwargs['edge_type'] = edge_type
+
+    params = {}
+    for key, param in inspect.signature(callback).parameters.items():
+        data = kwargs.get(key, inspect.Parameter.empty)
+        if data is inspect.Parameter.empty:
+            if param.default is inspect.Parameter.empty:
+                raise TypeError(f'Required parameter {key} is empty.')
+            data = param.default
+        params[key] = data
+
+    return callback(**params)
+
+
+class MaskEdges(EdgeUpdater):
+    r"""TODO
+    """
+    def forward(self, callback: Callable[..., BoolTensor],
+                edge_index_i: LongTensor, edge_index_j: LongTensor,
+                edge_weight: Tensor, edge_attr: OptTensor,
+                edge_type: Tensor, **kwargs) -> Dict:
+        mask = generate_mask(callback, edge_index_i, edge_index_j,
+                             edge_weight, edge_attr, edge_type, **kwargs)
+        assert mask.size() == edge_index_i.size()
+
+        return {
+            'edge_index_i': edge_index_i[mask],
+            'edge_index_j': edge_index_j[mask],
+            'edge_weight': edge_weight[mask],
+            'edge_attr': None if edge_attr is None else edge_attr[mask],
+            'edge_type': edge_type[mask],
+        }
+
+
+class RemoveSelfLoops(EdgeUpdater):
+    def __init__(self):
+        super().__init__()
+        self._masker = MaskEdges()
+
+    def forward(self, edge_index_i: LongTensor, edge_index_j: LongTensor,
+                edge_weight: Tensor, edge_attr: OptTensor,
+                edge_type: Tensor) -> Dict:
+        def non_self_loops(
+                edge_index_i: LongTensor,
+                edge_index_j: LongTensor
+        ) -> BoolTensor:
+            return edge_index_i != edge_index_j
+
+        return self._masker.forward(
+            non_self_loops,
+            edge_index_i, edge_index_j, edge_weight,
+            edge_attr, edge_type
+        )
+
+
+class SegregateSelfLoops(EdgeUpdater):
+    def __init__(self):
+        super().__init__()
+        self._masker = MaskEdges()
+
+    def forward(self, edge_index_i: LongTensor, edge_index_j: LongTensor,
+                edge_weight: Tensor, edge_attr: OptTensor,
+                edge_type: Tensor) -> Dict:
+        def self_loops(
+                edge_index_i: LongTensor,
+                edge_index_j: LongTensor
+        ) -> BoolTensor:
+            return edge_index_i == edge_index_j
+
+        return self._masker.forward(
+            self_loops,
+            edge_index_i, edge_index_j, edge_weight,
+            edge_attr, edge_type
+        )
+
+
+class AddMaskedSelfLoops(EdgeUpdater):
+    r"""TODO"""
+    def __init__(self,
+                 fill_value: Optional[Union[float, Tensor, str]] = 1.0):
+        super().__init__()
+        self.fill_value = fill_value
+
+    def forward(self, callback: Callable[..., BoolTensor],
+                edge_index_i: LongTensor, edge_index_j: LongTensor,
+                edge_weight: Tensor, edge_attr: OptTensor,
+                edge_type: Tensor, num_nodes: int,
+                fill_value: Optional[Union[float, Tensor, str]] = None,
+                **kwargs) -> Dict:
+        mask = generate_mask(callback, edge_index_i, edge_index_j,
+                             edge_weight, edge_attr, edge_type, **kwargs)
+        assert mask.size() == edge_index_i.size()
+
+        if fill_value is None:
+            fill_value = self.fill_value
+
+        def fill_tensor(input_tensor, fill_value, num_nodes, mask):
+            if input_tensor is not None:
+                if isinstance(fill_value, (int, float)):
+                    loop_attr = input_tensor.new_full((num_nodes,) + input_tensor.size()[1:],
+                                                      fill_value)
+                elif isinstance(fill_value, Tensor):
+                    loop_attr = fill_value.to(input_tensor.device, input_tensor.dtype)
+                    if input_tensor.dim() != loop_attr.dim():
+                        loop_attr = loop_attr.unsqueeze(0)
+                    sizes = [num_nodes] + [1] * (loop_attr.dim() - 1)
+                    loop_attr = loop_attr.repeat(*sizes)
+
+                elif isinstance(fill_value, str):
+                    loop_attr = scatter(input_tensor, edge_index_i, dim=0, dim_size=num_nodes,
+                                        reduce=fill_value)
+                else:
+                    raise AttributeError("No valid 'fill_value' provided")
+
+                inv_mask = ~mask
+                loop_attr[edge_index_j[inv_mask]] = input_tensor[inv_mask]
+
+                input_tensor = torch.cat([input_tensor[mask], loop_attr], dim=0)
+
+            return input_tensor
+
+        loop_index = torch.arange(0, num_nodes, dtype=torch.long, device=edge_index_i.device)
+
+        return {
+            'edge_index_i': torch.cat([edge_index_i[mask], loop_index], dim=0),
+            'edge_index_j': torch.cat([edge_index_j[mask], loop_index], dim=0),
+            'edge_weight': fill_tensor(edge_weight, fill_value, num_nodes, mask),
+            'edge_attr': fill_tensor(edge_attr, fill_value, num_nodes, mask),
+            'edge_type': fill_tensor(edge_type, fill_value, num_nodes, mask),
+        }
+
+
+class AddSelfLoops(EdgeUpdater):
+    r"""TODO"""
+    def __init__(self,
+                 fill_value: Optional[Union[float, Tensor, str]] = 1.0):
+        super().__init__()
+        self._masker = AddMaskedSelfLoops(fill_value)
+
+    def forward(self, edge_index_i: LongTensor, edge_index_j: LongTensor,
+                edge_weight: Tensor, edge_attr: OptTensor, edge_type: Tensor,
+                num_nodes: int,
+                fill_value: Optional[Union[float, Tensor, str]] = None) -> Dict:
+        def non_self_loops(edge_index_i) -> BoolTensor:
+            return torch.ones_like(edge_index_i).bool()
+
+        return self._masker.forward(non_self_loops, edge_index_i, edge_index_j,
+                edge_weight, edge_attr, edge_type, num_nodes, fill_value)
+
+
+class AddRemainingSelfLoops(EdgeUpdater):
+    r"""TODO"""
+    def __init__(self,
+                 fill_value: Optional[Union[float, Tensor, str]] = 1.0):
+        super().__init__()
+        self._masker = AddMaskedSelfLoops(fill_value)
+
+    def forward(self, edge_index_i: LongTensor, edge_index_j: LongTensor,
+                edge_weight: Tensor, edge_attr: OptTensor, edge_type: Tensor,
+                num_nodes: int,
+                fill_value: Optional[Union[float, Tensor, str]] = None) -> Dict:
+        def non_self_loops(
+                edge_index_i: LongTensor,
+                edge_index_j: LongTensor
+        ) -> BoolTensor:
+            return edge_index_i != edge_index_j
+
+        return self._masker.forward(non_self_loops, edge_index_i, edge_index_j,
+                edge_weight, edge_attr, edge_type, num_nodes, fill_value)
+
+
+if __name__ == '__main__':  # TODO REMOVE
+    edge_index = torch.tensor([
+        [1, 1], [2, 1], [2, 2]
+    ]).t()
+    edge_index_i, edge_index_j = edge_index
+    # edge_weight = torch.arange(3)
+    edge_weight = torch.ones(3)
+    edge_attr = torch.arange(3)
+    edge_type = torch.arange(3)
+
+    print(edge_index)
+    print(edge_weight)
+
+    # updater = RemoveSelfLoops()
+    # updater = SegregateSelfLoops()
+    updater = AddSelfLoops(fill_value='sum')
+    updater = AddRemainingSelfLoops(fill_value=-1)
+    x = updater(
+        edge_index_i=edge_index_i,
+        edge_index_j=edge_index_j,
+        edge_weight=edge_weight,
+        edge_attr=edge_attr,
+        edge_type=edge_type,
+        num_nodes=3,
+    )
+    print(x)
+


### PR DESCRIPTION
## Intro

This is a PR implementing the changes described in #6871.

I am still working on the code, but I'd assumed I can just start already the pull request and keep working on the changes, so that we can discuss the changes as I work on them.  I am mostly new to contributing on GitHub, so I assume I can keep pushing on my fork and changes will appear here. If that's not the case, I'll close the PR and create a new one when the code is ready.

Since the idea is to add `edge_update` in the logic of `propagate`, I figured out that the most convenient interface would be to let any subclass of `EdgeUpdate` define which arguments they want (just like the `message` method), and return a dictionary with the updated objects that will update `kwargs` in `propagate`. 

So far this is working nicely and it has allowed me to greatly overcome issues I was having. For example:
- The existing code for `gcn_norm` needs to take `flow` as an argument, and my implementation declares `edge_index_i` and `edge_index_j` directly in the method signature. 
- Existing code (e.g. to add self loops) had to deal with all the cases of different types for `edge_index`. By relying on `__collect__` the code for `edge_update` only has to deal with normal tensors.

**This is work-in-progress, so don't pay too much attention to the code for now. There are parts that I have not yet adapted nor tested.**

## Interface summary

`EdgeUpdater` is as simple as possible:
```python
class EdgeUpdater(torch.nn.Module):
    def __init__(self):
        super().__init__()

    def forward(self, *args, **kwargs) -> Dict:
        raise NotImplementedError

    def reset_parameters(self) -> None:
        pass
```

and propagate now is of the form:
```python
def propagate(self, edge_index: Adj, size: Size = None, **kwargs):
    size = self.__check_input__(edge_index, size)

    ################ NEW CODE
    coll_dict = self.__collect__(self.__edge_user_args__, edge_index, size,
                                 kwargs)

    edge_kwargs = self.inspector.distribute('edge_update', coll_dict)
    out = self.edge_update(**edge_kwargs)

    size = out.pop('size', size)  # This I need to figure out yet
    kwargs.update(out)
    ################ UNTIL HERE

    coll_dict = self.__collect__(self.__user_args__, edge_index,
                                 size, kwargs)

    msg_kwargs = self.inspector.distribute('message', coll_dict)
    out = self.message(**msg_kwargs)

    aggr_kwargs = self.inspector.distribute('aggregate', coll_dict)
    out = self.aggregate(out, **aggr_kwargs)

    update_kwargs = self.inspector.distribute('update', coll_dict)
    out = self.update(out, **update_kwargs)

    return out
```

Now some modules are greatly simplified. For example:
```python
class GCNNorm(EdgeUpdater):
    def forward(self, edge_index_i: LongTensor, edge_index_j: LongTensor,  
                edge_weight: Tensor, dim_size: int) -> Dict:
        deg = scatter(edge_weight, edge_index_i, dim=0, dim_size=dim_size, reduce='sum')
        deg_inv_sqrt = deg.pow_(-0.5)
        deg_inv_sqrt.masked_fill_(deg_inv_sqrt == float('inf'), 0)
        edge_weight = deg_inv_sqrt[edge_index_i] * edge_weight * deg_inv_sqrt[edge_index_j]

        return {
            'edge_weight': edge_weight
        }
```

and the previous behaviour of `gcn_norm` with `improved=True` and `add_self_loops=True` with caching could be reproduced using:
```python
edge_updater = Cache(Compose([
    AddRemainingSelfLoops(fill_value=2 if improved else 1),
    GCNNorm(),
]))
```
## RoadMap

- [x] Implemented `EdgeUpdater`.
- [ ] Implemented  `EdgeUpdater` subclasses
    - [x] `Fill` to set a constant as weights.
    - [x] `Cache` to cache a matrix.
    - [x] `GCNNorm` to reproduce `gcn_norm`.
    - [x] "Loop" edge updaters: `RemoveSelfLoops`, `SegregateSelfLoops`, `AddSelfLoops`, `AddRemainingSelfLoops`.
    - [x]  `Compose` subclass.
    - [ ] Attention edge updaters.
- [x] Adapt `MessagePassing` to use `EdgeUpdater`.
- [ ] Add weights to the aggregation functions.
- [ ] Add unit tests.
- [ ] Document code.
- [ ] Adapt existing classes.

## Things to fix/deal with
- [ ] Tests regarding "jittable" for `MessagePassing` are broken.
- [ ] Figure out how to deal with the case where `message_and_aggregate` is used.

## Other changes

I will add here a list of other changes I do in case you want to discuss any in detail:
- I plan to pass `edge_index_i` and `edge_index_j` as arguments to `__collect__` after calling `edge_update`, so I needed to:
    - keep the special args from `__user__args__` and variables alike. 
     - unify the behaviour of `__collect__` in the message passing class, simplifying the logic of `__lift__`.
     - compute `num_nodes` in `__collect__` exactly like `maybe_num_nodes`, so that the `EdgeUpdate` instances can access this info for free.
- I have temporarily changed `GATConv` to stop using `edge_updater` to stop tests from crashing.