### PR TITLE
refactor: migrate to `Flake8-pyproject`

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -90,7 +90,8 @@ PyG uses [GitHub Actions](https://github.com/pyg-team/pytorch_geometric/actions)
 
 Everytime you send a Pull Request, your commit will be built and checked against the PyG guidelines:
 
-1. Ensure that your code is formatted correctly by testing against the styleguide of [`flake8`](https://github.com/PyCQA/flake8). We also use the [`Flake8-pyproject`](https://pypi.org/project/Flake8-pyproject/) plugin for configuration:
+1. Ensure that your code is formatted correctly by testing against the styleguide of [`flake8`](https://github.com/PyCQA/flake8).
+   We use the [`Flake8-pyproject`](https://pypi.org/project/Flake8-pyproject/) plugin for configuration:
 
    ```bash
    flake8 .

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -90,7 +90,7 @@ PyG uses [GitHub Actions](https://github.com/pyg-team/pytorch_geometric/actions)
 
 Everytime you send a Pull Request, your commit will be built and checked against the PyG guidelines:
 
-1. Ensure that your code is formatted correctly by testing against the styleguide of [`flake8`](https://github.com/PyCQA/flake8):
+1. Ensure that your code is formatted correctly by testing against the styleguide of [`flake8`](https://github.com/PyCQA/flake8). We also use the [`Flake8-pyproject`](https://pypi.org/project/Flake8-pyproject/) plugin for configuration:
 
    ```bash
    flake8 .

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -53,3 +53,4 @@ repos:
     hooks:
       - id: flake8
         name: Check PEP8
+        additional_dependencies: [Flake8-pyproject]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -167,3 +167,6 @@ exclude_lines = [
     "torch.cuda.is_available",
     "WITH_PT2",
 ]
+
+[tool.flake8]
+ignore = ["F811", "W503", "W504"]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,9 +1,0 @@
-[aliases]
-test=pytest
-
-[flake8]
-ignore=
-    # ignore overload redefinition
-    F811,
-    # allow line breaks before/after binary operators
-    W503, W504,


### PR DESCRIPTION
Changes proposed by this PR can be summarized as follows: 

* Drop `setup.cfg` in favour of a `[tool.flake8]` section in `pyproject.toml` for `flake8` configuration.
* Add [`Flake8-pyproject`](https://pypi.org/project/Flake8-pyproject/) as an additional dependency in the `pre-commit` config file.
* Update docs to reflect the use of the plugin.

---

Because we currently we don't employ the use of `flake8` apart from simple ignore flags, the addition of this plugin shouldn't be an issue even for future development.

I've skipped making any changes to the `CHANGELOG` in line with older PRs suggesting refactors.