### PR TITLE
Exclude `num_nodes` and `num_edges` from keys lists returned from `node_types` and `node_edges`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- Exclude special fields `num_nodes` and `num_edges` from listing nodes/edges stores [#7354](https://github.com/pyg-team/pytorch_geometric/pull/7354)
 - Added an example for hierarichial sampling ([#7244](https://github.com/pyg-team/pytorch_geometric/pull/7244))
 - Added Kùzu remote backend examples ([#7298](https://github.com/pyg-team/pytorch_geometric/pull/7298))
 - Fixed tracing of `add_self_loops` for a dynamic number of nodes ([#7330](https://github.com/pyg-team/pytorch_geometric/pull/7330))

--- a/torch_geometric/data/hetero_data.py
+++ b/torch_geometric/data/hetero_data.py
@@ -249,22 +249,22 @@ class HeteroData(BaseData, FeatureStore, GraphStore):
     @property
     def node_types(self) -> List[NodeType]:
         r"""Returns a list of all node types of the graph."""
-        return list(self._node_store_dict.keys())
+        return list(k for k in self._node_store_dict.keys() if k!='num_nodes')
 
     @property
     def node_stores(self) -> List[NodeStorage]:
         r"""Returns a list of all node storages of the graph."""
-        return list(self._node_store_dict.values())
+        return list(v for k,v in self._node_store_dict.items() if k!='num_nodes')
 
     @property
     def edge_types(self) -> List[EdgeType]:
         r"""Returns a list of all edge types of the graph."""
-        return list(self._edge_store_dict.keys())
+        return list(k for k in self._edge_store_dict.keys() if k!='num_edges')
 
     @property
     def edge_stores(self) -> List[EdgeStorage]:
         r"""Returns a list of all edge storages of the graph."""
-        return list(self._edge_store_dict.values())
+        return list(v for k,v in self._edge_store_dict.items() if k!='num_edges')
 
     def node_items(self) -> List[Tuple[NodeType, NodeStorage]]:
         r"""Returns a list of node type and node storage pairs."""

--- a/torch_geometric/data/hetero_data.py
+++ b/torch_geometric/data/hetero_data.py
@@ -249,22 +249,26 @@ class HeteroData(BaseData, FeatureStore, GraphStore):
     @property
     def node_types(self) -> List[NodeType]:
         r"""Returns a list of all node types of the graph."""
-        return list(k for k in self._node_store_dict.keys() if k!='num_nodes')
+        return list(k for k in self._node_store_dict.keys()
+                    if k != 'num_nodes')
 
     @property
     def node_stores(self) -> List[NodeStorage]:
         r"""Returns a list of all node storages of the graph."""
-        return list(v for k,v in self._node_store_dict.items() if k!='num_nodes')
+        return list(v for k, v in self._node_store_dict.items()
+                    if k != 'num_nodes')
 
     @property
     def edge_types(self) -> List[EdgeType]:
         r"""Returns a list of all edge types of the graph."""
-        return list(k for k in self._edge_store_dict.keys() if k!='num_edges')
+        return list(k for k in self._edge_store_dict.keys()
+                    if k != 'num_edges')
 
     @property
     def edge_stores(self) -> List[EdgeStorage]:
         r"""Returns a list of all edge storages of the graph."""
-        return list(v for k,v in self._edge_store_dict.items() if k!='num_edges')
+        return list(v for k, v in self._edge_store_dict.items()
+                    if k != 'num_edges')
 
     def node_items(self) -> List[Tuple[NodeType, NodeStorage]]:
         r"""Returns a list of node type and node storage pairs."""


### PR DESCRIPTION
Keys `num_nodes` and `num_edges` are special fields storing number of nodes/edges explicitly. They should not be included when listing node/edge_types and node/edge_stores as the user expects to get the nodes/edges, not the extra fields used internally.