### PR TITLE
Let `coalesce()` and `sort_edge_index()` accept `edge_index` as a tuple of tensors

### DIFF
--- a/test/utils/test_coalesce.py
+++ b/test/utils/test_coalesce.py
@@ -26,7 +26,7 @@ def test_coalesce():
     assert out[1][0].tolist() == [[4], [3], [2], [6]]
     assert out[1][1].tolist() == [4, 3, 2, 6]
 
-    out = coalesce((edge_index[0,:], edge_index[1,:]))
+    out = coalesce((edge_index[0, :], edge_index[1, :]))
     assert out.tolist() == [[0, 1, 1, 2], [1, 0, 2, 1]]
 
 

--- a/test/utils/test_coalesce.py
+++ b/test/utils/test_coalesce.py
@@ -26,6 +26,9 @@ def test_coalesce():
     assert out[1][0].tolist() == [[4], [3], [2], [6]]
     assert out[1][1].tolist() == [4, 3, 2, 6]
 
+    out = coalesce((edge_index[0,:], edge_index[1,:]))
+    assert out.tolist() == [[0, 1, 1, 2], [1, 0, 2, 1]]
+
 
 def test_coalesce_without_duplicates():
     edge_index = torch.tensor([[2, 1, 1, 0], [1, 2, 0, 1]])

--- a/test/utils/test_coalesce.py
+++ b/test/utils/test_coalesce.py
@@ -26,8 +26,10 @@ def test_coalesce():
     assert out[1][0].tolist() == [[4], [3], [2], [6]]
     assert out[1][1].tolist() == [4, 3, 2, 6]
 
-    out = coalesce((edge_index[0, :], edge_index[1, :]))
-    assert out.tolist() == [[0, 1, 1, 2], [1, 0, 2, 1]]
+    out = coalesce((edge_index[0], edge_index[1]))
+    assert isinstance(out, tuple)
+    assert out[0].tolist() == [0, 1, 1, 2]
+    assert out[1].tolist() == [1, 0, 2, 1]
 
 
 def test_coalesce_without_duplicates():

--- a/test/utils/test_sort_edge_index.py
+++ b/test/utils/test_sort_edge_index.py
@@ -13,6 +13,11 @@ def test_sort_edge_index():
     out = sort_edge_index(edge_index)
     assert out.tolist() == [[0, 1, 1, 2], [1, 0, 2, 1]]
 
+    out = sort_edge_index((edge_index[0], edge_index[1]))
+    assert isinstance(out, tuple)
+    assert out[0].tolist() == [0, 1, 1, 2]
+    assert out[1].tolist() == [1, 0, 2, 1]
+
     out = sort_edge_index(edge_index, None)
     assert out[0].tolist() == [[0, 1, 1, 2], [1, 0, 2, 1]]
     assert out[1] is None

