### PR TITLE
Add `index_add` benchmark

### DIFF
--- a/test/utils/test_scatter.py
+++ b/test/utils/test_scatter.py
@@ -83,7 +83,7 @@ def test_scatter_argmax(device):
 if __name__ == '__main__':
     # Insights on GPU:
     # ================
-    # * "sum": Prefer `scatter_add_` implementation
+    # * "sum": Prefer `index_add_` implementation
     # * "mean": Prefer manual implementation via `scatter_add_` + `count`
     # * "min"/"max":
     #   * Prefer `scatter_reduce_` implementation without gradients
@@ -92,7 +92,7 @@ if __name__ == '__main__':
     #
     # Insights on CPU:
     # ================
-    # * "sum": Prefer `scatter_add_` implementation
+    # * "sum": Prefer `index_add_` implementation
     # * "mean": Prefer manual implementation via `scatter_add_` + `count`
     # * "min"/"max": Prefer `scatter_reduce_` implementation
     # * "mul" (probably not worth branching for this):
@@ -110,7 +110,7 @@ if __name__ == '__main__':
     num_nodes, num_edges = 1_000, 50_000
     x = torch.randn(num_edges, 64, device=args.device)
     index = torch.randint(num_nodes, (num_edges, ), device=args.device)
-    from torch_geometric import WITH_TORCH_SCATTER
+    from torch_geometric.typing import WITH_TORCH_SCATTER
     if WITH_TORCH_SCATTER:
         import torch_scatter
 

--- a/test/utils/test_scatter.py
+++ b/test/utils/test_scatter.py
@@ -6,6 +6,7 @@ from torch_geometric.testing import disableExtensions, withCUDA, withPackage
 from torch_geometric.utils import scatter
 from torch_geometric.utils.scatter import scatter_argmax
 
+
 def test_scatter_validate():
     src = torch.randn(100, 32)
     index = torch.randint(0, 10, (100, ), dtype=torch.long)
@@ -100,17 +101,18 @@ if __name__ == '__main__':
     #   * Prefer `torch_sparse` implementation with gradients
     import argparse
 
-
-
     parser = argparse.ArgumentParser()
     parser.add_argument('--device', type=str, default='cuda')
     parser.add_argument('--backward', action='store_true')
-    parser.add_argument('--aggr', type=str, default='all', help="Specify a specific aggr to benchmark or multiple seperated by commas")
+    parser.add_argument(
+        '--aggr', type=str, default='all', help=
+        "Specify a specific aggr to benchmark or multiple seperated by commas")
     args = parser.parse_args()
 
     for num_nodes in [1000, 2000, 4000, 8000, 16000, 32000, 64000, 128000]:
         num_edges = num_nodes * 50
-        print("Benchmarking w/ (num_nodes, num_edges) =", (num_nodes, num_edges))
+        print("Benchmarking w/ (num_nodes, num_edges) =",
+              (num_nodes, num_edges))
         x = torch.randn(num_edges, 64, device=args.device)
         index = torch.randint(num_nodes, (num_edges, ), device=args.device)
 
@@ -135,6 +137,7 @@ if __name__ == '__main__':
 
         def optimized_scatter(x, index, dim_size, reduce):
             return scatter(x, index, dim=0, dim_size=dim_size, reduce=reduce)
+
         if args.aggr == 'all':
             aggrs = ['sum', 'mean', 'min', 'max', 'mul']
         else:

--- a/test/utils/test_scatter.py
+++ b/test/utils/test_scatter.py
@@ -1,3 +1,5 @@
+from itertools import product
+
 import pytest
 import torch
 
@@ -84,7 +86,7 @@ def test_scatter_argmax(device):
 if __name__ == '__main__':
     # Insights on GPU:
     # ================
-    # * "sum": Prefer `index_add_` implementation
+    # * "sum": Prefer `scatter_add_` implementation
     # * "mean": Prefer manual implementation via `scatter_add_` + `count`
     # * "min"/"max":
     #   * Prefer `scatter_reduce_` implementation without gradients
