### PR TITLE
Allow `xfail` of `SNAPDataset` tests

### DIFF
--- a/.github/workflows/full_testing.yml
+++ b/.github/workflows/full_testing.yml
@@ -16,8 +16,12 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest]
         python-version: ['3.8', '3.10']
-        torch-version: [1.13.0, 2.0.0, nightly]
+        torch-version: [1.11.0, 1.12.0, 1.13.0, 2.0.0, nightly]
         include:
+          - torch-version: 1.11.0
+            torchvision-version: 0.12.0
+          - torch-version: 1.12.0
+            torchvision-version: 0.13.0
           - torch-version: 1.13.0
             torchvision-version: 0.14.0
           - torch-version: 2.0.0

--- a/test/datasets/test_snap_dataset.py
+++ b/test/datasets/test_snap_dataset.py
@@ -1,8 +1,11 @@
+import pytest
+
 from torch_geometric.testing import onlyFullTest, onlyOnline
 
 
 @onlyOnline
 @onlyFullTest
+@pytest.mark.xfail
 def test_ego_facebook_snap_dataset(get_dataset):
     dataset = get_dataset(name='ego-facebook')
     assert str(dataset) == 'SNAP-ego-facebook(10)'
@@ -11,6 +14,7 @@ def test_ego_facebook_snap_dataset(get_dataset):
 
 @onlyOnline
 @onlyFullTest
+@pytest.mark.xfail
 def test_soc_slashdot_snap_dataset(get_dataset):
     dataset = get_dataset(name='soc-Slashdot0811')
     assert str(dataset) == 'SNAP-soc-slashdot0811(1)'
@@ -19,6 +23,7 @@ def test_soc_slashdot_snap_dataset(get_dataset):
 
 @onlyOnline
 @onlyFullTest
+@pytest.mark.xfail
 def test_wiki_vote_snap_dataset(get_dataset):
     dataset = get_dataset(name='wiki-vote')
     assert str(dataset) == 'SNAP-wiki-vote(1)'


### PR DESCRIPTION
Workaround since `stanford.edu` is down.