### PR TITLE
Fix tolerance in tests with conv

### DIFF
--- a/test/nn/conv/test_ppf_conv.py
+++ b/test/nn/conv/test_ppf_conv.py
@@ -57,8 +57,8 @@ def test_ppf_conv():
     assert out.size() == (2, 32)
     assert torch.allclose(conv((x1, None), (pos1, pos2), (n1, n2), edge_index),
                           out, atol=1e-3)
-    assert torch.allclose(conv(x1, (pos1, pos2), (n1, n2), adj1.t()),
-                          out, atol=1e-3)
+    assert torch.allclose(conv(x1, (pos1, pos2), (n1, n2), adj1.t()), out,
+                          atol=1e-3)
     assert torch.allclose(conv((x1, None), (pos1, pos2), (n1, n2), adj1.t()),
                           out, atol=1e-3)
 

--- a/test/nn/conv/test_ppf_conv.py
+++ b/test/nn/conv/test_ppf_conv.py
@@ -34,21 +34,21 @@ def test_ppf_conv():
 
     out = conv(x1, pos1, n1, edge_index)
     assert out.size() == (4, 32)
-    assert torch.allclose(conv(x1, pos1, n1, adj1.t()), out, atol=1e-6)
+    assert torch.allclose(conv(x1, pos1, n1, adj1.t()), out, atol=1e-3)
 
     if torch_geometric.typing.WITH_TORCH_SPARSE:
         adj2 = SparseTensor.from_edge_index(edge_index, sparse_sizes=(4, 4))
-        assert torch.allclose(conv(x1, pos1, n1, adj2.t()), out, atol=1e-6)
+        assert torch.allclose(conv(x1, pos1, n1, adj2.t()), out, atol=1e-3)
 
     if is_full_test():
         t = '(OptTensor, Tensor, Tensor, Tensor) -> Tensor'
         jit = torch.jit.script(conv.jittable(t))
-        assert torch.allclose(jit(x1, pos1, n1, edge_index), out, atol=1e-6)
+        assert torch.allclose(jit(x1, pos1, n1, edge_index), out, atol=1e-3)
 
     if is_full_test() and torch_geometric.typing.WITH_TORCH_SPARSE:
         t = '(OptTensor, Tensor, Tensor, SparseTensor) -> Tensor'
         jit = torch.jit.script(conv.jittable(t))
-        assert torch.allclose(jit(x1, pos1, n1, adj2.t()), out, atol=1e-6)
+        assert torch.allclose(jit(x1, pos1, n1, adj2.t()), out, atol=1e-3)
 
     # Test bipartite message passing:
     adj1 = to_torch_csc_tensor(edge_index, size=(4, 2))
@@ -56,16 +56,17 @@ def test_ppf_conv():
     out = conv(x1, (pos1, pos2), (n1, n2), edge_index)
     assert out.size() == (2, 32)
     assert torch.allclose(conv((x1, None), (pos1, pos2), (n1, n2), edge_index),
-                          out, atol=1e-6)
-    assert torch.allclose(conv(x1, (pos1, pos2), (n1, n2), adj1.t()), out)
+                          out, atol=1e-3)
+    assert torch.allclose(conv(x1, (pos1, pos2), (n1, n2), adj1.t()),
+                          out, atol=1e-3)
     assert torch.allclose(conv((x1, None), (pos1, pos2), (n1, n2), adj1.t()),
-                          out, atol=1e-6)
+                          out, atol=1e-3)
 
     if torch_geometric.typing.WITH_TORCH_SPARSE:
         adj2 = SparseTensor.from_edge_index(edge_index, sparse_sizes=(4, 2))
         assert torch.allclose(conv(x1, (pos1, pos2), (n1, n2), adj2.t()), out)
         assert torch.allclose(
-            conv((x1, None), (pos1, pos2), (n1, n2), adj2.t()), out, atol=1e-6)
+            conv((x1, None), (pos1, pos2), (n1, n2), adj2.t()), out, atol=1e-3)
 
     if is_full_test():
         t = '(PairOptTensor, PairTensor, PairTensor, Tensor) -> Tensor'
@@ -77,4 +78,4 @@ def test_ppf_conv():
         t = '(PairOptTensor, PairTensor, PairTensor, SparseTensor) -> Tensor'
         jit = torch.jit.script(conv.jittable(t))
         assert torch.allclose(
-            jit((x1, None), (pos1, pos2), (n1, n2), adj2.t()), out, atol=1e-6)
+            jit((x1, None), (pos1, pos2), (n1, n2), adj2.t()), out, atol=1e-3)

--- a/test/nn/conv/test_rgcn_conv.py
+++ b/test/nn/conv/test_rgcn_conv.py
@@ -38,12 +38,12 @@ def test_rgcn_conv_equality(conf, device):
 
     out1 = conv1(x1, edge_index, edge_type)
     out2 = conv2(x1, edge_index, edge_type)
-    assert torch.allclose(out1, out2, atol=1e-6)
+    assert torch.allclose(out1, out2, atol=1e-3)
 
     if num_blocks is None:
         out1 = conv1(None, edge_index, edge_type)
         out2 = conv2(None, edge_index, edge_type)
-        assert torch.allclose(out1, out2, atol=1e-6)
+        assert torch.allclose(out1, out2, atol=1e-3)
 
 
 @withCUDA
