### PR TITLE
Optimize `from_networkx()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
+- Optimized `from_networkx` implementation for large graphs  by dropping unnecessary copies ([#7119](https://github.com/pyg-team/pytorch_geometric/pull/7119))
 - Added support for `Data.num_edges` for native `torch.sparse.Tensor` adjacency matrices ([#7104](https://github.com/pyg-team/pytorch_geometric/pull/7104))
 - Fixed crash of heterogeneous data loaders if node or edge types are missing ([#7060](https://github.com/pyg-team/pytorch_geometric/pull/7060), [#7087](https://github.com/pyg-team/pytorch_geometric/pull/7087))
 - Accelerated attention-based `MultiAggregation` ([#7077](https://github.com/pyg-team/pytorch_geometric/pull/7077))

--- a/torch_geometric/utils/convert.py
+++ b/torch_geometric/utils/convert.py
@@ -204,10 +204,13 @@ def from_networkx(
 
     G = nx.convert_node_labels_to_integers(G)
     G = G.to_directed() if not nx.is_directed(G) else G
-    edge_index = torch.empty(G.number_of_edges(), 2, dtype=torch.long)
-    for i, e in enumerate(G.edges):
-        edge_index[i, 0], edge_index[i, 1] = e
-    edge_index = edge_index.t().contiguous()
+    if isinstance(G, (nx.MultiGraph, nx.MultiDiGraph)):
+        edges = list(G.edges(keys=False))
+    else:
+        edges = list(G.edges)
+
+    edge_index = torch.tensor(edges, dtype=torch.long).t().contiguous()
+    del edges
 
     data = defaultdict(list)
 

--- a/torch_geometric/utils/convert.py
+++ b/torch_geometric/utils/convert.py
@@ -208,7 +208,7 @@ def from_networkx(
     for i, e in enumerate(G.edges):
         edge_index[i, 0], edge_index[i, 1] = e
     edge_index = edge_index.t().contiguous()
-    
+
     data = defaultdict(list)
 
     if G.number_of_nodes() > 0:

--- a/torch_geometric/utils/convert.py
+++ b/torch_geometric/utils/convert.py
@@ -204,7 +204,7 @@ def from_networkx(
 
     G = nx.convert_node_labels_to_integers(G)
     G = G.to_directed() if not nx.is_directed(G) else G
-    edge_index = torch.Tensor(G.number_of_edges(), 2)
+    edge_index = torch.empty(G.number_of_edges(), 2, dtype=torch.long)
     for i, e in enumerate(G.edges):
         edge_index[i, 0], edge_index[i, 1] = e
     edge_index = edge_index.t().contiguous()

--- a/torch_geometric/utils/convert.py
+++ b/torch_geometric/utils/convert.py
@@ -204,12 +204,11 @@ def from_networkx(
 
     G = G.to_directed() if not nx.is_directed(G) else G
 
-    edges = []
     mapping = dict(zip(G.nodes(), range(G.number_of_nodes())))
-    for src, dst in G.edges():
-        edges.append([mapping[src], mapping[dst]])
-    edge_index = torch.tensor(edges, dtype=torch.long).t().contiguous()
-    del edges
+    edge_index = torch.empty((2, G.number_of_edges()), dtype=torch.long)
+    for i, (src, dst) in enumerate(G.edges()):
+        edge_index[0, i] = mapping[src]
+        edge_index[1, i] = mapping[dst]
 
     data = defaultdict(list)
 

--- a/torch_geometric/utils/convert.py
+++ b/torch_geometric/utils/convert.py
@@ -204,14 +204,11 @@ def from_networkx(
 
     G = nx.convert_node_labels_to_integers(G)
     G = G.to_directed() if not nx.is_directed(G) else G
-
-    if isinstance(G, (nx.MultiGraph, nx.MultiDiGraph)):
-        edges = list(G.edges(keys=False))
-    else:
-        edges = list(G.edges)
-
-    edge_index = torch.tensor(edges, dtype=torch.long).t().contiguous()
-
+    edge_index = torch.Tensor(G.number_of_edges(), 2)
+    for i, e in enumerate(G.edges):
+        edge_index[i, 0], edge_index[i, 1] = e
+    edge_index = edge_index.t().contiguous()
+    
     data = defaultdict(list)
 
     if G.number_of_nodes() > 0:


### PR DESCRIPTION
Addresses issue #6964 by deleting unneeded copies by directly writing edges into a torch.Tensor rather than first converting to a list and then using torch.tensor() on top.