### PR TITLE
Measure test coverage of exceptions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -161,6 +161,7 @@ omit = [
 exclude_lines = [
     "pragma: no cover",
     "pass",
+    "raise NotImplementedError",
     "register_parameter",
     "warn",
     "torch.cuda.is_available",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -161,8 +161,6 @@ omit = [
 exclude_lines = [
     "pragma: no cover",
     "pass",
-    "raise",
-    "except",
     "register_parameter",
     "warn",
     "torch.cuda.is_available",


### PR DESCRIPTION
Part of #6528.

IMO, exceptions are also part of the public API so we should measure the test coverage over them, but feel free to close this PR if you think otherwise ;)