### PR TITLE
Add `DistDataset` for distributed training

### DIFF
--- a/test/distributed/test_dist_dataset.py
+++ b/test/distributed/test_dist_dataset.py
@@ -1,0 +1,102 @@
+import os.path as osp
+
+import torch
+
+from torch_geometric.datasets import FakeDataset, FakeHeteroDataset
+from torch_geometric.distributed import Partitioner
+from torch_geometric.typing import EdgeTypeStr
+from torch_geometric.distributed import DistDataset
+
+def test_dist_dataset_for_homo():
+    num_partitions = 2
+    save_dir = osp.join('./homo', 'partition')
+    dataset = FakeDataset()
+    data = dataset[0]
+
+    partitioner = Partitioner(root=save_dir, num_parts=num_partitions, data=data)
+    partitioner.generate_partition()
+
+    data_pidx=0
+    dataset0 = DistDataset()
+    dataset0.load(
+        root_dir=osp.join('./homo', 'partition'),
+        partition_idx=data_pidx,
+    )
+    data_pidx=1
+    dataset1 = DistDataset()
+    dataset1.load(
+        root_dir=osp.join('./homo', 'partition'),
+        partition_idx=data_pidx,
+    )
+
+    assert data.num_nodes==dataset0.data.num_nodes+dataset1.data.num_nodes
+    
+    graph_store1 = dataset0.graph
+    graph_store2 = dataset1.graph
+    attr1 = graph_store1.get_all_edge_attrs()
+    graph1 = graph_store1.get_edge_index(attr1[0])
+    attr2 = graph_store2.get_all_edge_attrs()
+    graph2 = graph_store2.get_edge_index(attr2[0])
+    assert graph1[0].size(0) + graph2[0].size(0) == data.num_edges
+
+    feature_store1 = dataset0.node_features
+    node_attrs1 = feature_store1.get_all_tensor_attrs()
+    node_feat1 = feature_store1.get_tensor(node_attrs1[0].group_name, node_attrs1[0].attr_name)
+    node_id1 = feature_store1.get_global_id(node_attrs1[0].group_name)
+    feature_store2 = dataset1.node_features
+    node_attrs2 = feature_store2.get_all_tensor_attrs()
+    node_feat2 = feature_store2.get_tensor(node_attrs2[0].group_name, node_attrs2[0].attr_name)
+    node_id2 = feature_store2.get_global_id(node_attrs2[0].group_name)
+    assert node_feat1.size(0) + node_feat2.size(0) == data.num_nodes
+    assert torch.allclose(data.x[node_id1], node_feat1)
+    assert torch.allclose(data.x[node_id2], node_feat2)
+
+def test_dist_dataset_for_hetero():
+    num_partitions = 2
+    save_dir = osp.join('./hetero', 'partition')
+    dataset = FakeHeteroDataset()
+    data = dataset[0]
+
+    node_types, edge_types = data.metadata()
+
+    partitioner = Partitioner(root=save_dir, num_parts=num_partitions, data=data)
+    partitioner.generate_partition()
+
+    data_pidx=0
+    dataset0 = DistDataset()
+    dataset0.load(
+        root_dir=osp.join('./hetero', 'partition'),
+        partition_idx=data_pidx,
+    )
+    data_pidx=1
+    dataset1 = DistDataset()
+    dataset1.load(
+        root_dir=osp.join('./hetero', 'partition'),
+        partition_idx=data_pidx,
+    )
+
+    graph_store1 = dataset0.graph
+    graph_store2 = dataset1.graph
+    
+    attr1 = graph_store1.get_all_edge_attrs()    
+    attr2 = graph_store2.get_all_edge_attrs()
+    assert len(edge_types)==len(attr1)==len(attr2)
+
+    ntypes1 = set()
+    for attr in attr1:
+        ntypes1.add(attr.edge_type[0])
+        ntypes1.add(attr.edge_type[2])
+    assert len(node_types) == len(ntypes1)
+
+    ntypes2 = set()
+    for attr in attr2:
+        ntypes2.add(attr.edge_type[0])
+        ntypes2.add(attr.edge_type[2])
+    assert len(node_types) == len(ntypes2)
+
+    feature_store1 = dataset0.node_features
+    assert feature_store1 == None
+    
+    feature_store2 = dataset1.node_features
+    assert feature_store2 == None
+

