### PR TITLE
Add padding capabilities to `HeteroData.to_homogeneous()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- Added padding capabilities to `HeteroData.to_homogeneous()` in case feature dimensionalities do not match ([#7374](https://github.com/pyg-team/pytorch_geometric/pull/7374))
 - Added an optional `batch_size` argument to `fps`, `knn`, `knn_graph`, `radius` and `radius_graph` ([#7368](https://github.com/pyg-team/pytorch_geometric/pull/7368))
 - Added `GPUPrefetcher` capabilities ([#7376](https://github.com/pyg-team/pytorch_geometric/pull/7376), [#7378](https://github.com/pyg-team/pytorch_geometric/pull/7378))
 - Added an example for hierarichial sampling ([#7244](https://github.com/pyg-team/pytorch_geometric/pull/7244))

--- a/test/data/test_hetero_data.py
+++ b/test/data/test_hetero_data.py
@@ -489,6 +489,22 @@ def test_to_homogeneous_and_vice_versa():
     assert out['author'].num_nodes == 200
 
 
+def test_to_homogeneous_padding():
+    data = HeteroData()
+    data['paper'].x = torch.randn(100, 128)
+    data['author'].x = torch.randn(50, 64)
+
+    out = data.to_homogeneous()
+    assert len(out) == 2
+    assert out.node_type.size() == (150, )
+    assert out.node_type[:100].abs().sum() == 0
+    assert out.node_type[100:].sub(1).abs().sum() == 0
+    assert out.x.size() == (150, 128)
+    assert torch.equal(out.x[:100], data['paper'].x)
+    assert torch.equal(out.x[100:, :64], data['author'].x)
+    assert out.x[100:, 64:].abs().sum() == 0
+
+
 def test_hetero_data_to_canonical():
     data = HeteroData()
     assert isinstance(data['user', 'product'], EdgeStorage)

--- a/torch_geometric/data/hetero_data.py
+++ b/torch_geometric/data/hetero_data.py
@@ -828,12 +828,8 @@ class HeteroData(BaseData, FeatureStore, GraphStore):
 
         def _consistent_size(stores: List[BaseStorage]) -> List[str]:
             sizes_dict = get_sizes(stores)
-            # pad x feature tensor
-            max_dim = max(sizes_dict.values()['x'])
-            if data[n_type].x.size(-1) < max_dim:
-              data[n_type].x = torch.cat((data[n_type].x, torch.zeros((data[n_type].x.size(0),max_dim - data[n_type].x.size(-1)))), dim=-1)
             return [
-                (key if)for key, sizes in sizes_dict.items()
+                key for key, sizes in sizes_dict.items()
                 if len(sizes) == len(stores)
             ]
 
@@ -861,7 +857,6 @@ class HeteroData(BaseData, FeatureStore, GraphStore):
             # for feature tensors such as 'x', pad them if they are not the same shape
             if len(values[0].size()) > 1:
                 max_dim = max([i.size(-1) for i in values])
-                print('max_dim=',max_dim)
                 for i, value in enumerate(values):
                     if value.size(-1) < max_dim:
                         values[i] = torch.cat((value, torch.zeros(value.size(0),max_dim - value.size(-1))), dim=-1)

--- a/torch_geometric/data/hetero_data.py
+++ b/torch_geometric/data/hetero_data.py
@@ -800,7 +800,7 @@ class HeteroData(BaseData, FeatureStore, GraphStore):
         def fill_dummy_(stores: List[BaseStorage],
                         keys: Optional[List[str]] = None):
             sizes_dict = get_sizes(stores)
-            
+
             if keys is not None:
                 sizes_dict = {
                     key: sizes

--- a/torch_geometric/data/hetero_data.py
+++ b/torch_geometric/data/hetero_data.py
@@ -854,7 +854,8 @@ class HeteroData(BaseData, FeatureStore, GraphStore):
             if key in {'ptr'}:
                 continue
             values = [store[key] for store in self.node_stores]
-            # for feature tensors such as 'x', pad them if they are not the same shape
+            # for feature tensors such as 'x',
+            # pad them if they are not the same shape
             if len(values[0].size()) > 1:
                 max_dim = max([i.size(-1) for i in values])
                 for i, value in enumerate(values):

--- a/torch_geometric/data/hetero_data.py
+++ b/torch_geometric/data/hetero_data.py
@@ -859,7 +859,10 @@ class HeteroData(BaseData, FeatureStore, GraphStore):
                 max_dim = max([i.size(-1) for i in values])
                 for i, value in enumerate(values):
                     if value.size(-1) < max_dim:
-                        values[i] = torch.cat((value, torch.zeros(value.size(0),max_dim - value.size(-1))), dim=-1)
+                        values[i] = torch.cat(
+                            (value,
+                             torch.zeros(value.size(0),
+                                         max_dim - value.size(-1))), dim=-1)
             dim = self.__cat_dim__(key, values[0], self.node_stores[0])
             value = torch.cat(values, dim) if len(values) > 1 else values[0]
             data[key] = value

--- a/torch_geometric/data/hetero_data.py
+++ b/torch_geometric/data/hetero_data.py
@@ -800,7 +800,7 @@ class HeteroData(BaseData, FeatureStore, GraphStore):
         def fill_dummy_(stores: List[BaseStorage],
                         keys: Optional[List[str]] = None):
             sizes_dict = get_sizes(stores)
-
+            
             if keys is not None:
                 sizes_dict = {
                     key: sizes
@@ -828,9 +828,13 @@ class HeteroData(BaseData, FeatureStore, GraphStore):
 
         def _consistent_size(stores: List[BaseStorage]) -> List[str]:
             sizes_dict = get_sizes(stores)
+            # pad x feature tensor
+            max_dim = max(sizes_dict.values()['x'])
+            if data[n_type].x.size(-1) < max_dim:
+              data[n_type].x = torch.cat((data[n_type].x, torch.zeros((data[n_type].x.size(0),max_dim - data[n_type].x.size(-1)))), dim=-1)
             return [
-                key for key, sizes in sizes_dict.items()
-                if len(sizes) == len(stores) and len(set(sizes)) == 1
+                (key if)for key, sizes in sizes_dict.items()
+                if len(sizes) == len(stores)
             ]
 
         if dummy_values:
@@ -854,6 +858,13 @@ class HeteroData(BaseData, FeatureStore, GraphStore):
             if key in {'ptr'}:
                 continue
             values = [store[key] for store in self.node_stores]
+            # for feature tensors such as 'x', pad them if they are not the same shape
+            if len(values[0].size()) > 1:
+                max_dim = max([i.size(-1) for i in values])
+                print('max_dim=',max_dim)
+                for i, value in enumerate(values):
+                    if value.size(-1) < max_dim:
+                        values[i] = torch.cat((value, torch.zeros(value.size(0),max_dim - value.size(-1))), dim=-1)
             dim = self.__cat_dim__(key, values[0], self.node_stores[0])
             value = torch.cat(values, dim) if len(values) > 1 else values[0]
             data[key] = value

--- a/torch_geometric/data/hetero_data.py
+++ b/torch_geometric/data/hetero_data.py
@@ -828,10 +828,20 @@ class HeteroData(BaseData, FeatureStore, GraphStore):
 
         def _consistent_size(stores: List[BaseStorage]) -> List[str]:
             sizes_dict = get_sizes(stores)
-            return [
-                key for key, sizes in sizes_dict.items()
-                if len(sizes) == len(stores)
-            ]
+            keys = []
+            for key, sizes in sizes_dict.items():
+                # The attribute needs to exist in all types:
+                if len(sizes) != len(stores):
+                    continue
+                # The attributes needs to have the same number of dimensions:
+                lengths = set([len(size) for size in sizes])
+                if len(lengths) != 1:
+                    continue
+                # The attributes needs to have the same size in all dimensions:
+                if len(sizes[0]) != 1 and len(set(sizes)) != 1:
+                    continue
+                keys.append(key)
+            return keys
 
         if dummy_values:
             self = copy.copy(self)


### PR DESCRIPTION
useful for putting randomly generated FakeHeteroDataset data into a fused GNN like RGCNConv, otherwise the fakeheterodataset usually has x's w/ diff num of features and the resulting Data would not have any node features w/o this PR