### PR TITLE
[Benchmark] Add compile option in benchmark kernel, citation and points

### DIFF
--- a/benchmark/citation/appnp.py
+++ b/benchmark/citation/appnp.py
@@ -24,6 +24,7 @@ parser.add_argument('--alpha', type=float, default=0.1)
 parser.add_argument('--inference', action='store_true')
 parser.add_argument('--profile', action='store_true')
 parser.add_argument('--bf16', action='store_true')
+parser.add_argument('--compile', action='store_true')
 args = parser.parse_args()
 
 
@@ -51,7 +52,7 @@ class Net(torch.nn.Module):
 dataset = get_planetoid_dataset(args.dataset, not args.no_normalize_features)
 permute_masks = random_planetoid_splits if args.random_splits else None
 run(dataset, Net(dataset), args.runs, args.epochs, args.lr, args.weight_decay,
-    args.early_stopping, args.inference, args.profile, args.bf16,
+    args.early_stopping, args.inference, args.profile, args.bf16, args.compile,
     permute_masks)
 
 if args.profile:

--- a/benchmark/citation/arma.py
+++ b/benchmark/citation/arma.py
@@ -25,6 +25,7 @@ parser.add_argument('--skip_dropout', type=float, default=0.75)
 parser.add_argument('--inference', action='store_true')
 parser.add_argument('--profile', action='store_true')
 parser.add_argument('--bf16', action='store_true')
+parser.add_argument('--compile', action='store_true')
 args = parser.parse_args()
 
 
@@ -53,7 +54,7 @@ class Net(torch.nn.Module):
 dataset = get_planetoid_dataset(args.dataset, not args.no_normalize_features)
 permute_masks = random_planetoid_splits if args.random_splits else None
 run(dataset, Net(dataset), args.runs, args.epochs, args.lr, args.weight_decay,
-    args.early_stopping, args.inference, args.profile, args.bf16,
+    args.early_stopping, args.inference, args.profile, args.bf16, args.compile,
     permute_masks)
 
 if args.profile:

--- a/benchmark/citation/cheb.py
+++ b/benchmark/citation/cheb.py
@@ -22,6 +22,7 @@ parser.add_argument('--num_hops', type=int, default=3)
 parser.add_argument('--inference', action='store_true')
 parser.add_argument('--profile', action='store_true')
 parser.add_argument('--bf16', action='store_true')
+parser.add_argument('--compile', action='store_true')
 args = parser.parse_args()
 
 
@@ -46,7 +47,7 @@ class Net(torch.nn.Module):
 dataset = get_planetoid_dataset(args.dataset, not args.no_normalize_features)
 permute_masks = random_planetoid_splits if args.random_splits else None
 run(dataset, Net(dataset), args.runs, args.epochs, args.lr, args.weight_decay,
-    args.early_stopping, args.inference, args.profile, args.bf16,
+    args.early_stopping, args.inference, args.profile, args.bf16, args.compile,
     permute_masks)
 
 if args.profile:

--- a/benchmark/citation/gat.py
+++ b/benchmark/citation/gat.py
@@ -23,6 +23,7 @@ parser.add_argument('--output_heads', type=int, default=1)
 parser.add_argument('--inference', action='store_true')
 parser.add_argument('--profile', action='store_true')
 parser.add_argument('--bf16', action='store_true')
+parser.add_argument('--compile', action='store_true')
 args = parser.parse_args()
 
 
@@ -51,7 +52,7 @@ class Net(torch.nn.Module):
 dataset = get_planetoid_dataset(args.dataset, not args.no_normalize_features)
 permute_masks = random_planetoid_splits if args.random_splits else None
 run(dataset, Net(dataset), args.runs, args.epochs, args.lr, args.weight_decay,
-    args.early_stopping, args.inference, args.profile, args.bf16,
+    args.early_stopping, args.inference, args.profile, args.bf16, args.compile,
     permute_masks)
 
 if args.profile:

--- a/benchmark/citation/gcn.py
+++ b/benchmark/citation/gcn.py
@@ -21,6 +21,7 @@ parser.add_argument('--no_normalize_features', action='store_true')
 parser.add_argument('--inference', action='store_true')
 parser.add_argument('--profile', action='store_true')
 parser.add_argument('--bf16', action='store_true')
