### PR TITLE
Add ROCm build instructions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
-- Added the instructions of ROCM build wheels into README.md ([#7143](https://github.com/pyg-team/pytorch_geometric/pull/7143))
+- Added instructions for ROCm build wheels ([#7143](https://github.com/pyg-team/pytorch_geometric/pull/7143))
 - Added a `ComposeFilters` class to compose `pre_filter` functions in `Dataset` ([#7097](https://github.com/pyg-team/pytorch_geometric/pull/7097))
 - Added a time-step aware variant of the `EllipticBitcoinDataset` called `EllipticBitcoinTemporalDataset` ([#7011](https://github.com/pyg-team/pytorch_geometric/pull/7011))
 - Added `to_dgl` and `from_dgl` conversion functions ([#7053](https://github.com/pyg-team/pytorch_geometric/pull/7053))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- Added the instructions of ROCM build wheels into README.md ([#7143](https://github.com/pyg-team/pytorch_geometric/pull/7143))
 - Added a `ComposeFilters` class to compose `pre_filter` functions in `Dataset` ([#7097](https://github.com/pyg-team/pytorch_geometric/pull/7097))
 - Added a time-step aware variant of the `EllipticBitcoinDataset` called `EllipticBitcoinTemporalDataset` ([#7011](https://github.com/pyg-team/pytorch_geometric/pull/7011))
 - Added `to_dgl` and `from_dgl` conversion functions ([#7053](https://github.com/pyg-team/pytorch_geometric/pull/7053))

--- a/README.md
+++ b/README.md
@@ -390,11 +390,11 @@ If you want to utilize the full set of features from PyG, there exists several a
 * **[`torch-cluster`](https://github.com/rusty1s/pytorch_cluster)**: Graph clustering routines
 * **[`torch-spline-conv`](https://github.com/rusty1s/pytorch_spline_conv)**: [`SplineConv`](https://pytorch-geometric.readthedocs.io/en/latest/generated/torch_geometric.nn.conv.SplineConv.html) support
 
-These packages come with their own CPU and GPU kernel implementations based on the [PyTorch C++/CUDA extension interface](https://github.com/pytorch/extension-cpp).
+These packages come with their own CPU and GPU kernel implementations based on the [PyTorch C++/CUDA/hip(ROCm) extension interface](https://github.com/pytorch/extension-cpp). 
 For a basic usage of PyG, these dependencies are **fully optional**.
 We recommend to start with a minimal installation, and install additional dependencies once you start to actually need them.
 
-For ease of installation of these extensions, we provide `pip` wheels for all major OS/PyTorch/CUDA combinations, see [here](https://data.pyg.org/whl).
+For ease of installation of these extensions, we provide `pip` wheels for all major OS/PyTorch/CUDA combinations, see [here](https://data.pyg.org/whl). ([ROCm build](#rocm-build-wheels))
 
 #### PyTorch 2.0
 
@@ -445,6 +445,12 @@ or install PyG **from master** via
 ```
 pip install git+https://github.com/pyg-team/pytorch_geometric.git
 ```
+
+### ROCm build wheels
+
+This is an external repo, and you need to make issues [here](https://github.com/Looong01/pyg-rocm-build/issues) if you have any questions about this.
+  
+https://github.com/Looong01/pyg-rocm-build
 
 ## Cite
 

--- a/README.md
+++ b/README.md
@@ -394,7 +394,7 @@ These packages come with their own CPU and GPU kernel implementations based on t
 For a basic usage of PyG, these dependencies are **fully optional**.
 We recommend to start with a minimal installation, and install additional dependencies once you start to actually need them.
 
-For ease of installation of these extensions, we provide `pip` wheels for all major OS/PyTorch/CUDA combinations, see [here](https://data.pyg.org/whl). ([ROCm build](#rocm-build-wheels))
+For ease of installation of these extensions, we provide `pip` wheels for all major OS/PyTorch/CUDA combinations, see [here](https://data.pyg.org/whl).
 
 #### PyTorch 2.0
 
@@ -446,11 +446,10 @@ or install PyG **from master** via
 pip install git+https://github.com/pyg-team/pytorch_geometric.git
 ```
 
-### ROCm build wheels
+### ROCm Wheels
 
-This is an external repo, and you need to make issues [here](https://github.com/Looong01/pyg-rocm-build/issues) if you have any questions about this.
-
-https://github.com/Looong01/pyg-rocm-build
+The external [`pyg-rocm-build` repository](https://github.com/Looong01/pyg-rocm-build) provides wheels and detailed instructions on how to install PyG for ROCm.
+If you have any questions about it, please open an issue [here](https://github.com/Looong01/pyg-rocm-build/issues).
 
 ## Cite
 

--- a/docs/source/install/installation.rst
+++ b/docs/source/install/installation.rst
@@ -50,7 +50,7 @@ If you want to utilize the full set of features from :pyg:`PyG`, there exists se
 * `torch-cluster <https://github.com/rusty1s/pytorch_cluster>`__: Graph clustering routines
 * `torch-spline-conv <https://github.com/rusty1s/pytorch_spline_conv>`__: :class:`~torch_geometric.nn.conv.SplineConv` support
 
-These packages come with their own CPU and GPU kernel implementations based on the :pytorch:`null` `PyTorch C++/CUDA extension interface <https://github.com/pytorch/extension-cpp/>`_.
+These packages come with their own CPU and GPU kernel implementations based on the :pytorch:`null` `PyTorch C++/CUDA/hip(ROCm) extension interface <https://github.com/pytorch/extension-cpp/>`_.
 For a basic usage of :pyg:`PyG`, these dependencies are **fully optional**.
 We recommend to start with a minimal installation, and install additional dependencies once you start to actually need them.
 
@@ -103,6 +103,9 @@ For ease of installation of these extensions, we provide :obj:`pip` wheels for t
 **Note:** Binaries of older versions are also provided for :pytorch:`PyTorch` 1.4.0, 1.5.0, 1.6.0, 1.7.0, 1.7.1, 1.8.0, 1.8.1, 1.9.0, 1.10.0, 1.10.1, 1.10.2, 1.11.0, 1.12.0 and 1.12.1 (following the same procedure).
 **For older versions, you need to explicitly specify the latest supported version number** or install via :obj:`pip install --no-index` in order to prevent a manual installation from source.
 You can look up the latest supported version number `here <https://data.pyg.org/whl>`__.
+
+**ROCm:** The external `pyg-rocm-build repository <https://github.com/Looong01/pyg-rocm-build>`__ provides wheels and detailed instructions on how to install :pyg:`PyG` for ROCm.
+If you have any questions about it, please open an issue `here <https://github.com/Looong01/pyg-rocm-build/issues>`__.
 
 Installation from Source
 ~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Add the external repo link of pyg-rocm-build's wheels.