### PR TITLE
[Aggregation] Clamp `StdAggregation` if there are edges for aggregation

### DIFF
--- a/test/nn/aggr/test_basic.py
+++ b/test/nn/aggr/test_basic.py
@@ -74,6 +74,15 @@ def test_var_aggregation():
     assert torch.allclose(out, expected, atol=1e-6)
 
 
+def test_std_aggregation_empty():
+    x = torch.tensor([]).reshape(0, 6)
+    index = torch.tensor([])
+    std_aggr = StdAggregation()
+    out = std_aggr(x, index, dim_size=10)
+    assert out.shape == (10, 6)
+    assert (out != 0).sum().item() == 0
+
+
 @pytest.mark.parametrize('Aggregation', [
     SoftmaxAggregation,
     PowerMeanAggregation,

--- a/test/nn/aggr/test_basic.py
+++ b/test/nn/aggr/test_basic.py
@@ -74,13 +74,15 @@ def test_var_aggregation():
     assert torch.allclose(out, expected, atol=1e-6)
 
 
-def test_std_aggregation_empty():
-    x = torch.tensor([]).reshape(0, 6)
-    index = torch.tensor([])
-    std_aggr = StdAggregation()
-    out = std_aggr(x, index, dim_size=10)
-    assert out.shape == (10, 6)
-    assert (out != 0).sum().item() == 0
+def test_empty_std_aggregation():
+    aggr = StdAggregation()
+
+    x = torch.empty(0, 6).reshape(0, 6)
+    index = torch.empty(0, dtype=torch.long)
+
+    out = aggr(x, index, dim_size=5)
+    assert out.size() == (5, 6)
+    assert float(out.abs().sum()) == 0.0
 
 
 @pytest.mark.parametrize('Aggregation', [

--- a/test/nn/aggr/test_fused.py
+++ b/test/nn/aggr/test_fused.py
@@ -30,27 +30,28 @@ def test_fused_aggregation(aggrs):
     out = torch.cat(aggr(x, index), dim=-1)
 
     expected = torch.cat([aggr(y, index) for aggr in aggrs], dim=-1)
-    assert torch.allclose(out, expected, atol=1e-6)
+    assert torch.allclose(out, expected, atol=1e-5)
 
     jit = torch.jit.script(aggr)
-    assert torch.allclose(torch.cat(jit(x, index), dim=-1), out, atol=1e-6)
+    assert torch.allclose(torch.cat(jit(x, index), dim=-1), out, atol=1e-5)
 
     out.mean().backward()
     assert x.grad is not None
     expected.mean().backward()
     assert y.grad is not None
-    assert torch.allclose(x.grad, y.grad)
+    assert torch.allclose(x.grad, y.grad, atol=1e-5)
 
 
-def test_fused_std_empty():
-    aggrs = ['mean', 'var', 'std']
-    aggrs = [aggregation_resolver(aggr) for aggr in aggrs]
-    x = torch.tensor([]).reshape(0, 6)
-    index = torch.tensor([])
+def test_empty_fused_std_aggregation():
+    aggrs = [aggregation_resolver(aggr) for aggr in ['mean', 'var', 'std']]
     aggr = FusedAggregation(aggrs)
-    out = torch.cat(aggr(x, index, dim_size=10), dim=-1)
-    assert out.shape == (10, 6 * 3)
-    assert (out != 0).sum().item() == 0
+
+    x = torch.empty(0, 6).reshape(0, 6)
+    index = torch.empty(0, dtype=torch.long)
+
+    out = torch.cat(aggr(x, index, dim_size=5), dim=-1)
+    assert out.size() == (5, 18)
+    assert float(out.abs().sum()) == 0.0
 
 
 if __name__ == '__main__':

--- a/test/nn/aggr/test_fused.py
+++ b/test/nn/aggr/test_fused.py
@@ -42,6 +42,17 @@ def test_fused_aggregation(aggrs):
     assert torch.allclose(x.grad, y.grad)
 
 
+def test_fused_std_empty():
+    aggrs = ['mean', 'var', 'std']
+    aggrs = [aggregation_resolver(aggr) for aggr in aggrs]
+    x = torch.tensor([]).reshape(0, 6)
+    index = torch.tensor([])
+    aggr = FusedAggregation(aggrs)
+    out = torch.cat(aggr(x, index, dim_size=10), dim=-1)
+    assert out.shape == (10, 6 * 3)
+    assert (out != 0).sum().item() == 0
+
+
 if __name__ == '__main__':
     import argparse
 

--- a/torch_geometric/nn/aggr/basic.py
+++ b/torch_geometric/nn/aggr/basic.py
@@ -131,7 +131,7 @@ class StdAggregation(Aggregation):
                 ptr: Optional[Tensor] = None, dim_size: Optional[int] = None,
                 dim: int = -2) -> Tensor:
         var = self.var_aggr(x, index, ptr, dim_size, dim)
-        if index.numel() == 0 and dim_size is not None:
+        if (index is None or index.numel() == 0) and dim_size is not None:
             return var.sqrt()
         # Only clamp var if there are edges for aggregation
         return var.clamp(min=1e-5).sqrt()

--- a/torch_geometric/nn/aggr/basic.py
+++ b/torch_geometric/nn/aggr/basic.py
@@ -133,7 +133,7 @@ class StdAggregation(Aggregation):
         var = self.var_aggr(x, index, ptr, dim_size, dim)
         if index.numel() == 0 and dim_size is not None:
             return var.sqrt()
-        # Only clamp var if there are edges for message passing
+        # Only clamp var if there are edges for aggregation
         return var.clamp(min=1e-5).sqrt()
 
 

--- a/torch_geometric/nn/aggr/basic.py
+++ b/torch_geometric/nn/aggr/basic.py
@@ -133,7 +133,9 @@ class StdAggregation(Aggregation):
                 dim: int = -2) -> Tensor:
         var = self.var_aggr(x, index, ptr, dim_size, dim)
         # Allow "undefined" gradient at `sqrt(0.0)`:
-        return (var + 1e-5).sqrt() - math.sqrt(1e-5)
+        out = var.clamp(min=1e-5).sqrt()
+        out = out.masked_fill(out <= math.sqrt(1e-5), 0.0)
+        return out
 
 
 class SoftmaxAggregation(Aggregation):

--- a/torch_geometric/nn/aggr/basic.py
+++ b/torch_geometric/nn/aggr/basic.py
@@ -131,6 +131,9 @@ class StdAggregation(Aggregation):
                 ptr: Optional[Tensor] = None, dim_size: Optional[int] = None,
                 dim: int = -2) -> Tensor:
         var = self.var_aggr(x, index, ptr, dim_size, dim)
+        if index.numel() == 0 and dim_size is not None:
+            return var.sqrt()
+        # Only clamp var if there are edges for message passing
         return var.clamp(min=1e-5).sqrt()
 
 

--- a/torch_geometric/nn/aggr/basic.py
+++ b/torch_geometric/nn/aggr/basic.py
@@ -1,3 +1,4 @@
+import math
 from typing import Optional
 
 import torch
@@ -131,10 +132,8 @@ class StdAggregation(Aggregation):
                 ptr: Optional[Tensor] = None, dim_size: Optional[int] = None,
                 dim: int = -2) -> Tensor:
         var = self.var_aggr(x, index, ptr, dim_size, dim)
