### PR TITLE
Add partition example info for distributed training

### DIFF
--- a/examples/distributed/partition_graph.py
+++ b/examples/distributed/partition_graph.py
@@ -1,0 +1,69 @@
+import argparse
+import os
+import os.path as osp
+import torch
+from ogb.nodeproppred import PygNodePropPredDataset
+
+from torch_geometric.distributed import Partitioner
+
+
+def partition_dataset(ogbn_dataset: str, root_dir: str, num_partitions: int):
+    save_dir = root_dir + f'/{ogbn_dataset}-' + "partitions"
+    download_dir = f'{ogbn_dataset}'
+    dataset = PygNodePropPredDataset(ogbn_dataset, download_dir)
+    data = dataset[0]
+
+    partitioner = Partitioner(root=save_dir, num_parts=num_partitions,
+                              data=data)
+    partitioner.generate_partition()
+    split_idx = dataset.get_idx_split()
+
+    print('-- Saving label ...')
+    label_dir = osp.join(root_dir, f'{ogbn_dataset}-label')
+    os.makedirs(label_dir, exist_ok=True)
+    torch.save(data.y.squeeze(), osp.join(label_dir, 'label.pt'))
+
+    print('-- Partitioning training idx ...')
+    train_idx = split_idx['train']
+    train_idx = train_idx.split(train_idx.size(0) // num_partitions)
+    train_idx_partitions_dir = osp.join(root_dir, f'{ogbn_dataset}-train-partitions')
+    os.makedirs(train_idx_partitions_dir, exist_ok=True)
+    for pidx in range(num_partitions):
+        torch.save(train_idx[pidx], osp.join(train_idx_partitions_dir, f'partition{pidx}.pt'))
+
+    print('-- Partitioning test idx ...')
+    test_idx = split_idx['test']
+    test_idx = test_idx.split(test_idx.size(0) // num_partitions)
+    test_idx_partitions_dir = osp.join(root_dir, f'{ogbn_dataset}-test-partitions')
+    os.makedirs(test_idx_partitions_dir, exist_ok=True)
+    for pidx in range(num_partitions):
+        torch.save(test_idx[pidx], osp.join(test_idx_partitions_dir, f'partition{pidx}.pt'))
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(
+        description="Arguments for ClusterData Partitioning.")
+    parser.add_argument(
+        "--dataset",
+        type=str,
+        default='ogbn-products',
+        help="The name of dataset.",
+    )
+    parser.add_argument(
+        "--root_dir",
+        type=str,
+        default='./data/products',
+        help="The root directory of input dataset and output partitions.",
+    )
+    parser.add_argument(
+        "--num_partitions",
+        type=int,
+        default=2,
+        help="Number of partitions",
+    )
+    args = parser.parse_args()
+
+    partition_dataset(
+        ogbn_dataset=args.dataset,
+        root_dir=osp.join(osp.dirname(osp.realpath(__file__)),
+                          args.root_dir), num_partitions=args.num_partitions)

--- a/examples/distributed/partition_hetero_graph.py
+++ b/examples/distributed/partition_hetero_graph.py
@@ -1,0 +1,70 @@
+import argparse
+import os.path as osp
+import torch
+import os
+
+from torch_geometric.datasets import OGB_MAG
+from torch_geometric.distributed import Partitioner
+
+
+def partition_dataset(ogbn_dataset: str, root_dir: str, num_partitions: int):
+    save_dir = root_dir + f'/{ogbn_dataset}-' + "partitions"
+    dataset = OGB_MAG(root=ogbn_dataset, preprocess='metapath2vec')
+    data = dataset[0]
+
+    partitioner = Partitioner(root=save_dir, num_parts=num_partitions,
+                              data=data)
+    partitioner.generate_partition()
+    # split_idx = data.get_idx_split()
+    n_nodes = data['paper'].x.shape[0]
+    n_train = int(n_nodes * 0.6)
+    n_val = int(n_nodes * 0.2)
+
+    print('-- Saving label ...')
+    label_dir = osp.join(root_dir, f'{ogbn_dataset}-label')
+    os.makedirs(label_dir, exist_ok=True)
+    torch.save(data['paper'].y.squeeze(), osp.join(label_dir, 'label.pt'))
+    print('-- Partitioning training idx ...')
+    train_idx = torch.arange(0, n_train)
+    train_idx = train_idx.split(train_idx.size(0) // num_partitions)
+    train_idx_partitions_dir = osp.join(root_dir, f'{ogbn_dataset}-train-partitions')
+    os.makedirs(train_idx_partitions_dir, exist_ok=True)
+    for pidx in range(num_partitions):
+        torch.save(train_idx[pidx], osp.join(train_idx_partitions_dir, f'partition{pidx}.pt'))
+
+    print('-- Partitioning test idx ...')
+    test_idx = torch.arange(n_train + n_val, n_nodes)
+    test_idx = test_idx.split(test_idx.size(0) // num_partitions)
+    test_idx_partitions_dir = osp.join(root_dir, f'{ogbn_dataset}-test-partitions')
+    os.makedirs(test_idx_partitions_dir, exist_ok=True)
+    for pidx in range(num_partitions):
+        torch.save(test_idx[pidx], osp.join(test_idx_partitions_dir, f'partition{pidx}.pt'))
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(
+        description="Arguments for ClusterData Partitioning.")
+    parser.add_argument(
+        "--dataset",
+        type=str,
+        default='ogbn-mags',
+        help="The name of dataset.",
+    )
+    parser.add_argument(
+        "--root_dir",
+        type=str,
+        default='./data/mags',
+        help="The root directory of input dataset and output partitions.",
+    )
+    parser.add_argument(
+        "--num_partitions",
+        type=int,
+        default=2,
+        help="Number of partitions",
+    )
+    args = parser.parse_args()
+
+    partition_dataset(
+        ogbn_dataset=args.dataset,
+        root_dir=osp.join(osp.dirname(osp.realpath(__file__)),
+                          args.root_dir), num_partitions=args.num_partitions)


### PR DESCRIPTION
This code belongs to the part of the whole distributed training for PyG.

We provide two scripts here: 
1) one to generate the ogbn-products homo partition dataset with the num_partitions (default=2) argument.
2) second to generate the ogbn-mags hetero partition dataset with the num_partitions (default=2) argument.

First will download the raw dataset in current folder; all partition results will be stored as below folder structure. 

1) homo partition
data
|-- products
    |-- ogbn-products-label
    |   `-- label.pt
    |-- ogbn-products-partitions
    |   |-- META.json
    |   |-- edge_map.pt
    |   |-- node_map.pt
    |   |-- part_0
    |   |   |-- edge_feats.pt
    |   |   |-- graph.pt
    |   |   `-- node_feats.pt
    |   `-- part_1
    |       |-- edge_feats.pt
    |       |-- graph.pt
    |       `-- node_feats.pt
    |-- ogbn-products-test-partitions
    |   |-- partition0.pt
    |   `-- partition1.pt
    `-- ogbn-products-train-partitions
        |-- partition0.pt
        `-- partition1.pt


2) hetero

data
|-- mags
|   |-- ogbn-mags-label
|   |   `-- label.pt
|   |-- ogbn-mags-partitions
|   |   |-- META.json
|   |   |-- edge_map
|   |   |   |-- author__affiliated_with__institution.pt
|   |   |   |-- author__writes__paper.pt
|   |   |   |-- paper__cites__paper.pt
|   |   |   `-- paper__has_topic__field_of_study.pt
|   |   |-- node_map
|   |   |   |-- author.pt
|   |   |   |-- field_of_study.pt
|   |   |   |-- institution.pt
|   |   |   `-- paper.pt
|   |   |-- part_0
|   |   |   |-- edge_feats.pt
|   |   |   |-- graph.pt
|   |   |   `-- node_feats.pt
|   |   `-- part_1
|   |       |-- edge_feats.pt
|   |       |-- graph.pt
|   |       `-- node_feats.pt
|   |-- ogbn-mags-test-partitions
|   |   |-- partition0.pt
|   |   `-- partition1.pt
|   `-- ogbn-mags-train-partitions
|       |-- partition0.pt
|       `-- partition1.pt

You can setup the different partition numbers to get the different partition dataset. This partition dataset already include the train_idx (seeds) /test_idx/ labels to make more easy to use. 

Any comments please let us know. thanks.

