### PR TITLE
Fix `torch_geometric.utils.scatter_argmax`

### DIFF
--- a/torch_geometric/utils/scatter.py
+++ b/torch_geometric/utils/scatter.py
@@ -181,7 +181,7 @@ def scatter_argmax(src: Tensor, index: Tensor, dim: int = 0,
         dim_size = index.max() + 1 if index.numel() > 0 else 0
 
     res = src.new_empty(dim_size)
-    res.scatter_reduce_(0, index, src.detach(), reduce='max',
+    res.scatter_reduce_(0, index, src.detach(), reduce='amax',
                         include_self=False)
 
     out = index.new_full((dim_size, ), fill_value=dim_size - 1)


### PR DESCRIPTION
Fixes a test failure introduced in #7481 to unblock my PR :)

- https://pytorch.org/docs/stable/generated/torch.Tensor.scatter_reduce_.html
- https://github.com/pyg-team/pytorch_geometric/actions/runs/5156873804/jobs/9288489563

```
_________________________ test_scatter_argmax[device0] _________________________

device = device(type='cpu')

    @withCUDA
    @disableExtensions
    def test_scatter_argmax(device):
        src = torch.arange(5, device=device)
        index = torch.tensor([2, 2, 0, 0, 3], device=device)
    
>       argmax = scatter_argmax(src, index, dim_size=6)

test/utils/test_scatter.py:80: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

src = tensor([0, 1, 2, 3, 4]), index = tensor([2, 2, 0, 0, 3]), dim = 0
dim_size = 6

    def scatter_argmax(src: Tensor, index: Tensor, dim: int = 0,
                       dim_size: Optional[int] = None) -> Tensor:
    
        if torch_geometric.typing.WITH_TORCH_SCATTER:
            out = torch_scatter.scatter_max(src, index, dim=dim, dim_size=dim_size)
            return out[1]
    
        # Only implemented under certain conditions for now :(
        assert dim == 0
        assert src.dim() == 1 and index.dim() == 1
    
        if dim_size is None:
            dim_size = index.max() + 1 if index.numel() > 0 else 0
    
        res = src.new_empty(dim_size)
>       res.scatter_reduce_(0, index, src.detach(), reduce='max',
                            include_self=False)
E       RuntimeError: reduce argument must be either sum, prod, mean, amax or amin.

torch_geometric/utils/scatter.py:184: RuntimeError
```