### PR TITLE
Update generate_mesh_normals.py

### DIFF
--- a/torch_geometric/transforms/generate_mesh_normals.py
+++ b/torch_geometric/transforms/generate_mesh_normals.py
@@ -18,11 +18,13 @@ class GenerateMeshNormals(BaseTransform):
         # Calculate face normals
         vec1 = pos[face[:, 1]] - pos[face[:, 0]]
         vec2 = pos[face[:, 2]] - pos[face[:, 0]]
-        face_norm = F.normalize(vec1.cross(vec2), p=2, dim=-1)  # [num_faces, 3]
+        face_norm = F.normalize(vec1.cross(vec2), p=2,
+                                dim=-1)  # [num_faces, 3]
 
         # Assign face normals to vertices
         idx = face.view(-1)
-        norm = scatter(face_norm.repeat(3, 1), idx, 0, pos.size(0), reduce='sum')
+        norm = scatter(face_norm.repeat(3, 1), idx, 0, pos.size(0),
+                       reduce='sum')
         norm = F.normalize(norm, p=2, dim=-1)  # [num_nodes, 3]
 
         data.norm = norm

--- a/torch_geometric/transforms/generate_mesh_normals.py
+++ b/torch_geometric/transforms/generate_mesh_normals.py
@@ -15,15 +15,15 @@ class GenerateMeshNormals(BaseTransform):
         assert 'face' in data
         pos, face = data.pos, data.face
 
-        vec1 = pos[face[1]] - pos[face[0]]
-        vec2 = pos[face[2]] - pos[face[0]]
-        face_norm = F.normalize(vec1.cross(vec2), p=2, dim=-1)  # [F, 3]
+        # Calculate face normals
+        vec1 = pos[face[:, 1]] - pos[face[:, 0]]
+        vec2 = pos[face[:, 2]] - pos[face[:, 0]]
+        face_norm = F.normalize(vec1.cross(vec2), p=2, dim=-1)  # [num_faces, 3]
 
-        idx = torch.cat([face[0], face[1], face[2]], dim=0)
-        face_norm = face_norm.repeat(3, 1)
-
-        norm = scatter(face_norm, idx, 0, pos.size(0), reduce='sum')
-        norm = F.normalize(norm, p=2, dim=-1)  # [N, 3]
+        # Assign face normals to vertices
+        idx = face.view(-1)
+        norm = scatter(face_norm.repeat(3, 1), idx, 0, pos.size(0), reduce='sum')
+        norm = F.normalize(norm, p=2, dim=-1)  # [num_nodes, 3]
 
         data.norm = norm
 


### PR DESCRIPTION
Currently, the normal vectors for each face are calculated individually using `F.normalize` and then repeated for each vertex in the face. This can be optimized by calculating the face normals only once and then assigning them to the corresponding vertices. This avoids redundant calculations and reduces memory usage.
If you have multiple graphs with different faces and positions, you can batch the operations to process them simultaneously. This can be achieved using functions like `torch.cat` and `scatter` with appropriate dimensions to handle multiple graphs efficiently.
@rusty1s 