### PR TITLE
Added support for `torch.sparse.Tensor` in `DataLoader`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- Added support for `torch.sparse.Tensor` in `DataLoader` ([#7252](https://github.com/pyg-team/pytorch_geometric/pull/7252))
 - Added a `AddRemainingSelfLoops` transform ([#7192](https://github.com/pyg-team/pytorch_geometric/pull/7192))
 - Added `optimizer_resolver` ([#7209](https://github.com/pyg-team/pytorch_geometric/pull/7209))
 - Added `type_ptr` argument to `HeteroLayerNorm` ([#7208](https://github.com/pyg-team/pytorch_geometric/pull/7208))

--- a/examples/gcn2_ppi.py
+++ b/examples/gcn2_ppi.py
@@ -9,10 +9,6 @@ import torch_geometric.transforms as T
 from torch_geometric.datasets import PPI
 from torch_geometric.loader import DataLoader
 from torch_geometric.nn import GCN2Conv
-from torch_geometric.typing import WITH_TORCH_SPARSE
-
-if not WITH_TORCH_SPARSE:
-    quit("This example requires 'torch-sparse'")
 
 path = osp.join(osp.dirname(osp.realpath(__file__)), '..', 'data', 'GCN2_PPI')
 pre_transform = T.Compose([T.GCNNorm(), T.ToSparseTensor()])

--- a/test/data/test_batch.py
+++ b/test/data/test_batch.py
@@ -1,12 +1,14 @@
 import os.path as osp
 
 import numpy as np
+import pytest
 import torch
 
 import torch_geometric
 from torch_geometric.data import Batch, Data, HeteroData
 from torch_geometric.testing import get_random_edge_index, withPackage
 from torch_geometric.typing import SparseTensor
+from torch_geometric.utils import to_edge_index, to_torch_sparse_tensor
 
 
 def test_batch_basic():
@@ -466,12 +468,10 @@ def test_nested_follow_batch():
     d4 = Data(xs=[tr(4, 3), tr(16, 4), tr(1, 2)], a={"aa": tr(8, 3)},
               x=tr(8, 5))
 
-    # Dataset
     data_list = [d1, d2, d3, d4]
 
     batch = Batch.from_data_list(data_list, follow_batch=['xs', 'a'])
 
-    # assert shapes
     assert batch.xs[0].shape == (19, 3)
     assert batch.xs[1].shape == (56, 4)
     assert batch.xs[2].shape == (7, 2)
@@ -480,7 +480,6 @@ def test_nested_follow_batch():
     assert len(batch.xs_batch) == 3
     assert len(batch.a_batch) == 1
 
-    # assert _batch
     assert batch.xs_batch[0].tolist() == \
            [0, 0, 0, 0, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 3, 3, 3, 3]
     assert batch.xs_batch[1].tolist() == \
@@ -490,3 +489,33 @@ def test_nested_follow_batch():
 
     assert batch.a_batch['aa'].tolist() == \
            [0] * 11 + [1] * 2 + [2] * 4 + [3] * 8
+
+
+@pytest.mark.parametrize('layout', [
+    torch.sparse_coo,
+    torch.sparse_csr,
+    torch.sparse_csc,
+])
+def test_torch_sparse_batch(layout):
+    if layout != torch.sparse_coo:
+        return
+
+    x_dense = torch.randn(3, 4)
+    x = x_dense.to_sparse(layout=layout)
+    edge_index = torch.tensor([[0, 1, 1, 2], [1, 0, 2, 1]])
+    edge_attr = torch.rand(4)
+    adj = to_torch_sparse_tensor(edge_index, edge_attr, layout=layout)
+
+    data = Data(x=x, adj=adj)
+
+    batch = Batch.from_data_list([data, data])
+
+    assert batch.x.size() == (6, 4)
+    assert batch.x.layout == layout
+    assert torch.equal(batch.x.to_dense(), torch.cat([x_dense, x_dense], 0))
+
+    assert batch.adj.size() == (6, 6)
+    assert batch.adj.layout == layout
+    out = to_edge_index(batch.adj)
+    assert torch.equal(out[0], torch.cat([edge_index, edge_index + 3], 1))
+    assert torch.equal(out[1], torch.cat([edge_attr, edge_attr], 0))

--- a/test/data/test_batch.py
+++ b/test/data/test_batch.py
@@ -497,9 +497,6 @@ def test_nested_follow_batch():
     torch.sparse_csc,
 ])
 def test_torch_sparse_batch(layout):
-    if layout != torch.sparse_coo:
-        return
-
     x_dense = torch.randn(3, 4)
     x = x_dense.to_sparse(layout=layout)
     edge_index = torch.tensor([[0, 1, 1, 2], [1, 0, 2, 1]])
@@ -516,6 +513,6 @@ def test_torch_sparse_batch(layout):
 
     assert batch.adj.size() == (6, 6)
     assert batch.adj.layout == layout
-    out = to_edge_index(batch.adj)
+    out = to_edge_index(batch.adj.to_sparse(layout=torch.sparse_csr))
     assert torch.equal(out[0], torch.cat([edge_index, edge_index + 3], 1))
     assert torch.equal(out[1], torch.cat([edge_attr, edge_attr], 0))

--- a/test/data/test_batch.py
+++ b/test/data/test_batch.py
@@ -491,6 +491,7 @@ def test_nested_follow_batch():
            [0] * 11 + [1] * 2 + [2] * 4 + [3] * 8
 
 
+@withPackage('torch>=2.0.0')
 @pytest.mark.parametrize('layout', [
     torch.sparse_coo,
     torch.sparse_csr,

--- a/torch_geometric/data/collate.py
+++ b/torch_geometric/data/collate.py
@@ -9,7 +9,7 @@ import torch_geometric.typing
 from torch_geometric.data.data import BaseData
 from torch_geometric.data.storage import BaseStorage, NodeStorage
 from torch_geometric.typing import SparseTensor, torch_sparse
-from torch_geometric.utils import is_sparse, is_torch_sparse_tensor, to_edge_index, 
+from torch_geometric.utils import is_sparse, is_torch_sparse_tensor, to_edge_index, to_torch_sparse_tensor
 
 def collate(
     cls,

--- a/torch_geometric/data/collate.py
+++ b/torch_geometric/data/collate.py
@@ -177,7 +177,7 @@ def _collate(
                 sparse_sizes[1] = max(sparse_sizes[1], value.size(1))
                 e_idxs_to_cat.append(to_edge_index(value)[0])
             print("e_idxs_to_cat.size()=",[e.size() for e in e_idxs_to_cat])
-            value = to_torch_sparse_tensor(torch.cat(e_idxs_to_cat, dim=1), size=sparse_sizes, layout=values[0].layout)
+            value = to_torch_sparse_tensor(torch.cat(e_idxs_to_cat, dim=1), size=sparse_sizes, layout=values[0].layout).T
             print("value.size()=",value.size())
         else:
             value = torch_sparse.cat(values, dim=cat_dim)

--- a/torch_geometric/data/collate.py
+++ b/torch_geometric/data/collate.py
@@ -9,7 +9,7 @@ import torch_geometric.typing
 from torch_geometric.data.data import BaseData
 from torch_geometric.data.storage import BaseStorage, NodeStorage
 from torch_geometric.typing import SparseTensor, torch_sparse
-
+from torch_geometric.utils import is_sparse, is_torch_sparse_tensor
 
 def collate(
     cls,
@@ -122,7 +122,7 @@ def _collate(
 
     elem = values[0]
 
-    if isinstance(elem, Tensor):
+    if isinstance(elem, Tensor) and not is_sparse(elem):
         # Concatenate a list of `torch.Tensor` along the `cat_dim`.
         # NOTE: We need to take care of incrementing elements appropriately.
         key = str(key)
@@ -160,7 +160,7 @@ def _collate(
         value = torch.cat(values, dim=cat_dim or 0, out=out)
         return value, slices, incs
 
-    elif isinstance(elem, SparseTensor) and increment:
+    elif is_sparse(elem) and increment:
         # Concatenate a list of `SparseTensor` along the `cat_dim`.
         # NOTE: `cat_dim` may return a tuple to allow for diagonal stacking.
         key = str(key)

--- a/torch_geometric/data/collate.py
+++ b/torch_geometric/data/collate.py
@@ -15,6 +15,7 @@ from torch_geometric.utils import (
     to_edge_index,
     to_torch_sparse_tensor,
 )
+from torch_geometric.utils.sparse import cat
 
 
 def collate(
@@ -175,18 +176,7 @@ def _collate(
         repeats = [[value.size(dim) for dim in cat_dims] for value in values]
         slices = cumsum(repeats)
         if is_torch_sparse_tensor(elem):
-            # (TODO) Replace w/ torch.cat once working upstream
-            sparse_sizes: List[int] = [0, 0]
-            e_idxs_to_cat = []
-            for value in values:
-                sparse_sizes[0] += value.size(0)
-                sparse_sizes[1] = max(sparse_sizes[1], value.size(1))
-                e_idxs_to_cat.append(to_edge_index(value)[0])
-            print("e_idxs_to_cat.size()=", [e.size() for e in e_idxs_to_cat])
-            value = to_torch_sparse_tensor(torch.cat(e_idxs_to_cat,
-                                                     dim=1), size=sparse_sizes,
-                                           layout=values[0].layout)
-            print("value.size()=", value.size())
+            value = cat(values, dim=cat_dim)
         else:
             value = torch_sparse.cat(values, dim=cat_dim)
         return value, slices, None

--- a/torch_geometric/data/collate.py
+++ b/torch_geometric/data/collate.py
@@ -9,12 +9,7 @@ import torch_geometric.typing
 from torch_geometric.data.data import BaseData
 from torch_geometric.data.storage import BaseStorage, NodeStorage
 from torch_geometric.typing import SparseTensor, torch_sparse
-from torch_geometric.utils import (
-    is_sparse,
-    is_torch_sparse_tensor,
-    to_edge_index,
-    to_torch_sparse_tensor,
-)
+from torch_geometric.utils import is_sparse, is_torch_sparse_tensor
 from torch_geometric.utils.sparse import cat
 
 

--- a/torch_geometric/data/collate.py
+++ b/torch_geometric/data/collate.py
@@ -168,7 +168,7 @@ def _collate(
         cat_dims = (cat_dim, ) if isinstance(cat_dim, int) else cat_dim
         repeats = [[value.size(dim) for dim in cat_dims] for value in values]
         slices = cumsum(repeats)
-        if is_sparse_tensor(elem):
+        if is_torch_sparse_tensor(elem):
             # (TODO) Replace w/ torch.cat once working upstream
             value = to_torch_sparse_tensor(torch.cat([to_edge_index(value) for value in values], dim=cat_dim), layout=values[0].layout)
         else:

--- a/torch_geometric/data/collate.py
+++ b/torch_geometric/data/collate.py
@@ -173,6 +173,7 @@ def _collate(
             e_idxs_to_cat = [to_edge_index(value)[0] for value in values]
             print("e_idxs_to_cat.size()=",[e.size() for e in e_idxs_to_cat])
             value = to_torch_sparse_tensor(torch.cat(e_idxs_to_cat, dim=1), layout=values[0].layout)
+            print("value.size()=",value.size())
         else:
             value = torch_sparse.cat(values, dim=cat_dim)
         return value, slices, None

--- a/torch_geometric/data/collate.py
+++ b/torch_geometric/data/collate.py
@@ -170,9 +170,13 @@ def _collate(
         slices = cumsum(repeats)
         if is_torch_sparse_tensor(elem):
             # (TODO) Replace w/ torch.cat once working upstream
-            e_idxs_to_cat = [to_edge_index(value)[0] for value in values]
+            sparse_sizes: List[int] = [0, 0]            
+            sparse_sizes[0] += value.sparse_size(0)
+            sparse_sizes[1] = max(sparse_sizes[1], value.sparse_size(1))
+            for value in values:
+                e_idxs_to_cat.append(to_edge_index(value)[0])
             print("e_idxs_to_cat.size()=",[e.size() for e in e_idxs_to_cat])
-            value = to_torch_sparse_tensor(torch.cat(e_idxs_to_cat, dim=1), layout=values[0].layout)
+            value = to_torch_sparse_tensor(torch.cat(e_idxs_to_cat, dim=1), size=sparse_sizes, layout=values[0].layout)
             print("value.size()=",value.size())
         else:
             value = torch_sparse.cat(values, dim=cat_dim)

--- a/torch_geometric/data/collate.py
+++ b/torch_geometric/data/collate.py
@@ -170,7 +170,7 @@ def _collate(
         slices = cumsum(repeats)
         if is_torch_sparse_tensor(elem):
             # (TODO) Replace w/ torch.cat once working upstream
-            value = to_torch_sparse_tensor(torch.cat([to_edge_index(value) for value in values], dim=cat_dim), layout=values[0].layout)
+            value = to_torch_sparse_tensor(torch.cat([to_edge_index(value)[0] for value in values], dim=cat_dim), layout=values[0].layout)
         else:
             value = torch_sparse.cat(values, dim=cat_dim)
         return value, slices, None

--- a/torch_geometric/data/collate.py
+++ b/torch_geometric/data/collate.py
@@ -172,8 +172,8 @@ def _collate(
             # (TODO) Replace w/ torch.cat once working upstream
             sparse_sizes: List[int] = [0, 0]            
             for value in values:
-                sparse_sizes[0] += value.sparse_size(0)
-                sparse_sizes[1] = max(sparse_sizes[1], value.sparse_size(1))
+                sparse_sizes[0] += value.size(0)
+                sparse_sizes[1] = max(sparse_sizes[1], value.size(1))
                 e_idxs_to_cat.append(to_edge_index(value)[0])
             print("e_idxs_to_cat.size()=",[e.size() for e in e_idxs_to_cat])
             value = to_torch_sparse_tensor(torch.cat(e_idxs_to_cat, dim=1), size=sparse_sizes, layout=values[0].layout)

--- a/torch_geometric/data/collate.py
+++ b/torch_geometric/data/collate.py
@@ -170,7 +170,9 @@ def _collate(
         slices = cumsum(repeats)
         if is_torch_sparse_tensor(elem):
             # (TODO) Replace w/ torch.cat once working upstream
-            value = to_torch_sparse_tensor(torch.cat([to_edge_index(value)[0] for value in values]), layout=values[0].layout)
+            e_idxs_to_cat = [to_edge_index(value)[0] for value in values]
+            print("e_idxs_to_cat.size()=",[e.size() for e in e_idxs_to_cat])
+            value = to_torch_sparse_tensor(torch.cat(e_idxs_to_cat), layout=values[0].layout)
         else:
             value = torch_sparse.cat(values, dim=cat_dim)
         return value, slices, None

--- a/torch_geometric/data/collate.py
+++ b/torch_geometric/data/collate.py
@@ -170,7 +170,8 @@ def _collate(
         slices = cumsum(repeats)
         if is_torch_sparse_tensor(elem):
             # (TODO) Replace w/ torch.cat once working upstream
-            sparse_sizes: List[int] = [0, 0]            
+            sparse_sizes: List[int] = [0, 0]     
+            e_idxs_to_cat = []       
             for value in values:
                 sparse_sizes[0] += value.size(0)
                 sparse_sizes[1] = max(sparse_sizes[1], value.size(1))

--- a/torch_geometric/data/collate.py
+++ b/torch_geometric/data/collate.py
@@ -185,7 +185,7 @@ def _collate(
             print("e_idxs_to_cat.size()=", [e.size() for e in e_idxs_to_cat])
             value = to_torch_sparse_tensor(torch.cat(e_idxs_to_cat,
                                                      dim=1), size=sparse_sizes,
-                                           layout=values[0].layout).T
+                                           layout=values[0].layout).transpose()
             print("value.size()=", value.size())
         else:
             value = torch_sparse.cat(values, dim=cat_dim)

--- a/torch_geometric/data/collate.py
+++ b/torch_geometric/data/collate.py
@@ -171,9 +171,9 @@ def _collate(
         if is_torch_sparse_tensor(elem):
             # (TODO) Replace w/ torch.cat once working upstream
             sparse_sizes: List[int] = [0, 0]            
-            sparse_sizes[0] += value.sparse_size(0)
-            sparse_sizes[1] = max(sparse_sizes[1], value.sparse_size(1))
             for value in values:
+                sparse_sizes[0] += value.sparse_size(0)
+                sparse_sizes[1] = max(sparse_sizes[1], value.sparse_size(1))
                 e_idxs_to_cat.append(to_edge_index(value)[0])
             print("e_idxs_to_cat.size()=",[e.size() for e in e_idxs_to_cat])
             value = to_torch_sparse_tensor(torch.cat(e_idxs_to_cat, dim=1), size=sparse_sizes, layout=values[0].layout)

--- a/torch_geometric/data/collate.py
+++ b/torch_geometric/data/collate.py
@@ -185,7 +185,7 @@ def _collate(
             print("e_idxs_to_cat.size()=", [e.size() for e in e_idxs_to_cat])
             value = to_torch_sparse_tensor(torch.cat(e_idxs_to_cat,
                                                      dim=1), size=sparse_sizes,
-                                           layout=values[0].layout).transpose(0, 1)
+                                           layout=values[0].layout)
             print("value.size()=", value.size())
         else:
             value = torch_sparse.cat(values, dim=cat_dim)

--- a/torch_geometric/data/collate.py
+++ b/torch_geometric/data/collate.py
@@ -185,7 +185,7 @@ def _collate(
             print("e_idxs_to_cat.size()=", [e.size() for e in e_idxs_to_cat])
             value = to_torch_sparse_tensor(torch.cat(e_idxs_to_cat,
                                                      dim=1), size=sparse_sizes,
-                                           layout=values[0].layout).transpose()
+                                           layout=values[0].layout).transpose(0, 1)
             print("value.size()=", value.size())
         else:
             value = torch_sparse.cat(values, dim=cat_dim)

--- a/torch_geometric/data/collate.py
+++ b/torch_geometric/data/collate.py
@@ -172,7 +172,7 @@ def _collate(
             # (TODO) Replace w/ torch.cat once working upstream
             e_idxs_to_cat = [to_edge_index(value)[0] for value in values]
             print("e_idxs_to_cat.size()=",[e.size() for e in e_idxs_to_cat])
-            value = to_torch_sparse_tensor(torch.cat(e_idxs_to_cat), layout=values[0].layout)
+            value = to_torch_sparse_tensor(torch.cat(e_idxs_to_cat), dim=1, layout=values[0].layout)
         else:
             value = torch_sparse.cat(values, dim=cat_dim)
         return value, slices, None

--- a/torch_geometric/data/collate.py
+++ b/torch_geometric/data/collate.py
@@ -170,7 +170,7 @@ def _collate(
         slices = cumsum(repeats)
         if is_torch_sparse_tensor(elem):
             # (TODO) Replace w/ torch.cat once working upstream
-            value = to_torch_sparse_tensor(torch.cat([to_edge_index(value)[0] for value in values], dim=cat_dim), layout=values[0].layout)
+            value = to_torch_sparse_tensor(torch.cat([to_edge_index(value)[0] for value in values]), layout=values[0].layout)
         else:
             value = torch_sparse.cat(values, dim=cat_dim)
         return value, slices, None

--- a/torch_geometric/data/collate.py
+++ b/torch_geometric/data/collate.py
@@ -172,7 +172,7 @@ def _collate(
             # (TODO) Replace w/ torch.cat once working upstream
             e_idxs_to_cat = [to_edge_index(value)[0] for value in values]
             print("e_idxs_to_cat.size()=",[e.size() for e in e_idxs_to_cat])
-            value = to_torch_sparse_tensor(torch.cat(e_idxs_to_cat), dim=1, layout=values[0].layout)
+            value = to_torch_sparse_tensor(torch.cat(e_idxs_to_cat, dim=1), layout=values[0].layout)
         else:
             value = torch_sparse.cat(values, dim=cat_dim)
         return value, slices, None

--- a/torch_geometric/data/data.py
+++ b/torch_geometric/data/data.py
@@ -37,7 +37,7 @@ from torch_geometric.typing import (
     OptTensor,
     SparseTensor,
 )
-from torch_geometric.utils import select, subgraph
+from torch_geometric.utils import is_sparse, select, subgraph
 
 
 class BaseData(object):
@@ -518,7 +518,7 @@ class Data(BaseData, FeatureStore, GraphStore):
         return self
 
     def __cat_dim__(self, key: str, value: Any, *args, **kwargs) -> Any:
-        if isinstance(value, SparseTensor) and 'adj' in key:
+        if is_sparse(value) and 'adj' in key:
             return (0, 1)
         elif 'index' in key or key == 'face':
             return -1

--- a/torch_geometric/data/separate.py
+++ b/torch_geometric/data/separate.py
@@ -65,7 +65,8 @@ def _separate(
         start, end = int(slices[idx]), int(slices[idx + 1])
         value = narrow(value, cat_dim or 0, start, end - start)
         value = value.squeeze(0) if cat_dim is None else value
-        if decrement and (incs.dim() > 1 or int(incs[idx]) != 0):
+        if (decrement and incs is not None
+                and (incs.dim() > 1 or int(incs[idx]) != 0)):
             value = value - incs[idx].to(value.device)
         return value
 

--- a/torch_geometric/utils/__init__.py
+++ b/torch_geometric/utils/__init__.py
@@ -26,8 +26,9 @@ from .to_dense_batch import to_dense_batch
 from .to_dense_adj import to_dense_adj
 from .nested import to_nested_tensor, from_nested_tensor
 from .sparse import (dense_to_sparse, is_sparse, is_torch_sparse_tensor,
-                     to_torch_sparse_tensor, to_torch_coo_tensor,
-                     to_torch_csr_tensor, to_torch_csc_tensor, to_edge_index)
+                     to_torch_coo_tensor, to_torch_csr_tensor,
+                     to_torch_csc_tensor, to_torch_sparse_tensor,
+                     to_edge_index)
 from .spmm import spmm
 from .unbatch import unbatch, unbatch_edge_index
 from .one_hot import one_hot
@@ -96,10 +97,10 @@ __all__ = [
     'dense_to_sparse',
     'is_torch_sparse_tensor',
     'is_sparse',
-    'to_torch_sparse_tensor',
     'to_torch_coo_tensor',
     'to_torch_csr_tensor',
     'to_torch_csc_tensor',
+    'to_torch_sparse_tensor',
     'to_edge_index',
     'spmm',
     'unbatch',

--- a/torch_geometric/utils/__init__.py
+++ b/torch_geometric/utils/__init__.py
@@ -26,7 +26,7 @@ from .to_dense_batch import to_dense_batch
 from .to_dense_adj import to_dense_adj
 from .nested import to_nested_tensor, from_nested_tensor
 from .sparse import (dense_to_sparse, is_sparse, is_torch_sparse_tensor,
-                     to_torch_coo_tensor, to_torch_csr_tensor,
+                     to_torch_sparse_tensor, to_torch_coo_tensor, to_torch_csr_tensor,
                      to_torch_csc_tensor, to_edge_index)
 from .spmm import spmm
 from .unbatch import unbatch, unbatch_edge_index
@@ -96,6 +96,7 @@ __all__ = [
     'dense_to_sparse',
     'is_torch_sparse_tensor',
     'is_sparse',
+    'to_torch_sparse_tensor',
     'to_torch_coo_tensor',
     'to_torch_csr_tensor',
     'to_torch_csc_tensor',

--- a/torch_geometric/utils/sparse.py
+++ b/torch_geometric/utils/sparse.py
@@ -82,6 +82,20 @@ def is_sparse(src: Any) -> bool:
     return is_torch_sparse_tensor(src) or isinstance(src, SparseTensor)
 
 
+def to_torch_sparse_tensor(edge_index: Tensor,
+    edge_attr: Optional[Tensor] = None,
+    size: Optional[Union[int, Tuple[int, int]]] = None,
+    is_coalesced: bool = False,
+    layout: torch.layout = torch.sparse_coo,
+):
+    if layout == torch.sparse_coo:
+        return to_torch_coo_tensor(edge_index, edge_attr, size, is_coalesced)
+    if layout == torch.sparse_csr:
+        return to_torch_csr_tensor(edge_index, edge_attr, size, is_coalesced)
+    if layout == torch.sparse_csc:
+        return to_torch_csc_tensor(edge_index, edge_attr, size, is_coalesced)
+
+
 def to_torch_coo_tensor(
     edge_index: Tensor,
     edge_attr: Optional[Tensor] = None,

--- a/torch_geometric/utils/sparse.py
+++ b/torch_geometric/utils/sparse.py
@@ -82,21 +82,6 @@ def is_sparse(src: Any) -> bool:
     return is_torch_sparse_tensor(src) or isinstance(src, SparseTensor)
 
 
-def to_torch_sparse_tensor(
-    edge_index: Tensor,
-    edge_attr: Optional[Tensor] = None,
-    size: Optional[Union[int, Tuple[int, int]]] = None,
-    is_coalesced: bool = False,
-    layout: torch.layout = torch.sparse_coo,
-):
-    if layout == torch.sparse_coo:
-        return to_torch_coo_tensor(edge_index, edge_attr, size, is_coalesced)
-    if layout == torch.sparse_csr:
-        return to_torch_csr_tensor(edge_index, edge_attr, size, is_coalesced)
-    if layout == torch.sparse_csc:
-        return to_torch_csc_tensor(edge_index, edge_attr, size, is_coalesced)
-
-
 def to_torch_coo_tensor(
     edge_index: Tensor,
     edge_attr: Optional[Tensor] = None,
@@ -252,6 +237,44 @@ def to_torch_csc_tensor(
     )
 
     return adj
+
+
+def to_torch_sparse_tensor(
+    edge_index: Tensor,
+    edge_attr: Optional[Tensor] = None,
+    size: Optional[Union[int, Tuple[int, int]]] = None,
+    is_coalesced: bool = False,
+    layout: torch.layout = torch.sparse_coo,
+):
+    r"""Converts a sparse adjacency matrix defined by edge indices and edge
+    attributes to a :class:`torch.sparse.Tensor` with custom :obj:`layout`.
+    See :meth:`~torch_geometric.utils.to_edge_index` for the reverse operation.
+
+    Args:
+        edge_index (LongTensor): The edge indices.
+        edge_attr (Tensor, optional): The edge attributes.
+            (default: :obj:`None`)
+        size (int or (int, int), optional): The size of the sparse matrix.
+            If given as an integer, will create a quadratic sparse matrix.
+            If set to :obj:`None`, will infer a quadratic sparse matrix based
+            on :obj:`edge_index.max() + 1`. (default: :obj:`None`)
+        is_coalesced (bool): If set to :obj:`True`, will assume that
+            :obj:`edge_index` is already coalesced and thus avoids expensive
+            computation. (default: :obj:`False`)
+        layout (torch.layout, optional): The layout of the output sparse tensor
+            (:obj:`torch.sparse_coo`, :obj:`torch.sparse_csr`,
+            :obj:`torch.sparse_csc`). (default: :obj:`torch.sparse_coo`)
+
+    :rtype: :class:`torch.sparse.Tensor`
+    """
+    if layout == torch.sparse_coo:
+        return to_torch_coo_tensor(edge_index, edge_attr, size, is_coalesced)
+    if layout == torch.sparse_csr:
+        return to_torch_csr_tensor(edge_index, edge_attr, size, is_coalesced)
+    if layout == torch.sparse_csc:
+        return to_torch_csc_tensor(edge_index, edge_attr, size, is_coalesced)
+
+    raise ValueError(f"Unexpected sparse tensor layout (got '{layout}')")
 
 
 def to_edge_index(adj: Union[Tensor, SparseTensor]) -> Tuple[Tensor, Tensor]:


### PR DESCRIPTION
this implementation isnt working yet, it currently fails with shape mismatch on a Linear layer but passes the collate part

example repro:
`cd /opt/pyg; pip uninstall -y torch-geometric torch-sparse; rm -rf pytorch_geometric; git clone -b collate_fix https://github.com/pyg-team/pytorch_geometric.git; cd /opt/pyg/pytorch_geometric; pip install .; python3 examples/gcn2_ppi.py` 
```
e_idxs_to_cat.size()= [torch.Size([2, 48146]), torch.Size([2, 88335])]
value.size()= torch.Size([4693, 2815])
Traceback (most recent call last):
  File "examples/gcn2_ppi.py", line 93, in <module>
    loss = train()
  File "examples/gcn2_ppi.py", line 70, in train
    loss = criterion(model(data.x, data.adj_t), data.y)
  File "/usr/local/lib/python3.8/dist-packages/torch/nn/modules/module.py", line 1533, in _call_impl
    return forward_call(*args, **kwargs)
  File "examples/gcn2_ppi.py", line 46, in forward
    h = conv(h, x_0, adj_t)
  File "/usr/local/lib/python3.8/dist-packages/torch/nn/modules/module.py", line 1533, in _call_impl
    return forward_call(*args, **kwargs)
  File "/usr/local/lib/python3.8/dist-packages/torch_geometric/nn/conv/gcn2_conv.py", line 138, in forward
    x = self.propagate(edge_index, x=x, edge_weight=edge_weight, size=None)
  File "/usr/local/lib/python3.8/dist-packages/torch_geometric/nn/conv/message_passing.py", line 437, in propagate
    out = self.message_and_aggregate(edge_index, **msg_aggr_kwargs)
  File "/usr/local/lib/python3.8/dist-packages/torch_geometric/nn/conv/gcn2_conv.py", line 159, in message_and_aggregate
    return spmm(adj_t, x, reduce=self.aggr)
  File "/usr/local/lib/python3.8/dist-packages/torch_geometric/utils/spmm.py", line 80, in spmm
    return torch.sparse.mm(src, other)
```
 (just remove the check that triggers `This example requires 'torch-sparse'`)
