### PR TITLE
Add `AddRemainingSelfLoops` transform

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- Added `AddRemainingSelfLoops` transform ([#7192](https://github.com/pyg-team/pytorch_geometric/pull/7192))
 - Added `type_ptr` argument to `HeteroLayerNorm` ([#7208](https://github.com/pyg-team/pytorch_geometric/pull/7208))
 - Added an option to benchmark scripts to write PyTorch profiler results to CSV ([#7114](https://github.com/pyg-team/pytorch_geometric/pull/7114))
 - Added subgraph type sampling option with bidirectional edge support ([#7199](https://github.com/pyg-team/pytorch_geometric/pull/7199), [#7200](https://github.com/pyg-team/pytorch_geometric/pull/7200))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
-- Added `AddRemainingSelfLoops` transform ([#7192](https://github.com/pyg-team/pytorch_geometric/pull/7192))
+- Added a `AddRemainingSelfLoops` transform ([#7192](https://github.com/pyg-team/pytorch_geometric/pull/7192))
 - Added `type_ptr` argument to `HeteroLayerNorm` ([#7208](https://github.com/pyg-team/pytorch_geometric/pull/7208))
 - Added an option to benchmark scripts to write PyTorch profiler results to CSV ([#7114](https://github.com/pyg-team/pytorch_geometric/pull/7114))
 - Added subgraph type sampling option with bidirectional edge support ([#7199](https://github.com/pyg-team/pytorch_geometric/pull/7199), [#7200](https://github.com/pyg-team/pytorch_geometric/pull/7200))

--- a/test/transforms/test_add_remaining_self_loops.py
+++ b/test/transforms/test_add_remaining_self_loops.py
@@ -5,6 +5,10 @@ from torch_geometric.transforms import AddRemainingSelfLoops
 
 
 def test_add_remaining_self_loops():
+    assert str(AddRemainingSelfLoops()) == 'AddRemainingSelfLoops()'
+
+    assert len(AddRemainingSelfLoops()(Data())) == 0
+
     # No self-loops in `edge_index`.
     edge_index = torch.tensor([[0, 1, 1, 2], [1, 0, 2, 1]])
     edge_weight = torch.tensor([1, 2, 3, 4])
@@ -40,14 +44,14 @@ def test_add_remaining_self_loops():
 
 
 def test_add_remaining_self_loops_all_loops_exist():
-    # All self-loops already in the data object.
+    # All self-loops already exist in the data object.
     edge_index = torch.tensor([[0, 1, 2], [0, 1, 2]])
     data = Data(edge_index=edge_index, num_nodes=3)
     data = AddRemainingSelfLoops()(data)
     assert data.edge_index.tolist() == edge_index.tolist()
 
-    # All self-loops already in the data object, some of them appear multiple
-    # times.
+    # All self-loops already exist in the data object, some of them appear
+    # multiple times.
     edge_index = torch.tensor([[0, 0, 1, 1, 2], [0, 0, 1, 1, 2]])
     data = Data(edge_index=edge_index, num_nodes=3)
     data = AddRemainingSelfLoops()(data)

--- a/test/transforms/test_add_remaining_self_loops.py
+++ b/test/transforms/test_add_remaining_self_loops.py
@@ -1,0 +1,68 @@
+import torch
+
+from torch_geometric.data import Data, HeteroData
+from torch_geometric.transforms import AddRemainingSelfLoops
+
+
+def test_add_remaining_self_loops():
+    # No self-loops in `edge_index`.
+    edge_index = torch.tensor([[0, 1, 1, 2], [1, 0, 2, 1]])
+    edge_weight = torch.tensor([1, 2, 3, 4])
+    edge_attr = torch.tensor([[1, 2], [3, 4], [5, 6], [7, 8]])
+
+    data = Data(edge_index=edge_index, num_nodes=3)
+    data = AddRemainingSelfLoops()(data)
+    assert len(data) == 2
+    assert data.edge_index.tolist() == [[0, 1, 1, 2, 0, 1, 2],
+                                        [1, 0, 2, 1, 0, 1, 2]]
+    assert data.num_nodes == 3
+
+    # Single self-loop in `edge_index`.
+    edge_index = torch.tensor([[0, 0, 1, 2], [1, 0, 2, 1]])
+    data = Data(edge_index=edge_index, num_nodes=3)
+    data = AddRemainingSelfLoops()(data)
+    assert len(data) == 2
+    assert data.edge_index.tolist() == [[0, 1, 2, 0, 1, 2], [1, 2, 1, 0, 1, 2]]
+    assert data.num_nodes == 3
+
+    data = Data(edge_index=edge_index, edge_weight=edge_weight, num_nodes=3)
+    data = AddRemainingSelfLoops(attr='edge_weight', fill_value=5)(data)
+    assert data.edge_index.tolist() == [[0, 1, 2, 0, 1, 2], [1, 2, 1, 0, 1, 2]]
+    assert data.num_nodes == 3
+    assert data.edge_weight.tolist() == [1, 3, 4, 2, 5, 5]
+
+    data = Data(edge_index=edge_index, edge_attr=edge_attr, num_nodes=3)
+    data = AddRemainingSelfLoops(attr='edge_attr', fill_value='add')(data)
+    assert data.edge_index.tolist() == [[0, 1, 2, 0, 1, 2], [1, 2, 1, 0, 1, 2]]
+    assert data.num_nodes == 3
+    assert data.edge_attr.tolist() == [[1, 2], [5, 6], [7, 8], [3, 4], [8, 10],
+                                       [5, 6]]
+
+
+def test_add_remaining_self_loops_all_loops_exist():
+    # All self-loops already in the data object.
+    edge_index = torch.tensor([[0, 1, 2], [0, 1, 2]])
+    data = Data(edge_index=edge_index, num_nodes=3)
+    data = AddRemainingSelfLoops()(data)
+    assert data.edge_index.tolist() == edge_index.tolist()
+
+    # All self-loops already in the data object, some of them appear multiple
+    # times.
+    edge_index = torch.tensor([[0, 0, 1, 1, 2], [0, 0, 1, 1, 2]])
+    data = Data(edge_index=edge_index, num_nodes=3)
+    data = AddRemainingSelfLoops()(data)
+    assert data.edge_index.tolist() == [[0, 1, 2], [0, 1, 2]]
+
+
+def test_hetero_add_remaining_self_loops():
+    edge_index = torch.tensor([[0, 0, 1, 2], [1, 0, 2, 1]])
+
+    data = HeteroData()
+    data['v'].num_nodes = 3
+    data['w'].num_nodes = 3
+    data['v', 'v'].edge_index = edge_index
+    data['v', 'w'].edge_index = edge_index
+    data = AddRemainingSelfLoops()(data)
+    assert data['v', 'v'].edge_index.tolist() == [[0, 1, 2, 0, 1, 2],
+                                                  [1, 2, 1, 0, 1, 2]]
+    assert data['v', 'w'].edge_index.tolist() == edge_index.tolist()

--- a/test/transforms/test_add_self_loops.py
+++ b/test/transforms/test_add_self_loops.py
@@ -36,6 +36,15 @@ def test_add_self_loops():
                                        [8, 10], [5, 6]]
 
 
+def test_add_self_loops_adds_existing_ones():
+    edge_index = torch.tensor([[0, 1, 2, 2], [1, 0, 2, 1]])
+    data = Data(edge_index=edge_index, num_nodes=3)
+    data = AddSelfLoops()(data)
+    assert data.edge_index.tolist() == [[0, 1, 2, 2, 0, 1, 2],
+                                        [1, 0, 2, 1, 0, 1, 2]]
+    assert data.num_nodes == 3
+
+
 def test_hetero_add_self_loops():
     edge_index = torch.tensor([[0, 1, 1, 2], [1, 0, 2, 1]])
 

--- a/test/transforms/test_add_self_loops.py
+++ b/test/transforms/test_add_self_loops.py
@@ -7,11 +7,11 @@ from torch_geometric.transforms import AddSelfLoops
 def test_add_self_loops():
     assert str(AddSelfLoops()) == 'AddSelfLoops()'
 
+    assert len(AddSelfLoops()(Data())) == 0
+
     edge_index = torch.tensor([[0, 1, 1, 2], [1, 0, 2, 1]])
     edge_weight = torch.tensor([1, 2, 3, 4])
     edge_attr = torch.tensor([[1, 2], [3, 4], [5, 6], [7, 8]])
-
-    assert len(AddSelfLoops()(Data())) == 0
 
     data = Data(edge_index=edge_index, num_nodes=3)
     data = AddSelfLoops()(data)
@@ -36,12 +36,11 @@ def test_add_self_loops():
                                        [8, 10], [5, 6]]
 
 
-def test_add_self_loops_adds_existing_ones():
-    edge_index = torch.tensor([[0, 1, 2, 2], [1, 0, 2, 1]])
+def test_add_self_loops_with_existing_self_loops():
+    edge_index = torch.tensor([[0, 1, 2], [0, 1, 2]])
     data = Data(edge_index=edge_index, num_nodes=3)
     data = AddSelfLoops()(data)
-    assert data.edge_index.tolist() == [[0, 1, 2, 2, 0, 1, 2],
-                                        [1, 0, 2, 1, 0, 1, 2]]
+    assert data.edge_index.tolist() == [[0, 1, 2, 0, 1, 2], [0, 1, 2, 0, 1, 2]]
     assert data.num_nodes == 3
 
 

--- a/torch_geometric/transforms/__init__.py
+++ b/torch_geometric/transforms/__init__.py
@@ -18,6 +18,7 @@ from .one_hot_degree import OneHotDegree
 from .target_indegree import TargetIndegree
 from .local_degree_profile import LocalDegreeProfile
 from .add_self_loops import AddSelfLoops
+from .add_remaining_self_loops import AddRemainingSelfLoops
 from .remove_isolated_nodes import RemoveIsolatedNodes
 from .remove_duplicated_edges import RemoveDuplicatedEdges
 from .knn_graph import KNNGraph
@@ -82,6 +83,7 @@ graph_transforms = [
     'TargetIndegree',
     'LocalDegreeProfile',
     'AddSelfLoops',
+    'AddRemainingSelfLoops',
     'RemoveIsolatedNodes',
     'RemoveDuplicatedEdges',
     'KNNGraph',

--- a/torch_geometric/transforms/add_remaining_self_loops.py
+++ b/torch_geometric/transforms/add_remaining_self_loops.py
@@ -1,0 +1,49 @@
+from typing import Optional, Union
+
+from torch import Tensor
+
+from torch_geometric.data import Data, HeteroData
+from torch_geometric.data.datapipes import functional_transform
+from torch_geometric.transforms import BaseTransform
+from torch_geometric.utils import add_remaining_self_loops
+
+
+@functional_transform('add_remaining_self_loops')
+class AddRemainingSelfLoops(BaseTransform):
+    r"""Adds remaining self-loops to the given homogeneous or heterogeneous
+    graph (functional name: :obj:`add_remaining_self_loops`).
+
+    Args:
+        attr (str, optional): The name of the attribute of edge weights
+            or multi-dimensional edge features to pass to
+            :meth:`torch_geometric.utils.add_remaining_self_loops`.
+            (default: :obj:`"edge_weight"`)
+        fill_value (float or Tensor or str, optional): The way to generate
+            edge features of self-loops (in case :obj:`attr != None`).
+            If given as :obj:`float` or :class:`torch.Tensor`, edge features of
+            self-loops will be directly given by :obj:`fill_value`.
+            If given as :obj:`str`, edge features of self-loops are computed by
+            aggregating all features of edges that point to the specific node,
+            according to a reduce operation. (:obj:`"add"`, :obj:`"mean"`,
+            :obj:`"min"`, :obj:`"max"`, :obj:`"mul"`). (default: :obj:`1.`)
+    """
+    def __init__(self, attr: Optional[str] = 'edge_weight',
+                 fill_value: Union[float, Tensor, str] = 1.0):
+        self.attr = attr
+        self.fill_value = fill_value
+
+    def __call__(
+        self,
+        data: Union[Data, HeteroData],
+    ) -> Union[Data, HeteroData]:
+        for store in data.edge_stores:
+            if store.is_bipartite() or 'edge_index' not in store:
+                continue
+
+            store.edge_index, edge_weight = add_remaining_self_loops(
+                store.edge_index, getattr(store, self.attr, None),
+                fill_value=self.fill_value, num_nodes=store.size(0))
+
+            setattr(store, self.attr, edge_weight)
+
+        return data


### PR DESCRIPTION
This PR adds the `AddRemainingSelfLoops` transform to generate only remaining self-loops instead of generating them on all the vertices like in the `AddSelfLoops` transform.