### PR TITLE
Update quick-start.html

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Accelerated sparse tensor conversion routines ([#7042](https://github.com/pyg-team/pytorch_geometric/pull/7042), [#7043](https://github.com/pyg-team/pytorch_geometric/pull/7043))
 - Change `torch_sparse.SparseTensor` logic to utilize `torch.sparse_csr` instead ([#7041](https://github.com/pyg-team/pytorch_geometric/pull/7041))
 - Added an optional `batch_size` and `max_num_nodes` arguments to `MemPooling` layer ([#7239](https://github.com/pyg-team/pytorch_geometric/pull/7239))
+- Fixed the installation warning message when `PyTorch 2.0.*` is chosen along `Cuda 11.6`. ([#7313](https://github.com/pyg-team/pytorch_geometric/pull/7313))
 
 ### Removed
 

--- a/docs/source/install/quick-start.html
+++ b/docs/source/install/quick-start.html
@@ -117,7 +117,7 @@
     }
 
     else if (torch == "torch-2.0.0" && cuda == "cu116") {
-      $("#command pre").text('# PyTorch 1.13.* binaries do not support CUDA 11.6');
+      $("#command pre").text('# PyTorch 2.0.* binaries do not support CUDA 11.6');
     }
 
     else if (os == "windows" && package == "conda") {


### PR DESCRIPTION
Update the warning when PyTorch 2.0.* version is chosen along Cuda 11.6. Warning was  `# PyTorch 1.13.* binaries do not support CUDA 11.6` though 2.0.* version is selected.