--- a/torch_geometric/distributed/__init__.py
+++ b/torch_geometric/distributed/__init__.py
@@ -1,9 +1,11 @@
 from .local_feature_store import LocalFeatureStore
 from .local_graph_store import LocalGraphStore
 from .partition import Partitioner
+from .dist_dataset import DistDataset
 
 __all__ = classes = [
     'LocalFeatureStore',
     'LocalGraphStore',
     'Partitioner',
+    'DistDataset',
 ]

--- a/torch_geometric/distributed/dist_dataset.py
+++ b/torch_geometric/distributed/dist_dataset.py
@@ -1,0 +1,229 @@
+
+import torch
+
+from typing import Dict, List, Optional, Union
+from torch_geometric.data import Data, HeteroData
+from torch_geometric.distributed.local_graph_store import LocalGraphStore as Graph
+from torch_geometric.distributed.local_feature_store import LocalFeatureStore as Feature
+
+from torch_geometric.distributed.partition import load_partition
+from torch_geometric.typing import (
+  NodeType, EdgeType, TensorDataType,
+)
+
+from torch_geometric.testing import get_random_edge_index
+
+
+class DistDataset():
+    r""" load the distributed graph/node_feats/edge_feats/label/partition books from partition files
+    and if load from other partition format it will be initialized by graphstore/featurestore format.
+    """
+    def __init__(
+        self,
+        num_partitions: int = 1,
+        partition_idx: int = 0,
+        graph_partition: Union[Graph, Dict[EdgeType, Graph]] = None,
+        node_feat_partition: Union[Feature, Dict[NodeType, Feature]] = None,
+        edge_feat_partition: Union[Feature, Dict[EdgeType, Feature]] = None,
+        node_labels: Union[TensorDataType, Dict[NodeType, TensorDataType]] = None,
+        node_pb: Union[torch.Tensor, Dict[NodeType, torch.Tensor]] = None,
+        edge_pb: Union[torch.Tensor, Dict[EdgeType, torch.Tensor]] = None,
+        node_feat_pb: Union[torch.Tensor, Dict[NodeType, torch.Tensor]] = None,
+        edge_feat_pb: Union[torch.Tensor, Dict[EdgeType, torch.Tensor]] = None,
+    ):
+        self.meta = None
+        self.num_partitions = num_partitions
+        self.partition_idx = partition_idx
+       
+        self.graph = graph_partition
+        self.node_features = node_feat_partition
+        self.edge_features = edge_feat_partition
+        self.node_labels = node_labels
+
+        self.node_pb = node_pb
+        self.edge_pb = edge_pb
+        
+        self._node_feat_pb = node_feat_pb
+        self._edge_feat_pb = edge_feat_pb
+        #self.data = None
+        
+    
+    def load(
+        self,
+        root_dir: str,
+        partition_idx: int,
+        node_label_file: Union[str, Dict[NodeType, str]] = None,
+        partition_format:  str = "pyg",
+        keep_pyg_data:  bool = True
+    ):
+        r""" Load one dataset partition from partitioned files.
+        
+        Args:
+            root_dir (str): The file path to load the partition data.
+            partition_idx (int): Current partition idx.
+            node_label_file (str): The path to the node labels
+            partition_format:  pyg/dgl/glt
+            keep_pyg_data:  keep the original pyg data besides graphstore/featurestore.
+        """
+        if partition_format=="pyg":
+            (
+                self.meta,
+                self.num_partitions,
+                self.partition_idx,
+                graph_data,
+                node_feat_data,
+                edge_feat_data,
+                self.node_pb,
+                self.edge_pb
+            ) = load_partition(root_dir, partition_idx)
+  
+           
+            # init graph/node feature/edge feature by graphstore/featurestore
+            if(self.meta["is_hetero"]):
+                # hetero ..
+                
+                # convert partition data into dict.
+                edge_id_dict, edge_index_dict, num_nodes_dict, edge_attr_dict = {}, {}, {}, {}
+                for etype in self.meta['edge_types']:
+                    edge_id_dict[tuple(etype)] = graph_data[tuple(etype)]['edge_id']
+                    edge_index_dict[tuple(etype)] = torch.tensor([graph_data[tuple(etype)]['row'].tolist(), graph_data[tuple(etype)]['col'].tolist()])
+                    num_nodes_dict[etype[0]] =  graph_data[tuple(etype)]['size'][0]
+                    num_nodes_dict[etype[2]] =  graph_data[tuple(etype)]['size'][1]
+
+                    if edge_feat_data[tuple(etype)]['feats']['edge_attr'] is not None:
+                        edge_attr_dict[tuple(etype)] = edge_feat_data[tuple(etype)]['feats']['edge_attr'] 
+
+                node_id_dict, x_dict = {}, {}
+                for ntype in self.meta['node_types']:
+                    node_id_dict[ntype] = node_feat_data[ntype]['global_id']
+                    
+                    if node_feat_data[ntype]['feats']['x'] is not None:
+                        x_dict[ntype] = node_feat_data[ntype]['feats']['x']
+                
+                # initialize graph
+                self.graph = Graph.from_hetero_data(edge_id_dict, edge_index_dict, num_nodes_dict)
+                
+                # initialize edge features
+                if len(edge_attr_dict)>0:
+                    self.edge_features = Feature.from_hetero_data(node_id_dict=node_id_dict, edge_id_dict=edge_id_dict, edge_attr_dict=edge_attr_dict)
+                    self._edge_feat_pb = self.edge_pb
+
+                # initialize node features
+                if len(x_dict)>0:
+                    self.node_features = Feature.from_hetero_data(node_id_dict=node_id_dict, x_dict=x_dict)
+                    self._node_feat_pb = self.node_pb
+
+            else:
+                # homo ..
+
+                # initialize graph
+                edge_index = torch.tensor([graph_data['row'].tolist(), graph_data['col'].tolist()])
+                self.graph = Graph.from_data(graph_data['edge_id'], edge_index, num_nodes=graph_data['size'][0])
+
+                # initialize node features
+                if node_feat_data['feats']['x'] is not None:
+                    self._node_feat_pb = self.node_pb
+                    self.node_features = Feature.from_data(node_id=node_feat_data['global_id'], x=node_feat_data['feats']['x'])
+
+                # initialize edge features
+                if edge_feat_data['feats']['edge_attr'] is not None:
+                    self._edge_feat_pb = self.edge_pb
+                    self.edge_features = Feature.from_data(node_id=node_feat_data['global_id'], 
+                            edge_id=edge_feat_data['global_id'], edge_attr=edge_feat_data['feats']['edge_attr'])
+       
+
+            if keep_pyg_data:
+                # This will also generate the PyG Data format from Store format for back compatibility
+                # besides the graphstore/featurestore format.
+                
+                if(self.meta["is_hetero"]):
+                    # heterogeneous.
+                    data = HeteroData()
+                    
+                    edge_attrs=self.graph.get_all_edge_attrs()
+                    edge_index={}
+                    edge_ids={}
+                    for item in edge_attrs:
+                        edge_index[item.edge_type] = self.graph.get_edge_index(item)
+                        edge_ids[item.edge_type] = self.graph.get_edge_id(item)
+                        data[item.edge_type].edge_index = edge_index[item.edge_type]
+
+                    if len(x_dict)>0:
+                        tensor_attrs = self.node_features.get_all_tensor_attrs()
+                        node_feat={}
+                        node_ids={}
+                        for item in tensor_attrs:
+                            node_feat[item.group_name] = self.node_features.get_tensor(item.fully_specify())
+                            node_ids[item.group_name] = self.node_features.get_global_id(item.group_name) 
+                            data[item.group_name].x = node_feat[item.group_name]
+        
+                    if len(edge_attr_dict)>0:
+                        edge_attrs=self.edge_features.get_all_edge_attrs()
+                        edge_feat={}
+                        edge_ids={}
+                        for item in edge_attrs:
+                            edge_feat[item.edge_type] = self.edge_features.get_tensor(item.fully_specify())
+                            edge_ids[item.edge_type] = self.edge_features.get_global_id(item.group_name) 
+                            data[item.edge_type].edge_attr = edge_feat[item.edge_type]
+                    self.data = data       
+        
+                else:
+                    # homogeneous.
+                    self.data = Data(x=node_feat_data['feats']['x'], edge_index=edge_index, edge_attr=edge_feat_data['feats']['edge_attr'])
+
+        else:  
+            # including other partition format, like dgl/glt ..
+            # use LocalGraphStore.from_data() and LocalFeatureStore.from_data() api for initialization ..
+            pass
+    
+        # init for labels
+        if node_label_file is not None:
+            if isinstance(node_label_file, dict):
+                whole_node_labels = {}
+                for ntype, file in node_label_file.items():
+                    whole_node_labels[ntype] = torch.load(file)
+            else:
+                whole_node_labels = torch.load(node_label_file)
+            self.node_labels = whole_node_labels
+    
+    @property
+    def node_feat_pb(self):
+      if self._node_feat_pb is None:
+        return self.node_pb
+      return self._node_feat_pb
+    
+    @property
+    def edge_feat_pb(self):
+      if self._edge_feat_pb is None:
+        return self.edge_pb
+      return self._edge_feat_pb
+
+    def get_node_types(self):
+        if(self.meta["is_hetero"]):
+            edge_attrs=self.graph.get_all_edge_attrs()
+            ntypes = set()
+            for attrs in edge_attrs:
+                ntypes.add(attrs.edge_type[0])
+                ntypes.add(attrs.edge_type[2])
+            self._node_types = list(ntypes)
+            return self._node_types
+        return None
+
+    def get_edge_types(self):
+        if(self.meta["is_hetero"]):
+            edge_attrs=self.graph.get_all_edge_attrs()
+            etypes = []
+            for attrs in edge_attrs:
+                etypes.append(attrs.edge_type)
+            self._edge_types = etypes 
+            return self._edge_types
+        return None
+
+    def get_node_label(self, ntype: Optional[NodeType] = None):
+        if isinstance(self.node_labels, torch.Tensor):
+            return self.node_labels
+        if isinstance(self.node_labels, dict):
+            assert ntype is not None
+            return self.node_labels.get(ntype, None)
+        return None
+

