### PR TITLE
`NetworkX` heterogeneous graphs can be converted to `HeteroData` using `from_hetero_networkx`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -282,6 +282,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Added `output_initializer` argument to `DimeNet` models ([#7774](https://github.com/pyg-team/pytorch_geometric/pull/7774), [#7780](https://github.com/pyg-team/pytorch_geometric/pull/7780))
 - Added `lexsort` implementation ([#7775](https://github.com/pyg-team/pytorch_geometric/pull/7775))
 - Added possibility to run inference benchmarks on XPU device ([#7705](https://github.com/pyg-team/pytorch_geometric/pull/7705))
+- Added `from_hetero_networkx` utility method ([#7340](https://github.com/pyg-team/pytorch_geometric/pull/7340))
 - Added `HeteroData` support in `to_networkx` ([#7713](https://github.com/pyg-team/pytorch_geometric/pull/7713))
 - Added `FlopsCount` support via `fvcore` ([#7693](https://github.com/pyg-team/pytorch_geometric/pull/7693))
 - Added back support for PyTorch >= 1.11.0 ([#7656](https://github.com/pyg-team/pytorch_geometric/pull/7656))

--- a/test/utils/test_convert.py
+++ b/test/utils/test_convert.py
@@ -942,7 +942,7 @@ def test_from_hetero_networkx_graph_node_selection():
     import networkx as nx
 
     G = nx.DiGraph()
-    G.add_node(0, type="A")
+    G.add_node(0, type="A", x=0)
     G.add_node("node_1", type="B", y=1)
     G.add_node(2, type="B", x=1)
 
@@ -950,8 +950,7 @@ def test_from_hetero_networkx_graph_node_selection():
                                 edge_type_attribute=None,
                                 graph_attrs=['x', 'y'], nodes=[0, "node_1"])
 
-    assert len(data['A'].type) == 1
-    assert len(data['B'].type) == 1
+    assert len(data['A'].x) == 1
     assert len(data['B'].y) == 1
 
 

--- a/test/utils/test_convert.py
+++ b/test/utils/test_convert.py
@@ -935,3 +935,21 @@ def test_from_hetero_networkx_graph_attrs_selection():
     assert data['x'] == 0
     assert data['y'] == 0
     assert 'z' not in data
+
+
+@withPackage('networkx')
+def test_from_hetero_networkx_graph_attrs_selection():
+    import networkx as nx
+
+    G = nx.DiGraph()
+    G.add_node(0, type="A")
+    G.add_node("node_1", type="B", y=1)
+    G.add_node(2, type="B", x=1)
+
+    data = from_hetero_networkx(G, node_type_attribute="type",
+                                edge_type_attribute=None,
+                                graph_attrs=['x', 'y'], nodes=[0, "node_1"])
+
+    assert len(data['A'].type) == 1
+    assert len(data['B'].type) == 1
+    assert len(data['B'].y) == 1

--- a/test/utils/test_convert.py
+++ b/test/utils/test_convert.py
@@ -938,7 +938,7 @@ def test_from_hetero_networkx_graph_attrs_selection():
 
 
 @withPackage('networkx')
-def test_from_hetero_networkx_graph_attrs_selection():
+def test_from_hetero_networkx_graph_node_selection():
     import networkx as nx
 
     G = nx.DiGraph()
@@ -953,3 +953,40 @@ def test_from_hetero_networkx_graph_attrs_selection():
     assert len(data['A'].type) == 1
     assert len(data['B'].type) == 1
     assert len(data['B'].y) == 1
+
+
+@withPackage('networkx')
+def test_from_hetero_networkx_attrs_selection():
+    import networkx as nx
+
+    G = nx.DiGraph()
+    G.add_node(0, type="A", u=0, v=0, a=0)
+    G.add_node(1, type="A", u=1, v=1, a=1)
+    G.add_node(2, type="B", u=2, v=2, b=2)
+    G.add_node(3, type="B", u=3, v=3, b=3)
+
+    G.add_edge(0, 1, u=1, a=1)
+    G.add_edge(2, 3, u=2, b=2)
+
+    data = from_hetero_networkx(G, node_type_attribute="type",
+                                group_node_attrs=["u",
+                                                  "v"], group_edge_attrs=["u"])
+
+    assert data['A']['x'].tolist() == [[0, 0], [1, 1]]
+    assert data['B']['x'].tolist() == [[2, 2], [3, 3]]
+    assert data[("A", "to", "A")]['edge_attr'].tolist() == [[1]]
+    assert data[("B", "to", "B")]['edge_attr'].tolist() == [[2]]
+
+
+@withPackage('networkx')
+def test_from_hetero_networkx_missing_attrs():
+    import networkx as nx
+
+    G = nx.DiGraph()
+    G.add_node(0, type="A", u=0, v=0)
+    G.add_node(1, type="B", u=1)
+
+    with pytest.raises(KeyError,
+                       match=r'Missing required attribute in group: .*') as _:
+        from_hetero_networkx(G, node_type_attribute="type",
+                             group_node_attrs=["u", "v"])

--- a/test/utils/test_convert.py
+++ b/test/utils/test_convert.py
@@ -849,3 +849,36 @@ def test_from_hetero_networkx_raise_different_node_attribute():
     with pytest.raises(ValueError) as _:
         from_hetero_networkx(G, node_type_attribute="type",
                              edge_type_attribute=None)
+
+
+@withPackage('networkx')
+def test_from_hetero_networkx_works_with_named_edge_types():
+    import networkx as nx
+
+    G = nx.DiGraph()
+    G.add_node(0, type="A", x=1)
+    G.add_node(1, type="A", x=1)
+    G.add_node(2, type="B", y=1)
+    G.add_edge(0, 1, type=('A', 'towards', 'A'), x=1)
+    G.add_edge(0, 2, type=('A', 'towards', 'B'))
+
+    data = from_hetero_networkx(G, node_type_attribute="type",
+                                edge_type_attribute="type")
+
+    assert data[('A', 'towards', 'A')].edge_index.tolist() == [[0], [1]]
+    assert data[('A', 'towards', 'B')].edge_index.tolist() == [[0], [0]]
+
+
+@withPackage('networkx')
+def test_from_hetero_networkx_works_with_non_string_types():
+    import networkx as nx
+
+    G = nx.Graph()
+    G.add_node(0, type=1, x=1)
+    G.add_node(1, type=False, x=1)
+
+    data = from_hetero_networkx(G, node_type_attribute="type",
+                                edge_type_attribute=None)
+
+    assert data[str(1)].x.tolist() == [1]
+    assert data[str(False)].x.tolist() == [1]

--- a/torch_geometric/utils/__init__.py
+++ b/torch_geometric/utils/__init__.py
@@ -46,6 +46,7 @@ from .convert import to_trimesh, from_trimesh
 from .convert import to_cugraph, from_cugraph
 from .convert import to_dgl, from_dgl
 from .smiles import from_rdmol, to_rdmol, from_smiles, to_smiles
+from .convert import from_hetero_networkx
 from .random import (erdos_renyi_graph, stochastic_blockmodel_graph,
                      barabasi_albert_graph)
 from ._negative_sampling import (negative_sampling, batched_negative_sampling,
@@ -148,6 +149,7 @@ __all__ = [
     'trim_to_layer',
     'get_ppr',
     'train_test_split_edges',
+    'from_hetero_networkx',
 ]
 
 # `structured_negative_sampling_feasible` is a long name and thus destroys the

--- a/torch_geometric/utils/convert.py
+++ b/torch_geometric/utils/convert.py
@@ -791,13 +791,20 @@ def from_hetero_networkx(
                         node_to_group[node_b])].append(i)
 
     for group, group_nodes in group_to_nodes.items():
-        hetero_data_dict[str(group)] = get_node_attributes(
-            G, nodes=group_nodes)
+        hetero_data_dict[str(group)] = {
+            k: v
+            for k, v in get_node_attributes(G, nodes=group_nodes).items()
+            if k != node_type_attribute
+        }
 
     for group, group_edges in group_to_edges.items():
         group_name = '__'.join(group)
-        hetero_data_dict[group_name] = get_edge_attributes(
-            G, edge_indexes=group_edges)
+        hetero_data_dict[group_name] = {
+            k: v
+            for k, v in get_edge_attributes(G,
+                                            edge_indexes=group_edges).items()
+            if k != edge_type_attribute
+        }
         edge_list = list(G.edges(data=False))
         global_edge_index = [edge_list[edge] for edge in group_edges]
         group_edge_index = [(node_to_group_id[node_a],

--- a/torch_geometric/utils/convert.py
+++ b/torch_geometric/utils/convert.py
@@ -640,10 +640,10 @@ def from_dgl(
 
 
 def from_hetero_networkx(
-    G: Any, node_type_attribute: str,
-    edge_type_attribute: Optional[str] = None,
-    graph_attrs: Optional[Iterable[str]] = None
-) -> 'torch_geometric.data.HeteroData':
+        G: Any, node_type_attribute: str,
+        edge_type_attribute: Optional[str] = None,
+        graph_attrs: Optional[Iterable[str]] = None,
+        nodes: Optional[List] = None) -> 'torch_geometric.data.HeteroData':
     r"""Converts a :obj:`networkx.Graph` or :obj:`networkx.DiGraph` to a
     :class:`torch_geometric.data.HeteroData` instance.
 
@@ -660,6 +660,9 @@ def from_hetero_networkx(
             must be set for every edge in the graph. (default: :obj:`None`)
         graph_attrs (iterable of str, optional): The graph attributes to be
             copied. (default: :obj:`None`)
+        nodes (list, optional): The list of nodes whose attributes are to
+            be collected. If set to :obj:`None`, all nodes of the graph
+            will be included. (default: :obj:`None`)
 
     Example:
 
@@ -740,6 +743,9 @@ def from_hetero_networkx(
         return data
 
     G = G.to_directed() if not nx.is_directed(G) else G
+
+    if nodes is not None:
+        G = nx.subgraph(G, nodes)
 
     hetero_data_dict = {}
 

--- a/torch_geometric/utils/convert.py
+++ b/torch_geometric/utils/convert.py
@@ -643,8 +643,8 @@ def from_hetero_networkx(
     G: Any, node_type_attribute: str,
     edge_type_attribute: Optional[str] = None,
     graph_attrs: Optional[Iterable[str]] = None, nodes: Optional[List] = None,
-    group_node_attrs: Optional[Union[List[str], all]] = None,
-    group_edge_attrs: Optional[Union[List[str], all]] = None
+    group_node_attrs: Optional[Union[List[str], Literal['all']]] = None,
+    group_edge_attrs: Optional[Union[List[str], Literal['all']]] = None
 ) -> 'torch_geometric.data.HeteroData':
     r"""Converts a :obj:`networkx.Graph` or :obj:`networkx.DiGraph` to a
     :class:`torch_geometric.data.HeteroData` instance.
@@ -665,10 +665,10 @@ def from_hetero_networkx(
         nodes (list, optional): The list of nodes whose attributes are to
             be collected. If set to :obj:`None`, all nodes of the graph
             will be included. (default: :obj:`None`)
-        group_node_attrs (List[str] or all, optional): The node attributes to
+        group_node_attrs (List[str] or "all", optional): The node attributes to
             be concatenated and added to :obj:`data.x`. They must be present
             for all nodes of each type. (default: :obj:`None`)
-        group_edge_attrs (List[str] or all, optional): The edge attributes to
+        group_edge_attrs (List[str] or "all", optional): The edge attributes to
             be concatenated and added to :obj:`data.edge_attr`. They must be
             present for all edge of each type. (default: :obj:`None`)
 
@@ -683,8 +683,8 @@ def from_hetero_networkx(
 
     from torch_geometric.data import HeteroData
 
-    def get_edge_attributes(G, edge_indexes: list,
-                            edge_attrs: list = None) -> dict:
+    def get_edge_attributes(G: Any, edge_indexes: list,
+                            edge_attrs: Optional[Iterable] = None) -> dict:
         r"""Collects the attributes of a list of graph edges in a dictionary.
 
         Args:
@@ -692,7 +692,7 @@ def from_hetero_networkx(
             edge_indexes (list, optional): The list of edge indexes whose
                 attributes are to be collected. If set to :obj:`None`, all
                 edges of the graph will be included. (default: :obj:`None`)
-            edge_attrs (list, optional): The list of expected attributes to
+            edge_attrs (iterable, optional): The list of expected attributes to
                 be found in every edge. If set to :obj:`None`, the first
                 edge encountered will set the values for the rest of the
                 process. (default: :obj:`None`)
@@ -715,8 +715,9 @@ def from_hetero_networkx(
 
         return data
 
-    def get_node_attributes(G, nodes: list,
-                            expected_node_attrs: list = None) -> dict:
+    def get_node_attributes(
+            G: Any, nodes: list,
+            expected_node_attrs: Optional[Iterable] = None) -> dict:
         r"""Collects the attributes of a list of graph nodes in a dictionary.
 
         Args:
@@ -724,7 +725,7 @@ def from_hetero_networkx(
             nodes (list, optional): The list of nodes whose attributes are to
                 be collected. If set to :obj:`None`, all nodes of the graph
                 will be included. (default: :obj:`None`)
-            expected_node_attrs (list, optional): The list of expected
+            expected_node_attrs (iterable, optional): The list of expected
                 attributes to be found in every node. If set to :obj:`None`,
                 the first node encountered will set the values for the rest
                 of the process. (default: :obj:`None`)
@@ -781,8 +782,7 @@ def from_hetero_networkx(
                     node_b] != node_type_b:
                 raise ValueError(f'Edge {node_a}-{node_b} of type\
                          {edge_data[edge_type_attribute]} joins nodes of types\
-                         {node_to_group[node_a]} and { node_to_group[node_b]}.'
-                                 )
+                         {node_to_group[node_a]} and {node_to_group[node_b]}.')
         else:
             edge_type = "to"
         group_to_edges[(node_to_group[node_a], edge_type,
@@ -795,8 +795,8 @@ def from_hetero_networkx(
             if k != node_type_attribute
         }
 
-    for group, group_edges in group_to_edges.items():
-        group_name = '__'.join(group)
+    for edge_group, group_edges in group_to_edges.items():
+        group_name = '__'.join(edge_group)
         hetero_data_dict[group_name] = {
             k: v
             for k, v in get_edge_attributes(G,

--- a/torch_geometric/utils/convert.py
+++ b/torch_geometric/utils/convert.py
@@ -673,7 +673,6 @@ def from_hetero_networkx(
             present for all edge of each type. (default: :obj:`None`)
 
     Example:
-
         >>> data = from_hetero_networkx(G, node_type_attribute="type",
         ...                    edge_type_attribute="type")
         <torch_geometric.data.HeteroData()>
@@ -734,7 +733,6 @@ def from_hetero_networkx(
             ValueError: If some of the nodes do not share the same
             list of attributes as the rest, an error will be raised.
         """
-
         data = defaultdict(list)
 
         node_to_data = G.nodes(data=True)


### PR DESCRIPTION
In order to answer the following issue: https://github.com/pyg-team/pytorch_geometric/issues/7340 this change proposes the implementation of a `from_hetero_networkx` method in the `convert` module.

Most of the unit tests have been copied from the `from_networkx` version and adapted. 

Some implementation questions can be discussed such as:
- Should the `edge_type_attribute` parameter accept being set to None? (currently, it does, and in that case, it defines the  edge type as 'to')
- Should  `edge_type_attribute` values be tuples `(node_a_type, type, node_b_type)`? Should it also/only accept a single value `type` and infer `node_a_type` and `node_b_type`? 
- When specified for a non-directed graph, what should happen with non-symmetrical `edge_type_attribute` which is bound to be incorrect in at least one of the directions (e.g. if an edge defines its type as `('A', 'to', 'B')` and the graph is not directed, the B -> A edge will have an incorrect label). Currently, it raises an error by checking node type coherency with edge type labels.

