### PR TITLE
Adds support for benchmarking bidirectional sampling

### DIFF
--- a/benchmark/loader/neighbor_loader.py
+++ b/benchmark/loader/neighbor_loader.py
@@ -35,6 +35,7 @@ def run(args: argparse.ArgumentParser):
             neighbor_sizes = (args.homo_neighbor_sizes
                               if args.homo_neighbor_sizes else None)
 
+        subgr_type = args.subgraph_type
         data = dataset[0].to(args.device)
         average_times = []
         profile = torch_profile() if args.profile else nullcontext()
@@ -50,6 +51,7 @@ def run(args: argparse.ArgumentParser):
                         batch_size=batch_size,
                         shuffle=True,
                         num_workers=args.num_workers,
+                        subgraph_type=subgr_type,
                     )
                     cpu_affinity = train_loader.enable_cpu_affinity(
                         args.loader_cores
@@ -81,6 +83,7 @@ def run(args: argparse.ArgumentParser):
                     batch_size=batch_size,
                     shuffle=False,
                     num_workers=args.num_workers,
+                    subgraph_type=subgr_type,
                 )
                 cpu_affinity = subgraph_loader.enable_cpu_affinity(
                     args.loader_cores) if args.cpu_affinity else nullcontext()
@@ -129,4 +132,6 @@ if __name__ == '__main__':
         help="Use DataLoader affinitzation.")
     add('--loader-cores', nargs='+', default=[], type=int,
         help="List of CPU core IDs to use for DataLoader workers.")
+    add('--subgraph-type', default='directional',
+        help="directional or bidirectional sampling")
     run(parser.parse_args())

--- a/benchmark/loader/neighbor_loader.py
+++ b/benchmark/loader/neighbor_loader.py
@@ -35,7 +35,6 @@ def run(args: argparse.ArgumentParser):
             neighbor_sizes = (args.homo_neighbor_sizes
                               if args.homo_neighbor_sizes else None)
 
-        subgr_type = args.subgraph_type
         data = dataset[0].to(args.device)
         average_times = []
         profile = torch_profile() if args.profile else nullcontext()
@@ -51,7 +50,7 @@ def run(args: argparse.ArgumentParser):
                         batch_size=batch_size,
                         shuffle=True,
                         num_workers=args.num_workers,
-                        subgraph_type=subgr_type,
+                        subgraph_type=args.subgraph_type,
                     )
                     cpu_affinity = train_loader.enable_cpu_affinity(
                         args.loader_cores
@@ -83,7 +82,6 @@ def run(args: argparse.ArgumentParser):
                     batch_size=batch_size,
                     shuffle=False,
                     num_workers=args.num_workers,
-                    subgraph_type=subgr_type,
                 )
                 cpu_affinity = subgraph_loader.enable_cpu_affinity(
                     args.loader_cores) if args.cpu_affinity else nullcontext()
@@ -132,6 +130,6 @@ if __name__ == '__main__':
         help="Use DataLoader affinitzation.")
     add('--loader-cores', nargs='+', default=[], type=int,
         help="List of CPU core IDs to use for DataLoader workers.")
-    add('--subgraph-type', default='directional',
-        help="directional or bidirectional sampling")
+    add('--subgraph-type', type=str, default='directional',
+        help="The type of the returned subgraph (directional, bidirectional)")
     run(parser.parse_args())


### PR DESCRIPTION
Simple addition to enable bidirectional neighbor loader benchmarking.
Results show a relative drop in performance moving from directional to bidirectional (example below) maybe due to the fact that, currently,  bidirectional sampling is implemented as a post-processing of regular sampling [#7200](https://github.com/pyg-team/pytorch_geometric/pull/7200/files#)

With directional sampling:
Dataset: products
Training sampling with [10, 5] neighbors
100%|█████████████████████████████████193/193 [00:03<00:00, 48.96it/s]
100%|█████████████████████████████████ 193/193 [00:03<00:00, 49.59it/s]
100%|█████████████████████████████████ 193/193 [00:03<00:00, 49.01it/s]
batch size=1024, iterations=579, runtimes=[3.943, 3.892, 3.939], average runtime=3.925

while with bidirectional sampling:
Dataset: products
Training sampling with [10, 5] neighbors
100%|██████████████████████████████████ 193/193 [00:04<00:00, 42.22it/s]
100%|██████████████████████████████████193/193 [00:04<00:00, 43.18it/s]
100%|██████████████████████████████████193/193 [00:04<00:00, 42.56it/s]
batch size=1024, iterations=579, runtimes=[4.572, 4.47, 4.535], average runtime=4.526