--- a/torch_geometric/distributed/partition.py
+++ b/torch_geometric/distributed/partition.py
@@ -2,13 +2,17 @@ import json
 import logging
 import os
 import os.path as osp
-from typing import List, Optional, Union
+from typing import List, Optional, Union, Tuple, Dict
 
 import torch
 
 from torch_geometric.data import Data, HeteroData
 from torch_geometric.loader import ClusterData
 from torch_geometric.typing import EdgeType, EdgeTypeStr, NodeType
+
+from torch_geometric.distributed.local_graph_store import LocalGraphStore as Graph
+from torch_geometric.distributed.local_feature_store import LocalFeatureStore as Feature
+from torch_geometric.typing import as_str
 
 
 class Partitioner:
@@ -237,3 +241,82 @@ class Partitioner:
             logging.info('Saving partition mapping info')
             torch.save(node_map, osp.join(self.root, 'node_map.pt'))
             torch.save(edge_map, osp.join(self.root, 'edge_map.pt'))
+
+
+
+
+def load_partition(
+    root_dir: str,
+    partition_idx: int,
+    device: torch.device = torch.device('cpu')
+) -> Tuple[Dict, int, int,
+    Graph,
+    Optional[Feature],
+    Optional[Feature],
+    torch.Tensor,
+    torch.Tensor]:
+
+
+    # load the partition with PyG format (graphstore/featurestore)
+    with open(os.path.join(root_dir, 'META.json'), 'rb') as infile:
+        meta = json.load(infile)
+    num_partitions = meta['num_parts']
+    assert partition_idx >= 0
+    assert partition_idx < num_partitions
+    partition_dir = os.path.join(root_dir, f'part_{partition_idx}')
+    assert os.path.exists(partition_dir)
+
+    graph_dir = os.path.join(partition_dir, 'graph.pt')
+    node_feat_dir = os.path.join(partition_dir, 'node_feats.pt')
+    edge_feat_dir = os.path.join(partition_dir, 'edge_feats.pt')
+
+
+    if meta['is_hetero']==False:
+        if os.path.exists(graph_dir):
+            graph = torch.load(graph_dir)
+        if os.path.exists(node_feat_dir):
+            node_feat = torch.load(node_feat_dir)
+        if os.path.exists(edge_feat_dir):
+            edge_feat = torch.load(edge_feat_dir)
+        else:
+            edge_feat = None
+        node_pb = torch.load(os.path.join(root_dir, 'node_map.pt'), map_location=device)
+        edge_pb = torch.load(os.path.join(root_dir, 'edge_map.pt'), map_location=device)
+
+        return (
+            meta, num_partitions, partition_idx,
+            graph, node_feat, edge_feat, node_pb, edge_pb
+        )
+    else:
+
+        graph_store = torch.load(graph_dir)
+
+        if os.path.exists(node_feat_dir):
+            node_feat_store = torch.load(node_feat_dir)
+        else:
+            node_feat_store = None
+
+        if os.path.exists(edge_feat_dir):
+            edge_feat_store = torch.load(edge_feat_dir)
+        else:
+            edge_feat_store = None
+
+        node_pb_dict = {}
+        node_pb_dir = os.path.join(root_dir, 'node_map')
+        for ntype in meta['node_types']:
+            node_pb_dict[ntype] = torch.load(
+                os.path.join(node_pb_dir, f'{as_str(ntype)}.pt'), map_location=device)
+
+
+        edge_pb_dict = {}
+        edge_pb_dir = os.path.join(root_dir, 'edge_map')
+        for etype in meta['edge_types']:
+            edge_pb_dict[tuple(etype)] = torch.load(
+                os.path.join(edge_pb_dir, f'{as_str(etype)}.pt'), map_location=device)
+
+        return (
+            meta, num_partitions, partition_idx,
+            graph_store, node_feat_store, edge_feat_store, node_pb_dict, edge_pb_dict
+        )
+
+

