### PR TITLE
Introduce `disable_dynamic_shapes` experimental flag; adding its use into `to_dense_batch function`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
-- Added the `disable_dynamic_shape` exeperimental flag ([#7246]https://github.com/pyg-team/pytorch_geometric/pull/7246)
+- Added the `disable_dynamic_shape` experimental flag ([#7246](https://github.com/pyg-team/pytorch_geometric/pull/7246))
 - Added the `MovieLens-1M` heterogeneous dataset ([#7479](https://github.com/pyg-team/pytorch_geometric/pull/7479))
 - Added a CPU-based and GPU-based `map_index` implementation ([#7493](https://github.com/pyg-team/pytorch_geometric/pull/7493))
 - Added the `AmazonBook` heterogeneous dataset ([#7483](https://github.com/pyg-team/pytorch_geometric/pull/7483))
@@ -52,6 +52,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Added support for `torch.jit.script` within `MessagePassing` layers without `torch_sparse` being installed ([#7061](https://github.com/pyg-team/pytorch_geometric/pull/7061), [#7062](https://github.com/pyg-team/pytorch_geometric/pull/7062))
 - Added unbatching logic for `torch.sparse` tensors ([#7037](https://github.com/pyg-team/pytorch_geometric/pull/7037))
 - Added the `RotatE` KGE model ([#7026](https://github.com/pyg-team/pytorch_geometric/pull/7026))
+
 ### Changed
 
 - Move the `scaler` tensor in `GeneralConv` to the correct device ([#7484](https://github.com/pyg-team/pytorch_geometric/pull/7484))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- Added `disable_dynamic_shape` exeperimental flag ([#7246]https://github.com/pyg-team/pytorch_geometric/pull/7246)
 - Added padding capabilities to `HeteroData.to_homogeneous()` in case feature dimensionalities do not match ([#7374](https://github.com/pyg-team/pytorch_geometric/pull/7374))
 - Added an optional `batch_size` argument to `fps`, `knn`, `knn_graph`, `radius` and `radius_graph` ([#7368](https://github.com/pyg-team/pytorch_geometric/pull/7368))
 - Added `PrefetchLoader` capabilities ([#7376](https://github.com/pyg-team/pytorch_geometric/pull/7376), [#7378](https://github.com/pyg-team/pytorch_geometric/pull/7378), [#7383](https://github.com/pyg-team/pytorch_geometric/pull/7383))
@@ -40,9 +41,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Added support for `torch.jit.script` within `MessagePassing` layers without `torch_sparse` being installed ([#7061](https://github.com/pyg-team/pytorch_geometric/pull/7061), [#7062](https://github.com/pyg-team/pytorch_geometric/pull/7062))
 - Added unbatching logic for `torch.sparse` tensors ([#7037](https://github.com/pyg-team/pytorch_geometric/pull/7037))
 - Added the `RotatE` KGE model ([#7026](https://github.com/pyg-team/pytorch_geometric/pull/7026))
-
 ### Changed
 
+- Added usage `disable_dynamic_shape` exeperimental flag in `to_dense_batch` function ([#7246]https://github.com/pyg-team/pytorch_geometric/pull/7246)
 - Added an optional `max_num_elements` argument to `SortAggregation` ([#7367](https://github.com/pyg-team/pytorch_geometric/pull/7367))
 - Added the option to pass `fill_value` as a `torch.tensor` to `utils.to_dense_batch` ([#7367](https://github.com/pyg-team/pytorch_geometric/pull/7367))
 - Fixed a bug in which inputs where modified in-place in `to_hetero_with_bases` ([#7363](https://github.com/pyg-team/pytorch_geometric/pull/7363))

--- a/test/test_experimental.py
+++ b/test/test_experimental.py
@@ -7,8 +7,7 @@ from torch_geometric import (
 )
 
 
-@pytest.mark.skip(reason='No experimental options available right now.')
-@pytest.mark.parametrize('options', [None])
+@pytest.mark.parametrize('options', ['disable_dynamic_shapes'])
 def test_experimental_mode(options):
     assert is_experimental_mode_enabled(options) is False
     with experimental_mode(options):

--- a/test/utils/test_to_dense_batch.py
+++ b/test/utils/test_to_dense_batch.py
@@ -54,34 +54,26 @@ def test_to_dense_batch(fill):
     out, mask = to_dense_batch(x, batch, batch_size=4, fill_value=fill)
     assert out.size() == (4, 3, 2)
 
-    with set_experimental_mode(True, "disable_dynamic_shapes"):
-        with pytest.raises(ValueError):
-            out, mask = to_dense_batch(x, batch, max_num_nodes=6,
-                                       fill_value=fill)
-        with pytest.raises(ValueError):
-            out, mask = to_dense_batch(x, batch, batch_size=4, fill_value=fill)
-        with pytest.raises(ValueError):
+
+def test_to_dense_batch_disable_dynamic_shapes():
+    x = torch.Tensor([[1, 2], [3, 4], [5, 6], [7, 8], [9, 10], [11, 12]])
+    batch = torch.tensor([0, 0, 1, 2, 2, 2])
+
+    with set_experimental_mode(True, 'disable_dynamic_shapes'):
+        with pytest.raises(ValueError, match="'batch_size' needs to be set"):
+            out, mask = to_dense_batch(x, batch, max_num_nodes=6)
+        with pytest.raises(ValueError, match="'max_num_nodes' needs to be"):
+            out, mask = to_dense_batch(x, batch, batch_size=4)
+        with pytest.raises(ValueError, match="'batch_size' needs to be set"):
             out, mask = to_dense_batch(x)
 
-        out, mask = to_dense_batch(x, batch_size=1, max_num_nodes=6,
-                                   fill_value=fill)
+        out, mask = to_dense_batch(x, batch_size=1, max_num_nodes=6)
         assert out.size() == (1, 6, 2)
-        assert out.tolist() == [[[1, 2], [3, 4], [5, 6], [7, 8], [9, 10],
-                                 [11, 12]]]
-        assert mask.tolist() == [[1, 1, 1, 1, 1, 1]]
+        assert mask.size() == (1, 6)
 
-        out, mask = to_dense_batch(x, batch, batch_size=3, max_num_nodes=10,
-                                   fill_value=fill)
+        out, mask = to_dense_batch(x, batch, batch_size=3, max_num_nodes=10)
         assert out.size() == (3, 10, 2)
-        assert torch.equal(
-            out[0, :3], torch.Tensor([[1.0, 2.0], [3.0, 4.0], [item, item]]))
-        assert torch.equal(
-            out[1, :3], torch.Tensor([[5.0, 6.0], [item, item], [item, item]]))
-        assert torch.equal(
-            out[2, :3], torch.Tensor([[7.0, 8.0], [9.0, 10.0], [11.0, 12.0]]))
-        assert mask.tolist() == [[1, 1, 0, 0, 0, 0, 0, 0, 0, 0],
-                                 [1, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-                                 [1, 1, 1, 0, 0, 0, 0, 0, 0, 0]]
+        assert mask.size() == (3, 10)
 
 
 @onlyFullTest

--- a/torch_geometric/utils/to_dense_batch.py
+++ b/torch_geometric/utils/to_dense_batch.py
@@ -10,7 +10,7 @@ from torch_geometric.experimental import (
 from torch_geometric.utils import scatter
 
 
-@disable_dynamic_shapes(required_args=["batch_size", "max_num_nodes"])
+@disable_dynamic_shapes(required_args=['batch_size', 'max_num_nodes'])
 def to_dense_batch(
     x: Tensor,
     batch: Optional[Tensor] = None,
@@ -112,7 +112,7 @@ def to_dense_batch(
 
     filter_nodes = False
     dynamic_shapes_disabled = is_experimental_mode_enabled(
-        "disable_dynamic_shapes")
+        'disable_dynamic_shapes')
 
     if max_num_nodes is None:
         max_num_nodes = int(num_nodes.max())

--- a/torch_geometric/utils/to_dense_batch.py
+++ b/torch_geometric/utils/to_dense_batch.py
@@ -3,6 +3,10 @@ from typing import Optional, Tuple, Union
 import torch
 from torch import Tensor
 
+from torch_geometric.experimental import (
+    disable_dynamic_shapes,
+    is_experimental_mode_enabled,
+)
 from torch_geometric.utils import scatter
 
 
@@ -18,6 +22,7 @@ def to_dense_batch(x, batch, fill_value, max_num_nodes, batch_size):  # noqa
     pass
 
 
+@disable_dynamic_shapes(required_args=["batch_size", "max_num_nodes"])
 def to_dense_batch(  # noqa
     x: Tensor,
     batch: Optional[Tensor] = None,
@@ -118,9 +123,12 @@ def to_dense_batch(  # noqa
     cum_nodes = torch.cat([batch.new_zeros(1), num_nodes.cumsum(dim=0)])
 
     filter_nodes = False
+    dynamic_shapes_disabled = is_experimental_mode_enabled(
+        "disable_dynamic_shapes")
+
     if max_num_nodes is None:
         max_num_nodes = int(num_nodes.max())
-    elif num_nodes.max() > max_num_nodes:
+    elif not dynamic_shapes_disabled and num_nodes.max() > max_num_nodes:
         filter_nodes = True
 
     tmp = torch.arange(batch.size(0), device=x.device) - cum_nodes[batch]


### PR DESCRIPTION
There are devices that do not support dynamic shapes - (compiling and optimizing only static graphs). The ability to set and read the "disable_dynamic_shapes" flag allows implementors to provide static shape-friendly implementations and report user-friendly messages if it is impossible to avoid using dynamic shapes.