### PR TITLE
LightGCN bug fix #7196:

### DIFF
--- a/test/nn/models/test_lightgcn.py
+++ b/test/nn/models/test_lightgcn.py
@@ -18,10 +18,11 @@ def test_lightgcn_ranking(embedding_dim, with_edge_weight, lambda_reg, alpha):
     model = LightGCN(num_nodes, embedding_dim, num_layers=2, alpha=alpha)
     assert str(model) == f'LightGCN(500, {embedding_dim}, num_layers=2)'
 
-    pred = model(edge_index, edge_label_index, edge_weight)
+    pred, nodes_indices = model(edge_index, edge_label_index, edge_weight)
     assert pred.size() == (100, )
 
-    loss = model.recommendation_loss(pred[:50], pred[50:], lambda_reg)
+    loss = model.recommendation_loss(pred[:50], pred[50:], nodes_indices,
+                                     lambda_reg)
     assert loss.dim() == 0 and loss > 0
 
     out = model.recommend(edge_index, edge_weight, k=2)
@@ -50,7 +51,7 @@ def test_lightgcn_link_prediction(embedding_dim, with_edge_weight, alpha):
     model = LightGCN(num_nodes, embedding_dim, num_layers=2, alpha=alpha)
     assert str(model) == f'LightGCN(500, {embedding_dim}, num_layers=2)'
 
-    pred = model(edge_index, edge_label_index, edge_weight)
+    pred, _ = model(edge_index, edge_label_index, edge_weight)
     assert pred.size() == (100, )
 
     loss = model.link_pred_loss(pred, edge_label)


### PR DESCRIPTION
1. In BPRLoss(_Loss)::forward, log_prob is divided by n_pairs twice. Changed the return clause to: return -log_prob + regularization / n_pairs

2. In LightGCN()::recommendation_loss, it calls BPRLoss::forward and passes in the embeddings of all nodes. It should pass in only the embeddings of the nodes in the mini-batch.