### PR TITLE
Test `return_emb` in `MLP`

### DIFF
--- a/test/nn/models/test_mlp.py
+++ b/test/nn/models/test_mlp.py
@@ -2,7 +2,6 @@ import pytest
 import torch
 
 from torch_geometric.nn import MLP
-from torch_geometric.testing import is_full_test
 
 
 @pytest.mark.parametrize('norm', ['batch_norm', None])
@@ -22,9 +21,8 @@ def test_mlp(norm, act_first, plain_last):
     out = mlp(x)
     assert out.size() == (4, 64)
 
-    if is_full_test():
-        jit = torch.jit.script(mlp)
-        assert torch.allclose(jit(x), out)
+    jit = torch.jit.script(mlp)
+    assert torch.allclose(jit(x), out)
 
     torch.manual_seed(12345)
     mlp = MLP(
@@ -37,6 +35,20 @@ def test_mlp(norm, act_first, plain_last):
         plain_last=plain_last,
     )
     assert torch.allclose(mlp(x), out)
+
+
+def test_mlp_return_emb():
+    x = torch.randn(4, 16)
+
+    mlp = MLP([16, 32, 1])
+
+    out, emb = mlp(x, return_emb=True)
+    assert out.size() == (4, 1)
+    assert emb.size() == (4, 32)
+
+    out, emb = mlp(x, return_emb=False)
+    assert out.size() == (4, 1)
+    assert emb is None
 
 
 @pytest.mark.parametrize('plain_last', [False, True])

--- a/torch_geometric/nn/models/mlp.py
+++ b/torch_geometric/nn/models/mlp.py
@@ -11,8 +11,6 @@ from torch_geometric.nn.resolver import (
     activation_resolver,
     normalization_resolver,
 )
-from torch_geometric.typing import NoneType
-
 
 class MLP(torch.nn.Module):
     r"""A Multi-Layer Perception (MLP) model.

--- a/torch_geometric/nn/models/mlp.py
+++ b/torch_geometric/nn/models/mlp.py
@@ -188,7 +188,7 @@ class MLP(torch.nn.Module):
     def forward(
         self,
         x: Tensor,
-        return_emb: NoneType = None,
+        return_emb: bool = False,
     ) -> Tensor:
         r"""
         Args:
@@ -211,7 +211,7 @@ class MLP(torch.nn.Module):
             x = self.lins[-1](x)
             x = F.dropout(x, p=self.dropout[-1], training=self.training)
 
-        return (x, emb) if isinstance(return_emb, bool) else x
+        return (x, emb) if return_emb else x
 
     def __repr__(self) -> str:
         return f'{self.__class__.__name__}({str(self.channel_list)[1:-1]})'

--- a/torch_geometric/nn/models/mlp.py
+++ b/torch_geometric/nn/models/mlp.py
@@ -12,6 +12,7 @@ from torch_geometric.nn.resolver import (
     normalization_resolver,
 )
 
+
 class MLP(torch.nn.Module):
     r"""A Multi-Layer Perception (MLP) model.
     There exists two ways to instantiate an :class:`MLP`:

--- a/torch_geometric/nn/models/mlp.py
+++ b/torch_geometric/nn/models/mlp.py
@@ -7,11 +7,11 @@ from torch import Tensor
 from torch.nn import Identity
 
 from torch_geometric.nn.dense.linear import Linear
-from torch_geometric.typing import NoneType
 from torch_geometric.nn.resolver import (
     activation_resolver,
     normalization_resolver,
 )
+from torch_geometric.typing import NoneType
 
 
 class MLP(torch.nn.Module):


### PR DESCRIPTION
There was a bug in the .forward method of the MLP class. If return_emb=False, then it would still return a tuple containing the embeddings. The line with the bug was:

```python
return (x, emb) if isinstance(return_emb, bool) else x
```
since `isinstance(False, bool)` is True. 
