### PR TITLE
Add possibility to use `CachedLoader` in inference benchmarks

### DIFF
--- a/benchmark/utils/utils.py
+++ b/benchmark/utils/utils.py
@@ -86,10 +86,8 @@ def get_dataset(name, root, use_sparse_tensor=False, bf16=False):
     return data, num_classes
 
 
-def get_model(name, params, metadata=None, model_decorator=None):
+def get_model(name, params, metadata=None):
     Model = models_dict.get(name, None)
-    if model_decorator is not None:
-        Model = model_decorator(Model)
     assert Model is not None, f'Model {name} not supported!'
 
     if name == 'rgat':


### PR DESCRIPTION
This PR adds `--cached-loader` option, that enables `CachedLoader` in inference loop.

Waiting for #7896.