+parser.add_argument('--compile', action='store_true')
 args = parser.parse_args()
 
 
@@ -45,7 +46,7 @@ class Net(torch.nn.Module):
 dataset = get_planetoid_dataset(args.dataset, not args.no_normalize_features)
 permute_masks = random_planetoid_splits if args.random_splits else None
 run(dataset, Net(dataset), args.runs, args.epochs, args.lr, args.weight_decay,
-    args.early_stopping, args.inference, args.profile, args.bf16,
+    args.early_stopping, args.inference, args.profile, args.bf16, args.compile,
     permute_masks)
 
 if args.profile:

--- a/benchmark/citation/sgc.py
+++ b/benchmark/citation/sgc.py
@@ -20,6 +20,7 @@ parser.add_argument('--K', type=int, default=2)
 parser.add_argument('--inference', action='store_true')
 parser.add_argument('--profile', action='store_true')
 parser.add_argument('--bf16', action='store_true')
+parser.add_argument('--compile', action='store_true')
 args = parser.parse_args()
 
 
@@ -41,7 +42,7 @@ class Net(torch.nn.Module):
 dataset = get_planetoid_dataset(args.dataset, not args.no_normalize_features)
 permute_masks = random_planetoid_splits if args.random_splits else None
 run(dataset, Net(dataset), args.runs, args.epochs, args.lr, args.weight_decay,
-    args.early_stopping, args.inference, args.profile, args.bf16,
+    args.early_stopping, args.inference, args.profile, args.bf16, args.compile,
     permute_masks)
 
 if args.profile:

--- a/benchmark/citation/train_eval.py
+++ b/benchmark/citation/train_eval.py
@@ -105,9 +105,10 @@ def run_train(dataset, model, runs, epochs, lr, weight_decay, early_stopping,
         with timeit():
             train(compiled_model, optimizer, data)
 
+
 @torch.no_grad()
-def run_inference(dataset, model, epochs, profiling, bf16, use_compile, permute_masks=None,
-                  logger=None):
+def run_inference(dataset, model, epochs, profiling, bf16, use_compile,
+                  permute_masks=None, logger=None):
     data = dataset[0]
     if permute_masks is not None:
         data = permute_masks(data, dataset.num_classes)
@@ -142,14 +143,17 @@ def run_inference(dataset, model, epochs, profiling, bf16, use_compile, permute_
             with timeit():
                 inference(compiled_model, data)
 
+
 def run(dataset, model, runs, epochs, lr, weight_decay, early_stopping,
-        inference, profiling, bf16, use_compile, permute_masks=None, logger=None):
+        inference, profiling, bf16, use_compile, permute_masks=None,
+        logger=None):
     if not inference:
         run_train(dataset, model, runs, epochs, lr, weight_decay,
-                  early_stopping, profiling, use_compile, permute_masks, logger)
+                  early_stopping, profiling, use_compile, permute_masks,
+                  logger)
     else:
-        run_inference(dataset, model, epochs, profiling, bf16, use_compile, permute_masks,
-                      logger)
+        run_inference(dataset, model, epochs, profiling, bf16, use_compile,
+                      permute_masks, logger)
 
 
 def train(model, optimizer, data):

--- a/benchmark/kernel/main_performance.py
+++ b/benchmark/kernel/main_performance.py
@@ -79,7 +79,8 @@ def run_train():
 
             model = Model(dataset, num_layers, hidden).to(device)
             optimizer = torch.optim.Adam(model.parameters(), lr=args.lr)
-
+            if args.compile:
+                model = torch_geometric.compile(model)
             loss_list = []
             acc_list = []
             for epoch in range(1, args.epochs + 1):
@@ -106,14 +107,6 @@ def run_train():
                 rename_profile_file(model_name, dataset_name, str(num_layers),
                                     str(hidden), 'train')
 
-            if args.compile:
-                print("Using torch.compile")
-                compiled_model = torch_geometric.compile(model)
-                eval_acc(compiled_model, val_loader)
-                eval_acc(compiled_model, val_loader)
-                with timeit():
-                    eval_acc(compiled_model, val_loader)
-
 
 @torch.no_grad()
 def run_inference():
