### PR TITLE
Fix `data.num_edges` for `torch.sparse.Tensor`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
+- Added support for `Data.num_edges` for native `torch.sparse.Tensor` adjacency matrices ([#7104](https://github.com/pyg-team/pytorch_geometric/pull/7104))
 - Fixed crash of heterogeneous data loaders if node or edge types are missing ([#7060](https://github.com/pyg-team/pytorch_geometric/pull/7060), [#7087](https://github.com/pyg-team/pytorch_geometric/pull/7087))
 - Accelerated attention-based `MultiAggregation` ([#7077](https://github.com/pyg-team/pytorch_geometric/pull/7077))
 - Edges in `HeterophilousGraphDataset` are now undirected by default ([#7065](https://github.com/pyg-team/pytorch_geometric/pull/7065))

--- a/torch_geometric/data/storage.py
+++ b/torch_geometric/data/storage.py
@@ -418,6 +418,8 @@ class EdgeStorage(BaseStorage):
         for value in self.values('adj', 'adj_t'):
             if isinstance(value, SparseTensor):
                 return value.nnz()
+            elif isinstance(value, Tensor) and (value.is_sparse or value.is_sparse_csr):
+                return value._nnz()
         return 0
 
     @property

--- a/torch_geometric/data/storage.py
+++ b/torch_geometric/data/storage.py
@@ -418,7 +418,8 @@ class EdgeStorage(BaseStorage):
         for value in self.values('adj', 'adj_t'):
             if isinstance(value, SparseTensor):
                 return value.nnz()
-            elif isinstance(value, Tensor) and (value.is_sparse or value.is_sparse_csr):
+            elif isinstance(value, Tensor) and (value.is_sparse
+                                                or value.is_sparse_csr):
                 return value._nnz()
         return 0
 

--- a/torch_geometric/data/storage.py
+++ b/torch_geometric/data/storage.py
@@ -26,6 +26,7 @@ from torch_geometric.typing import EdgeType, NodeType, SparseTensor
 from torch_geometric.utils import (
     coalesce,
     contains_isolated_nodes,
+    is_torch_sparse_tensor,
     is_undirected,
 )
 
@@ -418,8 +419,7 @@ class EdgeStorage(BaseStorage):
         for value in self.values('adj', 'adj_t'):
             if isinstance(value, SparseTensor):
                 return value.nnz()
-            elif isinstance(value, Tensor) and (value.is_sparse
-                                                or value.is_sparse_csr):
+            elif is_torch_sparse_tensor(value):
                 return value._nnz()
         return 0
 


### PR DESCRIPTION
Fixes zero `num_edges` when using native PyTorch sparse tensor (#7103).