### PR TITLE
Bipartite structured negative sampling

### DIFF
--- a/test/utils/test_negative_sampling.py
+++ b/test/utils/test_negative_sampling.py
@@ -191,8 +191,7 @@ def test_bipartite_structured_negative_sampling_feasible():
                                    [1, 2, 0, 2, 0, 1, 1]])
     assert structured_negative_sampling_feasible(edge_index, num_nodes=(3, 3))
 
-    edge_index = torch.as_tensor([[0, 0, 1, 2, 3],
-                                  [0, 1, 1, 1, 0]])
+    edge_index = torch.as_tensor([[0, 0, 1, 2, 3], [0, 1, 1, 1, 0]])
     assert structured_negative_sampling_feasible(edge_index, 4, True)
     assert structured_negative_sampling_feasible(edge_index, 4, False)
     assert not structured_negative_sampling_feasible(edge_index, (4, 2))

--- a/torch_geometric/utils/negative_sampling.py
+++ b/torch_geometric/utils/negative_sampling.py
@@ -202,9 +202,10 @@ def batched_negative_sampling(
     return torch.cat(neg_edge_indices, dim=1)
 
 
-def structured_negative_sampling(edge_index: Tensor,
-                                 num_nodes: Optional[Union[int, Tuple[int, int]]] = None,
-                                 contains_neg_self_loops: bool = True) -> tuple[Tensor, Tensor, Tensor]:
+def structured_negative_sampling(
+        edge_index: Tensor, num_nodes: Optional[Union[int, Tuple[int,
+                                                                 int]]] = None,
+        contains_neg_self_loops: bool = True) -> tuple[Tensor, Tensor, Tensor]:
     r"""Samples a negative edge :obj:`(i,k)` for every positive edge
     :obj:`(i,j)` in the graph given by :attr:`edge_index`, and returns it as a
     tuple of the form :obj:`(i,j,k)`.
@@ -230,8 +231,9 @@ def structured_negative_sampling(edge_index: Tensor,
         (tensor([0, 0, 1, 2]), tensor([0, 1, 2, 3]), tensor([2, 3, 0, 2]))
 
     """
-    if not structured_negative_sampling_feasible(edge_index=edge_index, num_nodes=num_nodes,
-                                                 contains_neg_self_loops=contains_neg_self_loops):
+    if not structured_negative_sampling_feasible(
+            edge_index=edge_index, num_nodes=num_nodes,
+            contains_neg_self_loops=contains_neg_self_loops):
         raise Exception("structured_negative_sampling is not feasible")
 
     size = num_nodes

--- a/torch_geometric/utils/negative_sampling.py
+++ b/torch_geometric/utils/negative_sampling.py
@@ -204,7 +204,7 @@ def batched_negative_sampling(
 
 def structured_negative_sampling(edge_index: Tensor,
                                  num_nodes: Optional[Union[int, Tuple[int, int]]] = None,
-                                 contains_neg_self_loops: bool = True) -> tuple[Tensor, Tensor, Tensor]:
+                                 contains_neg_self_loops: bool = True) -> Tensor:
     r"""Samples a negative edge :obj:`(i,k)` for every positive edge
     :obj:`(i,j)` in the graph given by :attr:`edge_index`, and returns it as a
     tuple of the form :obj:`(i,j,k)`.

--- a/torch_geometric/utils/negative_sampling.py
+++ b/torch_geometric/utils/negative_sampling.py
@@ -202,9 +202,10 @@ def batched_negative_sampling(
     return torch.cat(neg_edge_indices, dim=1)
 
 
-def structured_negative_sampling(edge_index: Tensor,
-                                 num_nodes: Optional[Union[int, Tuple[int, int]]] = None,
-                                 contains_neg_self_loops: bool = True) -> Tensor:
+def structured_negative_sampling(
+        edge_index: Tensor, num_nodes: Optional[Union[int, Tuple[int,
+                                                                 int]]] = None,
+        contains_neg_self_loops: bool = True) -> Tensor:
     r"""Samples a negative edge :obj:`(i,k)` for every positive edge
     :obj:`(i,j)` in the graph given by :attr:`edge_index`, and returns it as a
     tuple of the form :obj:`(i,j,k)`.
@@ -230,8 +231,9 @@ def structured_negative_sampling(edge_index: Tensor,
         (tensor([0, 0, 1, 2]), tensor([0, 1, 2, 3]), tensor([2, 3, 0, 2]))
 
     """
-    if not structured_negative_sampling_feasible(edge_index=edge_index, num_nodes=num_nodes,
-                                                 contains_neg_self_loops=contains_neg_self_loops):
+    if not structured_negative_sampling_feasible(
+            edge_index=edge_index, num_nodes=num_nodes,
+            contains_neg_self_loops=contains_neg_self_loops):
         raise Exception("structured_negative_sampling is not feasible")
 
     size = num_nodes


### PR DESCRIPTION
Now `structured_negative_sampling` support bipartite graph, also relevant test methods is provided
Fix #7799 