### PR TITLE
Avoid transforming original data in `ToUndirected` 

### DIFF
--- a/torch_geometric/transforms/to_undirected.py
+++ b/torch_geometric/transforms/to_undirected.py
@@ -38,6 +38,7 @@ class ToUndirected(BaseTransform):
         self,
         data: Union[Data, HeteroData],
     ) -> Union[Data, HeteroData]:
+        data = data.clone()
         for store in data.edge_stores:
             if 'edge_index' not in store:
                 continue


### PR DESCRIPTION
This PR clones the original data object in `ToUndirected` so that the method does not change the original data