### PR TITLE
Add node labelling procedure for `IGMC`

### DIFF
--- a/torch_geometric/nn/models/igmc.py
+++ b/torch_geometric/nn/models/igmc.py
@@ -2,23 +2,21 @@ from typing import Union
 
 import torch
 
-from torch_geometric.typing import EdgeType, NodeType
+from torch_geometric.data import Data, HeteroData
 
 
-def igmc_node_label(batch: Union[NodeType, dict[NodeType]],
-                    edge_index: Union[EdgeType,
-                                      dict[EdgeType]], num_sampled_edges: int):
+def igmc_node_label(batch: Union[Data, HeteroData], num_sampled_edges: int):
 
-    if isinstance(edge_index, torch.Tensor):
+    if isinstance(batch, Data):
 
-        label_list = [float('inf')] * len(batch)
+        label_list = [float('inf')] * len(batch.batch)
         for i in range(2):
             for j in range(num_sampled_edges):
                 label_list[(i * num_sampled_edges) + j] = i
 
-        for i in range(len(edge_index[0])):
-            v = edge_index[0][i]
-            u = edge_index[1][i]
+        for i in range(len(batch.edge_index[0])):
+            v = batch.edge_index[0][i]
+            u = batch.edge_index[1][i]
             if v > u:
                 label_list[v] = min(label_list[u] + 2, label_list[v])
 

--- a/torch_geometric/nn/models/igmc.py
+++ b/torch_geometric/nn/models/igmc.py
@@ -1,11 +1,13 @@
-from typing import Union
+from typing import Optional, Union
 
 import torch
 
 from torch_geometric.data import Data, HeteroData
+from torch_geometric.typing import NodeType
 
 
-def igmc_node_label(batch: Union[Data, HeteroData], num_sampled_edges: int):
+def igmc_node_label(batch: Union[Data, HeteroData], num_sampled_edges: int,
+                    edge_direction: Optional[NodeType] = None):
 
     if isinstance(batch, Data):
 
@@ -20,4 +22,31 @@ def igmc_node_label(batch: Union[Data, HeteroData], num_sampled_edges: int):
             if v > u:
                 label_list[v] = min(label_list[u] + 2, label_list[v])
 
-        return torch.tensor(label_list)
+        batch.igmc_id = torch.tensor(label_list)
+
+    if isinstance(batch, HeteroData):
+
+        assert edge_direction is not None
+
+        origin = edge_direction[0]
+        for node_type in batch.node_types:
+
+            if node_type == origin:
+                start_id = 0
+            else:
+                start_id = 1
+
+            igmc_id = 0 + start_id
+            label_list = [float('inf')] * len(batch[node_type].batch)
+            prev = 0
+
+            for index, i in batch[node_type].batch:
+
+                if i < prev:
+                    igmc_id += 2
+                label_list[index] = igmc_id
+                prev = i
+
+            batch[node_type].igmc_id = torch.tensor(label_list)
+
+    return batch

--- a/torch_geometric/nn/models/igmc.py
+++ b/torch_geometric/nn/models/igmc.py
@@ -1,10 +1,13 @@
+from typing import Union
+
 import torch
 
 from torch_geometric.typing import EdgeType, NodeType
 
 
-def igmc_node_label(batch: dict[NodeType], edge_index: dict[EdgeType],
-                    num_sampled_edges: int):
+def igmc_node_label(batch: Union[NodeType, dict[NodeType]],
+                    edge_index: Union[EdgeType,
+                                      dict[EdgeType]], num_sampled_edges: int):
 
     if isinstance(edge_index, torch.Tensor):
 

--- a/torch_geometric/nn/models/igmc.py
+++ b/torch_geometric/nn/models/igmc.py
@@ -1,0 +1,22 @@
+import torch
+
+from torch_geometric.typing import EdgeType, NodeType
+
+
+def igmc_node_label(batch: dict[NodeType], edge_index: dict[EdgeType],
+                    num_sampled_edges: int):
+
+    if isinstance(edge_index, torch.Tensor):
+
+        label_list = [float('inf')] * len(batch)
+        for i in range(2):
+            for j in range(num_sampled_edges):
+                label_list[(i * num_sampled_edges) + j] = i
+
+        for i in range(len(edge_index[0])):
+            v = edge_index[0][i]
+            u = edge_index[1][i]
+            if v > u:
+                label_list[v] = min(label_list[u] + 2, label_list[v])
+
+        return torch.tensor(label_list)

--- a/torch_geometric/nn/models/igmc.py
+++ b/torch_geometric/nn/models/igmc.py
@@ -40,7 +40,7 @@ def igmc_node_label(batch: Union[Data, HeteroData], num_sampled_edges: int,
             label_list = [float('inf')] * len(batch[node_type].batch)
             prev = 0
 
-            for index, i in batch[node_type].batch:
+            for index, i in enumerate(batch[node_type].batch):
 
                 if i < prev:
                     igmc_id += 2


### PR DESCRIPTION
Draft PR to track progress

- [x] Add igmc_node_label
- [ ] Add documentation
- [ ] Add tests

The current design assumes that the graphs are bipartite as in the paper and that they are outputs of the `LinkNeighborLoader`. 
For normal `Data` we essentially run dijksta, while for `HeteroData` we can use the fact that `LinkNeighborLoader` produces a nicely sorted output.