--- a/torch_geometric/typing.py
+++ b/torch_geometric/typing.py
@@ -258,3 +258,14 @@ MaybeHeteroEdgeTensor = Union[Tensor, Dict[EdgeType, Tensor]]
 
 InputNodes = Union[OptTensor, NodeType, Tuple[NodeType, OptTensor]]
 InputEdges = Union[OptTensor, EdgeType, Tuple[EdgeType, OptTensor]]
+
+# A representation of tensor data
+TensorDataType = Union[torch.Tensor, np.ndarray]
+
+def as_str(type: Union[NodeType, EdgeType]) -> str:
+    if isinstance(type, NodeType):
+        return type
+    elif isinstance(type, (list, tuple)) and len(type) == 3:
+        return EDGE_TYPE_STR_SPLIT.join(type)
+    return ''
+


### PR DESCRIPTION
This code belongs to the part of the whole distributed training for PyG.

This class will do
1) load the distributed partition of graph/node_feats/edge_feats/label/partition books from different partition files in different multiple nodes; 
2) initialize the partition data into LocalGraphStore/LocalFeatureStore format for later use
3) also keep the original PyG graph Data format for homo/hetero. 
4) keep the interface for other partition format for import, like dgl/glt, etc

The files related -
1)  distributed/dist_dataset.py
2)  distributed/partition.py  --- load_partition()
3)  test/test_dist_dataset.py to cover the home/hetero both format based on FakeDataset/FakeHeteroDataset

Any comments please let us know. thanks