### PR TITLE
Add conda build number 1 for republishing with Python 3.11

### DIFF
--- a/conda/pyg/meta.yaml
+++ b/conda/pyg/meta.yaml
@@ -25,6 +25,7 @@ requirements:
 
 build:
   string: py{{ environ.get('PYTHON_VERSION').replace('.', '') }}_torch_{{ environ['TORCH_VERSION'] }}_{{ environ['CUDA_VERSION'] }}
+  number: 1  
   script: pip install .
 
 test:

--- a/conda/pyg/meta.yaml
+++ b/conda/pyg/meta.yaml
@@ -25,7 +25,7 @@ requirements:
 
 build:
   string: py{{ environ.get('PYTHON_VERSION').replace('.', '') }}_torch_{{ environ['TORCH_VERSION'] }}_{{ environ['CUDA_VERSION'] }}
-  number: 1  
+  number: 1
   script: pip install .
 
 test:

--- a/conda/pytorch-geometric/meta.yaml
+++ b/conda/pytorch-geometric/meta.yaml
@@ -25,6 +25,7 @@ requirements:
 
 build:
   string: py{{ environ.get('PYTHON_VERSION').replace('.', '') }}_torch_{{ environ['TORCH_VERSION'] }}_{{ environ['CUDA_VERSION'] }}
+  number: 1
   script: pip install .
 
 test:


### PR DESCRIPTION
I think this is required before rerunning https://github.com/pyg-team/pytorch_geometric/actions/workflows/building_pyg_conda.yml to push the new conda packages with the python 3.11 versions from https://github.com/pyg-team/pytorch_geometric/pull/7485.