@@ -93,7 +95,7 @@ if __name__ == '__main__':
     #
     # Insights on CPU:
     # ================
-    # * "sum": Prefer `index_add_` implementation
+    # * "sum": Prefer `scatter_add_` implementation
     # * "mean": Prefer manual implementation via `scatter_add_` + `count`
     # * "min"/"max": Prefer `scatter_reduce_` implementation
     # * "mul" (probably not worth branching for this):
@@ -101,60 +103,72 @@ if __name__ == '__main__':
     #   * Prefer `torch_sparse` implementation with gradients
     import argparse
 
+    from torch_geometric.typing import WITH_TORCH_SCATTER, torch_scatter
+
     parser = argparse.ArgumentParser()
     parser.add_argument('--device', type=str, default='cuda')
     parser.add_argument('--backward', action='store_true')
-    parser.add_argument(
-        '--aggr', type=str, default='all', help=
-        "Specify a specific aggr to benchmark or multiple seperated by commas")
+    parser.add_argument('--aggr', type=str, default='all')
     args = parser.parse_args()
 
-    for num_nodes in [1000, 2000, 4000, 8000, 16000, 32000, 64000, 128000]:
+    num_nodes_list = [4_000, 8_000, 16_000, 32_000, 64_000]
+
+    if args.aggr == 'all':
+        aggrs = ['sum', 'mean', 'min', 'max', 'mul']
+    else:
+        aggrs = args.aggr.split(',')
+
+    def pytorch_scatter(x, index, dim_size, reduce):
+        if reduce == 'min' or reduce == 'max':
+            reduce = f'a{aggr}'  # `amin` or `amax`
+        elif reduce == 'mul':
+            reduce = 'prod'
+        out = x.new_zeros(dim_size, x.size(-1))
+        include_self = reduce in ['sum', 'mean']
+        index = index.view(-1, 1).expand(-1, x.size(-1))
+        out.scatter_reduce_(0, index, x, reduce, include_self=include_self)
+        return out
+
+    def pytorch_index_add(x, index, dim_size, reduce):
+        if reduce != 'sum':
+            raise NotImplementedError
+        out = x.new_zeros(dim_size, x.size(-1))
+        out.index_add_(0, index, x)
+        return out
+
+    def own_scatter(x, index, dim_size, reduce):
+        return torch_scatter.scatter(x, index, dim=0, dim_size=num_nodes,
+                                     reduce=reduce)
+
+    def optimized_scatter(x, index, dim_size, reduce):
+        return scatter(x, index, dim=0, dim_size=dim_size, reduce=reduce)
+
+    for aggr, num_nodes in product(aggrs, num_nodes_list):
         num_edges = num_nodes * 50
-        print("Benchmarking w/ (num_nodes, num_edges) =",
-              (num_nodes, num_edges))
+        print(f'aggr: {aggr}, #nodes: {num_nodes}, #edges: {num_edges}')
+
         x = torch.randn(num_edges, 64, device=args.device)
         index = torch.randint(num_nodes, (num_edges, ), device=args.device)
 
-        from torch_geometric.typing import WITH_TORCH_SCATTER
+        funcs = [pytorch_scatter]
+        func_names = ['PyTorch scatter_reduce']
+
+        if aggr == 'sum':
+            funcs.append(pytorch_index_add)
+            func_names.append('PyTorch index_add')
+
         if WITH_TORCH_SCATTER:
-            import torch_scatter
+            funcs.append(own_scatter)
+            func_names.append('torch_scatter')
 
-        def pytorch_scatter(x, index, dim_size, reduce):
-            if reduce == 'min' or reduce == 'max':
-                reduce = f'a{aggr}'  # `amin` or `amax`
-            elif reduce == 'mul':
-                reduce = 'prod'
-            out = x.new_zeros((dim_size, x.size(-1)))
-            include_self = reduce in ['sum', 'mean']
-            index = index.view(-1, 1).expand(-1, x.size(-1))
-            out.scatter_reduce_(0, index, x, reduce, include_self=include_self)
-            return out
+        funcs.append(optimized_scatter)
+        func_names.append('Optimized PyG Scatter')
 
