### PR TITLE
Fix `bfloat16` conversion in `HeteroData` benchmark scripts

### DIFF
--- a/benchmark/inference/inference_benchmark.py
+++ b/benchmark/inference/inference_benchmark.py
@@ -205,7 +205,7 @@ def run(args: argparse.ArgumentParser):
                                     if args.evaluate:
                                         test_acc = test(
                                             model, test_loader, device, hetero,
-                                            progress_bar=True)
+                                            progress_bar=True, )
                                         print(f'Mini Batch Test Accuracy: \
                                             {test_acc:.4f}')
 

--- a/benchmark/inference/inference_benchmark.py
+++ b/benchmark/inference/inference_benchmark.py
@@ -204,8 +204,12 @@ def run(args: argparse.ArgumentParser):
                                     )
                                     if args.evaluate:
                                         test_acc = test(
-                                            model, test_loader, device, hetero,
-                                            progress_bar=True, )
+                                            model,
+                                            test_loader,
+                                            device,
+                                            hetero,
+                                            progress_bar=True,
+                                        )
                                         print(f'Mini Batch Test Accuracy: \
                                             {test_acc:.4f}')
 

--- a/benchmark/inference/inference_benchmark.py
+++ b/benchmark/inference/inference_benchmark.py
@@ -11,6 +11,7 @@ from benchmark.utils import (
     get_split_masks,
     save_benchmark_data,
     write_to_csv,
+    test,
 )
 from torch_geometric.loader import NeighborLoader
 from torch_geometric.nn import PNAConv
@@ -31,13 +32,6 @@ def full_batch_inference(model, data):
     else:
         edge_index = data.edge_index
     return model(data.x, edge_index)
-
-
-def test(y, loader):
-    y_hat = y.argmax(dim=-1)
-    y = loader.data.y.to(y_hat.device)
-    mask = loader.data.test_mask
-    return int((y_hat[mask] == y[mask]).sum()) / int(mask.sum())
 
 
 def run(args: argparse.ArgumentParser):
@@ -209,11 +203,9 @@ def run(args: argparse.ArgumentParser):
                                         progress_bar=True,
                                     )
                                     if args.evaluate:
-                                        test_acc = model.test(
-                                            y,
-                                            test_loader,
-                                            device,
-                                            progress_bar=True,
+                                        test_acc = test(
+                                            model, test_loader, device,
+                                            hetero, progress_bar=True
                                         )
                                         print(f'Mini Batch Test Accuracy: \
                                             {test_acc:.4f}')

--- a/benchmark/inference/inference_benchmark.py
+++ b/benchmark/inference/inference_benchmark.py
@@ -10,8 +10,8 @@ from benchmark.utils import (
     get_model,
     get_split_masks,
     save_benchmark_data,
-    write_to_csv,
     test,
+    write_to_csv,
 )
 from torch_geometric.loader import NeighborLoader
 from torch_geometric.nn import PNAConv
@@ -204,9 +204,8 @@ def run(args: argparse.ArgumentParser):
                                     )
                                     if args.evaluate:
                                         test_acc = test(
-                                            model, test_loader, device,
-                                            hetero, progress_bar=True
-                                        )
+                                            model, test_loader, device, hetero,
+                                            progress_bar=True)
                                         print(f'Mini Batch Test Accuracy: \
                                             {test_acc:.4f}')
 

--- a/benchmark/training/training_benchmark.py
+++ b/benchmark/training/training_benchmark.py
@@ -14,8 +14,8 @@ from benchmark.utils import (
     get_model,
     get_split_masks,
     save_benchmark_data,
-    write_to_csv,
     test,
+    write_to_csv,
 )
 from torch_geometric.loader import NeighborLoader
 from torch_geometric.nn import PNAConv

--- a/benchmark/training/training_benchmark.py
+++ b/benchmark/training/training_benchmark.py
@@ -15,6 +15,7 @@ from benchmark.utils import (
     get_split_masks,
     save_benchmark_data,
     write_to_csv,
+    test,
 )
 from torch_geometric.loader import NeighborLoader
 from torch_geometric.nn import PNAConv
