### PR TITLE
Update `HGTConv` doc

### DIFF
--- a/torch_geometric/nn/conv/hgt_conv.py
+++ b/torch_geometric/nn/conv/hgt_conv.py
@@ -25,11 +25,6 @@ class HGTConv(MessagePassing):
         <https://github.com/pyg-team/pytorch_geometric/blob/master/examples/
         hetero/hgt_dblp.py>`_.
 
-    .. note::
-
-        For a faster alternative, use :class:`FastHGTConv` which does not
-        iterate over individual node and edge types.
-
     Args:
         in_channels (int or Dict[str, int]): Size of each input sample of every
             node type, or :obj:`-1` to derive the size from the first input(s)


### PR DESCRIPTION
Removed reference to `FastHGTConv`. It was "merged" with `HGTConv` [here](https://github.com/pyg-team/pytorch_geometric/pull/7117)