### PR TITLE
Fix `FastHGTConv` to correctly call the value module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
-- Accelerated sparse tensor conversion routiens ([#7042](https://github.com/pyg-team/pytorch_geometric/pull/7042), [#7043](https://github.com/pyg-team/pytorch_geometric/pull/7043))
+- Fixed a bug in `FastHGTConv` that computed values via parameters used to compute the keys ([#7050](https://github.com/pyg-team/pytorch_geometric/pull/7050))
+- Accelerated sparse tensor conversion routines ([#7042](https://github.com/pyg-team/pytorch_geometric/pull/7042), [#7043](https://github.com/pyg-team/pytorch_geometric/pull/7043))
 - Change `torch_sparse.SparseTensor` logic to utilize `torch.sparse_csr` instead ([#7041](https://github.com/pyg-team/pytorch_geometric/pull/7041))
 
 ### Removed

--- a/torch_geometric/nn/conv/fast_hgt_conv.py
+++ b/torch_geometric/nn/conv/fast_hgt_conv.py
@@ -127,7 +127,7 @@ class FastHGTConv(MessagePassing):
 
         type_vec = torch.cat(type_list, dim=0)
         k = self.k_rel(torch.cat(ks, dim=0), type_vec).view(-1, H, D)
-        v = self.k_rel(torch.cat(vs, dim=0), type_vec).view(-1, H, D)
+        v = self.v_rel(torch.cat(vs, dim=0), type_vec).view(-1, H, D)
 
         return k, v, offset
 


### PR DESCRIPTION
This fixes a small bug in the new `fast_hgt_conv` layer, which incorrectly called the module `self.k_rel` instead of `self.v_rel` to generate the value vectors `v`.