### PR TITLE
Add distributed feature info for distributed training

### DIFF
--- a/test/distributed/test_local_feature_store_new.py
+++ b/test/distributed/test_local_feature_store_new.py
@@ -1,20 +1,21 @@
-
-import unittest
 import socket
+import unittest
 
 import torch
 
-from torch_geometric.distributed import (
-    RpcRouter, RpcCallBase, rpc_register, rpc_request_async
-)
-
 import torch_geometric.distributed as pyg_dist
 import torch_geometric.distributed.rpc
+from torch_geometric.distributed import (
+    LocalFeatureStore,
+    RpcCallBase,
+    RpcRouter,
+    rpc_register,
+    rpc_request_async,
+)
 
-from torch_geometric.distributed import LocalFeatureStore
 
-
-def run_dist_feature_test(world_size: int, rank: int, feature: LocalFeatureStore,
+def run_dist_feature_test(world_size: int, rank: int,
+                          feature: LocalFeatureStore,
                           partition_book: torch.Tensor, master_port: int):
     # init the workers
     pyg_dist.init_worker_group(world_size, rank, 'dist-feature-test')
@@ -22,8 +23,8 @@ def run_dist_feature_test(world_size: int, rank: int, feature: LocalFeatureStore
 
     # collect all workers
     partition2workers = pyg_dist.rpc_partition2workers(world_size, rank)
-    
-    # find worker with partition id 
+
+    # find worker with partition id
     rpc_router = pyg_dist.RpcRouter(partition2workers)
 
     current_device = torch.device('cpu')
@@ -44,7 +45,7 @@ def run_dist_feature_test(world_size: int, rank: int, feature: LocalFeatureStore
 
     # global node ids
     global_id0 = torch.arange(128 * 2)
-    global_id1 = torch.arange(128 * 2) + 128*2
+    global_id1 = torch.arange(128 * 2) + 128 * 2
 
     # lookup the features from stores including locally and remotely
     tensor0 = feature.lookup_features(global_id0)
@@ -52,41 +53,40 @@ def run_dist_feature_test(world_size: int, rank: int, feature: LocalFeatureStore
 
     # expected searched results
     cpu_tensor0 = torch.cat([
-      torch.ones(128, 1024, dtype=torch.float32),
-      torch.ones(128, 1024, dtype=torch.float32)*2
+        torch.ones(128, 1024, dtype=torch.float32),
+        torch.ones(128, 1024, dtype=torch.float32) * 2
     ])
     cpu_tensor1 = torch.cat([
-      torch.zeros(128, 1024, dtype=torch.float32),
-      torch.zeros(128, 1024, dtype=torch.float32)
+        torch.zeros(128, 1024, dtype=torch.float32),
+        torch.zeros(128, 1024, dtype=torch.float32)
     ])
 
     # verify..
     assert torch.allclose(cpu_tensor0, tensor0.wait())
     assert torch.allclose(cpu_tensor1, tensor1.wait())
-    
-    pyg_dist.shutdown_rpc()
 
+    pyg_dist.shutdown_rpc()
 
 
 def test_dist_feature_lookup():
 
     cpu_tensor0 = torch.cat([
-      torch.ones(128, 1024, dtype=torch.float32),
-      torch.ones(128, 1024, dtype=torch.float32)*2
+        torch.ones(128, 1024, dtype=torch.float32),
+        torch.ones(128, 1024, dtype=torch.float32) * 2
     ])
     cpu_tensor1 = torch.cat([
-      torch.zeros(128, 1024, dtype=torch.float32),
-      torch.zeros(128, 1024, dtype=torch.float32)
+        torch.zeros(128, 1024, dtype=torch.float32),
+        torch.zeros(128, 1024, dtype=torch.float32)
     ])
 
     # global node ids
     global_id0 = torch.arange(128 * 2)
-    global_id1 = torch.arange(128 * 2) + 128*2
+    global_id1 = torch.arange(128 * 2) + 128 * 2
 
     # set the partition book for two features, partition 0, 1
     partition_book = torch.cat([
-      torch.zeros(128*2, dtype=torch.long),
-      torch.ones(128*2, dtype=torch.long)
+        torch.zeros(128 * 2, dtype=torch.long),
+        torch.ones(128 * 2, dtype=torch.long)
     ])
 
     # put the test tensor into the different feature stores with ids
@@ -98,7 +98,6 @@ def test_dist_feature_lookup():
     feature1.put_global_id(global_id1, group_name=None)
     feature1.put_tensor(cpu_tensor1, group_name=None, attr_name='x')
 
-
     mp_context = torch.multiprocessing.get_context('spawn')
     # get free port
     s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
@@ -106,19 +105,15 @@ def test_dist_feature_lookup():
     port = s.getsockname()[1]
     s.close()
 
-    w0 = mp_context.Process(
-      target=run_dist_feature_test,
-      args=(2, 0, feature0, partition_book, port)
-    )
-    w1 = mp_context.Process(
-      target=run_dist_feature_test,
-      args=(2, 1, feature1, partition_book, port)
-    )
+    w0 = mp_context.Process(target=run_dist_feature_test,
+                            args=(2, 0, feature0, partition_book, port))
+    w1 = mp_context.Process(target=run_dist_feature_test,
+                            args=(2, 1, feature1, partition_book, port))
     w0.start()
     w1.start()
     w0.join()
     w1.join()
 
+
 if __name__ == "__main__":
     test_dist_feature_lookup()
-

--- a/test/distributed/test_local_feature_store_new.py
+++ b/test/distributed/test_local_feature_store_new.py
@@ -1,0 +1,124 @@
+
+import unittest
+import socket
+
+import torch
+
+from torch_geometric.distributed import (
+    RpcRouter, RpcCallBase, rpc_register, rpc_request_async
+)
+
+import torch_geometric.distributed as pyg_dist
+import torch_geometric.distributed.rpc
+
+from torch_geometric.distributed import LocalFeatureStore
+
+
+def run_dist_feature_test(world_size: int, rank: int, feature: LocalFeatureStore,
+                          partition_book: torch.Tensor, master_port: int):
+    # init the workers
+    pyg_dist.init_worker_group(world_size, rank, 'dist-feature-test')
+    pyg_dist.init_rpc(master_addr='localhost', master_port=master_port)
+
+    # collect all workers
+    partition2workers = pyg_dist.rpc_partition2workers(world_size, rank)
+    
+    # find worker with partition id 
+    rpc_router = pyg_dist.RpcRouter(partition2workers)
+
+    current_device = torch.device('cpu')
+
+    meta = {
+        "edge_types": None,
+        "is_hetero": False,
+        "node_types": None,
+        "num_parts": 2
+    }
+
+    feature.set_num_partitions(world_size)
+    feature.set_partition_idx(rank)
+    feature.set_feature_pb(partition_book)
+    feature.set_partition_meta(meta)
+    feature.set_local_only(local_only=False)
+    feature.set_rpc_router(rpc_router)
+
+    # global node ids
+    global_id0 = torch.arange(128 * 2)
+    global_id1 = torch.arange(128 * 2) + 128*2
+
+    # lookup the features from stores including locally and remotely
+    tensor0 = feature.lookup_features(global_id0)
+    tensor1 = feature.lookup_features(global_id1)
+
+    # expected searched results
+    cpu_tensor0 = torch.cat([
+      torch.ones(128, 1024, dtype=torch.float32),
+      torch.ones(128, 1024, dtype=torch.float32)*2
+    ])
+    cpu_tensor1 = torch.cat([
+      torch.zeros(128, 1024, dtype=torch.float32),
+      torch.zeros(128, 1024, dtype=torch.float32)
+    ])
+
+    # verify..
+    assert torch.allclose(cpu_tensor0, tensor0.wait())
+    assert torch.allclose(cpu_tensor1, tensor1.wait())
+    
+    pyg_dist.shutdown_rpc()
+
+
+
+def test_dist_feature_lookup():
+
+    cpu_tensor0 = torch.cat([
+      torch.ones(128, 1024, dtype=torch.float32),
+      torch.ones(128, 1024, dtype=torch.float32)*2
+    ])
+    cpu_tensor1 = torch.cat([
+      torch.zeros(128, 1024, dtype=torch.float32),
+      torch.zeros(128, 1024, dtype=torch.float32)
+    ])
+
+    # global node ids
+    global_id0 = torch.arange(128 * 2)
+    global_id1 = torch.arange(128 * 2) + 128*2
+
+    # set the partition book for two features, partition 0, 1
+    partition_book = torch.cat([
+      torch.zeros(128*2, dtype=torch.long),
+      torch.ones(128*2, dtype=torch.long)
+    ])
+
+    # put the test tensor into the different feature stores with ids
+    feature0 = LocalFeatureStore()
+    feature0.put_global_id(global_id0, group_name=None)
+    feature0.put_tensor(cpu_tensor0, group_name=None, attr_name='x')
+
+    feature1 = LocalFeatureStore()
+    feature1.put_global_id(global_id1, group_name=None)
+    feature1.put_tensor(cpu_tensor1, group_name=None, attr_name='x')
+
+
+    mp_context = torch.multiprocessing.get_context('spawn')
+    # get free port
+    s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    s.bind(('127.0.0.1', 0))
+    port = s.getsockname()[1]
+    s.close()
+
+    w0 = mp_context.Process(
+      target=run_dist_feature_test,
+      args=(2, 0, feature0, partition_book, port)
+    )
+    w1 = mp_context.Process(
+      target=run_dist_feature_test,
+      args=(2, 1, feature1, partition_book, port)
+    )
+    w0.start()
+    w1.start()
+    w0.join()
+    w1.join()
+
+if __name__ == "__main__":
+    test_dist_feature_lookup()
+

--- a/torch_geometric/distributed/__init__.py
+++ b/torch_geometric/distributed/__init__.py
@@ -1,9 +1,17 @@
 from .rpc import (
-  init_rpc, shutdown_rpc, rpc_is_initialized,
-  get_rpc_master_addr, get_rpc_master_port,
-  global_all_gather, global_barrier,
-  RpcRouter, rpc_partition2workers,
-  RpcCallBase, rpc_register, rpc_request_async, rpc_request_sync,
+    init_rpc,
+    shutdown_rpc,
+    rpc_is_initialized,
+    get_rpc_master_addr,
+    get_rpc_master_port,
+    global_all_gather,
+    global_barrier,
+    RpcRouter,
+    rpc_partition2workers,
+    RpcCallBase,
+    rpc_register,
+    rpc_request_async,
+    rpc_request_sync,
 )
 
 from .local_feature_store import LocalFeatureStore

--- a/torch_geometric/distributed/__init__.py
+++ b/torch_geometric/distributed/__init__.py
@@ -1,3 +1,11 @@
+from .rpc import (
+  init_rpc, shutdown_rpc, rpc_is_initialized,
+  get_rpc_master_addr, get_rpc_master_port,
+  global_all_gather, global_barrier,
+  RpcRouter, rpc_partition2workers,
+  RpcCallBase, rpc_register, rpc_request_async, rpc_request_sync,
+)
+
 from .local_feature_store import LocalFeatureStore
 from .local_graph_store import LocalGraphStore
 from .partition import Partitioner

--- a/torch_geometric/distributed/dist_context.py
+++ b/torch_geometric/distributed/dist_context.py
@@ -1,0 +1,51 @@
+
+from enum import Enum
+from typing import Optional
+
+
+class DistRole(Enum):
+    WORKER = 1  # for worker mode
+
+_WORKER_GROUP_NAME = '_def_worker'
+
+class DistContext(object):
+    r""" Context info for distributed Info in the current process."""
+    def __init__(self,
+                 role: DistRole,
+                 rank: int,
+                 group_name: str,
+                 world_size: int,
+                 global_world_size: int,
+                 global_rank: int):
+      self.role = role
+      self.rank = rank
+      self.group_name = group_name
+      self.world_size = world_size
+      self.global_world_size = global_world_size
+      self.global_rank = global_rank
+    
+    def is_worker(self) -> bool:
+        return self.role == DistRole.WORKER
+    
+    @property
+    def worker_name(self) -> str:
+        return f"{self.group_name}-{self.rank}"
+
+_dist_context: DistContext = None
+
+def get_context() -> DistContext:
+    return _dist_context
+
+def init_worker_group(world_size: int, rank: int,
+                      group_name: Optional[str] = None):
+    global _dist_context
+    _dist_context = DistContext(
+      role=DistRole.WORKER,
+      world_size=world_size,
+      rank=rank,
+      group_name=(group_name if group_name is not None
+                  else _WORKER_GROUP_NAME),
+      global_world_size=world_size,
+      global_rank=rank
+    )
+

--- a/torch_geometric/distributed/dist_context.py
+++ b/torch_geometric/distributed/dist_context.py
@@ -1,4 +1,3 @@
-
 from enum import Enum
 from typing import Optional
 
@@ -6,46 +5,41 @@ from typing import Optional
 class DistRole(Enum):
     WORKER = 1  # for worker mode
 
+
 _WORKER_GROUP_NAME = '_def_worker'
+
 
 class DistContext(object):
     r""" Context info for distributed Info in the current process."""
-    def __init__(self,
-                 role: DistRole,
-                 rank: int,
-                 group_name: str,
-                 world_size: int,
-                 global_world_size: int,
-                 global_rank: int):
-      self.role = role
-      self.rank = rank
-      self.group_name = group_name
-      self.world_size = world_size
-      self.global_world_size = global_world_size
-      self.global_rank = global_rank
-    
+    def __init__(self, role: DistRole, rank: int, group_name: str,
+                 world_size: int, global_world_size: int, global_rank: int):
+        self.role = role
+        self.rank = rank
+        self.group_name = group_name
+        self.world_size = world_size
+        self.global_world_size = global_world_size
+        self.global_rank = global_rank
+
     def is_worker(self) -> bool:
         return self.role == DistRole.WORKER
-    
+
     @property
     def worker_name(self) -> str:
         return f"{self.group_name}-{self.rank}"
 
+
 _dist_context: DistContext = None
+
 
 def get_context() -> DistContext:
     return _dist_context
+
 
 def init_worker_group(world_size: int, rank: int,
                       group_name: Optional[str] = None):
     global _dist_context
     _dist_context = DistContext(
-      role=DistRole.WORKER,
-      world_size=world_size,
-      rank=rank,
-      group_name=(group_name if group_name is not None
-                  else _WORKER_GROUP_NAME),
-      global_world_size=world_size,
-      global_rank=rank
-    )
-
+        role=DistRole.WORKER, world_size=world_size, rank=rank,
+        group_name=(group_name
+                    if group_name is not None else _WORKER_GROUP_NAME),
+        global_world_size=world_size, global_rank=rank)

--- a/torch_geometric/distributed/local_feature_store.py
+++ b/torch_geometric/distributed/local_feature_store.py
@@ -12,6 +12,26 @@ from torch_geometric.data.feature_store import _field_status
 from torch_geometric.typing import EdgeType, NodeType
 
 
+from torch_geometric.distributed import (
+    RpcRouter, RpcCallBase, rpc_register, rpc_request_async
+)
+
+
+
+class RpcCallFeatureLookup(RpcCallBase):
+    r""" A wrapper for rpc remote call to get the feature data from remote"""
+
+    def __init__(self, dist_feature):
+        super().__init__()
+        self.dist_feature = dist_feature
+
+    def rpc_async_call(self, *args, **kwargs):
+        return self.dist_feature.rpc_local_feature_get(*args, **kwargs)
+
+    def rpc_sync_call(self, *args, **kwargs):
+        pass
+
+
 @dataclass
 class LocalTensorAttr(TensorAttr):
     r"""Tensor attribute for storing features without :obj:`index`."""
@@ -37,6 +57,19 @@ class LocalFeatureStore(FeatureStore):
 
         # Save the mapping from global node/edge IDs to indices in `_feat`:
         self._global_id_to_index: Dict[Union[NodeType, EdgeType], Tensor] = {}
+
+
+        # for partition/rpc info related to distributed features
+        self.num_partitions: int = 1
+        self.partition_idx: int = 0
+        self.feature_pb: Union[torch.Tensor, Dict[NodeType, torch.Tensor],
+                                Dict[EdgeType, torch.Tensor]]
+        self.local_only: bool = False
+        self.rpc_router: Optional[RpcRouter] = None
+        self.meta: Optional[Dict] = None
+        self.rpc_call_id = None
+
+
 
     @staticmethod
     def key(attr: TensorAttr) -> Tuple[str, str]:
@@ -107,6 +140,190 @@ class LocalFeatureStore(FeatureStore):
     def get_all_tensor_attrs(self) -> List[LocalTensorAttr]:
         return [self._tensor_attr_cls.cast(*key) for key in self._feat.keys()]
 
+    
+    
+    # starting the partition/rpc info related to distributed feature stores
+
+    def set_num_partitions(self, num_partitions: int) -> bool:
+        self.num_partitions = num_partitions
+        return True
+
+    def set_partition_idx(self, partition_idx: int) -> bool:
+        self.partition_idx = partition_idx
+        return True
+
+    def set_feature_pb(self, feature_pb: Union[torch.Tensor, Dict[NodeType, torch.Tensor]]) -> bool:
+        self.feature_pb = feature_pb
+        return True
+
+    def set_partition_meta(self, partition_meta: Dict) -> bool:
+        self.meta = partition_meta
+        return True
+
+    def set_local_only(self, local_only: bool) -> bool:
+        self.local_only = local_only
+        return True
+
+    def set_rpc_router(self, rpc_router: RpcRouter) -> bool:
+        self.rpc_router = rpc_router
+
+        if not self.local_only:
+            if self.rpc_router is None:
+                raise ValueError("A rpc router must be provided")
+            rpc_call = RpcCallFeatureLookup(self)
+            self.rpc_call_id = rpc_register(rpc_call)
+        else:
+            self.rpc_call_id = None
+        return True
+
+    
+    
+    
+    # lookup the distributed features
+
+    def lookup_features(
+        self,
+        ids: torch.Tensor,
+        is_node_feat: bool = True,
+        input_type: Optional[Union[NodeType, EdgeType]] = None
+    ) -> torch.futures.Future:
+        r""" Lookup the local/remote features based on node/edge ids """
+
+        remote_fut = self._remote_lookup_features(ids, is_node_feat, input_type)
+        local_feature = self._local_lookup_features(ids, is_node_feat, input_type)
+        res_fut = torch.futures.Future()
+        def when_finish(*_):
+            try:
+                remote_feature_list = remote_fut.wait()
+                # combine the feature from remote and local
+                result = torch.zeros(ids.shape[0], local_feature[0].shape[1], dtype=local_feature[0].dtype)
+                result[local_feature[1]] = local_feature[0]
+                for remote in remote_feature_list:
+                    result[remote[1]] = remote[0]
+            except Exception as e:
+                res_fut.set_exception(e)
+            else:
+                res_fut.set_result(result)
+        remote_fut.add_done_callback(when_finish)
+        return res_fut
+
+    def _local_lookup_features(
+        self,
+        ids: torch.Tensor,
+        is_node_feat: bool = True,
+        input_type: Optional[Union[NodeType, EdgeType]] = None
+    ) -> torch.Tensor:
+        r""" lookup the features in local nodes based on node/edge ids """
+
+        if(self.meta["is_hetero"]):
+            feat = self 
+            pb = self.feature_pb[input_type]
+        else:
+            feat = self 
+            pb = self.feature_pb
+
+        input_order= torch.arange(ids.size(0), dtype=torch.long)
+        partition_ids = pb[ids]
+
+        local_mask = (partition_ids == self.partition_idx)
+        local_ids = torch.masked_select(ids, local_mask)
+        local_index = torch.masked_select(input_order, local_mask)
+
+        if(self.meta["is_hetero"]):
+            if is_node_feat:
+                kwargs = dict(group_name=input_type, attr_name='x')
+                ret_feat = feat.get_tensor_from_global_id(index=local_ids, **kwargs)
+            else:
+                kwargs = dict(group_name=input_type, attr_name='edge_attr')
+                ret_feat = feat.get_tensor_from_global_id(index=local_ids, **kwargs)
+        else:
+            if is_node_feat:
+                kwargs = dict(group_name=None, attr_name='x')
+                ret_feat = feat.get_tensor_from_global_id(index=local_ids, **kwargs)
+            else:
+                kwargs = dict(group_name=(None, None), attr_name='edge_attr')
+                ret_feat = feat.get_tensor_from_global_id(index=local_ids, **kwargs)
+
+        return ret_feat, local_index
+
+
+    def _remote_lookup_features(
+        self,
+        ids: torch.Tensor,
+        is_node_feat: bool = True,
+        input_type: Optional[Union[NodeType, EdgeType]] = None
+    ) -> torch.futures.Future:
+        r""" fetch the remote features with the remote node/edge ids"""
+
+        if(self.meta["is_hetero"]):
+            pb = self.feature_pb[input_type]
+        else:
+            pb = self.feature_pb
+
+        input_order= torch.arange(ids.size(0), dtype=torch.long)
+        partition_ids = pb[ids]
+        futs, indexes = [], []
+        for pidx in range(0, self.num_partitions):
+            if pidx == self.partition_idx:
+                continue
+            remote_mask = (partition_ids == pidx)
+            remote_ids = torch.masked_select(ids, remote_mask)
+            if remote_ids.shape[0] > 0:
+                to_worker = self.rpc_router.get_to_worker(pidx)
+                futs.append(rpc_request_async(to_worker,
+                                            self.rpc_call_id,
+                                            args=(remote_ids.cpu(), is_node_feat, input_type)))
+                indexes.append(torch.masked_select(input_order, remote_mask))
+        collect_fut = torch.futures.collect_all(futs)
+        res_fut = torch.futures.Future()
+        def when_finish(*_):
+            try:
+                fut_list = collect_fut.wait()
+                result = []
+                for i, fut in enumerate(fut_list):
+                    result.append((fut.wait(), indexes[i]))
+            except Exception as e:
+                res_fut.set_exception(e)
+            else:
+                res_fut.set_result(result)
+        collect_fut.add_done_callback(when_finish)
+        return res_fut
+
+    def rpc_local_feature_get(
+        self,
+        ids: torch.Tensor,
+        is_node_feat: bool = True,
+        input_type: Optional[Union[NodeType, EdgeType]] = None
+    ) -> torch.Tensor:
+        r""" RPC_Lookup the features in remote nodes (remote locally) """
+
+        if(self.meta["is_hetero"]):
+            feat = self 
+            if is_node_feat:
+                kwargs = dict(group_name=input_type, attr_name='x')
+                ret_feat = feat.get_tensor_from_global_id(index=ids, **kwargs)
+            else:
+                kwargs = dict(group_name=input_type, attr_name='edge_attr')
+                ret_feat = feat.get_tensor_from_global_id(index=ids, **kwargs)
+        else:
+            feat = self 
+            if is_node_feat:
+                kwargs = dict(group_name=None, attr_name='x')
+                ret_feat = feat.get_tensor_from_global_id(index=ids, **kwargs)
+            else:
+                kwargs = dict(group_name=(None, None), attr_name='edge_attr')
+                ret_feat = feat.get_tensor_from_global_id(index=ids, **kwargs)
+
+        return ret_feat
+
+    
+    
+    
+    
+    
+    
+    
+    
     # Initialization ##########################################################
 
     @classmethod

--- a/torch_geometric/distributed/rpc.py
+++ b/torch_geometric/distributed/rpc.py
@@ -1,4 +1,3 @@
-
 import atexit
 import collections
 import functools
@@ -7,14 +6,10 @@ import threading
 from abc import ABC, abstractmethod
 from typing import Dict, List, Set
 
+from torch._C._distributed_rpc import _is_current_rpc_agent_set
 from torch.distributed import rpc
 
 from .dist_context import DistRole, get_context
-
-from torch._C._distributed_rpc import (
-    _is_current_rpc_agent_set,
-)
-
 
 _rpc_init_lock = threading.RLock()
 
@@ -26,19 +21,24 @@ _rpc_master_port: int = None
 
 _rpc_worker_names: Dict[DistRole, List[str]] = None
 
+
 def rpc_is_initialized():
     return _is_current_rpc_agent_set()
 
+
 def _require_initialized(func):
-    return rpc.api._require_initialized(func)    
+    return rpc.api._require_initialized(func)
+
 
 @_require_initialized
 def get_rpc_master_addr():
     return _rpc_master_addr
 
+
 @_require_initialized
 def get_rpc_master_port():
     return _rpc_master_port
+
 
 @_require_initialized
 def get_rpc_worker_names() -> Dict[DistRole, List[str]]:
@@ -46,6 +46,7 @@ def get_rpc_worker_names() -> Dict[DistRole, List[str]]:
 
 
 ## All gather objects from all role groups.
+
 
 @_require_initialized
 def global_all_gather(obj, timeout=None):
@@ -66,52 +67,47 @@ def global_barrier(timeout=None):
 
 ## RPC initialization and shutdown
 
-def init_rpc(master_addr: str,
-             master_port: int,
-             num_rpc_threads: int = 16,
+
+def init_rpc(master_addr: str, master_port: int, num_rpc_threads: int = 16,
              rpc_timeout: float = 240):
-    
+
     with _rpc_init_lock:
         if rpc_is_initialized() is True:
             return
         if rpc_is_initialized() is None:
-            raise RuntimeError("'init_rpc': error to re-init rpc after shutdown.")
-        
+            raise RuntimeError(
+                "'init_rpc': error to re-init rpc after shutdown.")
+
         ctx = get_context()
         if ctx is None:
             raise RuntimeError("'init_rpc': dist_context has not been set.")
-        
+
         options = rpc.TensorPipeRpcBackendOptions(
-            _transports=['ibv', 'uv'],
-            _channels=['mpt_uv', 'basic'],
-            num_worker_threads=num_rpc_threads,
-            rpc_timeout=rpc_timeout,
-            init_method=f'tcp://{master_addr}:{master_port}'
-        )
-        
-        rpc.init_rpc(
-            name=ctx.worker_name,
-            rank=ctx.global_rank,
-            world_size=ctx.global_world_size,
-            rpc_backend_options=options
-        )
-        
+            _transports=['ibv', 'uv'], _channels=['mpt_uv', 'basic'],
+            num_worker_threads=num_rpc_threads, rpc_timeout=rpc_timeout,
+            init_method=f'tcp://{master_addr}:{master_port}')
+
+        rpc.init_rpc(name=ctx.worker_name, rank=ctx.global_rank,
+                     world_size=ctx.global_world_size,
+                     rpc_backend_options=options)
+
         global _rpc_worker_names
         _rpc_worker_names = {}
         gathered_results = global_all_gather(
-            obj=(ctx.role, ctx.world_size, ctx.rank), timeout=rpc_timeout
-        )
-        for worker_name, (role, world_size, node_rank) in gathered_results.items():
+            obj=(ctx.role, ctx.world_size, ctx.rank), timeout=rpc_timeout)
+        for worker_name, (role, world_size,
+                          node_rank) in gathered_results.items():
             worker_list = _rpc_worker_names.get(role, None)
             if worker_list is None:
                 worker_list = [None for _ in range(world_size)]
             else:
                 if len(worker_list) != world_size:
-                    raise RuntimeError("'init_rpc': world size inconsistent with others.")
+                    raise RuntimeError(
+                        "'init_rpc': world size inconsistent with others.")
 
             worker_list[node_rank] = worker_name
             _rpc_worker_names[role] = worker_list
-        
+
         global_barrier(timeout=rpc_timeout)
 
 
@@ -119,10 +115,11 @@ def shutdown_rpc(graceful=True):
     if rpc_is_initialized() is True:
         rpc.shutdown(graceful=graceful)
 
+
 atexit.register(shutdown_rpc, False)
 
-
 ## RPC synchronization and routing with data partition mapping.
+
 
 class RpcRouter(object):
     r""" A router to get the worker based on partition id."""
@@ -132,7 +129,7 @@ class RpcRouter(object):
                 raise ValueError("no rpc worker is in worklist'.")
         self.partition2workers = partition2workers
         self.rpc_worker_indexs = [0 for _ in range(len(partition2workers))]
-    
+
     def get_to_worker(self, data_partition_idx: int) -> str:
         rpc_worker_list = self.partition2workers[data_partition_idx]
         worker_idx = self.rpc_worker_indexs[data_partition_idx]
@@ -144,10 +141,10 @@ class RpcRouter(object):
 
 @_require_initialized
 def rpc_partition2workers(num_data_partitions: int,
-                             current_partition_idx: int):
+                          current_partition_idx: int):
     r""" all_gather to get the mapping between partition and workers """
     ctx = get_context()
-    partition2workers  = [[] for _ in range(num_data_partitions)]
+    partition2workers = [[] for _ in range(num_data_partitions)]
     gathered_results = global_all_gather(
         (ctx.role, num_data_partitions, current_partition_idx))
     for worker_name, (role, nparts, idx) in gathered_results.items():
@@ -155,19 +152,19 @@ def rpc_partition2workers(num_data_partitions: int,
     return partition2workers
 
 
-
 class RpcCallBase(ABC):
-    r""" A wrapper base for rpc call in remote processes."""    
+    r""" A wrapper base for rpc call in remote processes."""
     def __init__(self):
         pass
-    
+
     @abstractmethod
     def rpc_sync_call(self, *args, **kwargs):
         pass
-    
+
     @abstractmethod
     def rpc_async_call(self, *args, **kwargs):
         pass
+
 
 _rpc_call_lock = threading.RLock()
 _rpc_call_id: int = 0
@@ -184,12 +181,14 @@ def rpc_register(call: RpcCallBase):
         if call_id in _rpc_call_pool:
             raise RuntimeError(f"'rpc_register': register with the twice.")
         _rpc_call_pool[call_id] = call
-    
+
     return call_id
+
 
 def _rpc_remote_async_call(call_id, *args, **kwargs):
     r""" Entry for rpc requests """
     return _rpc_call_pool.get(call_id).rpc_async_call(*args, **kwargs)
+
 
 def _rpc_remote_sync_all(call_id, *args, **kwargs):
     r""" Entry for rpc requests """
@@ -199,24 +198,15 @@ def _rpc_remote_sync_all(call_id, *args, **kwargs):
 @_require_initialized
 def rpc_request_async(worker_name, call_id, args=None, kwargs=None):
     r""" Perform a rpc request asynchronously and return a future. """
-    return rpc.rpc_async(
-        to=worker_name,
-        func=_rpc_remote_async_call,
-        args=(call_id, *args),
-        kwargs=kwargs
-    )
+    return rpc.rpc_async(to=worker_name, func=_rpc_remote_async_call,
+                         args=(call_id, *args), kwargs=kwargs)
 
 
 @_require_initialized
 def rpc_request_sync(worker_name, call_id, args=None, kwargs=None):
     r""" Perform a rpc request synchronously and return the results.
     """
-    fut = rpc.rpc_async(
-        to=worker_name,
-        func=_rpc_remote_sync_call,
-        args=(call_id, *args),
-        kwargs=kwargs
-    )
+    fut = rpc.rpc_async(to=worker_name, func=_rpc_remote_sync_call,
+                        args=(call_id, *args), kwargs=kwargs)
 
     return fut.wait()
-

--- a/torch_geometric/distributed/rpc.py
+++ b/torch_geometric/distributed/rpc.py
@@ -1,0 +1,222 @@
+
+import atexit
+import collections
+import functools
+import logging
+import threading
+from abc import ABC, abstractmethod
+from typing import Dict, List, Set
+
+from torch.distributed import rpc
+
+from .dist_context import DistRole, get_context
+
+from torch._C._distributed_rpc import (
+    _is_current_rpc_agent_set,
+)
+
+
+_rpc_init_lock = threading.RLock()
+
+_rpc_inited: bool = False
+r""" State of rpc initialization."""
+
+_rpc_master_addr: str = None
+_rpc_master_port: int = None
+
+_rpc_worker_names: Dict[DistRole, List[str]] = None
+
+def rpc_is_initialized():
+    return _is_current_rpc_agent_set()
+
+def _require_initialized(func):
+    return rpc.api._require_initialized(func)    
+
+@_require_initialized
+def get_rpc_master_addr():
+    return _rpc_master_addr
+
+@_require_initialized
+def get_rpc_master_port():
+    return _rpc_master_port
+
+@_require_initialized
+def get_rpc_worker_names() -> Dict[DistRole, List[str]]:
+    return _rpc_worker_names
+
+
+## All gather objects from all role groups.
+
+@_require_initialized
+def global_all_gather(obj, timeout=None):
+    r""" Gathers objects from all groups in a list."""
+    if timeout is None:
+        return rpc.api._all_gather(obj)
+    return rpc.api._all_gather(obj, timeout=timeout)
+
+
+@_require_initialized
+def global_barrier(timeout=None):
+    r""" Block until all local and remote RPC processes. """
+    try:
+        global_all_gather(obj=None, timeout=timeout)
+    except RuntimeError as ex:
+        logging.error("Failed to respond to global_barrier")
+
+
+## RPC initialization and shutdown
+
+def init_rpc(master_addr: str,
+             master_port: int,
+             num_rpc_threads: int = 16,
+             rpc_timeout: float = 240):
+    
+    with _rpc_init_lock:
+        if rpc_is_initialized() is True:
+            return
+        if rpc_is_initialized() is None:
+            raise RuntimeError("'init_rpc': error to re-init rpc after shutdown.")
+        
+        ctx = get_context()
+        if ctx is None:
+            raise RuntimeError("'init_rpc': dist_context has not been set.")
+        
+        options = rpc.TensorPipeRpcBackendOptions(
+            _transports=['ibv', 'uv'],
+            _channels=['mpt_uv', 'basic'],
+            num_worker_threads=num_rpc_threads,
+            rpc_timeout=rpc_timeout,
+            init_method=f'tcp://{master_addr}:{master_port}'
+        )
+        
+        rpc.init_rpc(
+            name=ctx.worker_name,
+            rank=ctx.global_rank,
+            world_size=ctx.global_world_size,
+            rpc_backend_options=options
+        )
+        
+        global _rpc_worker_names
+        _rpc_worker_names = {}
+        gathered_results = global_all_gather(
+            obj=(ctx.role, ctx.world_size, ctx.rank), timeout=rpc_timeout
+        )
+        for worker_name, (role, world_size, node_rank) in gathered_results.items():
+            worker_list = _rpc_worker_names.get(role, None)
+            if worker_list is None:
+                worker_list = [None for _ in range(world_size)]
+            else:
+                if len(worker_list) != world_size:
+                    raise RuntimeError("'init_rpc': world size inconsistent with others.")
+
+            worker_list[node_rank] = worker_name
+            _rpc_worker_names[role] = worker_list
+        
+        global_barrier(timeout=rpc_timeout)
+
+
+def shutdown_rpc(graceful=True):
+    if rpc_is_initialized() is True:
+        rpc.shutdown(graceful=graceful)
+
+atexit.register(shutdown_rpc, False)
+
+
+## RPC synchronization and routing with data partition mapping.
+
+class RpcRouter(object):
+    r""" A router to get the worker based on partition id."""
+    def __init__(self, partition2workers: List[List[str]]):
+        for pidx, rpc_worker_list in enumerate(partition2workers):
+            if len(rpc_worker_list) == 0:
+                raise ValueError("no rpc worker is in worklist'.")
+        self.partition2workers = partition2workers
+        self.rpc_worker_indexs = [0 for _ in range(len(partition2workers))]
+    
+    def get_to_worker(self, data_partition_idx: int) -> str:
+        rpc_worker_list = self.partition2workers[data_partition_idx]
+        worker_idx = self.rpc_worker_indexs[data_partition_idx]
+        router_worker = rpc_worker_list[worker_idx]
+        self.rpc_worker_indexs[data_partition_idx] = \
+            (worker_idx + 1) % len(rpc_worker_list)
+        return router_worker
+
+
+@_require_initialized
+def rpc_partition2workers(num_data_partitions: int,
+                             current_partition_idx: int):
+    r""" all_gather to get the mapping between partition and workers """
+    ctx = get_context()
+    partition2workers  = [[] for _ in range(num_data_partitions)]
+    gathered_results = global_all_gather(
+        (ctx.role, num_data_partitions, current_partition_idx))
+    for worker_name, (role, nparts, idx) in gathered_results.items():
+        partition2workers[idx].append(worker_name)
+    return partition2workers
+
+
+
+class RpcCallBase(ABC):
+    r""" A wrapper base for rpc call in remote processes."""    
+    def __init__(self):
+        pass
+    
+    @abstractmethod
+    def rpc_sync_call(self, *args, **kwargs):
+        pass
+    
+    @abstractmethod
+    def rpc_async_call(self, *args, **kwargs):
+        pass
+
+_rpc_call_lock = threading.RLock()
+_rpc_call_id: int = 0
+_rpc_call_pool: Dict[int, RpcCallBase] = {}
+
+
+@_require_initialized
+def rpc_register(call: RpcCallBase):
+    r""" Register a call for rpc requests """
+    global _rpc_call_id, _rpc_call_pool
+    with _rpc_call_lock:
+        call_id = _rpc_call_id
+        _rpc_call_id += 1
+        if call_id in _rpc_call_pool:
+            raise RuntimeError(f"'rpc_register': register with the twice.")
+        _rpc_call_pool[call_id] = call
+    
+    return call_id
+
+def _rpc_remote_async_call(call_id, *args, **kwargs):
+    r""" Entry for rpc requests """
+    return _rpc_call_pool.get(call_id).rpc_async_call(*args, **kwargs)
+
+def _rpc_remote_sync_all(call_id, *args, **kwargs):
+    r""" Entry for rpc requests """
+    return _rpc_call_pool.get(call_id).rpc_sync_call(*args, **kwargs)
+
+
+@_require_initialized
+def rpc_request_async(worker_name, call_id, args=None, kwargs=None):
+    r""" Perform a rpc request asynchronously and return a future. """
+    return rpc.rpc_async(
+        to=worker_name,
+        func=_rpc_remote_async_call,
+        args=(call_id, *args),
+        kwargs=kwargs
+    )
+
+
+@_require_initialized
+def rpc_request_sync(worker_name, call_id, args=None, kwargs=None):
+    r""" Perform a rpc request synchronously and return the results.
+    """
+    fut = rpc.rpc_async(
+        to=worker_name,
+        func=_rpc_remote_sync_call,
+        args=(call_id, *args),
+        kwargs=kwargs
+    )
+
+    return fut.wait()
+


### PR DESCRIPTION
This code belongs to the part of the whole distributed training for PyG.

This PR originally designed for the DistFeature class and now merged with LocalFeatureStore -

1) Add partition/rpc info into LocalFeatureStore like num_partition, partition_idx, feature_pb (feature_partitionbook), partition_meta, RpcRouter, etc
2) Add one new class (RpcCallFeatureLookup) to do real remote rpc feature_lookup work
3) Add one api ( .lookup_features() ) to do feature lookup in local node and remote nodes based on sampled global node ids/edge ids based on torch rpc apis
4) one unit test to verify the function of local/remote feature lookup under .test/distributed/. folder

Now we combined the local feature store and distributed feature properties (partition info and rpc remote access apis) into one FeatureStore. later on we will change the class name from LocalFeatureStore into PartitionFeatureStore with another PR.

Any comments please let us know. thanks.