### PR TITLE
Add `interval` argument to `transforms.Distance`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Added back support for PyTorch >= 1.11.0 ([#7656](https://github.com/pyg-team/pytorch_geometric/pull/7656))
 - Added `Data.sort()` and `HeteroData.sort()` functionalities ([#7649](https://github.com/pyg-team/pytorch_geometric/pull/7649))
 - Added `torch.nested_tensor` support in `Data` and `Batch` ([#7643](https://github.com/pyg-team/pytorch_geometric/pull/7643), [#7647](https://github.com/pyg-team/pytorch_geometric/pull/7647))
-- Added `interval` argument to `Cartesian` and `LocalCartesian` transformations ([#7533](https://github.com/pyg-team/pytorch_geometric/pull/7533), [#7614](https://github.com/pyg-team/pytorch_geometric/pull/7614))
+- Added `interval` argument to `Cartesian`, `LocalCartesian` and `Distance` transformations ([#7533](https://github.com/pyg-team/pytorch_geometric/pull/7533), [#7614](https://github.com/pyg-team/pytorch_geometric/pull/7614),  [#7700](https://github.com/pyg-team/pytorch_geometric/pull/7700))
 - Added a `LightGCN` example on the `AmazonBook` dataset ([7603](https://github.com/pyg-team/pytorch_geometric/pull/7603))
 - Added a tutorial on hierarchical neighborhood sampling ([#7594](https://github.com/pyg-team/pytorch_geometric/pull/7594))
 - Enabled different attention modes in `HypergraphConv` via the `attention_mode` argument ([#7601](https://github.com/pyg-team/pytorch_geometric/pull/7601))

--- a/torch_geometric/transforms/distance.py
+++ b/torch_geometric/transforms/distance.py
@@ -1,11 +1,8 @@
-from typing import Optional
-
+from typing import Optional, Tuple
 import torch
-
 from torch_geometric.data import Data
 from torch_geometric.data.datapipes import functional_transform
 from torch_geometric.transforms import BaseTransform
-
 
 @functional_transform('distance')
 class Distance(BaseTransform):
@@ -20,12 +17,20 @@ class Distance(BaseTransform):
             found in the data. (default: :obj:`None`)
         cat (bool, optional): If set to :obj:`False`, all existing edge
             attributes will be replaced. (default: :obj:`True`)
+        interval ((float, float), optional): A tuple specifying the lower and
+            upper bound for normalization. (default: :obj:`(0.0, 1.0)`)
     """
-    def __init__(self, norm: bool = True, max_value: Optional[float] = None,
-                 cat: bool = True):
+    def __init__(
+        self,
+        norm: bool = True,
+        max_value: Optional[float] = None,
+        cat: bool = True,
+        interval: Tuple[float, float] = (0.0, 1.0),
+    ):
         self.norm = norm
         self.max = max_value
         self.cat = cat
+        self.interval = interval
 
     def forward(self, data: Data) -> Data:
         (row, col), pos, pseudo = data.edge_index, data.pos, data.edge_attr
@@ -33,7 +38,11 @@ class Distance(BaseTransform):
         dist = torch.norm(pos[col] - pos[row], p=2, dim=-1).view(-1, 1)
 
         if self.norm and dist.numel() > 0:
-            dist = dist / (dist.max() if self.max is None else self.max)
+            max_value = dist.max() if self.max is None else self.max
+
+            length = self.interval[1] - self.interval[0]
+            center = (self.interval[0] + self.interval[1]) / 2
+            dist = length * (dist / max_value) + center
 
         if pseudo is not None and self.cat:
             pseudo = pseudo.view(-1, 1) if pseudo.dim() == 1 else pseudo
@@ -44,5 +53,7 @@ class Distance(BaseTransform):
         return data
 
     def __repr__(self) -> str:
-        return (f'{self.__class__.__name__}(norm={self.norm}, '
-                f'max_value={self.max})')
+        return (
+            f'{self.__class__.__name__}(norm={self.norm}, '
+            f'max_value={self.max}, interval={self.interval})'
+        )

--- a/torch_geometric/transforms/distance.py
+++ b/torch_geometric/transforms/distance.py
@@ -10,11 +10,12 @@ from torch_geometric.transforms import BaseTransform
 @functional_transform('distance')
 class Distance(BaseTransform):
     r"""Saves the Euclidean distance of linked nodes in its edge attributes
-    (functional name: :obj:`distance`).
+    (functional name: :obj:`distance`). Each distance gets globally normalized
+    to a specified interval (:math:`[0, 1]` by default).
 
     Args:
         norm (bool, optional): If set to :obj:`False`, the output will not be
-            normalized to the interval :math:`[0, 1]`. (default: :obj:`True`)
+            normalized. (default: :obj:`True`)
         max_value (float, optional): If set and :obj:`norm=True`, normalization
             will be performed based on this value instead of the maximum value
             found in the data. (default: :obj:`None`)
@@ -57,4 +58,4 @@ class Distance(BaseTransform):
 
     def __repr__(self) -> str:
         return (f'{self.__class__.__name__}(norm={self.norm}, '
-                f'max_value={self.max}, interval={self.interval})')
+                f'max_value={self.max})')

--- a/torch_geometric/transforms/distance.py
+++ b/torch_geometric/transforms/distance.py
@@ -45,8 +45,7 @@ class Distance(BaseTransform):
             max_value = dist.max() if self.max is None else self.max
 
             length = self.interval[1] - self.interval[0]
-            center = (self.interval[0] + self.interval[1]) / 2
-            dist = length * (dist / max_value) + center
+            dist = length * (dist / max_value) + self.interval[0]
 
         if pseudo is not None and self.cat:
             pseudo = pseudo.view(-1, 1) if pseudo.dim() == 1 else pseudo

--- a/torch_geometric/transforms/distance.py
+++ b/torch_geometric/transforms/distance.py
@@ -1,8 +1,11 @@
 from typing import Optional, Tuple
+
 import torch
+
 from torch_geometric.data import Data
 from torch_geometric.data.datapipes import functional_transform
 from torch_geometric.transforms import BaseTransform
+
 
 @functional_transform('distance')
 class Distance(BaseTransform):
@@ -21,11 +24,11 @@ class Distance(BaseTransform):
             upper bound for normalization. (default: :obj:`(0.0, 1.0)`)
     """
     def __init__(
-        self,
-        norm: bool = True,
-        max_value: Optional[float] = None,
-        cat: bool = True,
-        interval: Tuple[float, float] = (0.0, 1.0),
+            self,
+            norm: bool = True,
+            max_value: Optional[float] = None,
+            cat: bool = True,
+            interval: Tuple[float, float] = (0.0, 1.0),
     ):
         self.norm = norm
         self.max = max_value
@@ -53,7 +56,5 @@ class Distance(BaseTransform):
         return data
 
     def __repr__(self) -> str:
-        return (
-            f'{self.__class__.__name__}(norm={self.norm}, '
-            f'max_value={self.max}, interval={self.interval})'
-        )
+        return (f'{self.__class__.__name__}(norm={self.norm}, '
+                f'max_value={self.max}, interval={self.interval})')


### PR DESCRIPTION
@rusty1s following previous PRs regarding adding `interval` to other transforms, by adding `interval` to the code, we can use the `Distance` transformation and specify the `interval` parameter to control the range and normalization of the distances.