@@ -126,7 +119,8 @@ def run_inference():
             print(f'{dataset_name} - {model_name}- {num_layers} - {hidden}')
 
             model = Model(dataset, num_layers, hidden).to(device)
-
+            if args.compile:
+                model = torch_geometric.compile(model)
             with amp:
                 for epoch in range(1, args.epochs + 1):
                     if epoch == args.epochs:
@@ -141,14 +135,6 @@ def run_inference():
                     rename_profile_file(model_name, dataset_name,
                                         str(num_layers), str(hidden),
                                         'inference')
-
-                if args.compile:
-                    print("Using torch.compile")
-                    compiled_model = torch_geometric.compile(model)
-                    inference_run(compiled_model, test_loader, args.bf16)
-                    inference_run(compiled_model, test_loader, args.bf16)
-                    with timeit():
-                        inference_run(compiled_model, test_loader, args.bf16)
 
 
 if not args.inference:

--- a/benchmark/points/edge_cnn.py
+++ b/benchmark/points/edge_cnn.py
@@ -21,6 +21,7 @@ parser.add_argument('--weight_decay', type=float, default=0)
 parser.add_argument('--inference', action='store_true')
 parser.add_argument('--profile', action='store_true')
 parser.add_argument('--bf16', action='store_true')
+parser.add_argument('--compile', action='store_true')
 args = parser.parse_args()
 
 
@@ -60,7 +61,7 @@ train_dataset, test_dataset = get_dataset(num_points=1024)
 model = Net(train_dataset.num_classes)
 run(train_dataset, test_dataset, model, args.epochs, args.batch_size, args.lr,
     args.lr_decay_factor, args.lr_decay_step_size, args.weight_decay,
-    args.inference, args.profile, args.bf16)
+    args.inference, args.profile, args.bf16, args.compile)
 
 if args.profile:
     rename_profile_file('points', DynamicEdgeConv.__name__)

--- a/benchmark/points/mpnn.py
+++ b/benchmark/points/mpnn.py
@@ -21,6 +21,7 @@ parser.add_argument('--weight_decay', type=float, default=0)
 parser.add_argument('--inference', action='store_true')
 parser.add_argument('--profile', action='store_true')
 parser.add_argument('--bf16', action='store_true')
+parser.add_argument('--compile', action='store_true')
 args = parser.parse_args()
 
 
@@ -77,7 +78,7 @@ train_dataset, test_dataset = get_dataset(num_points=1024)
 model = Net(train_dataset.num_classes)
 run(train_dataset, test_dataset, model, args.epochs, args.batch_size, args.lr,
     args.lr_decay_factor, args.lr_decay_step_size, args.weight_decay,
-    args.inference, args.profile, args.bf16)
+    args.inference, args.profile, args.bf16, args.compile)
 
 if args.profile:
     rename_profile_file('points', NNConv.__name__)

--- a/benchmark/points/point_cnn.py
+++ b/benchmark/points/point_cnn.py
@@ -19,6 +19,7 @@ parser.add_argument('--weight_decay', type=float, default=0)
 parser.add_argument('--inference', action='store_true')
 parser.add_argument('--profile', action='store_true')
 parser.add_argument('--bf16', action='store_true')
+parser.add_argument('--compile', action='store_true')
 args = parser.parse_args()
 
 
@@ -65,7 +66,7 @@ train_dataset, test_dataset = get_dataset(num_points=1024)
 model = Net(train_dataset.num_classes)
 run(train_dataset, test_dataset, model, args.epochs, args.batch_size, args.lr,
     args.lr_decay_factor, args.lr_decay_step_size, args.weight_decay,
-    args.inference, args.profile, args.bf16)
+    args.inference, args.profile, args.bf16, args.compile)
 
 if args.profile:
     rename_profile_file('points', XConv.__name__)

--- a/benchmark/points/point_net.py
+++ b/benchmark/points/point_net.py
@@ -21,6 +21,7 @@ parser.add_argument('--weight_decay', type=float, default=0)
 parser.add_argument('--inference', action='store_true')
 parser.add_argument('--profile', action='store_true')
 parser.add_argument('--bf16', action='store_true')
