### PR TITLE
Fix bug in `get_degree_histogram`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
+- Fixed error in `get_degree_histogram` ([#7830](https://github.com/pyg-team/pytorch_geometric/pull/7830))
 - Fixed the shape of `edge_label_time` when using temporal sampling on homogeneous graphs ([#7807](https://github.com/pyg-team/pytorch_geometric/pull/7807))
 - Made `FieldStatus` enum picklable to avoid `PicklingError` in a multi-process setting ([#7808](https://github.com/pyg-team/pytorch_geometric/pull/7808))
 - Fixed `edge_label_index` computation in `LinkNeighborLoader` for the homogeneous+`disjoint` mode ([#7791](https://github.com/pyg-team/pytorch_geometric/pull/7791))

--- a/torch_geometric/nn/conv/pna_conv.py
+++ b/torch_geometric/nn/conv/pna_conv.py
@@ -196,7 +196,8 @@ class PNAConv(MessagePassing):
     def get_degree_histogram(loader: DataLoader) -> Tensor:
         r"""Returns the degree histogram to be used as input for the :obj:`deg`
         argument in :class:`PNAConv`."""
-        deg_histogram = torch.zeros(1, dtype=torch.long)
+        device = next(iter(loader)).edge_index.device
+        deg_histogram = torch.zeros(1, dtype=torch.long, device=device)
         for data in loader:
             d = degree(data.edge_index[1], num_nodes=data.num_nodes,
                        dtype=torch.long)


### PR DESCRIPTION
This PR fixes the following error:
`RuntimeError: Expected all tensors to be on the same device, but found at least two devices, xpu:0 and cpu!`
`deg_histogram` now inherits the device type from `edge_index`.