-        def own_scatter(x, index, dim_size, reduce):
-            return torch_scatter.scatter(x, index, dim=0, dim_size=num_nodes,
-                                         reduce=reduce)
-
-        def optimized_scatter(x, index, dim_size, reduce):
-            return scatter(x, index, dim=0, dim_size=dim_size, reduce=reduce)
-
-        if args.aggr == 'all':
-            aggrs = ['sum', 'mean', 'min', 'max', 'mul']
-        else:
-            aggrs = args.aggr.split(',')
-        for aggr in aggrs:
-            print(f'Aggregator: {aggr}')
-            funcs = [pytorch_scatter, optimized_scatter]
-            func_names = ['PyTorch Scatter', 'Optimized PyG Scatter']
-            if WITH_TORCH_SCATTER:
-                funcs.append(own_scatter)
-                func_names.append('torch_scatter')
-
-            benchmark(
-                funcs=funcs,
-                func_names=func_names,
-                args=(x, index, num_nodes, aggr),
-                num_steps=100 if args.device == 'cpu' else 1000,
-                num_warmups=50 if args.device == 'cpu' else 500,
-                backward=args.backward,
-            )
+        benchmark(
+            funcs=funcs,
+            func_names=func_names,
+            args=(x, index, num_nodes, aggr),
+            num_steps=100 if args.device == 'cpu' else 1000,
+            num_warmups=50 if args.device == 'cpu' else 500,
+            backward=args.backward,
+        )

--- a/test/utils/test_scatter.py
+++ b/test/utils/test_scatter.py
@@ -6,7 +6,6 @@ from torch_geometric.testing import disableExtensions, withCUDA, withPackage
 from torch_geometric.utils import scatter
 from torch_geometric.utils.scatter import scatter_argmax
 
-
 def test_scatter_validate():
     src = torch.randn(100, 32)
     index = torch.randint(0, 10, (100, ), dtype=torch.long)
@@ -101,7 +100,7 @@ if __name__ == '__main__':
     #   * Prefer `torch_sparse` implementation with gradients
     import argparse
 
-    import torch_scatter
+
 
     parser = argparse.ArgumentParser()
     parser.add_argument('--device', type=str, default='cuda')
@@ -111,6 +110,9 @@ if __name__ == '__main__':
     num_nodes, num_edges = 1_000, 50_000
     x = torch.randn(num_edges, 64, device=args.device)
     index = torch.randint(num_nodes, (num_edges, ), device=args.device)
+    from torch_geometric import WITH_TORCH_SCATTER
+    if WITH_TORCH_SCATTER:
+        import torch_scatter
 
     def pytorch_index_add(x, index, dim_size, reduce):
         assert reduce == 'sum'
@@ -137,8 +139,11 @@ if __name__ == '__main__':
     aggrs = ['sum', 'mean', 'min', 'max', 'mul']
     for aggr in aggrs:
         print(f'Aggregator: {aggr}')
-        funcs = [pytorch_scatter, own_scatter, optimized_scatter]
-        func_names = ['PyTorch Scatter', 'torch_scatter', 'Optimized']
+        funcs = [pytorch_scatter, optimized_scatter]
+        func_names = ['PyTorch Scatter', 'Optimized PyG Scatter']
+        if WITH_TORCH_SCATTER:
+            funcs.append(own_scatter)
+            func_names.append('torch_scatter')
         if aggr == 'sum':
             funcs = [pytorch_index_add] + funcs
             func_names = ['PyTorch Index Add'] + funcs

--- a/test/utils/test_scatter.py
+++ b/test/utils/test_scatter.py
@@ -146,7 +146,7 @@ if __name__ == '__main__':
             func_names.append('torch_scatter')
         if aggr == 'sum':
             funcs = [pytorch_index_add] + funcs
