### PR TITLE
skipping examples that need `torch-cluster`/`torch-sparse` for now if its not available

### DIFF
--- a/examples/correct_and_smooth.py
+++ b/examples/correct_and_smooth.py
@@ -8,8 +8,8 @@ from torch_geometric.nn import MLP, CorrectAndSmooth
 from torch_geometric.typing import WITH_TORCH_SPARSE
 
 if not WITH_TORCH_SPARSE:
-    print("This example requires 'torch-sparse'")
-    quit()
+    quit("This example requires 'torch-sparse'")
+
 root = osp.join(osp.dirname(osp.realpath(__file__)), '..', 'data', 'OGB')
 dataset = PygNodePropPredDataset('ogbn-products', root,
                                  transform=T.ToSparseTensor())

--- a/examples/correct_and_smooth.py
+++ b/examples/correct_and_smooth.py
@@ -6,10 +6,9 @@ from ogb.nodeproppred import Evaluator, PygNodePropPredDataset
 import torch_geometric.transforms as T
 from torch_geometric.nn import MLP, CorrectAndSmooth
 from torch_geometric.typing import WITH_TORCH_SPARSE
+
 if not WITH_TORCH_SPARSE:
-    print(
-        "This example requires 'torch-sparse'"
-    )
+    print("This example requires 'torch-sparse'")
     quit()
 root = osp.join(osp.dirname(osp.realpath(__file__)), '..', 'data', 'OGB')
 dataset = PygNodePropPredDataset('ogbn-products', root,

--- a/examples/correct_and_smooth.py
+++ b/examples/correct_and_smooth.py
@@ -5,7 +5,12 @@ from ogb.nodeproppred import Evaluator, PygNodePropPredDataset
 
 import torch_geometric.transforms as T
 from torch_geometric.nn import MLP, CorrectAndSmooth
-
+from torch_geometric.typing import WITH_TORCH_SPARSE
+if not WITH_TORCH_SPARSE:
+    print(
+        "This example requires 'torch-sparse'"
+    )
+    quit()
 root = osp.join(osp.dirname(osp.realpath(__file__)), '..', 'data', 'OGB')
 dataset = PygNodePropPredDataset('ogbn-products', root,
                                  transform=T.ToSparseTensor())

--- a/examples/egc.py
+++ b/examples/egc.py
@@ -13,12 +13,10 @@ import torch_geometric.transforms as T
 from torch_geometric.loader import DataLoader
 from torch_geometric.nn import EGConv, global_mean_pool
 from torch_geometric.typing import WITH_TORCH_SPARSE
-if not WITH_TORCH_SPARSE:
-    print(
-        "This example requires 'torch-sparse'"
-    )
-    quit()
 
+if not WITH_TORCH_SPARSE:
+    print("This example requires 'torch-sparse'")
+    quit()
 
 parser = argparse.ArgumentParser()
 parser.add_argument('--use_multi_aggregators', action='store_true',

--- a/examples/egc.py
+++ b/examples/egc.py
@@ -12,6 +12,13 @@ from torch.optim.lr_scheduler import ReduceLROnPlateau
 import torch_geometric.transforms as T
 from torch_geometric.loader import DataLoader
 from torch_geometric.nn import EGConv, global_mean_pool
+from torch_geometric.typing import WITH_TORCH_SPARSE
+if not WITH_TORCH_SPARSE:
+    print(
+        "This example requires 'torch-sparse'"
+    )
+    quit()
+
 
 parser = argparse.ArgumentParser()
 parser.add_argument('--use_multi_aggregators', action='store_true',

--- a/examples/egc.py
+++ b/examples/egc.py
@@ -15,8 +15,7 @@ from torch_geometric.nn import EGConv, global_mean_pool
 from torch_geometric.typing import WITH_TORCH_SPARSE
 
 if not WITH_TORCH_SPARSE:
-    print("This example requires 'torch-sparse'")
-    quit()
+    quit("This example requires 'torch-sparse'")
 
 parser = argparse.ArgumentParser()
 parser.add_argument('--use_multi_aggregators', action='store_true',

--- a/examples/gcn2_ppi.py
+++ b/examples/gcn2_ppi.py
@@ -10,10 +10,9 @@ from torch_geometric.datasets import PPI
 from torch_geometric.loader import DataLoader
 from torch_geometric.nn import GCN2Conv
 from torch_geometric.typing import WITH_TORCH_SPARSE
+
 if not WITH_TORCH_SPARSE:
-    print(
-        "This example requires 'torch-sparse'"
-    )
+    print("This example requires 'torch-sparse'")
     quit()
 path = osp.join(osp.dirname(osp.realpath(__file__)), '..', 'data', 'GCN2_PPI')
 pre_transform = T.Compose([T.GCNNorm(), T.ToSparseTensor()])

--- a/examples/gcn2_ppi.py
+++ b/examples/gcn2_ppi.py
@@ -9,7 +9,12 @@ import torch_geometric.transforms as T
 from torch_geometric.datasets import PPI
 from torch_geometric.loader import DataLoader
 from torch_geometric.nn import GCN2Conv
-
+from torch_geometric.typing import WITH_TORCH_SPARSE
+if not WITH_TORCH_SPARSE:
+    print(
+        "This example requires 'torch-sparse'"
+    )
+    quit()
 path = osp.join(osp.dirname(osp.realpath(__file__)), '..', 'data', 'GCN2_PPI')
 pre_transform = T.Compose([T.GCNNorm(), T.ToSparseTensor()])
 train_dataset = PPI(path, split='train', pre_transform=pre_transform)

--- a/examples/gcn2_ppi.py
+++ b/examples/gcn2_ppi.py
@@ -12,8 +12,8 @@ from torch_geometric.nn import GCN2Conv
 from torch_geometric.typing import WITH_TORCH_SPARSE
 
 if not WITH_TORCH_SPARSE:
-    print("This example requires 'torch-sparse'")
-    quit()
+    quit("This example requires 'torch-sparse'")
+
 path = osp.join(osp.dirname(osp.realpath(__file__)), '..', 'data', 'GCN2_PPI')
 pre_transform = T.Compose([T.GCNNorm(), T.ToSparseTensor()])
 train_dataset = PPI(path, split='train', pre_transform=pre_transform)

--- a/examples/graph_saint.py
+++ b/examples/graph_saint.py
@@ -8,7 +8,12 @@ from torch_geometric.datasets import Flickr
 from torch_geometric.loader import GraphSAINTRandomWalkSampler
 from torch_geometric.nn import GraphConv
 from torch_geometric.utils import degree
-
+from torch_geometric.typing import WITH_TORCH_SPARSE
+if not WITH_TORCH_SPARSE:
+    print(
+        "This example requires 'torch-sparse'"
+    )
+    quit()
 path = osp.join(osp.dirname(osp.realpath(__file__)), '..', 'data', 'Flickr')
 dataset = Flickr(path)
 data = dataset[0]

--- a/examples/graph_saint.py
+++ b/examples/graph_saint.py
@@ -11,8 +11,8 @@ from torch_geometric.typing import WITH_TORCH_SPARSE
 from torch_geometric.utils import degree
 
 if not WITH_TORCH_SPARSE:
-    print("This example requires 'torch-sparse'")
-    quit()
+    quit("This example requires 'torch-sparse'")
+
 path = osp.join(osp.dirname(osp.realpath(__file__)), '..', 'data', 'Flickr')
 dataset = Flickr(path)
 data = dataset[0]

--- a/examples/graph_saint.py
+++ b/examples/graph_saint.py
@@ -7,12 +7,11 @@ import torch.nn.functional as F
 from torch_geometric.datasets import Flickr
 from torch_geometric.loader import GraphSAINTRandomWalkSampler
 from torch_geometric.nn import GraphConv
-from torch_geometric.utils import degree
 from torch_geometric.typing import WITH_TORCH_SPARSE
+from torch_geometric.utils import degree
+
 if not WITH_TORCH_SPARSE:
-    print(
-        "This example requires 'torch-sparse'"
-    )
+    print("This example requires 'torch-sparse'")
     quit()
 path = osp.join(osp.dirname(osp.realpath(__file__)), '..', 'data', 'Flickr')
 dataset = Flickr(path)

--- a/examples/mnist_nn_conv.py
+++ b/examples/mnist_nn_conv.py
@@ -14,12 +14,11 @@ from torch_geometric.nn import (
     max_pool,
     max_pool_x,
 )
-from torch_geometric.utils import normalized_cut
 from torch_geometric.typing import WITH_TORCH_CLUSTER
+from torch_geometric.utils import normalized_cut
+
 if not WITH_TORCH_CLUSTER:
-    print(
-        "This example requires 'torch-cluster'"
-    )
+    print("This example requires 'torch-cluster'")
     quit()
 path = osp.join(osp.dirname(osp.realpath(__file__)), '..', 'data', 'MNIST')
 transform = T.Cartesian(cat=False)

--- a/examples/mnist_nn_conv.py
+++ b/examples/mnist_nn_conv.py
@@ -18,8 +18,8 @@ from torch_geometric.typing import WITH_TORCH_CLUSTER
 from torch_geometric.utils import normalized_cut
 
 if not WITH_TORCH_CLUSTER:
-    print("This example requires 'torch-cluster'")
-    quit()
+    quit("This example requires 'torch-cluster'")
+
 path = osp.join(osp.dirname(osp.realpath(__file__)), '..', 'data', 'MNIST')
 transform = T.Cartesian(cat=False)
 train_dataset = MNISTSuperpixels(path, True, transform=transform)

--- a/examples/mnist_nn_conv.py
+++ b/examples/mnist_nn_conv.py
@@ -15,7 +15,12 @@ from torch_geometric.nn import (
     max_pool_x,
 )
 from torch_geometric.utils import normalized_cut
-
+from torch_geometric.typing import WITH_TORCH_CLUSTER
+if not WITH_TORCH_CLUSTER:
+    print(
+        "This example requires 'torch-cluster'"
+    )
+    quit()
 path = osp.join(osp.dirname(osp.realpath(__file__)), '..', 'data', 'MNIST')
 transform = T.Cartesian(cat=False)
 train_dataset = MNISTSuperpixels(path, True, transform=transform)

--- a/examples/node2vec.py
+++ b/examples/node2vec.py
@@ -10,8 +10,7 @@ from torch_geometric.nn import Node2Vec
 from torch_geometric.typing import WITH_TORCH_CLUSTER
 
 if not WITH_TORCH_CLUSTER:
-    print("This example requires 'torch-cluster'")
-    quit()
+    quit("This example requires 'torch-cluster'")
 
 
 def main():

--- a/examples/node2vec.py
+++ b/examples/node2vec.py
@@ -7,7 +7,12 @@ from sklearn.manifold import TSNE
 
 from torch_geometric.datasets import Planetoid
 from torch_geometric.nn import Node2Vec
-
+from torch_geometric.typing import WITH_TORCH_CLUSTER
+if not WITH_TORCH_CLUSTER:
+    print(
+        "This example requires 'torch-cluster'"
+    )
+    quit()
 
 def main():
     dataset = 'Cora'

--- a/examples/node2vec.py
+++ b/examples/node2vec.py
@@ -8,11 +8,11 @@ from sklearn.manifold import TSNE
 from torch_geometric.datasets import Planetoid
 from torch_geometric.nn import Node2Vec
 from torch_geometric.typing import WITH_TORCH_CLUSTER
+
 if not WITH_TORCH_CLUSTER:
-    print(
-        "This example requires 'torch-cluster'"
-    )
+    print("This example requires 'torch-cluster'")
     quit()
+
 
 def main():
     dataset = 'Cora'

--- a/torch_geometric/typing.py
+++ b/torch_geometric/typing.py
@@ -34,6 +34,15 @@ except (ImportError, OSError) as e:
     WITH_TORCH_SCATTER = False
 
 try:
+    import torch_cluster  # noqa
+    WITH_TORCH_CLUSTER = True
+except (ImportError, OSError) as e:
+    if isinstance(e, OSError):
+        warnings.warn(f"An issue occurred while importing 'torch-cluster'. "
+                      f"Disabling its usage. Stacktrace: {e}")
+    WITH_TORCH_CLUSTER = False
+
+try:
     import torch_sparse  # noqa
     from torch_sparse import SparseStorage, SparseTensor
     WITH_TORCH_SPARSE = True
@@ -42,15 +51,6 @@ except (ImportError, OSError) as e:
         warnings.warn(f"An issue occurred while importing 'torch-sparse'. "
                       f"Disabling its usage. Stacktrace: {e}")
     WITH_TORCH_SPARSE = False
-
-try:
-    import torch_cluster  # noqa
-    WITH_TORCH_CLUSTER = True
-except (ImportError, OSError) as e:
-    if isinstance(e, OSError):
-        warnings.warn(f"An issue occurred while importing 'torch-cluster'. "
-                      f"Disabling its usage. Stacktrace: {e}")
-    WITH_TORCH_CLUSTER = False
 
     class SparseStorage:
         def __init__(*args, **kwargs):

--- a/torch_geometric/typing.py
+++ b/torch_geometric/typing.py
@@ -43,6 +43,15 @@ except (ImportError, OSError) as e:
                       f"Disabling its usage. Stacktrace: {e}")
     WITH_TORCH_SPARSE = False
 
+try:
+    import torch_cluster  # noqa
+    WITH_TORCH_CLUSTER = True
+except (ImportError, OSError) as e:
+    if isinstance(e, OSError):
+        warnings.warn(f"An issue occurred while importing 'torch-cluster'. "
+                      f"Disabling its usage. Stacktrace: {e}")
+    WITH_TORCH_CLUSTER = False
+
     class SparseStorage:
         def __init__(*args, **kwargs):
             raise ImportError("'SparseStorage' requires 'torch-sparse'")


### PR DESCRIPTION
 after this PR, i will work on getting all of these functionalities into pyg-lib and then update these examples accordingly (and for example the graph_saint test to use withPackage('pyg-lib') instead)

for now, if their torch-sparse and torch-cluster areuninstalled:
```
cd /opt/pyg; pip uninstall -y torch-geometric torch-scatter torch-sparse torch-spline-conv torch-cluster; rm -rf pytorch_geometric; git clone -b examples_req_checkl https://github.com/pyg-team/pytorch_geometric.git; cd /opt/pyg/pytorch_geometric; pip install .; python3 examples/egc.py; python3 examples/gcn2_ppi.py; python3 examples/graph_saint.py;  python3 examples/correct_and_smooth.py; python3 examples/node2vec.py; python3 examples/mnist_nn_conv.py
This example requires 'torch-sparse'
This example requires 'torch-sparse'
This example requires 'torch-sparse'
This example requires 'torch-sparse'
This example requires 'torch-cluster'
This example requires 'torch-cluster'
```