-        if (index is None or index.numel() == 0) and dim_size is not None:
-            return var.sqrt()
-        # Only clamp var if there are edges for aggregation
-        return var.clamp(min=1e-5).sqrt()
+        # Allow "undefined" gradient at `sqrt(0.0)`:
+        return (var + 1e-5).sqrt() - math.sqrt(1e-5)
 
 
 class SoftmaxAggregation(Aggregation):

--- a/torch_geometric/nn/aggr/fused.py
+++ b/torch_geometric/nn/aggr/fused.py
@@ -1,3 +1,4 @@
+import math
 from typing import Dict, List, Optional, Tuple, Union
 
 from torch import Tensor
@@ -316,11 +317,7 @@ class FusedAggregation(Aggregation):
                 assert mean is not None
                 var = (pow_sum / count) - (mean * mean)
 
-            if (index is None or index.numel() == 0) and dim_size is not None:
-                outs[i] = var.sqrt()
-            else:
-                # Only clamp var if there are edges for aggregation
-                outs[i] = var.clamp(min=1e-5).sqrt()
+            outs[i] = (var + 1e-5).sqrt() - math.sqrt(1e-5)
 
         #######################################################################
 

--- a/torch_geometric/nn/aggr/fused.py
+++ b/torch_geometric/nn/aggr/fused.py
@@ -319,7 +319,7 @@ class FusedAggregation(Aggregation):
             if index.numel() == 0 and dim_size is not None:
                 outs[i] = var.sqrt()
             else:
-                # Only clamp var if there are edges for message passing
+                # Only clamp var if there are edges for aggregation
                 outs[i] = var.clamp(min=1e-5).sqrt()
 
         #######################################################################

--- a/torch_geometric/nn/aggr/fused.py
+++ b/torch_geometric/nn/aggr/fused.py
@@ -316,7 +316,7 @@ class FusedAggregation(Aggregation):
                 assert mean is not None
                 var = (pow_sum / count) - (mean * mean)
 
-            if index.numel() == 0 and dim_size is not None:
+            if (index is None or index.numel() == 0) and dim_size is not None:
                 outs[i] = var.sqrt()
             else:
                 # Only clamp var if there are edges for aggregation

--- a/torch_geometric/nn/aggr/fused.py
+++ b/torch_geometric/nn/aggr/fused.py
@@ -316,7 +316,11 @@ class FusedAggregation(Aggregation):
                 assert mean is not None
                 var = (pow_sum / count) - (mean * mean)
 
-            outs[i] = var.clamp(min=1e-5).sqrt()
+            if index.numel() == 0 and dim_size is not None:
+                outs[i] = var.sqrt()
+            else:
+                # Only clamp var if there are edges for message passing
+                outs[i] = var.clamp(min=1e-5).sqrt()
 
         #######################################################################
 

--- a/torch_geometric/nn/aggr/fused.py
+++ b/torch_geometric/nn/aggr/fused.py
@@ -317,7 +317,11 @@ class FusedAggregation(Aggregation):
                 assert mean is not None
                 var = (pow_sum / count) - (mean * mean)
 
-            outs[i] = (var + 1e-5).sqrt() - math.sqrt(1e-5)
+            # Allow "undefined" gradient at `sqrt(0.0)`:
+            out = var.clamp(min=1e-5).sqrt()
+            out = out.masked_fill(out <= math.sqrt(1e-5), 0.0)
+
+            outs[i] = out
 
         #######################################################################
 


### PR DESCRIPTION
If there are no edges for aggregation and we specified `dim_size`, IMO std should be all zeros.
Previous implementation will clamp value to 0.00001 and in this scenario the aggregated std value will be around 0.0032.