### PR TITLE
Added `edge_index` property to `TemporalData`

### DIFF
--- a/test/data/test_temporal.py
+++ b/test/data/test_temporal.py
@@ -26,6 +26,12 @@ def test_temporal_data():
     assert data.src.tolist() == [0, 1, 2]
     assert data['src'].tolist() == [0, 1, 2]
 
+    assert data.edge_index.tolist() == [[0, 1, 2], [3, 4, 5]]
+    data.edge_index = 'edge_index'
+    assert data.edge_index == 'edge_index'
+    del data.edge_index
+    assert data.edge_index.tolist() == [[0, 1, 2], [3, 4, 5]]
+
     assert sorted(data.keys) == ['dst', 'msg', 'src', 't', 'y']
     assert sorted(data.to_dict().keys()) == sorted(data.keys)
 

--- a/torch_geometric/data/temporal.py
+++ b/torch_geometric/data/temporal.py
@@ -212,6 +212,10 @@ class TemporalData(BaseData):
         r"""Alias for :meth:`~torch_geometric.data.TemporalData.num_events`."""
         return self.num_events
 
+    @property
+    def edge_index(self) -> Any:
+        return self['edge_index'] if 'edge_index' in self._store else None
+
     def size(
         self, dim: Optional[int] = None
     ) -> Union[Tuple[Optional[int], Optional[int]], Optional[int]]:

--- a/torch_geometric/data/temporal.py
+++ b/torch_geometric/data/temporal.py
@@ -213,8 +213,14 @@ class TemporalData(BaseData):
         return self.num_events
 
     @property
-    def edge_index(self) -> Any:
-        return self['edge_index'] if 'edge_index' in self._store else None
+    def edge_index(self) -> Tensor:
+        r"""Returns the edge indices of the graph."""
+        if 'edge_index' in self:
+            return self._store['edge_index']
+        if self.src is not None and self.dst is not None:
+            return torch.stack([self.src, self.dst], dim=0)
+        raise ValueError(f"{self.__class__.__name__} does not contain "
+                         f"'edge_index' information")
 
     def size(
         self, dim: Optional[int] = None


### PR DESCRIPTION
Added the `edge_index` property in order to make it easier to visualize time series of temporal by simply doing a `test_data.edge_index` and using `networkx` which is useful for large multiple graph datasets. 
