### PR TITLE
Drop Python 3.7 support

### DIFF
--- a/.github/workflows/building_pyg_conda.yml
+++ b/.github/workflows/building_pyg_conda.yml
@@ -11,7 +11,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.8', '3.9', '3.10', '3.11']
         torch-version: [1.12.0, 1.13.0, 2.0.0]
         cuda-version: ['cpu', 'cu102', 'cu113', 'cu116', 'cu117', 'cu118']
         exclude:
@@ -29,8 +29,6 @@ jobs:
             cuda-version: 'cu113'
           - torch-version: 1.13.0
             cuda-version: 'cu118'
-          - torch-version: 2.0.0
-            python-version: '3.7'
           - torch-version: 2.0.0
             cuda-version: 'cu102'
           - torch-version: 2.0.0

--- a/.github/workflows/building_rusty1s_conda.yml
+++ b/.github/workflows/building_rusty1s_conda.yml
@@ -11,7 +11,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.8', '3.9', '3.10', '3.11']
         torch-version: [1.12.0, 1.13.0, 2.0.0]
         cuda-version: ['cpu', 'cu102', 'cu113', 'cu116', 'cu117', 'cu118']
         exclude:
@@ -29,8 +29,6 @@ jobs:
             cuda-version: 'cu113'
           - torch-version: 1.13.0
             cuda-version: 'cu118'
-          - torch-version: 2.0.0
-            python-version: '3.7'
           - torch-version: 2.0.0
             cuda-version: 'cu102'
           - torch-version: 2.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -148,6 +148,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Removed
 
+- Dropped Python 3.7 support ([#7939](https://github.com/pyg-team/pytorch_geometric/pull/7939))
 - Removed `layer_type` argument in `contrib.explain.GraphMaskExplainer` ([#7445](https://github.com/pyg-team/pytorch_geometric/pull/7445))
 - Replaced `FastHGTConv` with `HGTConv` ([#7117](https://github.com/pyg-team/pytorch_geometric/pull/7117))
 

--- a/README.md
+++ b/README.md
@@ -358,7 +358,7 @@ These approaches have been implemented in PyG, and can benefit from the above GN
 
 ## Installation
 
-PyG is available for Python 3.7 to Python 3.11.
+PyG is available for Python 3.8 to Python 3.11.
 
 ### Anaconda
 

--- a/docs/source/install/installation.rst
+++ b/docs/source/install/installation.rst
@@ -1,7 +1,7 @@
 Installation
 ============
 
-:pyg:`PyG` is available for Python 3.7 to Python 3.11.
+:pyg:`PyG` is available for Python 3.8 to Python 3.11.
 
 .. note::
    We do not recommend installation as a root user on your system Python.

--- a/torch_geometric/datasets/hydro_net.py
+++ b/torch_geometric/datasets/hydro_net.py
@@ -2,7 +2,7 @@ import copy
 import os
 import os.path as osp
 from dataclasses import dataclass
-from functools import lru_cache
+from functools import cached_property
 from glob import glob
 from pathlib import Path
 from typing import Callable, List, Optional, Tuple, Union
@@ -17,13 +17,6 @@ from torch_geometric.data import (
     download_url,
     extract_zip,
 )
-
-try:
-    from functools import cached_property
-except ImportError:  # Python 3.7 support.
-
-    def cached_property(func):
-        return property(fget=lru_cache(maxsize=1)(func))
 
 
 class HydroNet(InMemoryDataset):

--- a/torch_geometric/io/planetoid.py
+++ b/torch_geometric/io/planetoid.py
@@ -1,5 +1,4 @@
 import os.path as osp
-import sys
 import warnings
 from itertools import repeat
 
@@ -93,11 +92,8 @@ def read_file(folder, prefix, name):
         return read_txt_array(path, dtype=torch.long)
 
     with open(path, 'rb') as f:
-        if sys.version_info > (3, 0):
-            warnings.filterwarnings('ignore', '.*`scipy.sparse.csr` name.*')
-            out = pickle.load(f, encoding='latin1')
-        else:
-            out = pickle.load(f)
+        warnings.filterwarnings('ignore', '.*`scipy.sparse.csr` name.*')
+        out = pickle.load(f, encoding='latin1')
 
     if name == 'graph':
         return out


### PR DESCRIPTION
Drops Python 3.7 support as PyTorch 2.0.0 also did (https://github.com/pytorch/pytorch/issues/80513) and Python 3.7 reached EOL (https://devguide.python.org/versions/).