### PR TITLE
Can't use `deepcopy` on `Explanation`

### DIFF
--- a/torch_geometric/explain/explanation.py
+++ b/torch_geometric/explain/explanation.py
@@ -333,7 +333,7 @@ class HeteroExplanation(HeteroData, ExplanationMixin):
         node_mask_dict: Dict[NodeType, Tensor],
         edge_mask_dict: Dict[EdgeType, Tensor],
     ) -> 'HeteroExplanation':
-        out = copy.deepcopy(self)
+        out = copy.copy(self)
 
         for edge_type, edge_mask in edge_mask_dict.items():
             for key, value in self[edge_type].items():


### PR DESCRIPTION
Running the method `get_explanation_subgraph()` fails with: 

```
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/Users/ramonabendias/.local/share/virtualenvs/pydata-workshop-CALqWZ-I/lib/python3.11/site-packages/torch_geometric/explain/explanation.py", line 306, in get_explanation_subgraph
    return self._apply_masks(
           ^^^^^^^^^^^^^^^^^^
  File "/Users/ramonabendias/.local/share/virtualenvs/pydata-workshop-CALqWZ-I/lib/python3.11/site-packages/torch_geometric/explain/explanation.py", line 336, in _apply_masks
    out = copy.deepcopy(self)
          ^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/Cellar/python@3.11/3.11.2_1/Frameworks/Python.framework/Versions/3.11/lib/python3.11/copy.py", line 153, in deepcopy
    y = copier(memo)
        ^^^^^^^^^^^^
  File "/Users/ramonabendias/.local/share/virtualenvs/pydata-workshop-CALqWZ-I/lib/python3.11/site-packages/torch_geometric/data/hetero_data.py", line 203, in __deepcopy__
    out.__dict__[key] = copy.deepcopy(value, memo)
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/Cellar/python@3.11/3.11.2_1/Frameworks/Python.framework/Versions/3.11/lib/python3.11/copy.py", line 146, in deepcopy
    y = copier(x, memo)
        ^^^^^^^^^^^^^^^
  File "/opt/homebrew/Cellar/python@3.11/3.11.2_1/Frameworks/Python.framework/Versions/3.11/lib/python3.11/copy.py", line 231, in _deepcopy_dict
    y[deepcopy(key, memo)] = deepcopy(value, memo)
                             ^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/Cellar/python@3.11/3.11.2_1/Frameworks/Python.framework/Versions/3.11/lib/python3.11/copy.py", line 153, in deepcopy
    y = copier(memo)
        ^^^^^^^^^^^^
  File "/Users/ramonabendias/.local/share/virtualenvs/pydata-workshop-CALqWZ-I/lib/python3.11/site-packages/torch_geometric/data/storage.py", line 132, in __deepcopy__
    out._mapping = copy.deepcopy(out._mapping, memo)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/Cellar/python@3.11/3.11.2_1/Frameworks/Python.framework/Versions/3.11/lib/python3.11/copy.py", line 146, in deepcopy
    y = copier(x, memo)
        ^^^^^^^^^^^^^^^
  File "/opt/homebrew/Cellar/python@3.11/3.11.2_1/Frameworks/Python.framework/Versions/3.11/lib/python3.11/copy.py", line 231, in _deepcopy_dict
    y[deepcopy(key, memo)] = deepcopy(value, memo)
                             ^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/Cellar/python@3.11/3.11.2_1/Frameworks/Python.framework/Versions/3.11/lib/python3.11/copy.py", line 153, in deepcopy
    y = copier(memo)
        ^^^^^^^^^^^^
  File "/Users/ramonabendias/.local/share/virtualenvs/pydata-workshop-CALqWZ-I/lib/python3.11/site-packages/torch/_tensor.py", line 86, in __deepcopy__
    raise RuntimeError(
RuntimeError: Only Tensors created explicitly by the user (graph leaves) support the deepcopy protocol at the moment
```