### PR TITLE
fix `to_csc` in cugraph models

### DIFF
--- a/torch_geometric/nn/conv/cugraph/base.py
+++ b/torch_geometric/nn/conv/cugraph/base.py
@@ -34,7 +34,7 @@ class CuGraphModule(torch.nn.Module):  # pragma: no cover
     @staticmethod
     def to_csc(
         edge_index: Tensor,
-        size: Optional[Tuple[int, int]] = None,
+        size: Tuple[int, int],
         edge_attr: Optional[Tensor] = None,
     ) -> Union[Tuple[Tensor, Tensor], Tuple[Tuple[Tensor, Tensor], Tensor]]:
         r"""Returns a CSC representation of an :obj:`edge_index` tensor to be
@@ -42,13 +42,13 @@ class CuGraphModule(torch.nn.Module):  # pragma: no cover
 
         Args:
             edge_index (torch.Tensor): The edge indices.
-            size ((int, int), optional). The shape of :obj:`edge_index` in each
-                dimension. (default: :obj:`None`)
+            size ((int, int)). The shape of :obj:`edge_index` in each
+                dimension.
             edge_attr (torch.Tensor, optional): The edge features.
                 (default: :obj:`None`)
         """
         row, col = edge_index
-        num_target_nodes = size[1] if size is not None else int(col.max() + 1)
+        num_target_nodes = size[1]
         col, perm = index_sort(col, max_value=num_target_nodes)
         row = row[perm]
 

--- a/torch_geometric/nn/conv/cugraph/gat_conv.py
+++ b/torch_geometric/nn/conv/cugraph/gat_conv.py
@@ -61,10 +61,12 @@ class CuGraphGATConv(CuGraphModule):  # pragma: no cover
     def forward(
         self,
         x: Tensor,
-        csc: Tuple[Tensor, Tensor],
+        csc: Tuple[Tensor, Tensor, int],
         max_num_neighbors: Optional[int] = None,
     ) -> Tensor:
-        graph = self.get_cugraph(x.size(0), csc, max_num_neighbors)
+        assert x.size(0) == csc[
+            -1], "Size mismatch between node feature tensor and CuGraph graph."
+        graph = self.get_cugraph(csc, max_num_neighbors)
 
         x = self.lin(x)
         out = GATConvAgg(x, self.att, graph, self.heads, 'LeakyReLU',

--- a/torch_geometric/nn/conv/cugraph/rgcn_conv.py
+++ b/torch_geometric/nn/conv/cugraph/rgcn_conv.py
@@ -6,7 +6,6 @@ from torch.nn import Parameter
 
 from torch_geometric.nn.conv.cugraph import CuGraphModule
 from torch_geometric.nn.inits import glorot, zeros
-from torch_geometric.typing import OptTensor
 
 try:
     from pylibcugraphops.torch.autograd import \
@@ -71,8 +70,8 @@ class CuGraphRGCNConv(CuGraphModule):  # pragma: no cover
 
     def forward(
         self,
-        x: OptTensor,
-        csc: Tuple[Tensor, Tensor],
+        x: Tensor,
+        csc: Tuple[Tensor, Tensor, int],
         edge_type: Tensor,
         max_num_neighbors: Optional[int] = None,
     ) -> Tensor:
@@ -91,11 +90,10 @@ class CuGraphRGCNConv(CuGraphModule):  # pragma: no cover
                 on-the-fly, leading to slightly worse performance.
                 (default: :obj:`None`)
         """
-        if x is None:
-            x = torch.eye(self.in_channels, device=edge_type.device)
-
-        graph = self.get_typed_cugraph(x.size(0), csc, edge_type,
-                                       self.num_relations, max_num_neighbors)
+        assert x.size(0) == csc[
+            -1], "Size mismatch between node feature tensor and CuGraph graph."
+        graph = self.get_typed_cugraph(csc, edge_type, self.num_relations,
+                                       max_num_neighbors)
 
         out = RGCNConvAgg(x, self.comp, graph, concat_own=self.root_weight,
                           norm_by_out_degree=bool(self.aggr == 'mean'))

--- a/torch_geometric/nn/conv/cugraph/sage_conv.py
+++ b/torch_geometric/nn/conv/cugraph/sage_conv.py
@@ -62,10 +62,12 @@ class CuGraphSAGEConv(CuGraphModule):  # pragma: no cover
     def forward(
         self,
         x: Tensor,
-        csc: Tuple[Tensor, Tensor],
+        csc: Tuple[Tensor, Tensor, int],
         max_num_neighbors: Optional[int] = None,
     ) -> Tensor:
-        graph = self.get_cugraph(x.size(0), csc, max_num_neighbors)
+        assert x.size(0) == csc[
+            -1], "Size mismatch between node feature tensor and CuGraph graph."
+        graph = self.get_cugraph(csc, max_num_neighbors)
 
         if self.project:
             x = self.pre_lin(x).relu()


### PR DESCRIPTION
This PR:
- fixes the bug in `to_csc()` when `size` is not given, since PyG uses the same subgraph over all layers.
- absorb `num_src_nodes` into the `csc` tuple to make `get_cugraph` more concise
- misc: no longer allow identity node feature tensor (by setting `x=None`) in RGCN. It is an oversight from me in the previous PR to not remove it, since this is memory-inefficient

CC: @MatthiasKohl, @puririshi98 