+parser.add_argument('--compile', action='store_true')
 args = parser.parse_args()
 
 
@@ -73,7 +74,7 @@ train_dataset, test_dataset = get_dataset(num_points=1024)
 model = Net(train_dataset.num_classes)
 run(train_dataset, test_dataset, model, args.epochs, args.batch_size, args.lr,
     args.lr_decay_factor, args.lr_decay_step_size, args.weight_decay,
-    args.inference, args.profile, args.bf16)
+    args.inference, args.profile, args.bf16, args.compile)
 
 if args.profile:
     rename_profile_file('points', PointNetConv.__name__)

--- a/benchmark/points/spline_cnn.py
+++ b/benchmark/points/spline_cnn.py
@@ -19,6 +19,7 @@ parser.add_argument('--weight_decay', type=float, default=0)
 parser.add_argument('--inference', action='store_true')
 parser.add_argument('--profile', action='store_true')
 parser.add_argument('--bf16', action='store_true')
+parser.add_argument('--compile', action='store_true')
 args = parser.parse_args()
 
 
@@ -74,7 +75,7 @@ train_dataset, test_dataset = get_dataset(num_points=1024)
 model = Net(train_dataset.num_classes)
 run(train_dataset, test_dataset, model, args.epochs, args.batch_size, args.lr,
     args.lr_decay_factor, args.lr_decay_step_size, args.weight_decay,
-    args.inference, args.profile, args.bf16)
+    args.inference, args.profile, args.bf16, args.compile)
 
 if args.profile:
     rename_profile_file('points', SplineConv.__name__)

--- a/benchmark/points/train_eval.py
+++ b/benchmark/points/train_eval.py
@@ -15,6 +15,8 @@ def run_train(train_dataset, test_dataset, model, epochs, batch_size,
               use_compile, lr, lr_decay_factor, lr_decay_step_size,
               weight_decay):
     model = model.to(device)
+    if use_compile:
+        model = torch_geometric.compile(model)
     optimizer = Adam(model.parameters(), lr=lr, weight_decay=weight_decay)
 
     train_loader = DataLoader(train_dataset, batch_size, shuffle=True)
