### PR TITLE
Fix handling of missing node types in heterogeneous data loaders

### DIFF
--- a/torch_geometric/loader/utils.py
+++ b/torch_geometric/loader/utils.py
@@ -130,13 +130,13 @@ def filter_hetero_data(
 ) -> HeteroData:
     # Filters a heterogeneous data object to only hold nodes in `node` and
     # edges in `edge` for each node and edge type, respectively:
-    out = copy.copy(data)
+    out = data.node_type_subgraph(node_dict.keys())
 
-    for node_type in data.node_types:
+    for node_type in out.node_types:
         filter_node_store_(data[node_type], out[node_type],
                            node_dict[node_type])
 
-    for edge_type in data.edge_types:
+    for edge_type in out.edge_types:
         filter_edge_store_(
             data[edge_type],
             out[edge_type],

--- a/torch_geometric/nn/conv/fast_hgt_conv.py
+++ b/torch_geometric/nn/conv/fast_hgt_conv.py
@@ -127,7 +127,7 @@ class FastHGTConv(MessagePassing):
 
         type_vec = torch.cat(type_list, dim=0)
         k = self.k_rel(torch.cat(ks, dim=0), type_vec).view(-1, H, D)
-        v = self.k_rel(torch.cat(vs, dim=0), type_vec).view(-1, H, D)
+        v = self.v_rel(torch.cat(vs, dim=0), type_vec).view(-1, H, D)
 
         return k, v, offset
 


### PR DESCRIPTION
This addresses a bug in heterogeneous data loaders, which crash if a node type from the complete graph is not present in the sampled batch of nodes. This is can easily happen if a graph is disconnected or some node types are simply rare.

An unsafe dictionary access in the `filter_hetero_data` raises an exception in this case. I solved this by calling `HeteroData.node_type_subgraph` on the graph before the batch of nodes is filtered. I added a test for `HGTLoader` which covers this case and did not pass previously.

Note that the behavior of the data loaders now differs slightly from `HeteroData.subgraph`, as the loader will handle missing keys by not including any node of that type in the batch, while the `subgraph` method would retain all of the nodes. However, it seems more convenient for data loading if batches only contain nodes that where actually returned by the underlying sampler.