### PR TITLE
Fix `HeteroDictLinear` crashes if some node types are absent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- Fixed bug in HeteroDictLinear ([#7185](https://github.com/pyg-team/pytorch_geometric/pull/7185))
 - Extending `torch.sparse` support ([#7155](https://github.com/pyg-team/pytorch_geometric/pull/7155))
 - Added edge weight support to `LightGCN` ([#7157](https://github.com/pyg-team/pytorch_geometric/pull/7157))
 - Added `SparseTensor` support to`trim_to_layer` function ([#7089](https://github.com/pyg-team/pytorch_geometric/pull/7089))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
-- Fixed bug in HeteroDictLinear ([#7185](https://github.com/pyg-team/pytorch_geometric/pull/7185))
+- Fixed bug in `HeteroDictLinear` ([#7185](https://github.com/pyg-team/pytorch_geometric/pull/7185))
 - Extending `torch.sparse` support ([#7155](https://github.com/pyg-team/pytorch_geometric/pull/7155))
 - Added edge weight support to `LightGCN` ([#7157](https://github.com/pyg-team/pytorch_geometric/pull/7157))
 - Added `SparseTensor` support to`trim_to_layer` function ([#7089](https://github.com/pyg-team/pytorch_geometric/pull/7089))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,6 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
-- Fixed bug in `HeteroDictLinear` ([#7185](https://github.com/pyg-team/pytorch_geometric/pull/7185))
 - Extending `torch.sparse` support ([#7155](https://github.com/pyg-team/pytorch_geometric/pull/7155))
 - Added edge weight support to `LightGCN` ([#7157](https://github.com/pyg-team/pytorch_geometric/pull/7157))
 - Added `SparseTensor` support to`trim_to_layer` function ([#7089](https://github.com/pyg-team/pytorch_geometric/pull/7089))
@@ -21,6 +20,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
+- Allow missing node types in `HeteroDictLinear` ([#7185](https://github.com/pyg-team/pytorch_geometric/pull/7185))
 - Optimized `from_networkx` memory footprint by reducing unnecessary copies ([#7119](https://github.com/pyg-team/pytorch_geometric/pull/7119))
 - Added an optional `batch_size` argument to `LayerNorm`, `GraphNorm`, `InstanceNorm`, `GraphSizeNorm` and `PairNorm` ([#7135](https://github.com/pyg-team/pytorch_geometric/pull/7135))
 - Improved code coverage ([#7093](https://github.com/pyg-team/pytorch_geometric/pull/7093))

--- a/torch_geometric/nn/dense/linear.py
+++ b/torch_geometric/nn/dense/linear.py
@@ -377,9 +377,9 @@ class HeteroDictLinear(torch.nn.Module):
                 features for each individual type.
         """
         if torch_geometric.typing.WITH_GMM:
-            xs = [x_dict[key] for key in self.lins.keys()]
-            weights = [lin.weight.t() for lin in self.lins.values()]
-            biases = [lin.bias for lin in self.lins.values()]
+            xs = [x_dict[key] for key in x_dict.keys()]
+            weights = [self.lins[key].weight.t() for key in x_dict.keys()]
+            biases = [self.lins[key].bias for key in x_dict.keys()]
             biases = None if biases[0] is None else biases
             outs = pyg_lib.ops.grouped_matmul(xs, weights, biases)
             return {key: out for key, out in zip(x_dict.keys(), outs)}

--- a/torch_geometric/nn/dense/linear.py
+++ b/torch_geometric/nn/dense/linear.py
@@ -376,15 +376,26 @@ class HeteroDictLinear(torch.nn.Module):
             x_dict (Dict[Any, torch.Tensor]): A dictionary holding input
                 features for each individual type.
         """
+        out_dict = {}
+
         if torch_geometric.typing.WITH_GMM:
-            xs = [x_dict[key] for key in x_dict.keys()]
-            weights = [self.lins[key].weight.t() for key in x_dict.keys()]
-            biases = [self.lins[key].bias for key in x_dict.keys()]
+            xs, weights, biases = [], [], []
+            for key, lin in self.lins.items():
+                if key in x_dict:
+                    xs.append(x_dict[key])
+                    weights.append(lin.weight.t())
+                    biases.append(lin.bias)
             biases = None if biases[0] is None else biases
             outs = pyg_lib.ops.grouped_matmul(xs, weights, biases)
-            return {key: out for key, out in zip(x_dict.keys(), outs)}
+            for key, out in zip(self.lins.keys(), outs):
+                if key in x_dict:
+                    out_dict[key] = out
+        else:
+            for key, lin in self.lins.items():
+                if key in x_dict:
+                    out_dict[key] = lin(x_dict[key])
 
-        return {key: self.lins[key](x_dict[key]) for key in x_dict.keys()}
+        return out_dict
 
     @torch.no_grad()
     def initialize_parameters(self, module, input):

--- a/torch_geometric/nn/dense/linear.py
+++ b/torch_geometric/nn/dense/linear.py
@@ -384,7 +384,7 @@ class HeteroDictLinear(torch.nn.Module):
             outs = pyg_lib.ops.grouped_matmul(xs, weights, biases)
             return {key: out for key, out in zip(x_dict.keys(), outs)}
 
-        return {key: lin(x_dict[key]) for key, lin in self.lins.items()}
+        return {key: self.lins[key](x_dict[key]) for key in x_dict.keys()}
 
     @torch.no_grad()
     def initialize_parameters(self, module, input):


### PR DESCRIPTION
This pr fixes a bug in HeteroDictLinear forward function, which crashes if the input x_dict has some node types missing.