### PR TITLE
Ensure data is on the same device in `knn_graph`

### DIFF
--- a/torch_geometric/nn/pool/__init__.py
+++ b/torch_geometric/nn/pool/__init__.py
@@ -165,8 +165,8 @@ def knn_graph(
     if batch is not None and x.device != batch.device:
         warnings.warn("Input tensor 'x' and 'batch' are on different devices "
                       "in 'knn_graph'. Performing blocking device transfer")
-
         batch = batch.to(x.device)
+
     if not torch_geometric.typing.WITH_TORCH_CLUSTER_BATCH_SIZE:
         return torch_cluster.knn_graph(x, k, batch, loop, flow, cosine,
                                        num_workers)

--- a/torch_geometric/nn/pool/__init__.py
+++ b/torch_geometric/nn/pool/__init__.py
@@ -1,3 +1,4 @@
+import warnings
 from typing import Optional
 from torch import Tensor
 
@@ -161,6 +162,11 @@ def knn_graph(
 
     :rtype: :class:`torch.Tensor`
     """
+    if batch is not None and x.device != batch.device:
+        warnings.warn("Input tensor 'x' and 'batch' are on different devices "
+                      "in 'knn_graph'. Performing blocking device transfer")
+
+        batch = batch.to(x.device)
     if not torch_geometric.typing.WITH_TORCH_CLUSTER_BATCH_SIZE:
         return torch_cluster.knn_graph(x, k, batch, loop, flow, cosine,
                                        num_workers)
@@ -264,6 +270,11 @@ def radius_graph(
 
     :rtype: :class:`torch.Tensor`
     """
+    if batch is not None and x.device != batch.device:
+        warnings.warn("Input tensor 'x' and 'batch' are on different devices "
+                      "in 'radius_graph'. Performing blocking device transfer")
+        batch = batch.to(x.device)
+
     if not torch_geometric.typing.WITH_TORCH_CLUSTER_BATCH_SIZE:
         return torch_cluster.radius_graph(x, r, batch, loop, max_num_neighbors,
                                           flow, num_workers)

--- a/torch_geometric/transforms/knn_graph.py
+++ b/torch_geometric/transforms/knn_graph.py
@@ -1,3 +1,4 @@
+import torch
 import torch_geometric
 from torch_geometric.data import Data
 from torch_geometric.data.datapipes import functional_transform
@@ -48,6 +49,12 @@ class KNNGraph(BaseTransform):
     def forward(self, data: Data) -> Data:
         data.edge_attr = None
         batch = data.batch if 'batch' in data else None
+
+        device = data.pos.device  # Get the device of the input tensor
+
+        data.pos = data.pos.to(device)  # Move the pos tensor to the device
+        if batch is not None:
+            data.batch = batch.to(device)  # Move the batch tensor to the device
 
         edge_index = torch_geometric.nn.knn_graph(
             data.pos,

--- a/torch_geometric/transforms/knn_graph.py
+++ b/torch_geometric/transforms/knn_graph.py
@@ -50,7 +50,7 @@ class KNNGraph(BaseTransform):
         batch = data.batch if 'batch' in data else None
 
         edge_index = torch_geometric.nn.knn_graph(
-            data.pos,  # Transfer data to CPU if it's on CUDA
+            data.pos,
             self.k,
             batch,
             loop=self.loop,

--- a/torch_geometric/transforms/knn_graph.py
+++ b/torch_geometric/transforms/knn_graph.py
@@ -1,4 +1,5 @@
 import torch
+
 import torch_geometric
 from torch_geometric.data import Data
 from torch_geometric.data.datapipes import functional_transform
@@ -54,7 +55,8 @@ class KNNGraph(BaseTransform):
 
         data.pos = data.pos.to(device)  # Move the pos tensor to the device
         if batch is not None:
-            data.batch = batch.to(device)  # Move the batch tensor to the device
+            data.batch = batch.to(
+                device)  # Move the batch tensor to the device
 
         edge_index = torch_geometric.nn.knn_graph(
             data.pos,

--- a/torch_geometric/transforms/knn_graph.py
+++ b/torch_geometric/transforms/knn_graph.py
@@ -50,7 +50,9 @@ class KNNGraph(BaseTransform):
         batch = data.batch if 'batch' in data else None
 
         if data.pos.is_cuda:
-            print('Warning: The input data is on CUDA. Transferring to CPU for knn_graph computation.')
+            print(
+                'Warning: The input data is on CUDA. Transferring to CPU for knn_graph computation.'
+            )
 
         edge_index = torch_geometric.nn.knn_graph(
             data.pos.cpu(),  # Transfer data to CPU if it's on CUDA

--- a/torch_geometric/transforms/knn_graph.py
+++ b/torch_geometric/transforms/knn_graph.py
@@ -1,5 +1,3 @@
-import torch
-
 import torch_geometric
 from torch_geometric.data import Data
 from torch_geometric.data.datapipes import functional_transform
@@ -51,15 +49,11 @@ class KNNGraph(BaseTransform):
         data.edge_attr = None
         batch = data.batch if 'batch' in data else None
 
-        device = data.pos.device  # Get the device of the input tensor
-
-        data.pos = data.pos.to(device)  # Move the pos tensor to the device
-        if batch is not None:
-            data.batch = batch.to(
-                device)  # Move the batch tensor to the device
+        if data.pos.is_cuda:
+            print('Warning: The input data is on CUDA. Transferring to CPU for knn_graph computation.')
 
         edge_index = torch_geometric.nn.knn_graph(
-            data.pos,
+            data.pos.cpu(),  # Transfer data to CPU if it's on CUDA
             self.k,
             batch,
             loop=self.loop,

--- a/torch_geometric/transforms/knn_graph.py
+++ b/torch_geometric/transforms/knn_graph.py
@@ -49,13 +49,8 @@ class KNNGraph(BaseTransform):
         data.edge_attr = None
         batch = data.batch if 'batch' in data else None
 
-        if data.pos.is_cuda:
-            print(
-                'Warning: The input data is on CUDA. Transferring to CPU for knn_graph computation.'
-            )
-
         edge_index = torch_geometric.nn.knn_graph(
-            data.pos.cpu(),  # Transfer data to CPU if it's on CUDA
+            data.pos,  # Transfer data to CPU if it's on CUDA
             self.k,
             batch,
             loop=self.loop,


### PR DESCRIPTION
we can directly move the tensors to the desired device using the `to()` method provided by PyTorch. This ensures that all tensors within the data object are on the same device before calling `knn_graph`.
This seems to be a solution for #7475 issue.