--- a/torch_geometric/utils/coalesce.py
+++ b/torch_geometric/utils/coalesce.py
@@ -29,7 +29,7 @@ def coalesce(edge_index, edge_attr, num_nodes, reduce, is_sorted, sort_by_row):
 
 
 def coalesce(
-    edge_index: Union[Tensor, Tuple[Tensor, Tensor]],
+    edge_index: Tensor,
     edge_attr: Union[OptTensor, List[Tensor], str] = MISSING,
     num_nodes: Optional[int] = None,
     reduce: str = 'add',
@@ -41,9 +41,9 @@ def coalesce(
     together according to the given :obj:`reduce` option.
 
     Args:
-        edge_index (LongTensor or Tuple[LongTensor, LongTensor]): The edge indices.
-        edge_attr (Tensor or List[Tensor], optional): Edge weights or multi-
-            dimensional edge features.
+        edge_index (torch.Tensor): The edge indices.
+        edge_attr (torch.Tensor or List[torch.Tensor], optional): Edge weights
+            or multi-dimensional edge features.
             If given as a list, will re-shuffle and remove duplicates for all
             its entries. (default: :obj:`None`)
         num_nodes (int, optional): The number of nodes, *i.e.*
@@ -90,21 +90,22 @@ def coalesce(
                 [3, 1, 2]]),
         tensor([1., 1., 1.]))
     """
-    if isinstance(edge_index, (tuple, list)):
-        assert len(edge_index) == 2
-        edge_index = torch.stack(edge_index, dim=0)
-
-    nnz = edge_index.size(1)
+    num_edges = edge_index[0].size(0)
     num_nodes = maybe_num_nodes(edge_index, num_nodes)
 
-    idx = edge_index.new_empty(nnz + 1)
+    idx = edge_index[0].new_empty(num_edges + 1)
     idx[0] = -1
     idx[1:] = edge_index[1 - int(sort_by_row)]
     idx[1:].mul_(num_nodes).add_(edge_index[int(sort_by_row)])
 
     if not is_sorted:
         idx[1:], perm = index_sort(idx[1:], max_value=num_nodes * num_nodes)
-        edge_index = edge_index[:, perm]
+        if isinstance(edge_index, Tensor):
+            edge_index = edge_index[:, perm]
+        elif isinstance(edge_index, tuple):
+            edge_index = (edge_index[0][perm], edge_index[1][perm])
+        else:
+            raise NotImplementedError
         if isinstance(edge_attr, Tensor):
             edge_attr = edge_attr[perm]
         elif isinstance(edge_attr, (list, tuple)):
@@ -118,12 +119,17 @@ def coalesce(
             return edge_index, edge_attr
         return edge_index
 
-    edge_index = edge_index[:, mask]
+    if isinstance(edge_index, Tensor):
+        edge_index = edge_index[:, mask]
+    elif isinstance(edge_index, tuple):
+        edge_index = (edge_index[0][mask], edge_index[1][mask])
+    else:
+        raise NotImplementedError
 
     dim_size: Optional[int] = None
     if isinstance(edge_attr, (Tensor, list, tuple)) and len(edge_attr) > 0:
         dim_size = edge_index.size(1)
-        idx = torch.arange(0, nnz, device=edge_index.device)
+        idx = torch.arange(0, num_edges, device=edge_index.device)
         idx.sub_(mask.logical_not_().cumsum(dim=0))
 
     if edge_attr is None:

--- a/torch_geometric/utils/coalesce.py
+++ b/torch_geometric/utils/coalesce.py
@@ -29,7 +29,7 @@ def coalesce(edge_index, edge_attr, num_nodes, reduce, is_sorted, sort_by_row):
 
 
 def coalesce(
-    edge_index: Tensor,
+    edge_index: Union[Tensor, Tuple[Tensor, Tensor]],
     edge_attr: Union[OptTensor, List[Tensor], str] = MISSING,
     num_nodes: Optional[int] = None,
     reduce: str = 'add',
@@ -41,7 +41,7 @@ def coalesce(
     together according to the given :obj:`reduce` option.
 
     Args:
-        edge_index (LongTensor): The edge indices.
+        edge_index (LongTensor or Tuple[LongTensor, LongTensor]): The edge indices.
         edge_attr (Tensor or List[Tensor], optional): Edge weights or multi-
             dimensional edge features.
             If given as a list, will re-shuffle and remove duplicates for all
@@ -90,6 +90,10 @@ def coalesce(
                 [3, 1, 2]]),
         tensor([1., 1., 1.]))
     """
+    if isinstance(edge_index, (tuple, list)):
+        assert len(edge_index) == 2
+        edge_index = torch.stack(edge_index, dim=0)
+
     nnz = edge_index.size(1)
     num_nodes = maybe_num_nodes(edge_index, num_nodes)
 

--- a/torch_geometric/utils/sort_edge_index.py
+++ b/torch_geometric/utils/sort_edge_index.py
@@ -37,9 +37,9 @@ def sort_edge_index(  # noqa
     """Row-wise sorts :obj:`edge_index`.
 
     Args:
-        edge_index (LongTensor): The edge indices.
-        edge_attr (Tensor or List[Tensor], optional): Edge weights or multi-
-            dimensional edge features.
+        edge_index (torch.Tensor): The edge indices.
+        edge_attr (torch.Tensor or List[torch.Tensor], optional): Edge weights
+            or multi-dimensional edge features.
             If given as a list, will re-shuffle and remove duplicates for all
             its entries. (default: :obj:`None`)
         num_nodes (int, optional): The number of nodes, *i.e.*
@@ -81,7 +81,12 @@ def sort_edge_index(  # noqa
 
     _, perm = index_sort(idx, max_value=num_nodes * num_nodes)
 
-    edge_index = edge_index[:, perm]
+    if isinstance(edge_index, Tensor):
+        edge_index = edge_index[:, perm]
+    elif isinstance(edge_index, tuple):
+        edge_index = (edge_index[0][perm], edge_index[1][perm])
+    else:
+        raise NotImplementedError
 
     if edge_attr is None:
         return edge_index, None


### PR DESCRIPTION
This PR allows `coalesce()` and `sort_edge_index()` to accept `edge_index` as a tensor or a tuple of tensors.