### PR TITLE
Fix broken URLs in `HGBDataset`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,6 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
-- Fiexed broken links in `HGB` dataset ([#7907](https://github.com/pyg-team/pytorch_geometric/pull/7907))
 - Added nightly GPU tests ([#7895](https://github.com/pyg-team/pytorch_geometric/pull/7895))
 - Added the `HalfHop` graph upsampling augmentation ([#7827](https://github.com/pyg-team/pytorch_geometric/pull/7827))
 - Added the `Wikidata5M` dataset ([#7864](https://github.com/pyg-team/pytorch_geometric/pull/7864))
@@ -86,6 +85,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
+- Fixed broken links in `HGBDataset` ([#7907](https://github.com/pyg-team/pytorch_geometric/pull/7907))
 - Fixed an issue where `SetTransformerAggregation` produced `NaN` values for isolates nodes ([#7902](https://github.com/pyg-team/pytorch_geometric/pull/7902))
 - Fixed `model_summary` on modules with uninitialized parameters ([#7884](https://github.com/pyg-team/pytorch_geometric/pull/7884))
 - Updated `QM9` data pre-processing to include the SMILES string ([#7867](https://github.com/pyg-team/pytorch_geometric/pull/7867))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- Fiexed broken links in `HGB` dataset ([#7907](https://github.com/pyg-team/pytorch_geometric/pull/7907))
 - Added nightly GPU tests ([#7895](https://github.com/pyg-team/pytorch_geometric/pull/7895))
 - Added the `HalfHop` graph upsampling augmentation ([#7827](https://github.com/pyg-team/pytorch_geometric/pull/7827))
 - Added the `Wikidata5M` dataset ([#7864](https://github.com/pyg-team/pytorch_geometric/pull/7864))

--- a/torch_geometric/datasets/hgb_dataset.py
+++ b/torch_geometric/datasets/hgb_dataset.py
@@ -40,22 +40,22 @@ class HGBDataset(InMemoryDataset):
             transformed version. The data object will be transformed before
             being saved to disk. (default: :obj:`None`)
     """
-
-    urls = {
-        'acm':
-        'https://drive.google.com/uc?export=download&id=1xbJ4QE9pcDJOcALv7dYhHDCPITX2Iddz',
-        'dblp':
-        'https://drive.google.com/uc?export=download&id=1fLLoy559V7jJaQ_9mQEsC06VKd6Qd3SC',
-        'freebase':
-        'https://drive.google.com/uc?export=download&id=1vw-uqbroJZfFsWpriC1CWbtHCJMGdWJ7',
-        'imdb':
-        'https://drive.google.com/uc?export=download&id=18qXmmwKJBrEJxVQaYwKTL3Ny3fPqJeJ2',
-    }
     names = {
         'acm': 'ACM',
         'dblp': 'DBLP',
         'freebase': 'Freebase',
         'imdb': 'IMDB',
+    }
+
+    urls = {
+        'acm': ('https://drive.google.com/uc?'
+                'export=download&id=1xbJ4QE9pcDJOcALv7dYhHDCPITX2Iddz'),
+        'dblp': ('https://drive.google.com/uc?'
+                 'export=download&id=1fLLoy559V7jJaQ_9mQEsC06VKd6Qd3SC'),
+        'freebase': ('https://drive.google.com/uc?'
+                     'export=download&id=1vw-uqbroJZfFsWpriC1CWbtHCJMGdWJ7'),
+        'imdb': ('https://drive.google.com/uc?'
+                 'export=download&id=18qXmmwKJBrEJxVQaYwKTL3Ny3fPqJeJ2'),
     }
 
     def __init__(self, root: str, name: str,

--- a/torch_geometric/datasets/hgb_dataset.py
+++ b/torch_geometric/datasets/hgb_dataset.py
@@ -58,9 +58,13 @@ class HGBDataset(InMemoryDataset):
                  'export=download&id=18qXmmwKJBrEJxVQaYwKTL3Ny3fPqJeJ2'),
     }
 
-    def __init__(self, root: str, name: str,
-                 transform: Optional[Callable] = None,
-                 pre_transform: Optional[Callable] = None):
+    def __init__(
+        self,
+        root: str,
+        name: str,
+        transform: Optional[Callable] = None,
+        pre_transform: Optional[Callable] = None,
+    ):
         self.name = name.lower()
         assert self.name in set(self.names.keys())
         super().__init__(root, transform, pre_transform)

--- a/torch_geometric/datasets/hgb_dataset.py
+++ b/torch_geometric/datasets/hgb_dataset.py
@@ -42,10 +42,14 @@ class HGBDataset(InMemoryDataset):
     """
 
     urls = {
-        'acm': 'https://drive.google.com/uc?export=download&id=1xbJ4QE9pcDJOcALv7dYhHDCPITX2Iddz',
-        'dblp': 'https://drive.google.com/uc?export=download&id=1fLLoy559V7jJaQ_9mQEsC06VKd6Qd3SC',
-        'freebase': 'https://drive.google.com/uc?export=download&id=1vw-uqbroJZfFsWpriC1CWbtHCJMGdWJ7',
-        'imdb': 'https://drive.google.com/uc?export=download&id=18qXmmwKJBrEJxVQaYwKTL3Ny3fPqJeJ2',
+        'acm':
+        'https://drive.google.com/uc?export=download&id=1xbJ4QE9pcDJOcALv7dYhHDCPITX2Iddz',
+        'dblp':
+        'https://drive.google.com/uc?export=download&id=1fLLoy559V7jJaQ_9mQEsC06VKd6Qd3SC',
+        'freebase':
+        'https://drive.google.com/uc?export=download&id=1vw-uqbroJZfFsWpriC1CWbtHCJMGdWJ7',
+        'imdb':
+        'https://drive.google.com/uc?export=download&id=18qXmmwKJBrEJxVQaYwKTL3Ny3fPqJeJ2',
     }
     names = {
         'acm': 'ACM',

--- a/torch_geometric/datasets/hgb_dataset.py
+++ b/torch_geometric/datasets/hgb_dataset.py
@@ -41,9 +41,12 @@ class HGBDataset(InMemoryDataset):
             being saved to disk. (default: :obj:`None`)
     """
 
-    url = ('https://cloud.tsinghua.edu.cn/d/2d965d2fc2ee41d09def/files/'
-           '?p=%2F{}.zip&dl=1')
-
+    urls = {
+        'acm': 'https://drive.google.com/uc?export=download&id=1xbJ4QE9pcDJOcALv7dYhHDCPITX2Iddz',
+        'dblp': 'https://drive.google.com/uc?export=download&id=1fLLoy559V7jJaQ_9mQEsC06VKd6Qd3SC',
+        'freebase': 'https://drive.google.com/uc?export=download&id=1vw-uqbroJZfFsWpriC1CWbtHCJMGdWJ7',
+        'imdb': 'https://drive.google.com/uc?export=download&id=18qXmmwKJBrEJxVQaYwKTL3Ny3fPqJeJ2',
+    }
     names = {
         'acm': 'ACM',
         'dblp': 'DBLP',
@@ -77,7 +80,7 @@ class HGBDataset(InMemoryDataset):
         return 'data.pt'
 
     def download(self):
-        url = self.url.format(self.names[self.name])
+        url = self.urls[self.name]
         path = download_url(url, self.raw_dir)
         extract_zip(path, self.raw_dir)
         os.unlink(path)


### PR DESCRIPTION
Old links are not available. According to changes in its [repo](https://github.com/THUDM/HGB), dataset can be found in [here](https://drive.google.com/drive/folders/10-pf2ADCjq_kpJKFHHLHxr_czNNCJ3aX) now.