@@ -70,15 +70,15 @@ def test_rgcn_conv(cls, conf, device):
 
     if torch_geometric.typing.WITH_TORCH_SPARSE:
         adj = SparseTensor.from_edge_index(edge_index, edge_type, (4, 4))
-        assert torch.allclose(conv(x1, adj.t()), out1, atol=1e-6)
+        assert torch.allclose(conv(x1, adj.t()), out1, atol=1e-3)
 
     if num_blocks is None:
         out2 = conv(None, edge_index, edge_type)
         assert torch.allclose(conv(idx1, edge_index, edge_type), out2)
         assert out2.size() == (4, 32)
         if torch_geometric.typing.WITH_TORCH_SPARSE:
-            assert torch.allclose(conv(None, adj.t()), out2, atol=1e-6)
-            assert torch.allclose(conv(idx1, adj.t()), out2, atol=1e-6)
+            assert torch.allclose(conv(None, adj.t()), out2, atol=1e-3)
+            assert torch.allclose(conv(idx1, adj.t()), out2, atol=1e-3)
 
     if is_full_test():
         t = '(OptTensor, Tensor, OptTensor) -> Tensor'
@@ -93,8 +93,8 @@ def test_rgcn_conv(cls, conf, device):
         jit = torch.jit.script(conv.jittable(t))
         assert torch.allclose(jit(x1, adj.t()), out1)
         if num_blocks is None:
-            assert torch.allclose(jit(idx1, adj.t()), out2, atol=1e-6)
-            assert torch.allclose(jit(None, adj.t()), out2, atol=1e-6)
+            assert torch.allclose(jit(idx1, adj.t()), out2, atol=1e-3)
+            assert torch.allclose(jit(None, adj.t()), out2, atol=1e-3)
 
     # Test bipartite message passing:
     conv = cls((4, 16), 32, 2, num_bases, num_blocks, aggr='sum').to(device)
@@ -105,15 +105,15 @@ def test_rgcn_conv(cls, conf, device):
 
     if torch_geometric.typing.WITH_TORCH_SPARSE:
         adj = SparseTensor.from_edge_index(edge_index, edge_type, (4, 2))
-        assert torch.allclose(conv((x1, x2), adj.t()), out1, atol=1e-6)
+        assert torch.allclose(conv((x1, x2), adj.t()), out1, atol=1e-3)
 
     if num_blocks is None:
         out2 = conv((None, idx2), edge_index, edge_type)
         assert out2.size() == (2, 32)
         assert torch.allclose(conv((idx1, idx2), edge_index, edge_type), out2)
         if torch_geometric.typing.WITH_TORCH_SPARSE:
-            assert torch.allclose(conv((None, idx2), adj.t()), out2, atol=1e-6)
-            assert torch.allclose(conv((idx1, idx2), adj.t()), out2, atol=1e-6)
+            assert torch.allclose(conv((None, idx2), adj.t()), out2, atol=1e-3)
+            assert torch.allclose(conv((idx1, idx2), adj.t()), out2, atol=1e-3)
 
     if is_full_test():
         t = '(Tuple[OptTensor, Tensor], Tensor, OptTensor) -> Tensor'
@@ -121,14 +121,14 @@ def test_rgcn_conv(cls, conf, device):
         assert torch.allclose(jit((x1, x2), edge_index, edge_type), out1)
         if num_blocks is None:
             assert torch.allclose(jit((None, idx2), edge_index, edge_type),
-                                  out2, atol=1e-6)
+                                  out2, atol=1e-3)
             assert torch.allclose(jit((idx1, idx2), edge_index, edge_type),
-                                  out2, atol=1e-6)
+                                  out2, atol=1e-3)
 
     if is_full_test() and torch_geometric.typing.WITH_TORCH_SPARSE:
         t = '(Tuple[OptTensor, Tensor], SparseTensor, OptTensor) -> Tensor'
         jit = torch.jit.script(conv.jittable(t))
-        assert torch.allclose(jit((x1, x2), adj.t()), out1, atol=1e-6)
+        assert torch.allclose(jit((x1, x2), adj.t()), out1, atol=1e-3)
         if num_blocks is None:
-            assert torch.allclose(jit((None, idx2), adj.t()), out2, atol=1e-6)
-            assert torch.allclose(jit((idx1, idx2), adj.t()), out2, atol=1e-6)
+            assert torch.allclose(jit((None, idx2), adj.t()), out2, atol=1e-3)
+            assert torch.allclose(jit((idx1, idx2), adj.t()), out2, atol=1e-3)

--- a/test/nn/dense/test_linear.py
+++ b/test/nn/dense/test_linear.py
@@ -215,4 +215,4 @@ def test_hetero_linear_sort(type_vec, device):
     for i in range(type_vec.numel()):
         node_type = int(type_vec[i])
         expected = x[i] @ lin.weight[node_type] + lin.bias[node_type]
-        assert torch.allclose(out[i], expected, atol=1e-6)
+        assert torch.allclose(out[i], expected, atol=1e-3)


### PR DESCRIPTION
Some tests with conv need tolerance adjustment when used with a GPU backend (CUDA libraries used by the PyTorch convolutions may, non deterministic ops, mixed-precision etc)