### PR TITLE
Skip `dgl` in benchmark if not available

### DIFF
--- a/test/nn/dense/test_linear.py
+++ b/test/nn/dense/test_linear.py
@@ -228,7 +228,7 @@ if __name__ == '__main__':
     try:
         import dgl
         WITH_DLG = True
-    except: # noqa
+    except:  # noqa
         WITH_DGL = False
 
     warnings.filterwarnings('ignore', '.*API of nested tensors.*')

--- a/test/nn/dense/test_linear.py
+++ b/test/nn/dense/test_linear.py
@@ -284,20 +284,20 @@ if __name__ == '__main__':
         padded_x = torch.nested.nested_tensor(xs).to_padded_tensor(padding=0.0)
         weight = torch.randn(num_types, channels, channels, device=args.device)
         weights = list(weight.unbind(0))
-        funcs_to_test = [sequential, grouped, padded]
-        func_names_to_test = ['Sequential', 'Grouped', 'Padded']
+
+        funcs = [sequential, grouped, padded]
+        func_names = ['Sequential', 'Grouped', 'Padded']
+        args_list = [(xs, weights), (x, ptr, weight), (padded_x, weight)]
+
         if WITH_DGL:
-            funcs_to_test += [dgl_mm]
-            func_names_to_test += ['DGL']
+            funcs.append(dgl_mm)
+            func_names.append('DGL')
+            args_list.append((x, count, weight))
+
         benchmark(
-            funcs=funcs_to_test,
-            func_names=func_names_to_test,
-            args=[
-                (xs, weights),
-                (x, ptr, weight),
-                (padded_x, weight),
-                (x, count, weight),
-            ],
+            funcs=funcs,
+            func_names=func_names,
+            args=args_list,
             num_steps=50 if args.device == 'cpu' else 500,
             num_warmups=10 if args.device == 'cpu' else 100,
             backward=args.backward,

--- a/test/nn/dense/test_linear.py
+++ b/test/nn/dense/test_linear.py
@@ -225,8 +225,11 @@ def test_hetero_linear_sort(type_vec, device):
 
 if __name__ == '__main__':
     import argparse
-
-    import dgl
+    try:
+        import dgl
+        WITH_DLG = True
+    except: # noqa
+        WITH_DGL = False
 
     warnings.filterwarnings('ignore', '.*API of nested tensors.*')
     warnings.filterwarnings('ignore', '.*TypedStorage is deprecated.*')
@@ -281,10 +284,14 @@ if __name__ == '__main__':
         padded_x = torch.nested.nested_tensor(xs).to_padded_tensor(padding=0.0)
         weight = torch.randn(num_types, channels, channels, device=args.device)
         weights = list(weight.unbind(0))
-
+        funcs_to_test = [sequential, grouped, padded]
+        func_names_to_test = ['Sequential', 'Grouped', 'Padded']
+        if WITH_DGL:
+            funcs_to_test += [dgl_mm]
+            func_names_to_test += ['DGL']
         benchmark(
-            funcs=[sequential, grouped, padded, dgl_mm],
-            func_names=['Sequential', 'Grouped', 'Padded', 'DGL'],
+            funcs=funcs_to_test,
+            func_names=_func_names_to_test,
             args=[
                 (xs, weights),
                 (x, ptr, weight),

--- a/test/nn/dense/test_linear.py
+++ b/test/nn/dense/test_linear.py
@@ -291,7 +291,7 @@ if __name__ == '__main__':
             func_names_to_test += ['DGL']
         benchmark(
             funcs=funcs_to_test,
-            func_names=_func_names_to_test,
+            func_names=func_names_to_test,
             args=[
                 (xs, weights),
                 (x, ptr, weight),


### PR DESCRIPTION
In case you don't care to compare to DGL or don't have it available