### PR TITLE
Fix `HGTConv` `edge_type_vec` construction 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
+- Fixed `subgraph` on unordered inputs ([#7187](https://github.com/pyg-team/pytorch_geometric/pull/7187))
 - Allow missing node types in `HeteroDictLinear` ([#7185](https://github.com/pyg-team/pytorch_geometric/pull/7185))
 - Optimized `from_networkx` memory footprint by reducing unnecessary copies ([#7119](https://github.com/pyg-team/pytorch_geometric/pull/7119))
 - Added an optional `batch_size` argument to `LayerNorm`, `GraphNorm`, `InstanceNorm`, `GraphSizeNorm` and `PairNorm` ([#7135](https://github.com/pyg-team/pytorch_geometric/pull/7135))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Removed
 
+- Replaced `FastHGTConv` with `HGTConv` ([#7117](https://github.com/pyg-team/pytorch_geometric/pull/7117))
+
 ## [2.3.0] - 2023-03-23
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
+- Allow missing node types in `HeteroDictLinear` ([#7185](https://github.com/pyg-team/pytorch_geometric/pull/7185))
 - Optimized `from_networkx` memory footprint by reducing unnecessary copies ([#7119](https://github.com/pyg-team/pytorch_geometric/pull/7119))
 - Added an optional `batch_size` argument to `LayerNorm`, `GraphNorm`, `InstanceNorm`, `GraphSizeNorm` and `PairNorm` ([#7135](https://github.com/pyg-team/pytorch_geometric/pull/7135))
 - Improved code coverage ([#7093](https://github.com/pyg-team/pytorch_geometric/pull/7093))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
+- Fixed `HGTConv` type vector construction ([#7194](https://github.com/pyg-team/pytorch_geometric/pull/7194))
 - Fixed `subgraph` on unordered inputs ([#7187](https://github.com/pyg-team/pytorch_geometric/pull/7187))
 - Allow missing node types in `HeteroDictLinear` ([#7185](https://github.com/pyg-team/pytorch_geometric/pull/7185))
 - Optimized `from_networkx` memory footprint by reducing unnecessary copies ([#7119](https://github.com/pyg-team/pytorch_geometric/pull/7119))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
+- Fixed `HGTConv` utility function `_construct_src_node_feat` ([#7194](https://github.com/pyg-team/pytorch_geometric/pull/7194))
 - Added an optional `batch_size` argument to `avg_pool_x` and `max_pool_x` ([#7216](https://github.com/pyg-team/pytorch_geometric/pull/7216))
 - Fixed `subgraph` on unordered inputs ([#7187](https://github.com/pyg-team/pytorch_geometric/pull/7187))
 - Allow missing node types in `HeteroDictLinear` ([#7185](https://github.com/pyg-team/pytorch_geometric/pull/7185))

--- a/test/nn/conv/test_hgt_conv.py
+++ b/test/nn/conv/test_hgt_conv.py
@@ -204,9 +204,7 @@ def test_hgt_conv_missing_input_node_type():
          'paper'].edge_index = get_random_edge_index(4, 6, 20)
 
     metadata = (['author', 'paper',
-                 'university'], [('author', 'writes', 'paper'),
-                                 ('university', 'employs', 'author'),
-                                 ('author', 'works at', 'university')])
+                 'university'], [('author', 'writes', 'paper')])
     conv = HGTConv(-1, 64, metadata, heads=1)
 
     out_dict = conv(data.x_dict, data.edge_index_dict)

--- a/test/nn/conv/test_hgt_conv.py
+++ b/test/nn/conv/test_hgt_conv.py
@@ -230,7 +230,7 @@ def test_hgt_conv_missing_edge_type():
     out_dict = conv(data.x_dict, data.edge_index_dict)
     assert out_dict['author'].size() == (4, 64)
     assert out_dict['paper'].size() == (6, 64)
-    assert 'university' not  in out_dict
+    assert 'university' not in out_dict
 
 
 if __name__ == '__main__':

--- a/test/nn/conv/test_hgt_conv.py
+++ b/test/nn/conv/test_hgt_conv.py
@@ -196,25 +196,6 @@ def test_hgt_conv_missing_dst_node_type():
     assert out_dict['university'] is None
 
 
-def test_hgt_conv_missing_src_node_type():
-    data = HeteroData()
-    data['author'].x = torch.randn(4, 16)
-    data['paper'].x = torch.randn(6, 32)
-
-    data['author', 'writes', 'paper'].edge_index = get_random_edge_index(4, 6, 20)
-
-    metadata = (
-        ['author', 'paper', 'university'],
-        [('author', 'writes', 'paper'), ('university', 'employs', 'author')]
-    )
-    conv = HGTConv(-1, 64, metadata, heads=1)
-
-    out_dict = conv(data.x_dict, data.edge_index_dict)
-    assert out_dict['author'].size() == (4, 64)
-    assert out_dict['paper'].size() == (6, 64)
-    assert out_dict['university'] == (10, 64)
-
-
 def test_hgt_conv_missing_edge_type():
     data = HeteroData()
     data['author'].x = torch.randn(4, 16)

--- a/test/nn/conv/test_hgt_conv.py
+++ b/test/nn/conv/test_hgt_conv.py
@@ -203,6 +203,8 @@ def test_hgt_conv_missing_input_node_type():
     data['author', 'writes',
          'paper'].edge_index = get_random_edge_index(4, 6, 20)
 
+    # Some nodes from metadata are missing in data.
+    # This might happen while using NeighborLoader.
     metadata = (['author', 'paper',
                  'university'], [('author', 'writes', 'paper')])
     conv = HGTConv(-1, 64, metadata, heads=1)

--- a/test/nn/conv/test_hgt_conv.py
+++ b/test/nn/conv/test_hgt_conv.py
@@ -196,6 +196,46 @@ def test_hgt_conv_missing_dst_node_type():
     assert out_dict['university'] is None
 
 
+def test_hgt_conv_missing_src_node_type():
+    data = HeteroData()
+    data['author'].x = torch.randn(4, 16)
+    data['paper'].x = torch.randn(6, 32)
+
+    data['author', 'writes', 'paper'].edge_index = get_random_edge_index(4, 6, 20)
+
+    metadata = (
+        ['author', 'paper', 'university'],
+        [('author', 'writes', 'paper'), ('university', 'employs', 'author')]
+    )
+    conv = HGTConv(-1, 64, metadata, heads=1)
+
+    out_dict = conv(data.x_dict, data.edge_index_dict)
+    assert out_dict['author'].size() == (4, 64)
+    assert out_dict['paper'].size() == (6, 64)
+    assert out_dict['university'] == (10, 64)
+
+
+def test_hgt_conv_missing_edge_type():
+    data = HeteroData()
+    data['author'].x = torch.randn(4, 16)
+    data['paper'].x = torch.randn(6, 32)
+    data['university'].x = torch.randn(10, 32)
+
+    data['author', 'writes', 'paper'].edge_index = get_random_edge_index(4, 6, 20)
+
+    metadata = (
+        ['author', 'paper', 'university'],
+        [('author', 'writes', 'paper'), ('university', 'employs', 'author')]
+    )
+    conv = HGTConv(-1, 64, metadata, heads=1)
+
+    out_dict = conv(data.x_dict, data.edge_index_dict)
+    assert out_dict['author'].size() == (4, 64)
+    assert out_dict['paper'].size() == (6, 64)
+    assert out_dict['university'] is None
+
+
+
 if __name__ == '__main__':
     import argparse
 

--- a/test/nn/conv/test_hgt_conv.py
+++ b/test/nn/conv/test_hgt_conv.py
@@ -202,19 +202,18 @@ def test_hgt_conv_missing_edge_type():
     data['paper'].x = torch.randn(6, 32)
     data['university'].x = torch.randn(10, 32)
 
-    data['author', 'writes', 'paper'].edge_index = get_random_edge_index(4, 6, 20)
+    data['author', 'writes',
+         'paper'].edge_index = get_random_edge_index(4, 6, 20)
 
-    metadata = (
-        ['author', 'paper', 'university'],
-        [('author', 'writes', 'paper'), ('university', 'employs', 'author')]
-    )
+    metadata = (['author', 'paper',
+                 'university'], [('author', 'writes', 'paper'),
+                                 ('university', 'employs', 'author')])
     conv = HGTConv(-1, 64, metadata, heads=1)
 
     out_dict = conv(data.x_dict, data.edge_index_dict)
     assert out_dict['author'].size() == (4, 64)
     assert out_dict['paper'].size() == (6, 64)
     assert out_dict['university'] is None
-
 
 
 if __name__ == '__main__':

--- a/test/nn/conv/test_hgt_conv.py
+++ b/test/nn/conv/test_hgt_conv.py
@@ -230,7 +230,7 @@ def test_hgt_conv_missing_edge_type():
     out_dict = conv(data.x_dict, data.edge_index_dict)
     assert out_dict['author'].size() == (4, 64)
     assert out_dict['paper'].size() == (6, 64)
-    assert not 'university' in out_dict
+    assert 'university' not  in out_dict
 
 
 if __name__ == '__main__':

--- a/test/nn/conv/test_hgt_conv.py
+++ b/test/nn/conv/test_hgt_conv.py
@@ -200,12 +200,13 @@ def test_hgt_conv_missing_input_node_type():
     data = HeteroData()
     data['author'].x = torch.randn(4, 16)
     data['paper'].x = torch.randn(6, 32)
-    data['author', 'writes', 'paper'].edge_index = get_random_edge_index(4, 6, 20)
+    data['author', 'writes',
+         'paper'].edge_index = get_random_edge_index(4, 6, 20)
 
-    metadata = (
-        ['author', 'paper', 'university'],
-        [('author', 'writes', 'paper'), ('university', 'employs', 'author'), ('author', 'works at', 'university')]
-    )
+    metadata = (['author', 'paper',
+                 'university'], [('author', 'writes', 'paper'),
+                                 ('university', 'employs', 'author'),
+                                 ('author', 'works at', 'university')])
     conv = HGTConv(-1, 64, metadata, heads=1)
 
     out_dict = conv(data.x_dict, data.edge_index_dict)

--- a/test/nn/conv/test_hgt_conv.py
+++ b/test/nn/conv/test_hgt_conv.py
@@ -208,7 +208,6 @@ def test_hgt_conv_missing_input_node_type():
     conv = HGTConv(-1, 64, metadata, heads=1)
 
     out_dict = conv(data.x_dict, data.edge_index_dict)
-    assert out_dict['author'].size() == (4, 64)
     assert out_dict['paper'].size() == (6, 64)
     assert 'university' not in out_dict
 

--- a/test/nn/conv/test_hgt_conv.py
+++ b/test/nn/conv/test_hgt_conv.py
@@ -193,7 +193,25 @@ def test_hgt_conv_missing_dst_node_type():
     out_dict = conv(data.x_dict, data.edge_index_dict)
     assert out_dict['author'].size() == (4, 64)
     assert out_dict['paper'].size() == (6, 64)
-    assert out_dict['university'] is None
+    assert 'university' not in out_dict
+
+
+def test_hgt_conv_missing_input_node_type():
+    data = HeteroData()
+    data['author'].x = torch.randn(4, 16)
+    data['paper'].x = torch.randn(6, 32)
+    data['author', 'writes', 'paper'].edge_index = get_random_edge_index(4, 6, 20)
+
+    metadata = (
+        ['author', 'paper', 'university'],
+        [('author', 'writes', 'paper'), ('university', 'employs', 'author'), ('author', 'works at', 'university')]
+    )
+    conv = HGTConv(-1, 64, metadata, heads=1)
+
+    out_dict = conv(data.x_dict, data.edge_index_dict)
+    assert out_dict['author'].size() == (4, 64)
+    assert out_dict['paper'].size() == (6, 64)
+    assert 'university' not in out_dict
 
 
 def test_hgt_conv_missing_edge_type():
@@ -213,7 +231,7 @@ def test_hgt_conv_missing_edge_type():
     out_dict = conv(data.x_dict, data.edge_index_dict)
     assert out_dict['author'].size() == (4, 64)
     assert out_dict['paper'].size() == (6, 64)
-    assert out_dict['university'] is None
+    assert not 'university' in out_dict
 
 
 if __name__ == '__main__':

--- a/torch_geometric/nn/conv/hgt_conv.py
+++ b/torch_geometric/nn/conv/hgt_conv.py
@@ -71,8 +71,8 @@ class HGTConv(MessagePassing):
         self.heads = heads
         self.node_types = metadata[0]
         self.edge_types = metadata[1]
-        self.dst_node_types = list(set(metadata[1][1]))
-        self.src_types = [edge_type[0] for edge_type in self.edge_types]
+
+        self.dst_node_types = set([key[-1] for key in self.edge_types])
 
         self.kqv_lin = HeteroDictLinear(self.in_channels,
                                         self.out_channels * 3)

--- a/torch_geometric/nn/conv/hgt_conv.py
+++ b/torch_geometric/nn/conv/hgt_conv.py
@@ -206,7 +206,8 @@ class HGTConv(MessagePassing):
         # Reconstruct output node embeddings dict:
         for node_type, start_offset in dst_offset.items():
             end_offset = start_offset + q_dict[node_type].size(0)
-            out_dict[node_type] = out[start_offset:end_offset]
+            if node_type in self.dst_node_types:
+                out_dict[node_type] = out[start_offset:end_offset]
 
         # Transform output node embeddings:
         a_dict = self.out_lin({
@@ -216,11 +217,7 @@ class HGTConv(MessagePassing):
 
         # Iterate over node types:
         for node_type, out in out_dict.items():
-            if node_type not in self.dst_node_types:
-                out_dict[node_type] = None
-                continue
-            else:
-                out = a_dict[node_type]
+            out = a_dict[node_type]
 
             if out.size(-1) == x_dict[node_type].size(-1):
                 alpha = self.skip[node_type].sigmoid()

--- a/torch_geometric/nn/conv/hgt_conv.py
+++ b/torch_geometric/nn/conv/hgt_conv.py
@@ -145,7 +145,8 @@ class HGTConv(MessagePassing):
             N = k_dict[src].size(0)
             start_index = self.edge_types_map[edge_type] * H
             end_index = start_index+H
-            type_list.append(torch.arange(start_index, end_index, dtype=torch.long).repeat(N))
+            type_vec = torch.arange(start_index, end_index, dtype=torch.long).repeat(N)
+            type_list.append(type_vec)
             
             offset[edge_type] = cumsum
             cumsum += N

--- a/torch_geometric/nn/conv/hgt_conv.py
+++ b/torch_geometric/nn/conv/hgt_conv.py
@@ -145,8 +145,9 @@ class HGTConv(MessagePassing):
             cumsum += N
 
             # construct type_vec for curr edge_type with shape [H, D]
-            edge_type_offset = self.edge_types_map[edge_type] 
-            type_vec = torch.arange(H,dtype=torch.long).view(-1, 1).repeat(1, N) *num_edge_types + edge_type_offset
+            edge_type_offset = self.edge_types_map[edge_type]
+            type_vec = torch.arange(H, dtype=torch.long).view(-1, 1).repeat(
+                1, N) * num_edge_types + edge_type_offset
 
             type_list.append(type_vec)
             ks.append(k_dict[src])

--- a/torch_geometric/nn/conv/hgt_conv.py
+++ b/torch_geometric/nn/conv/hgt_conv.py
@@ -71,7 +71,10 @@ class HGTConv(MessagePassing):
         self.heads = heads
         self.node_types = metadata[0]
         self.edge_types = metadata[1]
-        self.edge_types_map = {edge_type: i for i, edge_type in enumerate(metadata[1])}
+        self.edge_types_map = {
+            edge_type: i
+            for i, edge_type in enumerate(metadata[1])
+        }
 
         self.dst_node_types = set([key[-1] for key in self.edge_types])
 
@@ -122,9 +125,7 @@ class HGTConv(MessagePassing):
         return torch.cat(outs, dim=0), offset
 
     def _construct_src_node_feat(
-        self,
-        k_dict: Dict[str, Tensor],
-        v_dict: Dict[str, Tensor],
+        self, k_dict: Dict[str, Tensor], v_dict: Dict[str, Tensor],
         edge_index_dict: Dict[EdgeType, Adj]
     ) -> Tuple[Tensor, Tensor, Dict[EdgeType, int]]:
         """Constructs the source node representations."""
@@ -144,10 +145,11 @@ class HGTConv(MessagePassing):
 
             N = k_dict[src].size(0)
             start_index = self.edge_types_map[edge_type] * H
-            end_index = start_index+H
-            type_vec = torch.arange(start_index, end_index, dtype=torch.long).repeat(N)
+            end_index = start_index + H
+            type_vec = torch.arange(start_index, end_index,
+                                    dtype=torch.long).repeat(N)
             type_list.append(type_vec)
-            
+
             offset[edge_type] = cumsum
             cumsum += N
 
@@ -192,7 +194,8 @@ class HGTConv(MessagePassing):
             v_dict[key] = val[:, 2 * F:].view(-1, H, D)
 
         q, dst_offset = self._cat(q_dict)
-        k, v, src_offset = self._construct_src_node_feat(k_dict, v_dict, edge_index_dict)
+        k, v, src_offset = self._construct_src_node_feat(
+            k_dict, v_dict, edge_index_dict)
 
         edge_index, edge_attr = construct_bipartite_edge_index(
             edge_index_dict, src_offset, dst_offset, edge_attr_dict=self.p_rel)

--- a/torch_geometric/nn/conv/hgt_conv.py
+++ b/torch_geometric/nn/conv/hgt_conv.py
@@ -71,7 +71,7 @@ class HGTConv(MessagePassing):
         self.heads = heads
         self.node_types = metadata[0]
         self.edge_types = metadata[1]
-        self.edge_types_map = {edge_type:i for i,edge_type in enumerate(metadata[1])}
+        self.edge_types_map = {edge_type: i for i, edge_type in enumerate(metadata[1])}
 
         self.dst_node_types = set([key[-1] for key in self.edge_types])
 
@@ -125,7 +125,7 @@ class HGTConv(MessagePassing):
         self,
         k_dict: Dict[str, Tensor],
         v_dict: Dict[str, Tensor],
-        edge_type_dict: Dict[EdgeType, Adj] 
+        edge_index_dict: Dict[EdgeType, Adj]
     ) -> Tuple[Tensor, Tensor, Dict[EdgeType, int]]:
         """Constructs the source node representations."""
         cumsum = 0
@@ -136,8 +136,8 @@ class HGTConv(MessagePassing):
         vs: List[Tensor] = []
         type_list: List[int] = []
         offset: Dict[EdgeType] = {}
-        for edge_type in edge_type_dict.keys():
-            src, _ , _ = edge_type
+        for edge_type in edge_index_dict.keys():
+            src = edge_type[0]
 
             ks.append(k_dict[src].reshape(-1, D))
             vs.append(v_dict[src].reshape(-1, D))

--- a/torch_geometric/nn/conv/hgt_conv.py
+++ b/torch_geometric/nn/conv/hgt_conv.py
@@ -87,8 +87,8 @@ class HGTConv(MessagePassing):
         dim = out_channels // heads
         num_types = heads * len(self.edge_types)
 
-        self.k_rel = HeteroLinear(dim, dim, num_types, bias=False, sorted=True)
-        self.v_rel = HeteroLinear(dim, dim, num_types, bias=False, sorted=True)
+        self.k_rel = HeteroLinear(dim, dim, num_types, bias=False, is_sorted=True)
+        self.v_rel = HeteroLinear(dim, dim, num_types, bias=False, is_sorted=True)
 
         self.skip = ParameterDict({
             node_type: Parameter(torch.Tensor(1))

--- a/torch_geometric/nn/dense/linear.py
+++ b/torch_geometric/nn/dense/linear.py
@@ -387,7 +387,7 @@ class HeteroDictLinear(torch.nn.Module):
                     biases.append(lin.bias)
             biases = None if biases[0] is None else biases
             outs = pyg_lib.ops.grouped_matmul(xs, weights, biases)
-            for key, out in zip(self.lins.keys(), outs):
+            for key, out in zip(x_dict.keys(), outs):
                 if key in x_dict:
                     out_dict[key] = out
         else:


### PR DESCRIPTION
This pr fixes the utility function https://github.com/pyg-team/pytorch_geometric/blob/3d4836bc24dbb1b180f29cbbbdbcd18b94116dd7/torch_geometric/nn/conv/hgt_conv.py#L123, which constructs the type_vec of edges wrong and also crashes if some edge_types are not present in the current edge_index_dict. 
Consider the following scenario:

```python
# N =2, D=2, H=2 (2 nodes, head_dim 2, 2 heads)
k = [
     [0,0,1,1],
     [2,2,3,3]
    ]
```

after calling this line:
https://github.com/pyg-team/pytorch_geometric/blob/3d4836bc24dbb1b180f29cbbbdbcd18b94116dd7/torch_geometric/nn/conv/hgt_conv.py#L141

the matrix k looks like this:

```python
k= [
     [0,0],
     [1,1],
     [2,2],
     [3,3]]

# the type vec should look like this
type_vec = [0,1,0,1]
# but at current implementation it would look like this
type_vec = [0,0,1,1]
```

After the reshape the attention heads are interleaved but  the type vector that  is currently constructed is sorted. 
We fixed this issue by constructing interleaved type vec. Alternatively we can transpose the k before the reshape to ensure that we can use sorted type vec. This will also allow us to set `is_sorted=True` for the heterolinear `k_rel` which would be more efficient.
Also note that we added a test case for missing edge type in edge_index_dict.