### PR TITLE
Fix errors in benchmarks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
+- Fixed bugs in benchmarks caused by a lack of the device conditions for CPU and unexpected `cache` argument in heterogeneous  models ([#7956](https://github.com/pyg-team/pytorch_geometric/pull/7956)
 - Fixed a bug in which `batch.e_id` was not correctly computed on unsorted graph inputs ([#7953](https://github.com/pyg-team/pytorch_geometric/pull/7953))
 - Fixed `from_networkx` conversion from `nx.stochastic_block_model` graphs ([#7941](https://github.com/pyg-team/pytorch_geometric/pull/7941))
 - Fixed the usage of `bias_initializer` in `HeteroLinear` ([#7923](https://github.com/pyg-team/pytorch_geometric/pull/7923))

--- a/benchmark/training/training_benchmark.py
+++ b/benchmark/training/training_benchmark.py
@@ -34,6 +34,7 @@ supported_sets = {
 }
 
 device_conditions = {
+    'cpu': (lambda: True),
     'cuda': (lambda: torch.cuda.is_available()),
     'mps':
     (lambda:

--- a/benchmark/utils/hetero_gat.py
+++ b/benchmark/utils/hetero_gat.py
@@ -16,7 +16,7 @@ class HeteroGAT(torch.nn.Module):
         return self.model(x_dict, edge_index_dict)
 
     @torch.no_grad()
-    def inference(self, loader, device, progress_bar=False):
+    def inference(self, loader, device, progress_bar=False, **kwargs):
         self.model.eval()
         if progress_bar:
             loader = tqdm(loader, desc="Inference")

--- a/benchmark/utils/hetero_sage.py
+++ b/benchmark/utils/hetero_sage.py
@@ -15,7 +15,7 @@ class HeteroGraphSAGE(torch.nn.Module):
         return self.model(x_dict, edge_index_dict)
 
     @torch.no_grad()
-    def inference(self, loader, device, progress_bar=False):
+    def inference(self, loader, device, progress_bar=False, **kwargs):
         self.model.eval()
         if progress_bar:
             loader = tqdm(loader, desc="Inference")


### PR DESCRIPTION
CPU case was not covered in the device validation process.
`cache` argument was not accepted by the `inference` method in heterogeneous models.