### PR TITLE
Update imbalanced_sampler.py

### DIFF
--- a/torch_geometric/loader/imbalanced_sampler.py
+++ b/torch_geometric/loader/imbalanced_sampler.py
@@ -68,13 +68,11 @@ class ImbalancedSampler(torch.utils.data.WeightedRandomSampler):
         num_samples: Optional[int] = None,
     ):
         # Compute class weights once and cache them for reuse
-        self.class_weights = self.compute_class_weights(dataset, input_nodes)
+        class_weights = self.compute_class_weights(dataset, input_nodes)
 
-        return super().__init__(self.class_weights, num_samples,
-                                replacement=True)
+        super().__init__(class_weights, num_samples, replacement=True)
 
-    def compute_class_weights(self, dataset: Union[Dataset, Data, List[Data],
-                                                   Tensor],
+    def compute_class_weights(self, dataset: Union[Dataset, Data, List[Data], Tensor],
                               input_nodes: Optional[Tensor] = None) -> Tensor:
         if isinstance(dataset, Data):
             y = dataset.y.view(-1)

--- a/torch_geometric/loader/imbalanced_sampler.py
+++ b/torch_geometric/loader/imbalanced_sampler.py
@@ -72,7 +72,8 @@ class ImbalancedSampler(torch.utils.data.WeightedRandomSampler):
 
         super().__init__(class_weights, num_samples, replacement=True)
 
-    def compute_class_weights(self, dataset: Union[Dataset, Data, List[Data], Tensor],
+    def compute_class_weights(self, dataset: Union[Dataset, Data, List[Data],
+                                                   Tensor],
                               input_nodes: Optional[Tensor] = None) -> Tensor:
         if isinstance(dataset, Data):
             y = dataset.y.view(-1)

--- a/torch_geometric/loader/imbalanced_sampler.py
+++ b/torch_geometric/loader/imbalanced_sampler.py
@@ -70,11 +70,12 @@ class ImbalancedSampler(torch.utils.data.WeightedRandomSampler):
         # Compute class weights once and cache them for reuse
         self.class_weights = self.compute_class_weights(dataset, input_nodes)
 
-        return super().__init__(self.class_weights, num_samples, replacement=True)
+        return super().__init__(self.class_weights, num_samples,
+                                replacement=True)
 
-    def compute_class_weights(
-        self, dataset: Union[Dataset, Data, List[Data], Tensor], input_nodes: Optional[Tensor] = None
-    ) -> Tensor:
+    def compute_class_weights(self, dataset: Union[Dataset, Data, List[Data],
+                                                   Tensor],
+                              input_nodes: Optional[Tensor] = None) -> Tensor:
         if isinstance(dataset, Data):
             y = dataset.y.view(-1)
             assert dataset.num_nodes == y.numel()


### PR DESCRIPTION
Can we compute the class weights once in the compute_class_weights method and take the dataset and input nodes as arguments? The computed class weights are then stored in the class_weights attribute of the ImbalancedSampler instance. When creating an instance of ImbalancedSampler, the cached class weights are used to initialize the WeightedRandomSampler superclass, eliminating the need to compute the class weights every time.