### PR TITLE
`QuantileAggregation` - pass `output_size` to the `repeat_interleave` operation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Added an optional `batch_size` and `max_num_nodes` arguments to `MemPooling` layer ([#7239](https://github.com/pyg-team/pytorch_geometric/pull/7239))
 - Fixed training issues of the GraphGPS example ([#7377](https://github.com/pyg-team/pytorch_geometric/pull/7377))
 - Allowed `CaptumExplainer` to be called multiple times in a row ([#7391](https://github.com/pyg-team/pytorch_geometric/pull/7391))
+- Set output size in the `repeat_interleave` operation in `QuantileAggregation` operation ([#7426](https://github.com/pyg-team/pytorch_geometric/pull/7391))
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
+- Set `output_size` in the `repeat_interleave` operation in `QuantileAggregation` ([#7426](https://github.com/pyg-team/pytorch_geometric/pull/7426))
 - Re-factored `ClusterLoader` to integrate `pyg-lib` METIS routine ([#7416](https://github.com/pyg-team/pytorch_geometric/pull/7416))
 - Fixed an index-out-of-range bug in `QuantileAggregation` when `dim_size` is passed ([#7407](https://github.com/pyg-team/pytorch_geometric/pull/7407))
 - The `filter_per_worker` option will not get automatically inferred by default based on the device of the underlying data ([#7399](https://github.com/pyg-team/pytorch_geometric/pull/7399))
@@ -73,7 +74,6 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Added an optional `batch_size` and `max_num_nodes` arguments to `MemPooling` layer ([#7239](https://github.com/pyg-team/pytorch_geometric/pull/7239))
 - Fixed training issues of the GraphGPS example ([#7377](https://github.com/pyg-team/pytorch_geometric/pull/7377))
 - Allowed `CaptumExplainer` to be called multiple times in a row ([#7391](https://github.com/pyg-team/pytorch_geometric/pull/7391))
-- Set output size in the `repeat_interleave` operation in `QuantileAggregation` operation ([#7426](https://github.com/pyg-team/pytorch_geometric/pull/7391))
 
 ### Removed
 

--- a/torch_geometric/nn/aggr/quantile.py
+++ b/torch_geometric/nn/aggr/quantile.py
@@ -116,9 +116,8 @@ class QuantileAggregation(Aggregation):
 
         # If the number of elements is zero, fill with pre-defined value:
         repeats = self.q.numel()
-        output_size = repeats * count.numel()
         mask = (count == 0).repeat_interleave(
-            repeats, output_size=output_size).view(shape)
+            repeats, output_size=repeats * count.numel()).view(shape)
         out = quantile.masked_fill(mask, self.fill_value)
 
         if self.q.numel() > 1:

--- a/torch_geometric/nn/aggr/quantile.py
+++ b/torch_geometric/nn/aggr/quantile.py
@@ -115,7 +115,10 @@ class QuantileAggregation(Aggregation):
                 quantile = 0.5 * l_quant + 0.5 * r_quant
 
         # If the number of elements is zero, fill with pre-defined value:
-        mask = (count == 0).repeat_interleave(self.q.numel()).view(shape)
+        repeats = self.q.numel()
+        output_size = repeats * count.numel()
+        mask = (count == 0).repeat_interleave(
+            repeats, output_size=output_size).view(shape)
         out = quantile.masked_fill(mask, self.fill_value)
 
         if self.q.numel() > 1:


### PR DESCRIPTION
Repeat interleave meta backend https://github.com/pytorch/pytorch/blob/ee95e37a692a2ada87b6523aeae822fe73a2d304/torch/_meta_registrations.py#L1526 throws an exception if output_size is None. Meta backends are used in custom torch.compile backends. Output size can be easily set in repeat interleave in QuantileAggregation operation.