### PR TITLE
`Pooling`:  Support kwargs

### DIFF
--- a/test/nn/pool/test_pooling_base.py
+++ b/test/nn/pool/test_pooling_base.py
@@ -26,7 +26,7 @@ class DummySelect2(Select):
 
 
 class DummyConnect(Connect):
-    def forward(self, cluster, edge_index, edge_attr, batch):
+    def forward(self, cluster, edge_index, num_nodes, edge_attr, batch):
         # Return empty graph connection:
         if edge_attr is not None:
             edge_attr = edge_attr.new_empty((0, ) + edge_attr.size()[1:])

--- a/torch_geometric/nn/aggr/base.py
+++ b/torch_geometric/nn/aggr/base.py
@@ -3,6 +3,7 @@ from typing import Optional, Tuple
 import torch
 from torch import Tensor
 
+from torch_geometric.nn.conv.utils.inspector import Inspector
 from torch_geometric.utils import scatter, segment, to_dense_batch
 
 
@@ -58,6 +59,13 @@ class Aggregation(torch.nn.Module):
         - **output:** graph features :math:`(*, |\mathcal{G}|, F_{out})` or
           node features :math:`(*, |\mathcal{V}|, F_{out})`
     """
+    def __init__(self):
+        super().__init__()
+        self.inspector = Inspector(self)
+        self.inspector.inspect(self.forward)
+        for pop_arg in ['x', 'index', 'ptr', 'dim_size', 'dim']:
+            self.inspector.params['forward'].pop(pop_arg, None)
+
     def forward(self, x: Tensor, index: Optional[Tensor] = None,
                 ptr: Optional[Tensor] = None, dim_size: Optional[int] = None,
                 dim: int = -2) -> Tensor:

--- a/torch_geometric/nn/pool/base.py
+++ b/torch_geometric/nn/pool/base.py
@@ -75,6 +75,9 @@ class Pooling(torch.nn.Module):
             batch (torch.Tensor, optional): The batch vector
                 :math:`\mathbf{b} \in {\{ 0, \ldots, B-1\}}^N`, which assigns
                 each node to a specific graph. (default: :obj:`None`)
+            **kwargs (optional): Additional arguments passed to the
+                :meth:`forward` methods of :obj:`select`, :obj:`reduce` and
+                :obj:`connect`.
         """
 
         select_kwargs = self.select.inspector.distribute('forward', kwargs)

--- a/torch_geometric/nn/pool/base.py
+++ b/torch_geometric/nn/pool/base.py
@@ -86,6 +86,9 @@ class Pooling(torch.nn.Module):
         # Some nodes might not be part of any
         # cluster.
         dropped_nodes_mask = cluster == -1
+        for key, value in kwargs.items():
+            if isinstance(value, Tensor) and value.size(0) == x.size(0):
+                kwargs[key] = value[~dropped_nodes_mask]
 
         reduce_kwargs = self.reduce.inspector.distribute('forward', kwargs)
         x = self.reduce(x[~dropped_nodes_mask], cluster[~dropped_nodes_mask],

--- a/torch_geometric/nn/pool/connect/base.py
+++ b/torch_geometric/nn/pool/connect/base.py
@@ -18,7 +18,9 @@ class Connect(torch.nn.Module):
         super().__init__()
         self.inspector = Inspector(self)
         self.inspector.inspect(self.forward)
-        for pop_arg in ['cluster', 'edge_index', 'edge_attr', 'batch']:
+        for pop_arg in [
+                'cluster', 'edge_index', 'edge_attr', 'batch', 'num_nodes'
+        ]:
             self.inspector.params['forward'].pop(pop_arg, None)
 
     def reset_parameters(self):
@@ -29,6 +31,7 @@ class Connect(torch.nn.Module):
         self,
         cluster: Tensor,
         edge_index: Tensor,
+        num_nodes: int,
         edge_attr: Optional[Tensor] = None,
         batch: Optional[Tensor] = None,
     ) -> Tuple[Tensor, Optional[Tensor]]:
