### PR TITLE
Don't implicitly chain exceptions when accessing non-existent storage attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
+- Unchained exceptions raised when accessing non-existent data attributes for better readability ([#7734](https://github.com/pyg-team/pytorch_geometric/pull/7734))
 - Raise error when collecting non-existing attributes in `HeteroData` ([#7714](https://github.com/pyg-team/pytorch_geometric/pull/7714))
 - Renamed `dest` argument to `dst` in `utils.geodesic_distance` ([#7708](https://github.com/pyg-team/pytorch_geometric/pull/7708))
 - Changed `add_random_edge` to only add true negative edges ([#7654](https://github.com/pyg-team/pytorch_geometric/pull/7654))

--- a/test/data/test_storage.py
+++ b/test/data/test_storage.py
@@ -1,6 +1,7 @@
 import copy
 from typing import Any
 
+import pytest
 import torch
 
 from torch_geometric.data.storage import BaseStorage
@@ -51,6 +52,9 @@ def test_base_storage():
     assert storage.x.data_ptr() != deepcopied_storage.x.data_ptr()
     assert int(storage.x) == 0
     assert int(deepcopied_storage.x) == 0
+
+    with pytest.raises(AttributeError, match="has no attribute 'asdf'"):
+        storage.asdf
 
 
 def test_storage_tensor_methods():

--- a/torch_geometric/data/storage.py
+++ b/torch_geometric/data/storage.py
@@ -80,7 +80,7 @@ class BaseStorage(MutableMapping):
             return self[key]
         except KeyError:
             raise AttributeError(
-                f"'{self.__class__.__name__}' object has no attribute '{key}'")
+                f"'{self.__class__.__name__}' object has no attribute '{key}'") from None
 
     def __setattr__(self, key: str, value: Any):
         propobj = getattr(self.__class__, key, None)

--- a/torch_geometric/data/storage.py
+++ b/torch_geometric/data/storage.py
@@ -80,7 +80,8 @@ class BaseStorage(MutableMapping):
             return self[key]
         except KeyError:
             raise AttributeError(
-                f"'{self.__class__.__name__}' object has no attribute '{key}'") from None
+                f"'{self.__class__.__name__}' object has no attribute '{key}'"
+            ) from None
 
     def __setattr__(self, key: str, value: Any):
         propobj = getattr(self.__class__, key, None)


### PR DESCRIPTION
This PR changes the traceback when a user tries to access attributes on `Data` that doesn't exist:

```python
import torch_geometric

data = torch_geometric.data.Data()
data.asdf
```

## Before

```diff
Traceback (most recent call last):
  File "/workspaces/pytorch_geometric/torch_geometric/data/storage.py", line 80, in __getattr__
    return self[key]
  File "/workspaces/pytorch_geometric/torch_geometric/data/storage.py", line 105, in __getitem__
    return self._mapping[key]
KeyError: 'asdf'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/workspaces/pytorch_geometric/test.py", line 4, in <module>
    data.asdf
  File "/workspaces/pytorch_geometric/torch_geometric/data/data.py", line 475, in __getattr__
    return getattr(self._store, key)
  File "/workspaces/pytorch_geometric/torch_geometric/data/storage.py", line 82, in __getattr__
    raise AttributeError(
AttributeError: 'GlobalStorage' object has no attribute 'asdf'
```

## After

```
Traceback (most recent call last):
  File "/workspaces/pytorch_geometric/test.py", line 4, in <module>
    data.asdf
  File "/workspaces/pytorch_geometric/torch_geometric/data/data.py", line 475, in __getattr__
    return getattr(self._store, key)
  File "/workspaces/pytorch_geometric/torch_geometric/data/storage.py", line 82, in __getattr__
    raise AttributeError(
AttributeError: 'GlobalStorage' object has no attribute 'asdf'
```

## Alternative

By explicitly chaining exceptions, one of the lines in the error changes:
```diff
-       except KeyError:
+       except KeyError as e:
            raise AttributeError(
-               f"'{self.__class__.__name__}' object has no attribute '{key}'")
+               f"'{self.__class__.__name__}' object has no attribute '{key}'") from e
```

```diff
- During handling of the above exception, another exception occurred:
+ The above exception was the direct cause of the following exception:
```