### PR TITLE
Update antisymmetric_conv.py

### DIFF
--- a/torch_geometric/nn/conv/antisymmetric_conv.py
+++ b/torch_geometric/nn/conv/antisymmetric_conv.py
@@ -87,10 +87,9 @@ class AntiSymmetricConv(torch.nn.Module):
     def reset_parameters(self):
         torch.nn.init.kaiming_uniform_(self.W, a=math.sqrt(5))
         self.phi.reset_parameters()
-        
+
         if self.bias is not None:
             zeros(self.bias)
-
 
     def forward(self, x: Tensor, edge_index: Adj, *args, **kwargs) -> Tensor:
         r"""Runs the forward pass of the module."""

--- a/torch_geometric/nn/conv/antisymmetric_conv.py
+++ b/torch_geometric/nn/conv/antisymmetric_conv.py
@@ -85,10 +85,12 @@ class AntiSymmetricConv(torch.nn.Module):
         self.reset_parameters()
 
     def reset_parameters(self):
-        r"""Resets all learnable parameters of the module."""
         torch.nn.init.kaiming_uniform_(self.W, a=math.sqrt(5))
         self.phi.reset_parameters()
-        zeros(self.bias)
+        
+        if self.bias is not None:
+            zeros(self.bias)
+
 
     def forward(self, x: Tensor, edge_index: Adj, *args, **kwargs) -> Tensor:
         r"""Runs the forward pass of the module."""


### PR DESCRIPTION
the bias parameter is optional, so it might not be initialized. I couldn't find where we check if the bias parameter is `None` or not. I guess calling `zeros` on `None` might raise an error in some cases.