@@ -36,6 +39,7 @@ class Connect(torch.nn.Module):
         Args:
             cluster (torch.Tensor): The mapping from nodes to supernodes.
             edge_index (torch.Tensor): The edge indices.
+            num_nodes (int): The number of nodes in the input graph.
             edge_attr (torch.Tensor, optional): The edge features.
                 (default: :obj:`None`)
             batch (torch.Tensor, optional): The batch vector

--- a/torch_geometric/nn/pool/connect/base.py
+++ b/torch_geometric/nn/pool/connect/base.py
@@ -3,6 +3,8 @@ from typing import Optional, Tuple
 import torch
 from torch import Tensor
 
+from torch_geometric.nn.conv.utils.inspector import Inspector
+
 
 class Connect(torch.nn.Module):
     r"""An abstract base class implementing custom edge connection operators.
@@ -12,6 +14,13 @@ class Connect(torch.nn.Module):
     nodes in the two supernodes.
     The operator also computes new coarsened edge features (if present).
     """
+    def __init__(self):
+        super().__init__()
+        self.inspector = Inspector(self)
+        self.inspector.inspect(self.forward)
+        for pop_arg in ['cluster', 'edge_index', 'edge_attr', 'batch']:
+            self.inspector.params['forward'].pop(pop_arg, None)
+
     def reset_parameters(self):
         r"""Resets all learnable parameters of the module."""
         pass

--- a/torch_geometric/nn/pool/select/base.py
+++ b/torch_geometric/nn/pool/select/base.py
@@ -3,6 +3,8 @@ from typing import Optional, Tuple
 import torch
 from torch import Tensor
 
+from torch_geometric.nn.conv.utils.inspector import Inspector
+
 
 class Select(torch.nn.Module):
     r"""An abstract base class implementing custom node selections that map the
@@ -13,6 +15,13 @@ class Select(torch.nn.Module):
     to one of :math:`C` super nodes.
     In addition, :class:`Select` returns the number of super nodes.
     """
+    def __init__(self):
+        super().__init__()
+        self.inspector = Inspector(self)
+        self.inspector.inspect(self.forward)
+        for pop_arg in ['x', 'edge_index', 'edge_attr', 'batch']:
+            self.inspector.params['forward'].pop(pop_arg, None)
+
     def reset_parameters(self):
         pass
 
@@ -26,12 +35,6 @@ class Select(torch.nn.Module):
         r"""
         Args:
             x (torch.Tensor): The input node features.
-            edge_index (torch.Tensor): The edge indices.
-            edge_attr (torch.Tensor, optional): The edge features.
-                (default: :obj:`None`)
-            batch (torch.Tensor, optional): The batch vector
-                :math:`\mathbf{b} \in {\{ 0, \ldots, B-1\}}^N`, which assigns
-                each node to a specific graph. (default: :obj:`None`)
         """
         raise NotImplementedError
 


### PR DESCRIPTION
This PR updates `Pooling` class. This update is made to support additional arguments that might be passed to `Select`, `Reduce` and `Connect`. 
Why was this needed?
We plan to refactor all functions in `torch_geometric/nn/pool` using the select reduct connect paradigm , through `Pooling` class. While trying to refactor [topkpool](https://github.com/pyg-team/pytorch_geometric/blob/master/torch_geometric/nn/pool/topk_pool.py), 
1. The current implementation of `forward` in [Pooling](https://github.com/pyg-team/pytorch_geometric/blob/master/torch_geometric/nn/pool/base.py), does not support passing the `attn` argument to `Select` and `Reduce`. This PR fixes that by using `inspector` to distribute `kwargs` to functions.
2. The current implementation of `forward` also doesn't support a node not being part of any cluster and being dropped from the graph, like done in topkpool . This PR fixes that too.

This PR is a draft. In a follow up PR built on this PR , i'll refactor topk pool to make sure the current implementation of `Pooling` is "good".