### PR TITLE
Publish Pyg 2.3.1 conda packages

### DIFF
--- a/conda/pyg/meta.yaml
+++ b/conda/pyg/meta.yaml
@@ -1,9 +1,9 @@
 package:
   name: pyg
-  version: 2.3.0
+  version: 2.3.1
 
 source:
-  url: https://files.pythonhosted.org/packages/43/b5/be9795db7756e6c1fa2606c8145ec637552487e72c6428ed0b231f8bcbd3/torch_geometric-2.3.0.tar.gz
+  url: https://files.pythonhosted.org/packages/06/a5/9f5af849c4185da5ea55f70ef17e23f93355cd4e989d82cfc8ba2d8747af/torch_geometric-2.3.1.tar.gz
 
 requirements:
   host:

--- a/conda/pytorch-geometric/meta.yaml
+++ b/conda/pytorch-geometric/meta.yaml
@@ -1,9 +1,9 @@
 package:
   name: pytorch-geometric
-  version: 2.3.0
+  version: 2.3.1
 
 source:
-  url: https://files.pythonhosted.org/packages/43/b5/be9795db7756e6c1fa2606c8145ec637552487e72c6428ed0b231f8bcbd3/torch_geometric-2.3.0.tar.gz
+  url: https://files.pythonhosted.org/packages/06/a5/9f5af849c4185da5ea55f70ef17e23f93355cd4e989d82cfc8ba2d8747af/torch_geometric-2.3.1.tar.gz
 
 requirements:
   host:


### PR DESCRIPTION
Current version of pyg on conda is 2.3.0: https://anaconda.org/pyg/pyg