### PR TITLE
Fix for `from_networkx` re-calling the constructor of the `nx.Graph`

### DIFF
--- a/torch_geometric/utils/convert.py
+++ b/torch_geometric/utils/convert.py
@@ -1,3 +1,4 @@
+from copy import deepcopy
 from collections import defaultdict
 from typing import Any, Iterable, List, Optional, Tuple, Union
 
@@ -205,6 +206,7 @@ def from_networkx(
     # convert node labels to integers WITHOUT re-calling the constructor
     N = G.number_of_nodes()
     mapping = dict(zip(G.nodes(), range(N)))
+    G = deepcopy(G)
     G = nx.relabel.relabel_nodes(G, mapping, copy=False)
     G = G.to_directed() if not nx.is_directed(G) else G
 

--- a/torch_geometric/utils/convert.py
+++ b/torch_geometric/utils/convert.py
@@ -205,7 +205,7 @@ def from_networkx(
     # convert node labels to integers WITHOUT re-calling the constructor
     N = G.number_of_nodes() + first_label
     mapping = dict(zip(G.nodes(), range(first_label, N)))
-    G = nx.relabel.relabel_nodes(G, mapping)
+    G = nx.relabel.relabel_nodes(G, mapping, copy=False)
     G = G.to_directed() if not nx.is_directed(G) else G
 
     if isinstance(G, (nx.MultiGraph, nx.MultiDiGraph)):

--- a/torch_geometric/utils/convert.py
+++ b/torch_geometric/utils/convert.py
@@ -203,11 +203,9 @@ def from_networkx(
 
     from torch_geometric.data import Data
 
-    # convert node labels to integers WITHOUT re-calling the constructor
     N = G.number_of_nodes()
     mapping = dict(zip(G.nodes(), range(N)))
-    G = deepcopy(G)
-    G = nx.relabel.relabel_nodes(G, mapping, copy=False)
+    G = nx.relabel.relabel_nodes(G, mapping, copy=True)
     G = G.to_directed() if not nx.is_directed(G) else G
 
     if isinstance(G, (nx.MultiGraph, nx.MultiDiGraph)):

--- a/torch_geometric/utils/convert.py
+++ b/torch_geometric/utils/convert.py
@@ -1,5 +1,5 @@
-from copy import deepcopy
 from collections import defaultdict
+from copy import deepcopy
 from typing import Any, Iterable, List, Optional, Tuple, Union
 
 import scipy.sparse

--- a/torch_geometric/utils/convert.py
+++ b/torch_geometric/utils/convert.py
@@ -202,16 +202,12 @@ def from_networkx(
 
     from torch_geometric.data import Data
 
-    N = G.number_of_nodes()
-    mapping = dict(zip(G.nodes(), range(N)))
-    G = nx.relabel.relabel_nodes(G, mapping, copy=False)
     G = G.to_directed() if not nx.is_directed(G) else G
 
-    if isinstance(G, (nx.MultiGraph, nx.MultiDiGraph)):
-        edges = list(G.edges(keys=False))
-    else:
-        edges = list(G.edges)
-
+    edges = []
+    mapping = dict(zip(G.nodes(), range(G.number_of_nodes())))
+    for src, dst in G.edges():
+        edges.append([mapping[src], mapping[dst]])
     edge_index = torch.tensor(edges, dtype=torch.long).t().contiguous()
 
     data = defaultdict(list)

--- a/torch_geometric/utils/convert.py
+++ b/torch_geometric/utils/convert.py
@@ -1,5 +1,4 @@
 from collections import defaultdict
-from copy import deepcopy
 from typing import Any, Iterable, List, Optional, Tuple, Union
 
 import scipy.sparse
@@ -205,7 +204,7 @@ def from_networkx(
 
     N = G.number_of_nodes()
     mapping = dict(zip(G.nodes(), range(N)))
-    G = nx.relabel.relabel_nodes(G, mapping, copy=True)
+    G = nx.relabel.relabel_nodes(G, mapping, copy=False)
     G = G.to_directed() if not nx.is_directed(G) else G
 
     if isinstance(G, (nx.MultiGraph, nx.MultiDiGraph)):

--- a/torch_geometric/utils/convert.py
+++ b/torch_geometric/utils/convert.py
@@ -202,7 +202,10 @@ def from_networkx(
 
     from torch_geometric.data import Data
 
-    G = nx.convert_node_labels_to_integers(G)
+    # convert node labels to integers WITHOUT re-calling the constructor
+    N = G.number_of_nodes() + first_label
+    mapping = dict(zip(G.nodes(), range(first_label, N)))
+    G = nx.relabel.relabel_nodes(G, mapping)
     G = G.to_directed() if not nx.is_directed(G) else G
 
     if isinstance(G, (nx.MultiGraph, nx.MultiDiGraph)):

--- a/torch_geometric/utils/convert.py
+++ b/torch_geometric/utils/convert.py
@@ -203,8 +203,8 @@ def from_networkx(
     from torch_geometric.data import Data
 
     # convert node labels to integers WITHOUT re-calling the constructor
-    N = G.number_of_nodes() + first_label
-    mapping = dict(zip(G.nodes(), range(first_label, N)))
+    N = G.number_of_nodes()
+    mapping = dict(zip(G.nodes(), range(N)))
     G = nx.relabel.relabel_nodes(G, mapping, copy=False)
     G = G.to_directed() if not nx.is_directed(G) else G
 


### PR DESCRIPTION
https://github.com/pyg-team/pytorch_geometric/issues/7112
repro.py:
```
import networkx as nx
from torch_geometric.utils import from_networkx
class MetroNetwork(nx.Graph):
    def __init__(self, debug_mode=False, testing=False, **attr):
        super().__init__(**attr)
        self.num_access = None
        self.num_main = None
        self.num_core = None
        self.num_nodes = None
        self.num_edges = None
        self.max_pp = None
        self.max_ram = None
        self.max_bw = None
        self.max_link_delay = None
        self.max_placement_delay = None
        if testing:
            self.create_network4()
        else:
            self.add_edges_from([(1, 4, {'tier': 0, 'max_bw': 2000., 'remaining_bw': 2000., 'delay': 1.8, 'bw_req': 0})])
    def create_network4(self):
        num_access = 44
        num_main = 6
        num_core = 2
        self.num_access = num_access
        self.num_main = num_main
        self.num_core = num_core
        self.num_nodes = num_access + num_main + num_core
        tier_0_node_attributes = {'max_pp': 4000., 'remaining_pp': 4000., 'pp_req': 0,
                                  'max_ram': 100., 'remaining_ram': 100., 'ram_req': 0,
                                  'tier': 0, 'is_core': 0}
        tier_1_node_attributes = {'max_pp': 6000., 'remaining_pp': 6000., 'pp_req': 0,
                                  'max_ram': 150., 'remaining_ram': 150., 'ram_req': 0,
                                  'tier': 1, 'is_core': 1}
        tier_2_node_attributes = {'max_pp': 12000., 'remaining_pp': 12000., 'pp_req': 0,
                                  'max_ram': 300., 'remaining_ram': 300., 'ram_req': 0,
                                  'tier': 2, 'is_core': 1}
        node_idx = 0
        node_list = [(node_idx + i, tier_0_node_attributes) for i in range(num_core)]
        node_idx += num_core
        node_list.extend([(node_idx + i, tier_1_node_attributes) for i in range(num_main)])
        node_idx += num_main
        node_list.extend([(node_idx + i, tier_2_node_attributes) for i in range(num_access)])
        self.add_nodes_from(node_list)
        tier_0_link_attributes = {'tier': 0, 'max_bw': 2000., 'remaining_bw': 2000., 'delay': 1.8, 'bw_req': 0}
        tier_1_link_attributes = {'tier': 1, 'max_bw': 3000., 'remaining_bw': 3000., 'delay': 4.8, 'bw_req': 0}
        edge_list = [(0, 7, tier_1_link_attributes),
                     (0, 2, tier_1_link_attributes),
                     (0, 3, tier_1_link_attributes),
                     (0, 27, tier_0_link_attributes),
                     (0, 8, tier_0_link_attributes),
                     (0, 44, tier_0_link_attributes),
                     (1, 5, tier_1_link_attributes),
                     (1, 7, tier_1_link_attributes),
                     (1, 30, tier_0_link_attributes),
                     (1, 28, tier_0_link_attributes),
                     (1, 11, tier_0_link_attributes),
                     (1, 50, tier_0_link_attributes),
                     (1, 22, tier_0_link_attributes),
                     (2, 4, tier_1_link_attributes),
                     (2, 37, tier_0_link_attributes),
                     (2, 24, tier_0_link_attributes),
                     (3, 4, tier_1_link_attributes),
                     (3, 7, tier_1_link_attributes),
                     (3, 5, tier_1_link_attributes),
                     (3, 21, tier_0_link_attributes),
                     (3, 20, tier_0_link_attributes),
                     (3, 49, tier_0_link_attributes),
                     (4, 18, tier_0_link_attributes),
                     (4, 10, tier_0_link_attributes),
                     (5, 19, tier_0_link_attributes),
                     (5, 43, tier_0_link_attributes),
                     (5, 11, tier_0_link_attributes),
                     (5, 6, tier_1_link_attributes),
                     (7, 32, tier_0_link_attributes),
                     (7, 33, tier_0_link_attributes),
                     (7, 25, tier_0_link_attributes),
                     (7, 17, tier_0_link_attributes),
                     (8, 44, tier_0_link_attributes),
                     (8, 14, tier_0_link_attributes),
                     (9, 10, tier_0_link_attributes),
                     (10, 40, tier_0_link_attributes),
                     (11, 34, tier_0_link_attributes),
                     (11, 48, tier_0_link_attributes),
                     (12, 39, tier_0_link_attributes),
                     (12, 51, tier_0_link_attributes),
                     (13, 23, tier_0_link_attributes),
                     (13, 27, tier_0_link_attributes),
                     (14, 21, tier_0_link_attributes),
                     (14, 16, tier_0_link_attributes),
                     (14, 42, tier_0_link_attributes),
                     (15, 20, tier_0_link_attributes),
                     (15, 50, tier_0_link_attributes),
                     (15, 51, tier_0_link_attributes),
                     (16, 42, tier_0_link_attributes),
                     (16, 44, tier_0_link_attributes),
                     (17, 42, tier_0_link_attributes),
                     (17, 39, tier_0_link_attributes),
                     (18, 40, tier_0_link_attributes),
                     (22, 41, tier_0_link_attributes),
                     (23, 38, tier_0_link_attributes),
                     (24, 38, tier_0_link_attributes),
                     (24, 49, tier_0_link_attributes),
                     (25, 51, tier_0_link_attributes),
                     (26, 47, tier_0_link_attributes),
                     (28, 30, tier_0_link_attributes),
                     (29, 31, tier_0_link_attributes),
                     (29, 41, tier_0_link_attributes),
                     (31, 34, tier_0_link_attributes),
                     (32, 33, tier_0_link_attributes),
                     (35, 40, tier_0_link_attributes),
                     (36, 37, tier_0_link_attributes),
                     (37, 40, tier_0_link_attributes),
                     (39, 42, tier_0_link_attributes),
                     (43, 47, tier_0_link_attributes),
                     (45, 46, tier_0_link_attributes),
                     (45, 47, tier_0_link_attributes),
                     (46, 48, tier_0_link_attributes),
                     ]
        # Add edges with networkx format
        self.add_edges_from(edge_list)
        self.num_edges = len(edge_list)
        self.max_pp = 12000
        self.max_ram = 300
        self.max_bw = 5000
        self.max_link_delay = 4.8
        self.max_placement_delay = 30
network = MetroNetwork(testing = True)
print('Ground Truth NetworkX num_edges=', network.num_edges)
from_netx = from_networkx(network)
print('num_edges after convert to PyG=', from_netx.num_edges)
print("PyG to_string=", from_netx)
print("NetworkX to_string=", network)
```

command:
`git checkout fromnetworkx-fix;git pull origin fromnetworkx-fix; pip uninstall -y torch-geometric; pip install .; python3 repro.py`
->
w/ fix:
```
Ground Truth NetworkX num_edges= 72
num_edges after convert to PyG= 144
```
w/o fix:
```
Ground Truth NetworkX num_edges= 72
num_edges after convert to PyG= 146
```