### PR TITLE
Add `add_pad_mask` argument to `Pad` transform

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- Added an optional `add_pad_mask` argument to the `Pad` transform ([#7339](https://github.com/pyg-team/pytorch_geometric/pull/7339))
 - Added `keep_inter_cluster_edges` option to `ClusterData` to support inter-subgraph edge connections when doing graph partitioning ([#7326](https://github.com/pyg-team/pytorch_geometric/pull/7326))
 - Unify graph pooling framework ([#7308](https://github.com/pyg-team/pytorch_geometric/pull/7308))
 - Added support for tuples as keys in `ModuleDict`/`ParameterDict` ([#7294](https://github.com/pyg-team/pytorch_geometric/pull/7294))
@@ -54,7 +55,6 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Accelerated sparse tensor conversion routines ([#7042](https://github.com/pyg-team/pytorch_geometric/pull/7042), [#7043](https://github.com/pyg-team/pytorch_geometric/pull/7043))
 - Change `torch_sparse.SparseTensor` logic to utilize `torch.sparse_csr` instead ([#7041](https://github.com/pyg-team/pytorch_geometric/pull/7041))
 - Added an optional `batch_size` and `max_num_nodes` arguments to `MemPooling` layer ([#7239](https://github.com/pyg-team/pytorch_geometric/pull/7239))
-- Added an optional `add_masks_to_data` argument to `Pad` transform ([#7339](https://github.com/pyg-team/pytorch_geometric/pull/7339))
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Accelerated sparse tensor conversion routines ([#7042](https://github.com/pyg-team/pytorch_geometric/pull/7042), [#7043](https://github.com/pyg-team/pytorch_geometric/pull/7043))
 - Change `torch_sparse.SparseTensor` logic to utilize `torch.sparse_csr` instead ([#7041](https://github.com/pyg-team/pytorch_geometric/pull/7041))
 - Added an optional `batch_size` and `max_num_nodes` arguments to `MemPooling` layer ([#7239](https://github.com/pyg-team/pytorch_geometric/pull/7239))
+- Added an optional `add_masks_to_data` argument to `Pad` transform ([#7339](https://github.com/pyg-team/pytorch_geometric/pull/7339))
 
 ### Removed
 

--- a/test/transforms/test_pad.py
+++ b/test/transforms/test_pad.py
@@ -56,19 +56,22 @@ def _generate_heterodata_edges(
             yield edge_type, attr
 
 
-def _check_homo_data_nodes(original: Data, padded: Data,
-                           max_num_nodes: Union[int, Dict[NodeType, int]],
-                           node_pad_value: Optional[Padding] = None,
-                           is_mask_available: Optional[bool] = None,
-                           exclude_keys: Optional[List[str]] = None):
+def _check_homo_data_nodes(
+    original: Data,
+    padded: Data,
+    max_num_nodes: Union[int, Dict[NodeType, int]],
+    node_pad_value: Optional[Padding] = None,
+    is_mask_available: bool = False,
+    exclude_keys: Optional[List[str]] = None,
+):
     assert padded.num_nodes == max_num_nodes
 
     compare_pad_start_idx = original.num_nodes
 
     if is_mask_available:
-        assert padded.nodes_mask.shape[0] == padded.num_nodes
-        assert torch.all(padded.nodes_mask[:compare_pad_start_idx])
-        assert not torch.any(padded.nodes_mask[compare_pad_start_idx:])
+        assert padded.pad_node_mask.numel() == padded.num_nodes
+        assert torch.all(padded.pad_node_mask[:compare_pad_start_idx])
+        assert not torch.any(padded.pad_node_mask[compare_pad_start_idx:])
 
     for attr in _generate_homodata_node_attrs(original):
         if attr in exclude_keys:
@@ -94,11 +97,14 @@ def _check_homo_data_nodes(original: Data, padded: Data,
                            padded[attr][:compare_pad_start_idx])
 
 
-def _check_homo_data_edges(original: Data, padded: Data,
-                           max_num_edges: Optional[int] = None,
-                           edge_pad_value: Optional[Padding] = None,
-                           is_mask_available: Optional[bool] = None,
-                           exclude_keys: Optional[List[str]] = None):
+def _check_homo_data_edges(
+    original: Data,
+    padded: Data,
+    max_num_edges: Optional[int] = None,
+    edge_pad_value: Optional[Padding] = None,
+    is_mask_available: bool = False,
+    exclude_keys: Optional[List[str]] = None,
+):
     # Check edge index attribute.
     if max_num_edges is None:
         max_num_edges = padded.num_nodes**2
@@ -118,9 +124,9 @@ def _check_homo_data_edges(original: Data, padded: Data,
                        padded.edge_index[:, :compare_pad_start_idx])
 
     if is_mask_available:
-        assert padded.edges_mask.shape[0] == padded.num_edges
-        assert torch.all(padded.edges_mask[:compare_pad_start_idx])
-        assert not torch.any(padded.edges_mask[compare_pad_start_idx:])
+        assert padded.pad_edge_mask.numel() == padded.num_edges
+        assert torch.all(padded.pad_edge_mask[:compare_pad_start_idx])
+        assert not torch.any(padded.pad_edge_mask[compare_pad_start_idx:])
 
     # Check other attributes.
     for attr in _generate_homodata_edge_attrs(original):
@@ -149,14 +155,17 @@ def _check_homo_data_edges(original: Data, padded: Data,
                            padded[attr][:compare_pad_start_idx, :])
 
 
-def _check_hetero_data_nodes(original: HeteroData, padded: HeteroData,
-                             max_num_nodes: Union[int, Dict[NodeType, int]],
-                             node_pad_value: Optional[Padding] = None,
-                             is_mask_available: Optional[bool] = None,
-                             exclude_keys: Optional[List[str]] = None):
+def _check_hetero_data_nodes(
+    original: HeteroData,
+    padded: HeteroData,
+    max_num_nodes: Union[int, Dict[NodeType, int]],
+    node_pad_value: Optional[Padding] = None,
+    is_mask_available: bool = False,
+    exclude_keys: Optional[List[str]] = None,
+):
     if is_mask_available:
-        for _, store in padded.node_items():
-            assert 'nodes_mask' in store.keys()
+        for store in padded.node_stores:
+            assert 'pad_node_mask' in store
 
     expected_nodes = max_num_nodes
 
@@ -173,8 +182,8 @@ def _check_hetero_data_nodes(original: HeteroData, padded: HeteroData,
         compare_pad_start_idx = original[node_type].num_nodes
         padded_tensor = padded[node_type][attr]
 
-        if attr == 'nodes_mask':
-            assert padded_tensor.shape[0] == padded[node_type].num_nodes
+        if attr == 'pad_node_mask':
+            assert padded_tensor.numel() == padded[node_type].num_nodes
             assert torch.all(padded_tensor[:compare_pad_start_idx])
             assert not torch.any(padded_tensor[compare_pad_start_idx:])
             continue
@@ -198,16 +207,17 @@ def _check_hetero_data_nodes(original: HeteroData, padded: HeteroData,
                            padded_tensor[:compare_pad_start_idx])
 
 
-def _check_hetero_data_edges(original: HeteroData, padded: HeteroData,
-                             max_num_edges: Optional[Union[int,
-                                                           Dict[EdgeType,
-                                                                int]]] = None,
-                             edge_pad_value: Optional[Padding] = None,
-                             is_mask_available: Optional[bool] = None,
-                             exclude_keys: Optional[List[str]] = None):
+def _check_hetero_data_edges(
+    original: HeteroData,
+    padded: HeteroData,
+    max_num_edges: Optional[Union[int, Dict[EdgeType, int]]] = None,
+    edge_pad_value: Optional[Padding] = None,
+    is_mask_available: bool = False,
+    exclude_keys: Optional[List[str]] = None,
+):
     if is_mask_available:
-        for _, store in padded.edge_items():
-            assert 'edges_mask' in store.keys()
+        for store in padded.edge_stores:
+            assert 'pad_edge_mask' in store
 
     for edge_type, attr in _generate_heterodata_edges(padded):
         if attr in exclude_keys:
@@ -222,8 +232,8 @@ def _check_hetero_data_edges(original: HeteroData, padded: HeteroData,
         compare_pad_start_idx = original[edge_type].num_edges
         padded_tensor = padded[edge_type][attr]
 
-        if attr == 'edges_mask':
-            assert padded_tensor.shape[0] == padded[edge_type].num_edges
+        if attr == 'pad_edge_mask':
+            assert padded_tensor.numel() == padded[edge_type].num_edges
             assert torch.all(padded_tensor[:compare_pad_start_idx])
             assert not torch.any(padded_tensor[compare_pad_start_idx:])
             continue
@@ -272,15 +282,16 @@ def _check_hetero_data_edges(original: HeteroData, padded: HeteroData,
                                padded_tensor[:compare_pad_start_idx, :])
 
 
-def _check_data(original: Union[Data, HeteroData], padded: Union[Data,
-                                                                 HeteroData],
-                max_num_nodes: Union[int, Dict[NodeType, int]],
-                max_num_edges: Optional[Union[int, Dict[EdgeType,
-                                                        int]]] = None,
-                node_pad_value: Optional[Union[Padding, int, float]] = None,
-                edge_pad_value: Optional[Union[Padding, int, float]] = None,
-                is_mask_available: Optional[bool] = None,
-                exclude_keys: Optional[List[str]] = None):
+def _check_data(
+    original: Union[Data, HeteroData],
+    padded: Union[Data, HeteroData],
+    max_num_nodes: Union[int, Dict[NodeType, int]],
+    max_num_edges: Optional[Union[int, Dict[EdgeType, int]]] = None,
+    node_pad_value: Optional[Union[Padding, int, float]] = None,
+    edge_pad_value: Optional[Union[Padding, int, float]] = None,
+    is_mask_available: bool = False,
+    exclude_keys: Optional[List[str]] = None,
+):
 
     if not isinstance(node_pad_value, Padding) and node_pad_value is not None:
         node_pad_value = UniformPadding(node_pad_value)
@@ -316,45 +327,42 @@ def test_pad_repr():
 
 @pytest.mark.parametrize('data', [fake_data(), fake_hetero_data()])
 @pytest.mark.parametrize('num_nodes', [32, 64])
-@pytest.mark.parametrize('add_masks_to_data', [True, False])
-def test_pad_auto_edges(data, num_nodes, add_masks_to_data):
+@pytest.mark.parametrize('add_pad_mask', [True, False])
+def test_pad_auto_edges(data, num_nodes, add_pad_mask):
     original = data
     data = deepcopy(data)
-    transform = Pad(max_num_nodes=num_nodes,
-                    add_masks_to_data=add_masks_to_data)
+    transform = Pad(max_num_nodes=num_nodes, add_pad_mask=add_pad_mask)
 
     padded = transform(data)
-    _check_data(original, padded, num_nodes,
-                is_mask_available=add_masks_to_data)
+    _check_data(original, padded, num_nodes, is_mask_available=add_pad_mask)
 
 
 @pytest.mark.parametrize('num_nodes', [32, 64])
 @pytest.mark.parametrize('num_edges', [300, 411])
-@pytest.mark.parametrize('add_masks_to_data', [True, False])
-def test_pad_data_explicit_edges(num_nodes, num_edges, add_masks_to_data):
+@pytest.mark.parametrize('add_pad_mask', [True, False])
+def test_pad_data_explicit_edges(num_nodes, num_edges, add_pad_mask):
     data = fake_data()
     original = deepcopy(data)
     transform = Pad(max_num_nodes=num_nodes, max_num_edges=num_edges,
-                    add_masks_to_data=add_masks_to_data)
+                    add_pad_mask=add_pad_mask)
 
     padded = transform(data)
     _check_data(original, padded, num_nodes, num_edges,
-                is_mask_available=add_masks_to_data)
+                is_mask_available=add_pad_mask)
 
 
 @pytest.mark.parametrize('num_nodes', [32, {'v0': 64, 'v1': 36}])
 @pytest.mark.parametrize('num_edges', [300, {('v0', 'e0', 'v1'): 397}])
-@pytest.mark.parametrize('add_masks_to_data', [True, False])
-def test_pad_heterodata_explicit_edges(num_nodes, num_edges,
-                                       add_masks_to_data):
+@pytest.mark.parametrize('add_pad_mask', [True, False])
+def test_pad_heterodata_explicit_edges(num_nodes, num_edges, add_pad_mask):
     data = fake_hetero_data()
     original = deepcopy(data)
     transform = Pad(max_num_nodes=num_nodes, max_num_edges=num_edges,
-                    add_masks_to_data=add_masks_to_data)
+                    add_pad_mask=add_pad_mask)
 
     padded = transform(data)
     _check_data(original, padded, num_nodes, num_edges,
-                is_mask_available=add_masks_to_data)
+                is_mask_available=add_pad_mask)
 
 
 @pytest.mark.parametrize('node_pad_value', [10, AttrNamePadding({'x': 3.0})])
@@ -401,20 +409,22 @@ def test_pad_heterodata_pad_values(node_pad_value, edge_pad_value):
 
 
 @pytest.mark.parametrize('data', [fake_data(), fake_hetero_data()])
-@pytest.mark.parametrize('add_masks_to_data', [True, False])
-@pytest.mark.parametrize('exclude_keys',
-                         [['y'], ['edge_attr'], ['y', 'edge_attr']])
-def test_pad_data_exclude_keys(data, add_masks_to_data, exclude_keys):
+@pytest.mark.parametrize('add_pad_mask', [True, False])
+@pytest.mark.parametrize('exclude_keys', [
+    ['y'],
+    ['edge_attr'],
+    ['y', 'edge_attr'],
+])
+def test_pad_data_exclude_keys(data, add_pad_mask, exclude_keys):
     original = data
     data = deepcopy(data)
     num_nodes = 32
-    transform = Pad(max_num_nodes=num_nodes,
-                    add_masks_to_data=add_masks_to_data,
+    transform = Pad(max_num_nodes=num_nodes, add_pad_mask=add_pad_mask,
                     exclude_keys=exclude_keys)
 
     padded = transform(data)
-    _check_data(original, padded, num_nodes,
-                is_mask_available=add_masks_to_data, exclude_keys=exclude_keys)
+    _check_data(original, padded, num_nodes, is_mask_available=add_pad_mask,
+                exclude_keys=exclude_keys)
 
 
 @pytest.mark.parametrize('data', [fake_data(), fake_hetero_data(node_types=1)])

--- a/torch_geometric/transforms/pad.py
+++ b/torch_geometric/transforms/pad.py
@@ -265,16 +265,11 @@ class Pad(BaseTransform):
         mask_pad_value (bool, optional): The fill value to use for
             :obj:`train_mask`, :obj:`val_mask` and :obj:`test_mask` attributes
             (default: :obj:`False`).
-        add_masks_to_data (bool, optional): If set to :obj:`True`, masks object
-            are attached to data object. They represents two levels of
-            padding:
-
-            - :obj:`nodes_mask`  - node level mask
-            - :obj:`edges_mask`  - edge level mask
-
-            Mask objects indicates which elements in the data are real
-            (represented by :obj:`True` value) and which were added as a
-            padding (represented by :obj:`False` value).
+        add_pad_mask (bool, optional): If set to :obj:`True`, will attach
+            node-level :obj:`pad_node_mask` and edge-level :obj:`pad_edge_mask`
+            attributes to the output which indicates which elements in the data
+            are real (represented by :obj:`True`) and which were added as a
+            result of padding (represented by :obj:`False`).
             (default: :obj:`False`)
         exclude_keys ([str], optional): Keys to be removed
             from the input data object. (default: :obj:`None`)
@@ -286,7 +281,7 @@ class Pad(BaseTransform):
         node_pad_value: Union[int, float, Padding] = 0.0,
         edge_pad_value: Union[int, float, Padding] = 0.0,
         mask_pad_value: bool = False,
-        add_masks_to_data: Optional[bool] = False,
+        add_pad_mask: bool = False,
         exclude_keys: Optional[List[str]] = None,
     ):
         self.max_num_nodes = self._NumNodes(max_num_nodes)
@@ -305,8 +300,7 @@ class Pad(BaseTransform):
             for key in ['train_mask', 'val_mask', 'test_mask']
         }
 
-        self.add_masks_to_data = add_masks_to_data
-
+        self.add_pad_mask = add_pad_mask
         self.exclude_keys = set(exclude_keys or [])
 
     class _IntOrDict(ABC):
@@ -462,9 +456,9 @@ class Pad(BaseTransform):
             f'({store.num_nodes}).'
         num_pad_nodes = num_target_nodes - store.num_nodes
 
-        if self.add_masks_to_data:
-            nodes_mask = torch.arange(num_target_nodes) < store.num_nodes
-            setattr(store, 'nodes_mask', nodes_mask)
+        if self.add_pad_mask:
+            pad_node_mask = torch.arange(num_target_nodes) < store.num_nodes
+            store.pad_node_mask = pad_node_mask
 
         for attr_name in attrs_to_pad:
             attr = store[attr_name]
@@ -488,9 +482,9 @@ class Pad(BaseTransform):
             f'({store.num_edges}).'
         num_pad_edges = num_target_edges - store.num_edges
 
-        if self.add_masks_to_data:
-            edges_mask = torch.arange(num_target_edges) < store.num_edges
-            setattr(store, 'edges_mask', edges_mask)
+        if self.add_pad_mask:
+            pad_edge_mask = torch.arange(num_target_edges) < store.num_edges
+            store.pad_edge_mask = pad_edge_mask
 
         if isinstance(num_nodes, tuple):
             src_pad_value, dst_pad_value = num_nodes

--- a/torch_geometric/transforms/pad.py
+++ b/torch_geometric/transforms/pad.py
@@ -457,7 +457,8 @@ class Pad(BaseTransform):
         num_pad_nodes = num_target_nodes - store.num_nodes
 
         if self.add_pad_mask:
-            pad_node_mask = torch.arange(num_target_nodes) < store.num_nodes
+            pad_node_mask = torch.ones(num_target_nodes, dtype=torch.bool)
+            pad_node_mask[store.num_nodes:] = False
             store.pad_node_mask = pad_node_mask
 
         for attr_name in attrs_to_pad:
@@ -483,7 +484,8 @@ class Pad(BaseTransform):
         num_pad_edges = num_target_edges - store.num_edges
 
         if self.add_pad_mask:
-            pad_edge_mask = torch.arange(num_target_edges) < store.num_edges
+            pad_edge_mask = torch.ones(num_target_edges, dtype=torch.bool)
+            pad_edge_mask[store.num_edges:] = False
             store.pad_edge_mask = pad_edge_mask
 
         if isinstance(num_nodes, tuple):


### PR DESCRIPTION
add_masks_to_data is an optional argument that will cause the addition of two masks to data object. They will indicate which elements in the data are real and which are added as a padding.