### PR TITLE
Make `EdgePooling` parallel

### DIFF
--- a/examples/proteins_edge_pool.py
+++ b/examples/proteins_edge_pool.py
@@ -1,0 +1,108 @@
+import os.path as osp
+
+import torch
+import torch.nn.functional as F
+
+from torch_geometric.datasets import TUDataset
+from torch_geometric.loader import DataLoader
+from torch_geometric.nn import EdgePooling, GraphConv
+from torch_geometric.nn import global_max_pool as gmp
+from torch_geometric.nn import global_mean_pool as gap
+
+path = osp.join(osp.dirname(osp.realpath(__file__)), '..', 'data', 'PROTEINS')
+dataset = TUDataset(path, name='PROTEINS')
+dataset = dataset.shuffle()
+n = len(dataset) // 10
+test_dataset = dataset[:2 * n]
+valid_dataset = dataset[2 * n:3 * n]
+train_dataset = dataset[3 * n:]
+test_loader = DataLoader(test_dataset, batch_size=60)
+valid_loader = DataLoader(valid_dataset, batch_size=60)
+train_loader = DataLoader(train_dataset, batch_size=60)
+
+
+class Net(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+        self.conv1 = GraphConv(dataset.num_features, 128)
+        self.pool1 = EdgePooling(128)
+        self.conv2 = GraphConv(128, 128)
+        self.pool2 = EdgePooling(128)
+        self.conv3 = GraphConv(128, 128)
+        self.pool3 = EdgePooling(128)
+
+        self.lin1 = torch.nn.Linear(256, 128)
+        self.lin2 = torch.nn.Linear(128, 64)
+        self.lin3 = torch.nn.Linear(64, dataset.num_classes)
+
+    def forward(self, data):
+        x, edge_index, batch = data.x, data.edge_index, data.batch
+
+        x = F.relu(self.conv1(x, edge_index))
+        x, edge_index, batch, _ = self.pool1(x, edge_index, batch)
+        x1 = torch.cat([gmp(x, batch), gap(x, batch)], dim=1)
+
+        x = F.relu(self.conv2(x, edge_index))
+        x, edge_index, batch, _ = self.pool2(x, edge_index, batch)
+        x2 = torch.cat([gmp(x, batch), gap(x, batch)], dim=1)
+
+        x = F.relu(self.conv3(x, edge_index))
+        x, edge_index, batch, _ = self.pool3(x, edge_index, batch)
+        x3 = torch.cat([gmp(x, batch), gap(x, batch)], dim=1)
+
+        x = x1 + x2 + x3
+
+        x = F.relu(self.lin1(x))
+        x = F.dropout(x, p=0.5, training=self.training)
+        x = F.relu(self.lin2(x))
+        x = F.log_softmax(self.lin3(x), dim=-1)
+
+        return x
+
+
+device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
+model = Net().to(device)
+optimizer = torch.optim.Adam(model.parameters(), lr=0.0005)
+
+
+def train():
+    model.train()
+
+    loss_all = 0
+    for data in train_loader:
+        data = data.to(device)
+        optimizer.zero_grad()
+        output = model(data)
+        loss = F.nll_loss(output, data.y)
+        loss.backward()
+        loss_all += data.num_graphs * loss.item()
+        optimizer.step()
+    return loss_all / len(train_dataset)
+
+
+def test(loader):
+    model.eval()
+
+    correct = 0
+    for data in loader:
+        data = data.to(device)
+        pred = model(data).max(dim=1)[1]
+        correct += pred.eq(data.y).sum().item()
+    return correct / len(loader.dataset)
+
+
+best_valid_acc = test_acc = 0.
+for epoch in range(1, 101):
+    loss = train()
+    train_acc = test(train_loader)
+    valid_acc = test(valid_loader)
+
+    if valid_acc > best_valid_acc:
+        best_valid_acc = valid_acc
+        test_acc = test(test_loader)
+
+    print(f'Epoch: {epoch:03d}, Loss: {loss:.5f}, Train Acc: {train_acc:.5f}, '
+          f'Valid Acc: {valid_acc:.5f}')
+
+print(f'\nTest Acc: {test_acc:.5f}\n')

--- a/test/utils/test_matching.py
+++ b/test/utils/test_matching.py
@@ -1,0 +1,64 @@
+import torch
+
+from torch_geometric.testing import is_full_test
+from torch_geometric.utils import maximal_matching
+
+
+def test_maximal_matching_undirected():
+    n, m = 5, 12
+    index = torch.tensor([[0, 0, 1, 1, 1, 2, 2, 3, 3, 4, 4, 4],
+                          [1, 4, 0, 2, 4, 1, 3, 2, 4, 0, 1, 3]]).long()
+
+    perm1 = torch.arange(m)
+    obs1 = maximal_matching(edge_index=index, num_nodes=n, perm=perm1)
+    exp1 = torch.tensor([1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0]).bool()
+
+    assert torch.equal(obs1, exp1)
+
+    perm2 = perm1.roll(-1, 0)
+    obs2 = maximal_matching(edge_index=index, num_nodes=n, perm=perm2)
+    exp2 = torch.tensor([0, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0]).bool()
+
+    assert torch.equal(obs2, exp2)
+
+    perm3 = torch.arange(m).flip(-1)
+    obs3 = maximal_matching(edge_index=index, num_nodes=n, perm=perm3)
+    exp3 = torch.tensor([0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 1]).bool()
+
+    assert torch.equal(obs3, exp3)
+
+    if is_full_test():
+        jit = torch.jit.script(maximal_matching)
+        assert exp1.equal(jit(index, perm=perm1))
+        assert exp2.equal(jit(index, perm=perm2))
+        assert exp3.equal(jit(index, perm=perm3))
+
+
+def test_maximal_matching_directed():
+    n, m = 5, 9
+    index = torch.tensor([[0, 0, 1, 2, 2, 3, 4, 4, 4],
+                          [1, 4, 4, 1, 3, 2, 0, 2, 3]]).long()
+
+    perm1 = torch.arange(m)
+    obs1 = maximal_matching(edge_index=index, num_nodes=n, perm=perm1)
+    exp1 = torch.tensor([1, 0, 0, 0, 1, 0, 0, 0, 0]).bool()
+
+    assert torch.equal(obs1, exp1)
+
+    perm2 = perm1.roll(-1, 0)
+    obs2 = maximal_matching(edge_index=index, num_nodes=n, perm=perm2)
+    exp2 = torch.tensor([0, 1, 0, 1, 0, 0, 0, 0, 0]).bool()
+
+    assert torch.equal(obs2, exp2)
+
+    perm3 = torch.arange(m).flip(-1)
+    obs3 = maximal_matching(edge_index=index, num_nodes=n, perm=perm3)
+    exp3 = torch.tensor([0, 0, 0, 1, 0, 0, 0, 0, 1]).bool()
+
+    assert torch.equal(obs3, exp3)
+
+    if is_full_test():
+        jit = torch.jit.script(maximal_matching)
+        assert exp1.equal(jit(index, perm=perm1))
+        assert exp2.equal(jit(index, perm=perm2))
+        assert exp3.equal(jit(index, perm=perm3))

--- a/torch_geometric/nn/pool/__init__.py
+++ b/torch_geometric/nn/pool/__init__.py
@@ -7,7 +7,7 @@ from torch_geometric.typing import OptTensor
 
 from .asap import ASAPooling
 from .avg_pool import avg_pool, avg_pool_neighbor_x, avg_pool_x
-from .edge_pool import EdgePooling
+from .edge_pool import EdgePooling, maximal_matching_cluster
 from .glob import global_add_pool, global_max_pool, global_mean_pool
 from .graclus import graclus
 from .max_pool import max_pool, max_pool_neighbor_x, max_pool_x
@@ -336,6 +336,7 @@ __all__ = [
     'avg_pool_x',
     'avg_pool_neighbor_x',
     'graclus',
+    'maximal_matching_cluster',
     'voxel_grid',
     'fps',
     'knn',

--- a/torch_geometric/utils/__init__.py
+++ b/torch_geometric/utils/__init__.py
@@ -19,6 +19,7 @@ from .homophily import homophily
 from .assortativity import assortativity
 from .get_laplacian import get_laplacian
 from .get_mesh_laplacian import get_mesh_laplacian
+from .matching import maximal_matching
 from .mask import mask_select, index_to_mask, mask_to_index
 from .select import select, narrow
 from .to_dense_batch import to_dense_batch
@@ -85,6 +86,7 @@ __all__ = [
     'mask_select',
     'index_to_mask',
     'mask_to_index',
+    'maximal_matching',
     'select',
     'narrow',
     'to_dense_batch',

--- a/torch_geometric/utils/matching.py
+++ b/torch_geometric/utils/matching.py
@@ -1,0 +1,71 @@
+from typing import Optional
+
+import torch
+
+from torch_geometric.typing import Adj, OptTensor, SparseTensor, Tensor
+from torch_geometric.utils import scatter
+
+
+def maximal_matching(edge_index: Adj, num_nodes: Optional[int] = None,
+                     perm: OptTensor = None) -> Tensor:
+    r"""Returns a Maximal Matching of a graph, i.e., a set of edges (as a
+    :class:`ByteTensor`) such that none of them are incident to a common
+    vertex, and any edge in the graph is incident to an edge in the returned
+    set.
+
+    The algorithm greedily selects the edges in their canonical order. If a
+    permutation :obj:`perm` is provided, the edges are extracted following
+    that permutation instead.
+
+    This method implements `Blelloch's Alogirithm
+    <https://arxiv.org/abs/1202.3205>`_.
+
+    Args:
+        edge_index (Tensor or SparseTensor): The graph connectivity.
+        num_nodes (int, optional): The number of nodes in the graph.
+        perm (LongTensor, optional): Permutation vector. Must be of size
+            :obj:`(m,)` (defaults to :obj:`None`).
+
+    :rtype: :class:`ByteTensor`
+    """
+    if isinstance(edge_index, SparseTensor):
+        row, col, _ = edge_index.coo()
+        device = edge_index.device()
+        n, m = edge_index.size(0), edge_index.nnz()
+    else:
+        row, col = edge_index[0], edge_index[1]
+        device = row.device
+        n, m = num_nodes, row.size(0)
+
+        if n is None:
+            n = edge_index.max().item() + 1
+
+    if perm is None:
+        rank = torch.arange(m, dtype=torch.long, device=device)
+    else:
+        rank = torch.zeros_like(perm)
+        rank[perm] = torch.arange(m, dtype=torch.long, device=device)
+
+    match = torch.zeros(m, dtype=torch.bool, device=device)
+    mask = torch.ones(m, dtype=torch.bool, device=device)
+
+    # TODO: Use scatter's `out` and `include_self` arguments,
+    #       when available, instead of adding self-loops
+    max_rank = torch.full((n, ), fill_value=n * n, dtype=torch.long,
+                          device=device)
+    max_idx = torch.arange(n, dtype=torch.long, device=device)
+
+    while mask.any():
+        src = torch.cat([rank[mask], rank[mask], max_rank])
+        idx = torch.cat([row[mask], col[mask], max_idx])
+        node_rank = scatter(src, idx, reduce='min')
+        edge_rank = torch.minimum(node_rank[row], node_rank[col])
+
+        match = match | torch.eq(rank, edge_rank)
+
+        unmatched = torch.ones(n, dtype=torch.bool, device=device)
+        idx = torch.cat([row[match], col[match]], dim=0)
+        unmatched[idx] = False
+        mask = mask & unmatched[row] & unmatched[col]
+
+    return match


### PR DESCRIPTION
Hi,

with this PR, `EdgePooling` should be faster and executable on GPU. The gist of it is that, instead of selecting and contracting the edge sequentially, we can first select a maximal set of pairwise disjoint edges (i.e., a maximal matching), and then contract it. The greedy algorithm that iteratively selects and discard edges following a predefined ordering (or *edge score*, as in EdgePool) is called "lexicographically first" maximal matching, and can be computed in parallel via Blelloch's algorithm [1], which I implemented in `utils/matching.py`. 

In `nn/pool/edge_pool.py` I added the method `maximal_matching_cluster` that takes a matching (as edge mask) and converts it as a "clustering" vector. Notice that this is basically the same thing that "Graclus" does, with the only differences being that *(i)* this algorithm works also with directed graphs, and *(ii)* this algorithm is deterministic. On the other hand, Graclus is much faster than my (JIT-ed) implementation. Here I made a comparison between the two:
```python
import torch
from torch_geometric.datasets import CoraFull
from torch_geometric.nn.pool import graclus, maximal_matching_cluster


@torch.jit.script
def graclus2(edge_index: torch.Tensor, num_nodes: int) -> torch.Tensor:
    perm = torch.randperm(edge_index.size(1), dtype=torch.long,
                          device=edge_index.device)
    return maximal_matching_cluster(edge_index, num_nodes, perm)[1]


data = CoraFull('./data/')[0].cuda()
num_nodes, edge_index = data.num_nodes, data.edge_index
```
```python
%timeit graclus(edge_index=edge_index, num_nodes=num_nodes)

1.78 ms ± 14.5 µs per loop (mean ± std. dev. of 7 runs, 1,000 loops each)
```
```python
%timeit graclus2(edge_index=edge_index, num_nodes=num_nodes)

4.08 ms ± 69.7 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)
```

Lastly, I had to change two test cases of the old `test_edge_pool.py` since my new implementation returned a isomorphic, but different graph (i.e., the output vertices were permuted). I also added an example if `EdgePooling` on Proteins.

Let me know if I can be of help!

Bests,
Francesco


[1] G. E. Blelloch, J. T. Fineman, and J. Shun, *“Greedy sequential maximal independent set and matching are parallel on average,”* in Proceedings of the twenty-fourth annual ACM symposium on Parallelism in algorithms and architectures, in SPAA ’12. New York, NY, USA: Association for Computing Machinery, Jun. 2012, pp. 308–317. doi: [10.1145/2312005.2312058](https://doi.org/10.1145/2312005.2312058).