### PR TITLE
Modify `dtype` in `ogbn-products` GAT example #7703 

### DIFF
--- a/examples/ogbn_products_gat.py
+++ b/examples/ogbn_products_gat.py
@@ -165,7 +165,7 @@ for run in range(1, 11):
     model.reset_parameters()
     optimizer = torch.optim.Adam(model.parameters(), lr=0.001)
 
-    best_val_acc = final_test_acc = 0
+    best_val_acc = final_test_acc = 0.0
     for epoch in range(1, 101):
         loss, acc = train(epoch)
         print(f'Epoch {epoch:02d}, Loss: {loss:.4f}, Approx. Train: {acc:.4f}')


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "ogbn_products_gat.py", line 185, in <module>
    print(f'Final Test: {test_acc.mean():.4f} ± {test_acc.std():.4f}')
RuntimeError: mean(): could not infer output dtype. Input dtype must be either a floating point or complex dtype. Got: Long
```