### PR TITLE
using global node ids for partitioned graph's row/col

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -139,7 +139,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Added an optional `batch_size` and `max_num_nodes` arguments to `MemPooling` layer ([#7239](https://github.com/pyg-team/pytorch_geometric/pull/7239))
 - Fixed training issues of the GraphGPS example ([#7377](https://github.com/pyg-team/pytorch_geometric/pull/7377))
 - Allowed `CaptumExplainer` to be called multiple times in a row ([#7391](https://github.com/pyg-team/pytorch_geometric/pull/7391))
-
+- Change row/col to global node id in graphstore when do partition for distributed training ([#7910](https://github.com/pyg-team/pytorch_geometric/pull/7910))
 ### Removed
 
 - Removed `layer_type` argument in `contrib.explain.GraphMaskExplainer` ([#7445](https://github.com/pyg-team/pytorch_geometric/pull/7445))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -139,7 +139,6 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Added an optional `batch_size` and `max_num_nodes` arguments to `MemPooling` layer ([#7239](https://github.com/pyg-team/pytorch_geometric/pull/7239))
 - Fixed training issues of the GraphGPS example ([#7377](https://github.com/pyg-team/pytorch_geometric/pull/7377))
 - Allowed `CaptumExplainer` to be called multiple times in a row ([#7391](https://github.com/pyg-team/pytorch_geometric/pull/7391))
-- Change row/col to global node id in graphstore when do partition for distributed training ([#7910](https://github.com/pyg-team/pytorch_geometric/pull/7910))
 ### Removed
 
 - Removed `layer_type` argument in `contrib.explain.GraphMaskExplainer` ([#7445](https://github.com/pyg-team/pytorch_geometric/pull/7445))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -139,6 +139,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Added an optional `batch_size` and `max_num_nodes` arguments to `MemPooling` layer ([#7239](https://github.com/pyg-team/pytorch_geometric/pull/7239))
 - Fixed training issues of the GraphGPS example ([#7377](https://github.com/pyg-team/pytorch_geometric/pull/7377))
 - Allowed `CaptumExplainer` to be called multiple times in a row ([#7391](https://github.com/pyg-team/pytorch_geometric/pull/7391))
+
 ### Removed
 
 - Removed `layer_type` argument in `contrib.explain.GraphMaskExplainer` ([#7445](https://github.com/pyg-team/pytorch_geometric/pull/7445))

--- a/torch_geometric/distributed/partition.py
+++ b/torch_geometric/distributed/partition.py
@@ -150,10 +150,14 @@ class Partitioner:
                     size = (self.data[src].num_nodes, self.data[dst].num_nodes)
 
                     mask = part_data.edge_type == i
+                    rows = part_data.edge_index[0, mask]
+                    cols = part_data.edge_index[1, mask]
+                    global_rows = node_id[rows]
+                    global_cols = node_perm[cols]
                     out[edge_type] = {
                         'edge_id': edge_id[mask],
-                        'row': part_data.edge_index[0, mask],
-                        'col': part_data.edge_index[1, mask],
+                        'row': global_rows,
+                        'col': global_cols,
                         'size': size,
                     }
                 torch.save(out, osp.join(path, 'graph.pt'))
@@ -213,12 +217,16 @@ class Partitioner:
 
                 node_id = node_perm[start:end]
                 node_map[node_id] = pid
+                rows = part_data.edge_index[0]
+                cols = part_data.edge_index[1]
+                global_rows = node_id[rows]
+                global_cols = node_perm[cols]
 
                 torch.save(
                     {
                         'edge_id': edge_id,
-                        'row': part_data.edge_index[0],
-                        'col': part_data.edge_index[1],
+                        'row': global_rows,
+                        'col': global_cols,
                         'size': (data.num_nodes, data.num_nodes),
                     }, osp.join(path, 'graph.pt'))
 


### PR DESCRIPTION
@rusty1s For distributed pyg training development, we prefer to use global node ids to represent partitioned graph store. It would be convenient for us to neighbor sample the partitioned graph if we use global ids for rows/cols. 