### PR TITLE
Make edges in `HeterohilousGraphDataset` undirected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
+- Edges in `HeterophilousGraphDataset` are now undirected by default ([#7065](https://github.com/pyg-team/pytorch_geometric/pull/7065))
 - Fixed a bug in `FastHGTConv` that computed values via parameters used to compute the keys ([#7050](https://github.com/pyg-team/pytorch_geometric/pull/7050))
 - Accelerated sparse tensor conversion routines ([#7042](https://github.com/pyg-team/pytorch_geometric/pull/7042), [#7043](https://github.com/pyg-team/pytorch_geometric/pull/7043))
 - Change `torch_sparse.SparseTensor` logic to utilize `torch.sparse_csr` instead ([#7041](https://github.com/pyg-team/pytorch_geometric/pull/7041))

--- a/torch_geometric/datasets/heterophilous_graph_dataset.py
+++ b/torch_geometric/datasets/heterophilous_graph_dataset.py
@@ -5,6 +5,7 @@ import numpy as np
 import torch
 
 from torch_geometric.data import Data, InMemoryDataset, download_url
+from torch_geometric.transforms import ToUndirected
 
 
 class HeterophilousGraphDataset(InMemoryDataset):
@@ -117,6 +118,8 @@ class HeterophilousGraphDataset(InMemoryDataset):
 
         data = Data(x=x, y=y, edge_index=edge_index, train_mask=train_mask,
                     val_mask=val_mask, test_mask=test_mask)
+
+        data = ToUndirected()(data)
 
         if self.pre_transform is not None:
             data = self.pre_transform(data)

--- a/torch_geometric/datasets/heterophilous_graph_dataset.py
+++ b/torch_geometric/datasets/heterophilous_graph_dataset.py
@@ -112,14 +112,13 @@ class HeterophilousGraphDataset(InMemoryDataset):
         x = torch.from_numpy(raw['node_features'])
         y = torch.from_numpy(raw['node_labels'])
         edge_index = torch.from_numpy(raw['edges']).t().contiguous()
+        edge_index = to_undirected(edge_index, num_nodes=x.size(0))
         train_mask = torch.from_numpy(raw['train_masks']).t().contiguous()
         val_mask = torch.from_numpy(raw['val_masks']).t().contiguous()
         test_mask = torch.from_numpy(raw['test_masks']).t().contiguous()
 
         data = Data(x=x, y=y, edge_index=edge_index, train_mask=train_mask,
                     val_mask=val_mask, test_mask=test_mask)
-
-        data.edge_index = to_undirected(data.edge_index)
 
         if self.pre_transform is not None:
             data = self.pre_transform(data)

--- a/torch_geometric/datasets/heterophilous_graph_dataset.py
+++ b/torch_geometric/datasets/heterophilous_graph_dataset.py
@@ -119,7 +119,7 @@ class HeterophilousGraphDataset(InMemoryDataset):
         data = Data(x=x, y=y, edge_index=edge_index, train_mask=train_mask,
                     val_mask=val_mask, test_mask=test_mask)
 
-        data = ToUndirected()(data)
+        data.edge_index = to_undirected(data.edge_index)
 
         if self.pre_transform is not None:
             data = self.pre_transform(data)

--- a/torch_geometric/datasets/heterophilous_graph_dataset.py
+++ b/torch_geometric/datasets/heterophilous_graph_dataset.py
@@ -5,7 +5,7 @@ import numpy as np
 import torch
 
 from torch_geometric.data import Data, InMemoryDataset, download_url
-from torch_geometric.transforms import ToUndirected
+from torch_geometric.utils import to_undirected
 
 
 class HeterophilousGraphDataset(InMemoryDataset):


### PR DESCRIPTION
Hi! The graphs [here](https://github.com/yandex-research/heterophilous-graphs) are meant to be undirected. Since PyG treats all graphs as directed, I've added a call to transforms.ToUndirected to double the edges.