### PR TITLE
Fixed a spelling error in HeteroBatchNorm.forward

### DIFF
--- a/torch_geometric/nn/norm/batch_norm.py
+++ b/torch_geometric/nn/norm/batch_norm.py
@@ -175,7 +175,7 @@ class HeteroBatchNorm(torch.nn.Module):
             type_vec (torch.Tensor): A vector that maps each entry to a type.
         """
         if not self.training and self.track_running_stats:
-            mean, var = self.running_mean, self.running_Var
+            mean, var = self.running_mean, self.running_var
         else:
             with torch.no_grad():
                 mean, var = self.mean_var(x, type_vec, dim_size=self.num_types)


### PR DESCRIPTION
There is a spelling error "self.running_Var" at line 178 in batch_norm.py (`forward` of `HeteroBatchNorm`) that would cause an AttributeError during testing (`model.eval()`).

> epoch [1/200] train: 100%|██████████████████| 1081/1081 [01:39<00:00, 10.89it/s, train_loss=3.15]
>   0%|                                                                                           | 0/270 [00:00<?, ?it/s]
> Traceback (most recent call last):
>   File "/home/amax/lhy/GraphCompton/train_hetero.py", line 98, in <module>
>     out = model(batch)
>   File "/home/amax/anaconda3/envs/torch2/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1501, in _call_impl
>     return forward_call(*args, **kwargs)
>   File "/home/amax/lhy/GraphCompton/Models/GraphCompton.py", line 83, in forward
>     x = self.bn(x, type_vec)
>   File "/home/amax/anaconda3/envs/torch2/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1501, in _call_impl
>     return forward_call(*args, **kwargs)
>   File "/home/amax/anaconda3/envs/torch2/lib/python3.10/site-packages/torch_geometric/nn/norm/batch_norm.py", line 178, in forward
>     mean, var = self.running_mean, self.running_Var
>   File "/home/amax/anaconda3/envs/torch2/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1614, in __getattr__
>     raise AttributeError("'{}' object has no attribute '{}'".format(
> AttributeError: **'HeteroBatchNorm' object has no attribute 'running_Var'. Did you mean: 'running_var'?**

It's just a simple spelling bug though. Actually this is my first time contributing to a large open-source project😂
BTW, could you guys provide some examples of implementing `HeteroBatchNorm`? It would be more easy to understand how to use it with some example, and I referred to [https://github.com/puririshi98/rgcn_pyg_lib_forward_bench/blob/70564721508f10cbe3717347dab09b729dcbdfa2/bench_heteronorm.py#L4](url) when I try. Hope it may help.