@@ -76,42 +77,6 @@ def train_hetero(model, loader, optimizer, device, progress_bar=True, desc="",
         loss = F.cross_entropy(out, target)
         loss.backward()
         optimizer.step()
-
-
-@torch.no_grad()
-def test(model, loader, device, hetero, progress_bar=True, desc="") -> None:
-    if progress_bar:
-        loader = tqdm(loader, desc=desc)
-    total_examples = total_correct = 0
-    if hetero:
-        for batch in loader:
-            batch = batch.to(device)
-            if len(batch.adj_t_dict) > 0:
-                edge_index_dict = batch.adj_t_dict
-            else:
-                edge_index_dict = batch.edge_index_dict
-            out = model(batch.x_dict, edge_index_dict)
-            batch_size = batch['paper'].batch_size
-            out = out['paper'][:batch_size]
-            pred = out.argmax(dim=-1)
-
-            total_examples += batch_size
-            total_correct += int((pred == batch['paper'].y[:batch_size]).sum())
-    else:
-        for batch in loader:
-            batch = batch.to(device)
-            if hasattr(batch, 'adj_t'):
-                edge_index = batch.adj_t
-            else:
-                edge_index = batch.edge_index
-            out = model(batch.x, edge_index)
-            batch_size = batch.batch_size
-            out = out[:batch_size]
-            pred = out.argmax(dim=-1)
-
-            total_examples += batch_size
-            total_correct += int((pred == batch.y[:batch_size]).sum())
-    return total_correct / total_examples
 
 
 def run(args: argparse.ArgumentParser):

--- a/benchmark/utils/__init__.py
+++ b/benchmark/utils/__init__.py
@@ -3,6 +3,7 @@ from .utils import get_dataset, get_dataset_with_transformation
 from .utils import get_model
 from .utils import get_split_masks
 from .utils import save_benchmark_data, write_to_csv
+from .utils import test
 
 __all__ = [
     'emit_itt',
@@ -12,4 +13,5 @@ __all__ = [
     'get_split_masks',
     'save_benchmark_data',
     'write_to_csv',
+    'test',
 ]

--- a/benchmark/utils/utils.py
+++ b/benchmark/utils/utils.py
@@ -13,6 +13,8 @@ from torch_geometric.utils import index_to_mask
 
 from .hetero_gat import HeteroGAT
 from .hetero_sage import HeteroGraphSAGE
+from torch_geometric.data import HeteroData
+from tqdm import tqdm
 
 try:
     from torch.autograd.profiler import emit_itt
@@ -70,7 +72,11 @@ def get_dataset_with_transformation(name, root, use_sparse_tensor=False,
         data.y = data.y.squeeze()
 
     if bf16:
-        data.x = data.x.to(torch.bfloat16)
+        if isinstance(data, HeteroData):
+            for node_type in data.node_types:
+                data[node_type].x = data[node_type].x.to(torch.bfloat16)
+        else:
+            data.x = data.x.to(torch.bfloat16)
 
     return data, dataset.num_classes, transform
 
@@ -145,3 +151,39 @@ def write_to_csv(csv_data, training=False):
     with_header = not osp.exists(csv_path)
     df = pd.DataFrame(csv_data)
     df.to_csv(csv_path, mode='a', index_label='TEST_ID', header=with_header)
+
+
+@torch.no_grad()
+def test(model, loader, device, hetero, progress_bar=True, desc="Evaluation") -> None:
+    if progress_bar:
+        loader = tqdm(loader, desc=desc)
+    total_examples = total_correct = 0
+    if hetero:
+        for batch in loader:
+            batch = batch.to(device)
+            if len(batch.adj_t_dict) > 0:
+                edge_index_dict = batch.adj_t_dict
+            else:
+                edge_index_dict = batch.edge_index_dict
+            out = model(batch.x_dict, edge_index_dict)
+            batch_size = batch['paper'].batch_size
+            out = out['paper'][:batch_size]
+            pred = out.argmax(dim=-1)
+
+            total_examples += batch_size
+            total_correct += int((pred == batch['paper'].y[:batch_size]).sum())
+    else:
+        for batch in loader:
+            batch = batch.to(device)
+            if hasattr(batch, 'adj_t'):
+                edge_index = batch.adj_t
+            else:
+                edge_index = batch.edge_index
+            out = model(batch.x, edge_index)
+            batch_size = batch.batch_size
+            out = out[:batch_size]
+            pred = out.argmax(dim=-1)
+
+            total_examples += batch_size
+            total_correct += int((pred == batch.y[:batch_size]).sum())
+    return total_correct / total_examples

--- a/benchmark/utils/utils.py
+++ b/benchmark/utils/utils.py
@@ -5,16 +5,16 @@ from datetime import datetime
 import pandas as pd
 import torch
 from ogb.nodeproppred import PygNodePropPredDataset
+from tqdm import tqdm
 
 import torch_geometric.transforms as T
+from torch_geometric.data import HeteroData
 from torch_geometric.datasets import OGB_MAG, Reddit
 from torch_geometric.nn import GAT, GCN, PNA, EdgeCNN, GraphSAGE
 from torch_geometric.utils import index_to_mask
 
 from .hetero_gat import HeteroGAT
 from .hetero_sage import HeteroGraphSAGE
-from torch_geometric.data import HeteroData
-from tqdm import tqdm
 
 try:
     from torch.autograd.profiler import emit_itt
@@ -154,7 +154,8 @@ def write_to_csv(csv_data, training=False):
 
 
 @torch.no_grad()
-def test(model, loader, device, hetero, progress_bar=True, desc="Evaluation") -> None:
+def test(model, loader, device, hetero, progress_bar=True,
+         desc="Evaluation") -> None:
     if progress_bar:
         loader = tqdm(loader, desc=desc)
     total_examples = total_correct = 0


### PR DESCRIPTION
This PR is to fix the issues:

1. Re-use `test` function in training benchmark to avoid mismatch between `Data` and `HeteroData` in evaluation mode.
2. `HeteroData` to convert to `bfloat16` datatype in inference and training benchmarks.