### PR TITLE
feat(benchmark/kernel): add BatchNorm sequentially

### DIFF
--- a/benchmark/kernel/gin.py
+++ b/benchmark/kernel/gin.py
@@ -13,6 +13,7 @@ class GIN0(torch.nn.Module):
             Sequential(
                 Linear(dataset.num_features, hidden),
                 ReLU(),
+                BN(hidden),
                 Linear(hidden, hidden),
                 ReLU(),
                 BN(hidden),
@@ -24,6 +25,7 @@ class GIN0(torch.nn.Module):
                     Sequential(
                         Linear(hidden, hidden),
                         ReLU(),
+                        BN(hidden),
                         Linear(hidden, hidden),
                         ReLU(),
                         BN(hidden),
@@ -60,6 +62,7 @@ class GIN0WithJK(torch.nn.Module):
             Sequential(
                 Linear(dataset.num_features, hidden),
                 ReLU(),
+                BN(hidden),
                 Linear(hidden, hidden),
                 ReLU(),
                 BN(hidden),
@@ -71,6 +74,7 @@ class GIN0WithJK(torch.nn.Module):
                     Sequential(
                         Linear(hidden, hidden),
                         ReLU(),
+                        BN(hidden),
                         Linear(hidden, hidden),
                         ReLU(),
                         BN(hidden),
@@ -115,6 +119,7 @@ class GIN(torch.nn.Module):
             Sequential(
                 Linear(dataset.num_features, hidden),
                 ReLU(),
+                BN(hidden),
                 Linear(hidden, hidden),
                 ReLU(),
                 BN(hidden),
@@ -126,6 +131,7 @@ class GIN(torch.nn.Module):
                     Sequential(
                         Linear(hidden, hidden),
                         ReLU(),
+                        BN(hidden),
                         Linear(hidden, hidden),
                         ReLU(),
                         BN(hidden),
@@ -162,6 +168,7 @@ class GINWithJK(torch.nn.Module):
             Sequential(
                 Linear(dataset.num_features, hidden),
                 ReLU(),
+                BN(hidden),
                 Linear(hidden, hidden),
                 ReLU(),
                 BN(hidden),
@@ -173,6 +180,7 @@ class GINWithJK(torch.nn.Module):
                     Sequential(
                         Linear(hidden, hidden),
                         ReLU(),
+                        BN(hidden),
                         Linear(hidden, hidden),
                         ReLU(),
                         BN(hidden),


### PR DESCRIPTION
This PR aims to update the GIN implementation in the kernel benchmark based on the discussions in [#2863](https://github.com/pyg-team/pytorch_geometric/issues/2863) and results as reported in [Does the position of BatchNorm matter in Graph Isomorphism Networks (GIN)](https://wandb.ai/graph-neural-networks/GIN/reports/Does-the-position-of-BatchNorm-matter-in-Graph-Isomorphism-Networks-GIN---Vmlldzo1MDkwMTM3).

![](https://user-images.githubusercontent.com/61241031/263945331-9c5de4c1-4d07-4db4-8ad6-eca5c13925e3.png)

Request for Review: @rusty1s 