### PR TITLE
ARM support in AffinityMixin

### DIFF
--- a/torch_geometric/loader/mixin.py
+++ b/torch_geometric/loader/mixin.py
@@ -141,6 +141,7 @@ class AffinityMixin:
             if numa_info and len(numa_info[0]) > self.num_workers:
                 # Take one thread per each node 0 core:
                 node0_cores = [cpus[0] for core_id, cpus in numa_info[0]]
+                node0_cores.sort()
             else:
                 node0_cores = list(range(psutil.cpu_count(logical=False)))
 


### PR DESCRIPTION
`enable_cpu_affinity` with `loader_cores=None` has a different behavior when the arch changes.
Which results in inconsistent behavior accross archs and this test failing with ARM:
```
___________________ test_cpu_affinity_neighbor_loader[None] ____________________
loader_cores = None
    @onlyLinux
    @onlyNeighborSampler
    @pytest.mark.parametrize('loader_cores', [None, [1]])
    def test_cpu_affinity_neighbor_loader(loader_cores):
        data = Data(x=torch.randn(1, 1))
        loader = NeighborLoader(data, num_neighbors=[-1], batch_size=1,
                                num_workers=1)
    
        out = []
        with loader.enable_cpu_affinity(loader_cores):
            iterator = loader._get_iterator().iterator
            workers = iterator._workers
            for worker in workers:
                sleep(1)  # Gives time for worker to initialize.
                process = subprocess.Popen(
                    ['taskset', '-c', '-p', f'{worker.pid}'],
                    stdout=subprocess.PIPE)
                stdout = process.communicate()[0].decode('utf-8')
                out.append(int(stdout.split(':')[1].strip()))
            if not loader_cores:
>               assert out == [0]
E               assert [40] == [0]
E                 At index 0 diff: 40 != 0
E                 Use -v to get more diff
test/loader/test_neighbor_loader.py:610: AssertionError
```