-            func_names = ['PyTorch Index Add'] + funcs
+            func_names = ['PyTorch Index Add'] + func_names
 
         benchmark(
             funcs=funcs,

--- a/test/utils/test_scatter.py
+++ b/test/utils/test_scatter.py
@@ -116,7 +116,8 @@ if __name__ == '__main__':
 
     def pytorch_index_add(x, index, dim_size, reduce):
         assert reduce == 'sum'
-        return x.new_zeros(dim_size).index_add_(0, index, x)
+        out = x.new_zeros((dim_size, x.size(-1)))
+        return out.index_add_(0, index, x)
 
     def pytorch_scatter(x, index, dim_size, reduce):
         if reduce == 'min' or reduce == 'max':

--- a/test/utils/test_scatter.py
+++ b/test/utils/test_scatter.py
@@ -112,6 +112,10 @@ if __name__ == '__main__':
     x = torch.randn(num_edges, 64, device=args.device)
     index = torch.randint(num_nodes, (num_edges, ), device=args.device)
 
+    def pytorch_index_add(x, index, dim_size, reduce):
+        assert reduce == 'sum'
+        return x.new_zeros(dim_size).index_add_(0, index, x)
+
     def pytorch_scatter(x, index, dim_size, reduce):
         if reduce == 'min' or reduce == 'max':
             reduce = f'a{aggr}'  # `amin` or `amax`
@@ -133,6 +137,8 @@ if __name__ == '__main__':
     aggrs = ['sum', 'mean', 'min', 'max', 'mul']
     for aggr in aggrs:
         print(f'Aggregator: {aggr}')
+        if aggr == 'sum'
+
         benchmark(
             funcs=[pytorch_scatter, own_scatter, optimized_scatter],
             func_names=['PyTorch', 'torch_scatter', 'Optimized'],

--- a/test/utils/test_scatter.py
+++ b/test/utils/test_scatter.py
@@ -106,7 +106,7 @@ if __name__ == '__main__':
     parser.add_argument('--device', type=str, default='cuda')
     parser.add_argument('--backward', action='store_true')
     args = parser.parse_args()
-    for num_nodes in [1000, 2000, 4000, 8000, 16000]
+    for num_nodes in [1000, 2000, 4000, 8000, 16000]:
         num_edges = num_nodes * 50
         print("Benchmarking w/ (num_nodes, num_edges) =", (num_nodes, num_edges))
         x = torch.randn(num_edges, 64, device=args.device)

--- a/test/utils/test_scatter.py
+++ b/test/utils/test_scatter.py
@@ -137,11 +137,15 @@ if __name__ == '__main__':
     aggrs = ['sum', 'mean', 'min', 'max', 'mul']
     for aggr in aggrs:
         print(f'Aggregator: {aggr}')
-        if aggr == 'sum'
+        funcs = [pytorch_scatter, own_scatter, optimized_scatter]
+        func_names = ['PyTorch Scatter', 'torch_scatter', 'Optimized']
+        if aggr == 'sum':
+            funcs = [pytorch_index_add] + funcs
+            func_names = ['PyTorch Index Add'] + funcs
 
         benchmark(
-            funcs=[pytorch_scatter, own_scatter, optimized_scatter],
-            func_names=['PyTorch', 'torch_scatter', 'Optimized'],
+            funcs=funcs,
+            func_names=func_names,
             args=(x, index, num_nodes, aggr),
             num_steps=100 if args.device == 'cpu' else 1000,
             num_warmups=50 if args.device == 'cpu' else 500,

--- a/test/utils/test_scatter.py
+++ b/test/utils/test_scatter.py
@@ -106,7 +106,7 @@ if __name__ == '__main__':
     parser.add_argument('--device', type=str, default='cuda')
     parser.add_argument('--backward', action='store_true')
     args = parser.parse_args()
-    for num_nodes in [1000, 2000, 4000, 8000, 16000]:
+    for num_nodes in [1000, 2000, 4000, 8000, 16000, 32000, 64000, 128000]:
         num_edges = num_nodes * 50
         print("Benchmarking w/ (num_nodes, num_edges) =", (num_nodes, num_edges))
         x = torch.randn(num_edges, 64, device=args.device)

--- a/test/utils/test_scatter.py
+++ b/test/utils/test_scatter.py
@@ -137,7 +137,7 @@ if __name__ == '__main__':
         if args.aggr == 'all':
             aggrs = ['sum', 'mean', 'min', 'max', 'mul']
         else:
-            aggrs = args.aggrs.split(',')
+            aggrs = args.aggr.split(',')
         for aggr in aggrs:
             print(f'Aggregator: {aggr}')
             funcs = [pytorch_scatter, optimized_scatter]

--- a/test/utils/test_scatter.py
+++ b/test/utils/test_scatter.py
@@ -113,6 +113,7 @@ if __name__ == '__main__':
         print("Benchmarking w/ (num_nodes, num_edges) =", (num_nodes, num_edges))
         x = torch.randn(num_edges, 64, device=args.device)
         index = torch.randint(num_nodes, (num_edges, ), device=args.device)
+
         from torch_geometric.typing import WITH_TORCH_SCATTER
         if WITH_TORCH_SCATTER:
             import torch_scatter

--- a/test/utils/test_scatter.py
+++ b/test/utils/test_scatter.py
@@ -105,7 +105,9 @@ if __name__ == '__main__':
     parser = argparse.ArgumentParser()
     parser.add_argument('--device', type=str, default='cuda')
     parser.add_argument('--backward', action='store_true')
+    parser.add_argument('--aggr', type=str, default='all', help="Specify a specific aggr to benchmark or multiple seperated by commas")
     args = parser.parse_args()
+
     for num_nodes in [1000, 2000, 4000, 8000, 16000, 32000, 64000, 128000]:
         num_edges = num_nodes * 50
         print("Benchmarking w/ (num_nodes, num_edges) =", (num_nodes, num_edges))
@@ -132,8 +134,10 @@ if __name__ == '__main__':
 
         def optimized_scatter(x, index, dim_size, reduce):
             return scatter(x, index, dim=0, dim_size=dim_size, reduce=reduce)
-
-        aggrs = ['sum', 'mean', 'min', 'max', 'mul']
+        if args.aggr == 'all':
+            aggrs = ['sum', 'mean', 'min', 'max', 'mul']
+        else:
+            aggrs = args.aggrs.split(',')
         for aggr in aggrs:
             print(f'Aggregator: {aggr}')
             funcs = [pytorch_scatter, optimized_scatter]

--- a/test/utils/test_scatter.py
+++ b/test/utils/test_scatter.py
@@ -115,11 +115,6 @@ if __name__ == '__main__':
         if WITH_TORCH_SCATTER:
             import torch_scatter
 
-        def pytorch_index_add(x, index, dim_size, reduce):
-            assert reduce == 'sum'
-            out = x.new_zeros((dim_size, x.size(-1)))
-            return out.index_add_(0, index, x)
-
         def pytorch_scatter(x, index, dim_size, reduce):
             if reduce == 'min' or reduce == 'max':
                 reduce = f'a{aggr}'  # `amin` or `amax`
@@ -146,9 +141,6 @@ if __name__ == '__main__':
             if WITH_TORCH_SCATTER:
                 funcs.append(own_scatter)
                 func_names.append('torch_scatter')
-            if aggr == 'sum':
-                funcs = [pytorch_index_add] + funcs
-                func_names = ['PyTorch Index Add'] + func_names
 
             benchmark(
                 funcs=funcs,

--- a/torch_geometric/utils/scatter.py
+++ b/torch_geometric/utils/scatter.py
@@ -67,10 +67,10 @@ if has_pytorch112:  # pragma: no cover
             index = broadcast(index, src, dim)
             return src.new_zeros(size).scatter_(dim, index, src)
 
-        # For "sum" and "mean" reduction, we make use of `index_add_`
-        # since its faster than `scatter_add_`:
+        # For "sum" and "mean" reduction, we make use of `scatter_add_`:
         if reduce == 'sum' or reduce == 'add':
-            return src.new_zeros(size).index_add_(dim, index, src)
+            index = broadcast(index, src, dim)
+            return src.new_zeros(size).scatter_add_(dim, index, src)
 
         if reduce == 'mean':
             count = src.new_zeros(dim_size)

--- a/torch_geometric/utils/scatter.py
+++ b/torch_geometric/utils/scatter.py
@@ -67,10 +67,10 @@ if has_pytorch112:  # pragma: no cover
             index = broadcast(index, src, dim)
             return src.new_zeros(size).scatter_(dim, index, src)
 
-        # For "sum" and "mean" reduction, we make use of `scatter_add_`:
+        # For "sum" and "mean" reduction, we make use of `index_add_`
+        # since its faster than `scatter_add_`:
         if reduce == 'sum' or reduce == 'add':
-            index = broadcast(index, src, dim)
-            return src.new_zeros(size).scatter_add_(dim, index, src)
+            return src.new_zeros(size).index_add_(dim, index, src)
 
         if reduce == 'mean':
             count = src.new_zeros(dim_size)


### PR DESCRIPTION
using: https://github.com/puririshi98/rgcn_pyg_lib_forward_bench/blob/main/scatter_v_index_bench.py
I find that index_add is faster
```
original implementation takes 3.62396240234375e-07 s/iter
new implementation takes 2.765655517578125e-07 s/iter
```

however using test/utils/test_scatter.py
I am seeing the opposite result
```
Benchmarking w/ (num_nodes, num_edges) = (1000, 50000)
Aggregator: sum
+-----------------------+-----------+
| Name                  | Forward   |
|-----------------------+-----------|
| PyTorch Scatter       | 0.0512s   |
| Optimized PyG Scatter | 0.0699s   |
+-----------------------+-----------+
Benchmarking w/ (num_nodes, num_edges) = (2000, 100000)
Aggregator: sum
+-----------------------+-----------+
| Name                  | Forward   |
|-----------------------+-----------|
| PyTorch Scatter       | 0.0752s   |
| Optimized PyG Scatter | 0.1124s   |
+-----------------------+-----------+
Benchmarking w/ (num_nodes, num_edges) = (4000, 200000)
Aggregator: sum
+-----------------------+-----------+
| Name                  | Forward   |
|-----------------------+-----------|
| PyTorch Scatter       | 0.1227s   |
| Optimized PyG Scatter | 0.2087s   |
+-----------------------+-----------+
Benchmarking w/ (num_nodes, num_edges) = (8000, 400000)
Aggregator: sum
+-----------------------+-----------+
| Name                  | Forward   |
|-----------------------+-----------|
| PyTorch Scatter       | 0.2408s   |
| Optimized PyG Scatter | 0.4129s   |
+-----------------------+-----------+
Benchmarking w/ (num_nodes, num_edges) = (16000, 800000)
Aggregator: sum
+-----------------------+-----------+
| Name                  | Forward   |
|-----------------------+-----------|
| PyTorch Scatter       | 0.5714s   |
| Optimized PyG Scatter | 0.8529s   |
+-----------------------+-----------+
Benchmarking w/ (num_nodes, num_edges) = (32000, 1600000)
Aggregator: sum
+-----------------------+-----------+
| Name                  | Forward   |
|-----------------------+-----------|
| PyTorch Scatter       | 1.3682s   |
| Optimized PyG Scatter | 1.8042s   |
+-----------------------+-----------+
Benchmarking w/ (num_nodes, num_edges) = (64000, 3200000)
Aggregator: sum
+-----------------------+-----------+
| Name                  | Forward   |
|-----------------------+-----------|
| PyTorch Scatter       | 3.2057s   |
| Optimized PyG Scatter | 3.7839s   |
+-----------------------+-----------+
Benchmarking w/ (num_nodes, num_edges) = (128000, 6400000)
Aggregator: sum
+-----------------------+-----------+
| Name                  | Forward   |
|-----------------------+-----------|
| PyTorch Scatter       | 6.9272s   |
| Optimized PyG Scatter | 7.8657s   |
+-----------------------+-----------+
```
