### PR TITLE
Update initialization of `attribution_method` in `CaptumExplainer` 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,7 +67,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Change `torch_sparse.SparseTensor` logic to utilize `torch.sparse_csr` instead ([#7041](https://github.com/pyg-team/pytorch_geometric/pull/7041))
 - Added an optional `batch_size` and `max_num_nodes` arguments to `MemPooling` layer ([#7239](https://github.com/pyg-team/pytorch_geometric/pull/7239))
 - Fixed training issues of the GraphGPS example ([#7377](https://github.com/pyg-team/pytorch_geometric/pull/7377))
-- Allowed `CaptumExplainer` to be called multiple times in a row ([#7391](https://github.com/pyg-team/pytorch_geometric/pull/7391)
+- Allowed `CaptumExplainer` to be called multiple times in a row ([#7391](https://github.com/pyg-team/pytorch_geometric/pull/7391))
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Change `torch_sparse.SparseTensor` logic to utilize `torch.sparse_csr` instead ([#7041](https://github.com/pyg-team/pytorch_geometric/pull/7041))
 - Added an optional `batch_size` and `max_num_nodes` arguments to `MemPooling` layer ([#7239](https://github.com/pyg-team/pytorch_geometric/pull/7239))
 - Fixed training issues of the GraphGPS example ([#7377](https://github.com/pyg-team/pytorch_geometric/pull/7377))
+- Allowed `CaptumExplainer` to be called multiple times in a row ([#7391](https://github.com/pyg-team/pytorch_geometric/pull/7391)
 
 ### Removed
 

--- a/torch_geometric/explain/algorithm/captum_explainer.py
+++ b/torch_geometric/explain/algorithm/captum_explainer.py
@@ -150,7 +150,7 @@ class CaptumExplainer(ExplainerAlgorithm):
             metadata = None
             captum_model = CaptumModel(model, mask_type, index)
 
-        self.attribution_method = self.attribution_method(captum_model)
+        attribution_method = self.attribution_method(captum_model)
 
         # In captum, the target is the index for which
         # the attribution is computed.
@@ -159,7 +159,7 @@ class CaptumExplainer(ExplainerAlgorithm):
         else:
             target = target[index]
 
-        attributions = self.attribution_method.attribute(
+        attributions = attribution_method.attribute(
             inputs=inputs,
             target=target,
             additional_forward_args=add_forward_args,


### PR DESCRIPTION
This allows the algorithm to be called multiple time without raising an error, close #7390 