@@ -41,19 +43,13 @@ def run_train(train_dataset, test_dataset, model, epochs, batch_size,
             for param_group in optimizer.param_groups:
                 param_group['lr'] = lr_decay_factor * param_group['lr']
 
-    if use_compile:
-        print("Using torch.compile")
-        compiled_model = torch_geometric.compile(model)
-        test(compiled_model, test_loader, device)
-        test(compiled_model, test_loader, device)
-        with timeit():
-            test(compiled_model, test_loader, device)
-
 
 @torch.no_grad()
 def run_inference(test_dataset, model, epochs, batch_size, profiling, bf16,
                   use_compile):
     model = model.to(device)
+    if use_compile:
+        model = torch_geometric.compile(model)
     test_loader = DataLoader(test_dataset, batch_size, shuffle=False)
 
     if torch.cuda.is_available():
@@ -73,14 +69,6 @@ def run_inference(test_dataset, model, epochs, batch_size, profiling, bf16,
         if profiling:
             with torch_profile():
                 inference(model, test_loader, device, bf16)
-
-        if use_compile:
-            print("Using torch.compile")
-            compiled_model = torch_geometric.compile(model)
-            inference(compiled_model, test_loader, device, bf16)
-            inference(compiled_model, test_loader, device, bf16)
-            with timeit():
-                inference(compiled_model, test_loader, device, bf16)
 
 
 def run(train_dataset, test_dataset, model, epochs, batch_size, lr,

--- a/benchmark/points/train_eval.py
+++ b/benchmark/points/train_eval.py
@@ -11,8 +11,9 @@ from torch_geometric.profile import timeit, torch_profile
 device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
 
 
-def run_train(train_dataset, test_dataset, model, epochs, batch_size, use_compile, lr,
-              lr_decay_factor, lr_decay_step_size, weight_decay):
+def run_train(train_dataset, test_dataset, model, epochs, batch_size,
+              use_compile, lr, lr_decay_factor, lr_decay_step_size,
+              weight_decay):
     model = model.to(device)
     optimizer = Adam(model.parameters(), lr=lr, weight_decay=weight_decay)
 
@@ -48,8 +49,10 @@ def run_train(train_dataset, test_dataset, model, epochs, batch_size, use_compil
         with timeit():
             test(compiled_model, test_loader, device)
 
+
 @torch.no_grad()
-def run_inference(test_dataset, model, epochs, batch_size, profiling, bf16, use_compile):
+def run_inference(test_dataset, model, epochs, batch_size, profiling, bf16,
+                  use_compile):
     model = model.to(device)
     test_loader = DataLoader(test_dataset, batch_size, shuffle=False)
 
@@ -79,14 +82,17 @@ def run_inference(test_dataset, model, epochs, batch_size, profiling, bf16, use_
             with timeit():
                 inference(compiled_model, test_loader, device, bf16)
 
+
 def run(train_dataset, test_dataset, model, epochs, batch_size, lr,
         lr_decay_factor, lr_decay_step_size, weight_decay, inference,
         profiling, bf16, use_compile):
     if not inference:
-        run_train(train_dataset, test_dataset, model, epochs, batch_size, use_compile, lr,
-                  lr_decay_factor, lr_decay_step_size, weight_decay)
+        run_train(train_dataset, test_dataset, model, epochs, batch_size,
+                  use_compile, lr, lr_decay_factor, lr_decay_step_size,
+                  weight_decay)
     else:
-        run_inference(test_dataset, model, epochs, batch_size, profiling, bf16, use_compile)
+        run_inference(test_dataset, model, epochs, batch_size, profiling, bf16,
+                      use_compile)
 
 
 def train(model, optimizer, train_loader, device):

--- a/torch_geometric/profile/benchmark.py
+++ b/torch_geometric/profile/benchmark.py
@@ -5,6 +5,7 @@ import torch
 from torch import Tensor
 
 from torch_geometric.utils import is_torch_sparse_tensor
+from torch_geometric.data import Data
 
 
 def require_grad(x: Any, requires_grad: bool = True) -> Any:
@@ -63,7 +64,7 @@ def benchmark(
                          f"'func_names' (got {len(func_names)}) must be equal")
 
     # Zero-copy `args` for each function (if necessary):
-    args_list = [args] * len(funcs) if isinstance(args, tuple) else args
+    args_list = [args] * len(funcs) if isinstance(args, tuple) or isinstance(args, Data) else args
 
     ts: List[List[str]] = []
     for func, args, name in zip(funcs, args_list, func_names):
@@ -75,7 +76,10 @@ def benchmark(
                 torch.cuda.synchronize()
             t_start = time.perf_counter()
 
-            out = func(*args)
+            if isinstance(args, tuple):
+                out = func(*args)
+            else:
+                out = func(args)
 
             if torch.cuda.is_available():
                 torch.cuda.synchronize()

--- a/torch_geometric/profile/benchmark.py
+++ b/torch_geometric/profile/benchmark.py
@@ -5,7 +5,6 @@ import torch
 from torch import Tensor
 
 from torch_geometric.utils import is_torch_sparse_tensor
-from torch_geometric.data import Data
 
 
 def require_grad(x: Any, requires_grad: bool = True) -> Any:
@@ -64,7 +63,7 @@ def benchmark(
                          f"'func_names' (got {len(func_names)}) must be equal")
 
     # Zero-copy `args` for each function (if necessary):
-    args_list = [args] * len(funcs) if isinstance(args, tuple) or isinstance(args, Data) else args
+    args_list = [args] * len(funcs) if isinstance(args, tuple) else args
 
     ts: List[List[str]] = []
     for func, args, name in zip(funcs, args_list, func_names):
@@ -76,10 +75,7 @@ def benchmark(
                 torch.cuda.synchronize()
             t_start = time.perf_counter()
 
-            if isinstance(args, tuple):
-                out = func(*args)
-            else:
-                out = func(args)
+            out = func(*args)
 
             if torch.cuda.is_available():
                 torch.cuda.synchronize()


### PR DESCRIPTION
Citation uses `Data` as input, which can be extended in `profile/benchmark.py`.

Kernel and points use `DataLoader`. They only compile(model), does not use `profile/benchmark.py` structure.