### PR TITLE
Update knn_graph.py

### DIFF
--- a/torch_geometric/transforms/knn_graph.py
+++ b/torch_geometric/transforms/knn_graph.py
@@ -1,9 +1,10 @@
 import torch
+
 import torch_geometric
 from torch_geometric.data import Data
 from torch_geometric.data.datapipes import functional_transform
 from torch_geometric.transforms import BaseTransform
-from torch_geometric.utils import to_undirected, to_device
+from torch_geometric.utils import to_device, to_undirected
 
 
 @functional_transform('knn_graph')
@@ -51,7 +52,8 @@ class KNNGraph(BaseTransform):
         batch = data.batch if 'batch' in data else None
 
         device = data.pos.device  # Get the device of the input tensor
-        data = to_device(data, device)  # Move the entire data object to the device
+        data = to_device(data,
+                         device)  # Move the entire data object to the device
 
         edge_index = torch_geometric.nn.knn_graph(
             data.pos,

--- a/torch_geometric/transforms/knn_graph.py
+++ b/torch_geometric/transforms/knn_graph.py
@@ -1,8 +1,9 @@
+import torch
 import torch_geometric
 from torch_geometric.data import Data
 from torch_geometric.data.datapipes import functional_transform
 from torch_geometric.transforms import BaseTransform
-from torch_geometric.utils import to_undirected
+from torch_geometric.utils import to_undirected, to_device
 
 
 @functional_transform('knn_graph')
@@ -48,6 +49,9 @@ class KNNGraph(BaseTransform):
     def forward(self, data: Data) -> Data:
         data.edge_attr = None
         batch = data.batch if 'batch' in data else None
+
+        device = data.pos.device  # Get the device of the input tensor
+        data = to_device(data, device)  # Move the entire data object to the device
 
         edge_index = torch_geometric.nn.knn_graph(
             data.pos,


### PR DESCRIPTION
we introduced the `to_device` function from `torch_geometric.utils` to move the entire data object to the device of the input tensor `data.pos`. This ensures that all tensors within the data object are on the same device before calling `knn_graph`.
It seems this can fix this bug: #7475 knn_graph is not working on cuda