### PR TITLE
Filter out empty tensors inside `trim_to_layer`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,7 +86,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Added unbatching logic for `torch.sparse` tensors ([#7037](https://github.com/pyg-team/pytorch_geometric/pull/7037))
 - Added the `RotatE` KGE model ([#7026](https://github.com/pyg-team/pytorch_geometric/pull/7026))
 - Added support for Apple silicon GPU acceleration in some main examples ([#7770](https://github.com/pyg-team/pytorch_geometric/pull/7770), [#7711](https://github.com/pyg-team/pytorch_geometric/pull/7711), [#7784](https://github.com/pyg-team/pytorch_geometric/pull/7784), [#7785](https://github.com/pyg-team/pytorch_geometric/pull/7785))
-
+- filter out empty tensor for `x`, `edge_index`, `edge_attr` after calling `trim_to_layer` function ([#7942](https://github.com/pyg-team/pytorch_geometric/pull/7942))
 ### Changed
 
 - Fixed `from_networkx` conversion from `nx.stochastic_block_model` graphs ([#7941](https://github.com/pyg-team/pytorch_geometric/pull/7941))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,6 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
-- Added `trim_to_layer` function to filter out empty tensor for `x`, `edge_index`, `edge_attr` ([#7942](https://github.com/pyg-team/pytorch_geometric/pull/7942))
 - Added a warning for isolated/non-existing node types in `HeteroData.validate()` ([#7995](https://github.com/pyg-team/pytorch_geometric/pull/7995))
 - Added `utils.cumsum` implementation ([#7994](https://github.com/pyg-team/pytorch_geometric/pull/7994))
 - Added the `BrcaTcga` dataset ([#7905](https://github.com/pyg-team/pytorch_geometric/pull/7905))
@@ -97,6 +96,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
+- Changed the `trim_to_layer` function to filter out non-reachable node and edge types when operating on heterogeneous graphs ([#7942](https://github.com/pyg-team/pytorch_geometric/pull/7942))
 - Accelerated and simplified `top_k` computation in `TopKPooling` ([#7737](https://github.com/pyg-team/pytorch_geometric/pull/7737))
 - Updated `GIN` implementation in kernel benchmarks to have sequential batchnorms ([#7955](https://github.com/pyg-team/pytorch_geometric/pull/7955))
 - Fixed bugs in benchmarks caused by a lack of the device conditions for CPU and unexpected `cache` argument in heterogeneous  models ([#7956](https://github.com/pyg-team/pytorch_geometric/pull/7956)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- Added `trim_to_layer` function to filter out empty tensor for `x`, `edge_index`, `edge_attr` ([#7942](https://github.com/pyg-team/pytorch_geometric/pull/7942))
 - Added a warning for isolated/non-existing node types in `HeteroData.validate()` ([#7995](https://github.com/pyg-team/pytorch_geometric/pull/7995))
 - Added `utils.cumsum` implementation ([#7994](https://github.com/pyg-team/pytorch_geometric/pull/7994))
 - Added the `BrcaTcga` dataset ([#7905](https://github.com/pyg-team/pytorch_geometric/pull/7905))
@@ -93,7 +94,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Added unbatching logic for `torch.sparse` tensors ([#7037](https://github.com/pyg-team/pytorch_geometric/pull/7037))
 - Added the `RotatE` KGE model ([#7026](https://github.com/pyg-team/pytorch_geometric/pull/7026))
 - Added support for Apple silicon GPU acceleration in some main examples ([#7770](https://github.com/pyg-team/pytorch_geometric/pull/7770), [#7711](https://github.com/pyg-team/pytorch_geometric/pull/7711), [#7784](https://github.com/pyg-team/pytorch_geometric/pull/7784), [#7785](https://github.com/pyg-team/pytorch_geometric/pull/7785))
-- filter out empty tensor for `x`, `edge_index`, `edge_attr` after calling `trim_to_layer` function ([#7942](https://github.com/pyg-team/pytorch_geometric/pull/7942))
+
 ### Changed
 
 - Accelerated and simplified `top_k` computation in `TopKPooling` ([#7737](https://github.com/pyg-team/pytorch_geometric/pull/7737))

--- a/test/utils/test_trim_to_layer.py
+++ b/test/utils/test_trim_to_layer.py
@@ -197,3 +197,31 @@ def test_trim_to_layer_with_neighbor_loader():
     assert out2.size() == (2, 16)
 
     assert torch.allclose(out1, out2)
+
+
+def test_trim_to_layer_with_filtering_empty_tensor():
+    x_dict = {
+        'paper': torch.rand((13, 128)),
+        'author': torch.rand((5, 128)),
+        'field_of_study': torch.rand((6, 128))
+    }
+    edge_index_dict = {
+        ('author', 'writes', 'paper'):
+        torch.tensor([[0, 1, 2, 3, 4], [0, 0, 1, 2, 2]]),
+        ('paper', 'has_topic', 'field_of_study'):
+        torch.tensor([[6, 7, 8, 9], [0, 0, 1, 1]])
+    }
+    num_sampled_nodes_dict = {
+        'paper': [1, 2, 10],
+        'author': [0, 2, 3],
+        'field_of_study': [0, 2, 4]
+    }
+    num_sampled_edges_dict = {
+        ('author', 'writes', 'paper'): [2, 3],
+        ('paper', 'has_topic', 'field_of_study'): [0, 4]
+    }
+    x_dict, edge_index_dict, _ = trim_to_layer(
+        layer=1, num_sampled_nodes_per_hop=num_sampled_nodes_dict,
+        num_sampled_edges_per_hop=num_sampled_edges_dict, x=x_dict,
+        edge_index=edge_index_dict)
+    assert list(edge_index_dict.keys()) == [('author', 'writes', 'paper')]

--- a/test/utils/test_trim_to_layer.py
+++ b/test/utils/test_trim_to_layer.py
@@ -199,7 +199,7 @@ def test_trim_to_layer_with_neighbor_loader():
     assert torch.allclose(out1, out2)
 
 
-def test_trim_to_layer_with_filtering_empty_tensor():
+def test_trim_to_layer_filtering():
     x_dict = {
         'paper': torch.rand((13, 128)),
         'author': torch.rand((5, 128)),
@@ -221,12 +221,15 @@ def test_trim_to_layer_with_filtering_empty_tensor():
         ('paper', 'has_topic', 'field_of_study'): [0, 4]
     }
     x_dict, edge_index_dict, _ = trim_to_layer(
-        layer=1, num_sampled_nodes_per_hop=num_sampled_nodes_dict,
-        num_sampled_edges_per_hop=num_sampled_edges_dict, x=x_dict,
-        edge_index=edge_index_dict)
+        layer=1,
+        num_sampled_nodes_per_hop=num_sampled_nodes_dict,
+        num_sampled_edges_per_hop=num_sampled_edges_dict,
+        x=x_dict,
+        edge_index=edge_index_dict,
+    )
     assert list(edge_index_dict.keys()) == [('author', 'writes', 'paper')]
-    assert torch.allclose(edge_index_dict[('author', 'writes', 'paper')],
-                          torch.tensor([[0, 1], [0, 0]]))
-    assert x_dict['paper'].shape == torch.Size([3, 128])
-    assert x_dict['author'].shape == torch.Size([2, 128])
-    assert x_dict['field_of_study'].shape == torch.Size([2, 128])
+    assert torch.equal(edge_index_dict[('author', 'writes', 'paper')],
+                       torch.tensor([[0, 1], [0, 0]]))
+    assert x_dict['paper'].size() == (3, 128)
+    assert x_dict['author'].size() == (2, 128)
+    assert x_dict['field_of_study'].size() == (2, 128)

--- a/test/utils/test_trim_to_layer.py
+++ b/test/utils/test_trim_to_layer.py
@@ -225,3 +225,8 @@ def test_trim_to_layer_with_filtering_empty_tensor():
         num_sampled_edges_per_hop=num_sampled_edges_dict, x=x_dict,
         edge_index=edge_index_dict)
     assert list(edge_index_dict.keys()) == [('author', 'writes', 'paper')]
+    assert torch.allclose(edge_index_dict[('author', 'writes', 'paper')],
+                          torch.tensor([[0, 1], [0, 0]]))
+    assert x_dict['paper'].shape == torch.Size([3, 128])
+    assert x_dict['author'].shape == torch.Size([2, 128])
+    assert x_dict['field_of_study'].shape == torch.Size([2, 128])

--- a/torch_geometric/utils/trim_to_layer.py
+++ b/torch_geometric/utils/trim_to_layer.py
@@ -16,7 +16,7 @@ from torch_geometric.typing import (
 
 def filter_empty_tensor(input_tensor: Union[MaybeHeteroNodeTensor,
                                             MaybeHeteroEdgeTensor]):
-    r"""filter out empty tensor for x, edge_index, edge_attr after trim.
+    r"""Filter out empty tensor for x, edge_index, edge_attr after trim.
     This can avoid some unnecessary computation when some node/edge
     types get empty output"""
     if input_tensor is None:

--- a/torch_geometric/utils/trim_to_layer.py
+++ b/torch_geometric/utils/trim_to_layer.py
@@ -14,6 +14,19 @@ from torch_geometric.typing import (
 )
 
 
+def filter_empty_tensor(input_tensor: Union[MaybeHeteroNodeTensor,
+                                            MaybeHeteroEdgeTensor]):
+    r"""filter out empty tensor for x, edge_index, edge_attr after trim.
+    This can avoid some unnecessary computation when some node/edge
+    types get empty output"""
+    if input_tensor is None:
+        return
+    for k in list(input_tensor.keys()):
+        if input_tensor[k].numel() == 0:
+            del input_tensor[k]
+    return input_tensor
+
+
 def trim_to_layer(
     layer: int,
     num_sampled_nodes_per_hop: Union[List[int], Dict[NodeType, List[int]]],
@@ -69,6 +82,9 @@ def trim_to_layer(
                 k: trim_feat(v, layer, num_sampled_edges_per_hop[k])
                 for k, v in edge_attr.items()
             }
+        x = filter_empty_tensor(x)
+        edge_index = filter_empty_tensor(edge_index)
+        edge_attr = filter_empty_tensor(edge_attr)
         return x, edge_index, edge_attr
 
     x = trim_feat(x, layer, num_sampled_nodes_per_hop)

--- a/torch_geometric/utils/trim_to_layer.py
+++ b/torch_geometric/utils/trim_to_layer.py
@@ -20,7 +20,7 @@ def filter_empty_tensor(input_tensor: Union[MaybeHeteroNodeTensor,
     This can avoid some unnecessary computation when some node/edge
     types get empty output"""
     if input_tensor is None:
-        return
+        return None
     for k in list(input_tensor.keys()):
         if input_tensor[k].numel() == 0:
             del input_tensor[k]

--- a/torch_geometric/utils/trim_to_layer.py
+++ b/torch_geometric/utils/trim_to_layer.py
@@ -17,7 +17,7 @@ from torch_geometric.typing import (
 
 def filter_empty_entries(
         input_dict: Dict[Union[Any], Tensor]) -> Dict[Any, Tensor]:
-    r"""Remove empty tensors from a dictionary. This avoids unnecessary
+    r"""Removes empty tensors from a dictionary. This avoids unnecessary
     computation when some node/edge types are non-reachable after trimming."""
     out_dict = copy.copy(input_dict)
     for key, value in input_dict.items():


### PR DESCRIPTION
filter out empty tensor for `x`, `edge_index`, `edge_attr` after calling `trim_to_layer` function. This can avoid unnecessary computation when some node/edge types get empty output. For example: when I train `igbh-tiny` dataset with 3 hops sampler and use `trim_to_layer` function, I get a lot of empty edge_index tensor for edge type '('author', 'affiliated_to', 'institute')', but the feature tensor for 'author' node type is still sent to compute in `HeteroConv` implementation.