### PR TITLE
Add `batch_size` argument to `avg_pool_x` and `max_pool_x`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
-- Added an optional `batch_size` argument to `avg_pool_x` and `max_pool_x` ([#XXXX](https://github.com/pyg-team/pytorch_geometric/pull/XXXX))
+- Added an optional `batch_size` argument to `avg_pool_x` and `max_pool_x` ([#7216](https://github.com/pyg-team/pytorch_geometric/pull/7216))
 - Fixed `subgraph` on unordered inputs ([#7187](https://github.com/pyg-team/pytorch_geometric/pull/7187))
 - Allow missing node types in `HeteroDictLinear` ([#7185](https://github.com/pyg-team/pytorch_geometric/pull/7185))
 - Optimized `from_networkx` memory footprint by reducing unnecessary copies ([#7119](https://github.com/pyg-team/pytorch_geometric/pull/7119))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
+- Added an optional `batch_size` argument to `avg_pool_x` and `max_pool_x` ([#XXXX](https://github.com/pyg-team/pytorch_geometric/pull/XXXX))
 - Fixed `subgraph` on unordered inputs ([#7187](https://github.com/pyg-team/pytorch_geometric/pull/7187))
 - Allow missing node types in `HeteroDictLinear` ([#7185](https://github.com/pyg-team/pytorch_geometric/pull/7185))
 - Optimized `from_networkx` memory footprint by reducing unnecessary copies ([#7119](https://github.com/pyg-team/pytorch_geometric/pull/7119))

--- a/test/nn/pool/test_avg_pool.py
+++ b/test/nn/pool/test_avg_pool.py
@@ -23,10 +23,17 @@ def test_avg_pool_x():
     out, _ = avg_pool_x(cluster, x, batch, size=2)
     assert out.tolist() == [[3, 4], [5, 6], [10, 11], [0, 0]]
 
+    batch_size = int(batch.max().item()) + 1
+    out2, _ = avg_pool_x(cluster, x, batch, batch_size=batch_size, size=2)
+    assert torch.equal(out, out2)
+
     if is_full_test():
         jit = torch.jit.script(avg_pool_x)
         out, _ = jit(cluster, x, batch, size=2)
         assert out.tolist() == [[3, 4], [5, 6], [10, 11], [0, 0]]
+
+        out2, _ = jit(cluster, x, batch, batch_size=batch_size, size=2)
+        assert torch.equal(out, out2)
 
 
 def test_avg_pool():

--- a/test/nn/pool/test_max_pool.py
+++ b/test/nn/pool/test_max_pool.py
@@ -23,10 +23,17 @@ def test_max_pool_x():
     out, _ = max_pool_x(cluster, x, batch, size=2)
     assert out.tolist() == [[5, 6], [7, 8], [11, 12], [0, 0]]
 
+    batch_size = int(batch.max().item()) + 1
+    out2, _ = max_pool_x(cluster, x, batch, batch_size=batch_size, size=2)
+    assert torch.equal(out, out2)
+
     if is_full_test():
         jit = torch.jit.script(max_pool_x)
         out, _ = jit(cluster, x, batch, size=2)
         assert out.tolist() == [[5, 6], [7, 8], [11, 12], [0, 0]]
+
+        out2, _ = jit(cluster, x, batch, batch_size=batch_size, size=2)
+        assert torch.equal(out, out2)
 
 
 def test_max_pool():

--- a/torch_geometric/nn/pool/avg_pool.py
+++ b/torch_geometric/nn/pool/avg_pool.py
@@ -20,6 +20,7 @@ def avg_pool_x(
     cluster: Tensor,
     x: Tensor,
     batch: Tensor,
+    batch_size: Optional[int] = None,
     size: Optional[int] = None,
 ) -> Tuple[Tensor, Optional[Tensor]]:
     r"""Average pools node features according to the clustering defined in
@@ -34,6 +35,8 @@ def avg_pool_x(
         batch (torch.Tensor): The batch vector
             :math:`\mathbf{b} \in {\{ 0, \ldots, B-1\}}^N`, which assigns each
             node to a specific example.
+        batch_size (int, optional): The number of examples :math:`B`.
+                Automatically calculated if not given. (default: :obj:`None`)
         size (int, optional): The maximum number of clusters in a single
             example. (default: :obj:`None`)
 
@@ -41,7 +44,8 @@ def avg_pool_x(
         :obj:`None`, else :class:`torch.Tensor`
     """
     if size is not None:
-        batch_size = int(batch.max().item()) + 1
+        if batch_size is None:
+            batch_size = int(batch.max().item()) + 1
         return _avg_pool_x(cluster, x, batch_size * size), None
 
     cluster, perm = consecutive_cluster(cluster)

--- a/torch_geometric/nn/pool/avg_pool.py
+++ b/torch_geometric/nn/pool/avg_pool.py
@@ -36,7 +36,7 @@ def avg_pool_x(
             :math:`\mathbf{b} \in {\{ 0, \ldots, B-1\}}^N`, which assigns each
             node to a specific example.
         batch_size (int, optional): The number of examples :math:`B`.
-                Automatically calculated if not given. (default: :obj:`None`)
+            Automatically calculated if not given. (default: :obj:`None`)
         size (int, optional): The maximum number of clusters in a single
             example. (default: :obj:`None`)
 

--- a/torch_geometric/nn/pool/max_pool.py
+++ b/torch_geometric/nn/pool/max_pool.py
@@ -20,6 +20,7 @@ def max_pool_x(
     cluster: Tensor,
     x: Tensor,
     batch: Tensor,
+    batch_size: Optional[int] = None,
     size: Optional[int] = None,
 ) -> Tuple[Tensor, Optional[Tensor]]:
     r"""Max-Pools node features according to the clustering defined in
@@ -33,6 +34,8 @@ def max_pool_x(
         batch (torch.Tensor): The batch vector
             :math:`\mathbf{b} \in {\{ 0, \ldots, B-1\}}^N`, which assigns each
             node to a specific example.
+        batch_size (int, optional): The number of examples :math:`B`.
+                Automatically calculated if not given. (default: :obj:`None`)
         size (int, optional): The maximum number of clusters in a single
             example. This property is useful to obtain a batch-wise dense
             representation, *e.g.* for applying FC layers, but should only be
@@ -43,7 +46,8 @@ def max_pool_x(
         :obj:`None`, else :class:`torch.Tensor`
     """
     if size is not None:
-        batch_size = int(batch.max().item()) + 1
+        if batch_size is None:
+            batch_size = int(batch.max().item()) + 1
         return _max_pool_x(cluster, x, batch_size * size), None
 
     cluster, perm = consecutive_cluster(cluster)

--- a/torch_geometric/nn/pool/max_pool.py
+++ b/torch_geometric/nn/pool/max_pool.py
@@ -35,7 +35,7 @@ def max_pool_x(
             :math:`\mathbf{b} \in {\{ 0, \ldots, B-1\}}^N`, which assigns each
             node to a specific example.
         batch_size (int, optional): The number of examples :math:`B`.
-                Automatically calculated if not given. (default: :obj:`None`)
+            Automatically calculated if not given. (default: :obj:`None`)
         size (int, optional): The maximum number of clusters in a single
             example. This property is useful to obtain a batch-wise dense
             representation, *e.g.* for applying FC layers, but should only be


### PR DESCRIPTION
It can speedup runtime because:
1. We do not need to go through the batch dimension and look for max value.
2. We do not have to read tensor value which is placed on the device.

Besides dim_size can be used if a user is using fixed size datasets.