### PR TITLE
Add `DistNeighborSampler`

### DIFF
--- a/torch_geometric/distributed/dist_neighbor_sampler.py
+++ b/torch_geometric/distributed/dist_neighbor_sampler.py
@@ -1,0 +1,560 @@
+from typing import Dict, List, Optional, Tuple, Union
+
+import numpy as np
+import torch
+import torch.multiprocessing as mp
+from ordered_set import OrderedSet
+from torch import Tensor
+
+from torch_geometric.distributed import LocalFeatureStore, LocalGraphStore
+from torch_geometric.distributed.dist_context import DistContext, DistRole
+from torch_geometric.distributed.event_loop import (
+    ConcurrentEventLoop,
+    wrap_torch_future,
+)
+from torch_geometric.distributed.rpc import (
+    RPCCallBase,
+    RPCRouter,
+    rpc_async,
+    rpc_partition_to_workers,
+    rpc_register,
+    shutdown_rpc,
+)
+from torch_geometric.distributed.utils import BatchDict, NodeDict
+from torch_geometric.sampler import (
+    EdgeSamplerInput,
+    HeteroSamplerOutput,
+    NegativeSampling,
+    NeighborSampler,
+    NodeSamplerInput,
+    SamplerOutput,
+    edge_sample_async,
+)
+from torch_geometric.sampler.base import SubgraphType
+from torch_geometric.sampler.utils import remap_keys
+from torch_geometric.typing import (
+    Dict,
+    EdgeType,
+    NodeType,
+    NumNeighbors,
+    OptTensor,
+    Tuple,
+)
+
+
+class RpcSamplingCallee(RPCCallBase):
+    r""" A wrapper for rpc callee that will perform rpc sampling from
+    remote processes.
+    """
+    def __init__(self, sampler: NeighborSampler, device: torch.device):
+        super().__init__()
+        self.sampler = sampler
+        self.device = device
+
+    def rpc_async(self, *args, **kwargs):
+        output = self.sampler._sample_one_hop(*args, **kwargs)
+
+        return output
+
+    def rpc_sync(self, *args, **kwargs):
+        pass
+
+
+class DistNeighborSampler:
+    r"""An implementation of a distributed and asynchronised neighbor sampler
+    used by :class:`~torch_geometric.distributed.DistNeighborLoader`."""
+    def __init__(
+        self,
+        current_ctx: DistContext,
+        rpc_worker_names: Dict[DistRole, List[str]],
+        data: Tuple[LocalGraphStore, LocalFeatureStore],
+        channel: mp.Queue(),
+        num_neighbors: Optional[NumNeighbors] = None,
+        with_edge: bool = True,
+        replace: bool = False,
+        subgraph_type: Union[SubgraphType, str] = 'directional',
+        disjoint: bool = False,
+        temporal_strategy: str = 'uniform',
+        time_attr: Optional[str] = None,
+        concurrency: int = 1,
+        device: Optional[torch.device] = None,
+        **kwargs,
+    ):
+        self.current_ctx = current_ctx
+        self.rpc_worker_names = rpc_worker_names
+
+        self.data = data
+        self.dist_graph = data[1]
+        self.dist_feature = data[0]
+        assert isinstance(
+            self.dist_graph, LocalGraphStore
+        ), "Provided data is in incorrect format: self.dist_graph must be "
+        f"`LocalGraphStore`, got {type(self.dist_graph)}"
+        assert isinstance(
+            self.dist_feature, LocalFeatureStore
+        ), "Provided data is in incorrect format: self.dist_feature must be "
+        f"`LocalFeatureStore`, got {type(self.dist_feature)}"
+        self.is_hetero = self.dist_graph.meta['is_hetero']
+
+        self.num_neighbors = num_neighbors
+        self.with_edge = with_edge
+        self.channel = channel
+        self.concurrency = concurrency
+        self.device = device
+        self.event_loop = None
+        self.replace = replace
+        self.subgraph_type = subgraph_type
+        self.disjoint = disjoint
+        self.temporal_strategy = temporal_strategy
+        self.time_attr = time_attr
+        self.csc = True  # always true?
+        self.with_edge_attr = self.dist_feature.has_edge_attr()
+
+    def register_sampler_rpc(self):
+        partition2workers = rpc_partition_to_workers(
+            current_ctx=self.current_ctx,
+            num_partitions=self.dist_graph.num_partitions,
+            current_partition_idx=self.dist_graph.partition_idx)
+
+        self.rpc_router = RPCRouter(partition2workers)
+        self.dist_feature.set_rpc_router(self.rpc_router)
+
+        self._sampler = NeighborSampler(
+            data=(self.dist_feature, self.dist_graph),
+            num_neighbors=self.num_neighbors,
+            subgraph_type=self.subgraph_type,
+            replace=self.replace,
+            disjoint=self.disjoint,
+            temporal_strategy=self.temporal_strategy,
+            time_attr=self.time_attr,
+        )
+
+        # rpc register
+        rpc_sample_callee = RpcSamplingCallee(self._sampler, self.device)
+        self.rpc_sample_callee_id = rpc_register(rpc_sample_callee)
+
+    def init_event_loop(self):
+        self.event_loop = ConcurrentEventLoop(self.concurrency)
+        self.event_loop._loop.call_soon_threadsafe(self.device)
+        self.event_loop.start_loop()
+
+    # Node-based distributed sampling #########################################
+
+    def sample_from_nodes(
+            self, inputs: NodeSamplerInput,
+            **kwargs) -> Optional[Union[SamplerOutput, HeteroSamplerOutput]]:
+        inputs = NodeSamplerInput.cast(inputs)
+        if self.channel is None:
+            # synchronous sampling
+            return self.event_loop.run_task(
+                coro=self._sample_from(self.node_sample, inputs))
+
+        # asynchronous sampling
+        cb = kwargs.get('callback', None)
+        self.event_loop.add_task(
+            coro=self._sample_from(self.node_sample, inputs), callback=cb)
+        return None
+
+    # Edge-based distributed sampling #########################################
+
+    def sample_from_edges(
+        self,
+        inputs: EdgeSamplerInput,
+        neg_sampling: Optional[NegativeSampling] = None,
+        **kwargs,
+    ) -> Optional[Union[SamplerOutput, HeteroSamplerOutput]]:
+        if self.channel is None:
+            # synchronous sampling
+            return self.event_loop.run_task(coro=self._sample_from(
+                edge_sample_async, inputs, self.node_sample,
+                self._sampler.num_nodes, self.disjoint,
+                self._sampler.node_time, neg_sampling, distributed=True))
+
+        # asynchronous sampling
+        cb = kwargs.get('callback', None)
+        self.event_loop.add_task(
+            coro=self._sample_from(edge_sample_async, inputs, self.node_sample,
+                                   self._sampler.num_nodes, self.disjoint,
+                                   self._sampler.node_time, neg_sampling,
+                                   distributed=True), callback=cb)
+        return None
+
+    async def _sample_from(
+            self, async_func, *args,
+            **kwargs) -> Optional[Union[SamplerOutput, HeteroSamplerOutput]]:
+
+        sampler_output = await async_func(*args, **kwargs)
+        res = await self._colloate_fn(sampler_output)
+
+        if self.channel is None:
+            return res
+        self.channel.put(res)
+        return None
+
+    async def node_sample(
+        self,
+        inputs: NodeSamplerInput,
+    ) -> Union[SamplerOutput, HeteroSamplerOutput]:
+        r"""Performs layer by layer distributed sampling from a
+        :class:`NodeSamplerInput` and returns the output of the sampling
+        procedure.
+
+        Note:
+            In case of distributed training it is required to synchronize the
+            results between machines after each layer.
+        """
+        seed = inputs.node.to(self.device)
+        seed_time = inputs.time.to(
+            self.device) if inputs.time is not None else None
+        input_type = inputs.input_type
+        self.input_type = input_type
+        metadata = (seed, seed_time)
+        batch_size = seed.numel()
+        src_batch = torch.arange(batch_size) if self.disjoint else None
+
+        if self.is_hetero:
+            if input_type is None:
+                raise ValueError("Input type should be defined")
+
+            node_dict = NodeDict(self._sampler.node_types)
+            batch_dict = BatchDict(self._sampler.node_types, self.disjoint)
+
+            edge_dict: Dict[EdgeType, Tensor] = {}
+
+            seed_time_dict: Dict[NodeType, Tensor] = {input_type: seed_time}
+            num_sampled_nodes_dict: Dict[NodeType, List[int]] = {}
+
+            sampled_nbrs_per_node_dict: Dict[EdgeType, List[int]] = {}
+            num_sampled_edges_dict: Dict[EdgeType, List[int]] = {}
+
+            for ntype in self._sampler.node_types:
+                num_sampled_nodes_dict.update({ntype: [0]})
+
+            for etype in self._sampler.edge_types:
+                edge_dict.update({etype: torch.empty(0, dtype=torch.int64)})
+                num_sampled_edges_dict.update({etype: []})
+                sampled_nbrs_per_node_dict.update({etype: []})
+
+            node_dict.src[input_type] = seed
+            batch_dict.src[input_type] = src_batch if self.disjoint else None
+
+            node_dict.out[input_type] = OrderedSet(
+                seed.tolist()) if not self.disjoint else OrderedSet(
+                    tuple(zip(src_batch.tolist(), seed.tolist())))
+            num_sampled_nodes_dict[input_type].append(seed.numel())
+
+            # loop over the layers
+            for i in range(self._sampler.num_hops):
+                # create tasks
+                task_dict = {}
+                for etype in self._sampler.edge_types:
+                    src = etype[0] if not self.csc else etype[2]
+
+                    if node_dict.src[src].numel():
+                        seed_time = seed_time_dict.get(
+                            src, None) if seed_time_dict.get(
+                                src, None) is not None else None
+                        one_hop_num = self.num_neighbors[i] if isinstance(
+                            self.num_neighbors,
+                            List) else self.num_neighbors[etype][i]
+
+                        task_dict[etype] = self.event_loop._loop.create_task(
+                            self.sample_one_hop(node_dict.src[src],
+                                                one_hop_num, seed_time,
+                                                batch_dict.src[src], etype))
+
+                for etype, task in task_dict.items():
+                    out: HeteroSamplerOutput = await task
+
+                    # remove duplicates
+                    # TODO: find better method to remove duplicates
+                    node_wo_dupl = OrderedSet(
+                        (out.node
+                         ).tolist()) if not self.disjoint else OrderedSet(
+                             zip((out.batch).tolist(), (out.node).tolist()))
+                    if len(node_wo_dupl) == 0:
+                        # no neighbors were sampled
+                        break
+                    dst = etype[2] if not self.csc else etype[0]
+                    duplicates = node_dict.out[dst].intersection(node_wo_dupl)
+                    node_wo_dupl.difference_update(duplicates)
+                    node_dict.src[dst] = Tensor(
+                        node_wo_dupl if not self.disjoint else list(
+                            zip(*node_wo_dupl))[1]).type(torch.int64)
+                    node_dict.out[dst].update(node_wo_dupl)
+
+                    node_dict.with_dupl[dst] = torch.cat(
+                        [node_dict.with_dupl[dst], out.node])
+                    edge_dict[etype] = torch.cat([edge_dict[etype], out.edge])
+
+                    if self.disjoint:
+                        batch_dict.src[dst] = Tensor(
+                            list(zip(*node_wo_dupl))[0]).type(torch.int64)
+                        batch_dict.with_dupl[dst] = torch.cat(
+                            [batch_dict.with_dupl[dst], out.batch])
+
+                    num_sampled_nodes_dict[dst].append(len(node_dict.src[dst]))
+                    num_sampled_edges_dict[etype].append(len(out.node))
+                    sampled_nbrs_per_node_dict[etype] += out.metadata
+
+            sampled_nbrs_per_node_dict = remap_keys(sampled_nbrs_per_node_dict,
+                                                    self._sampler.to_rel_type)
+
+            row_dict, col_dict = torch.ops.pyg.hetero_relabel_neighborhood(
+                self._sampler.node_types, self._sampler.edge_types,
+                {input_type: seed}, node_dict.with_dupl,
+                sampled_nbrs_per_node_dict, self._sampler.num_nodes,
+                batch_dict.with_dupl, self.csc, self.disjoint)
+
+            node_dict.out = {
+                ntype: Tensor(node_dict.out[ntype]).type(torch.int64)
+                for ntype in self._sampler.node_types
+            }
+            if self.disjoint:
+                for ntype in self._sampler.node_types:
+                    batch_dict.out[ntype], node_dict.out[
+                        ntype] = node_dict.out[ntype].t().contiguous()
+
+            sampler_output = HeteroSamplerOutput(
+                node=node_dict.out, row=remap_keys(row_dict,
+                                                   self._sampler.to_edge_type),
+                col=remap_keys(col_dict,
+                               self._sampler.to_edge_type), edge=edge_dict,
+                batch=batch_dict.out if self.disjoint else None,
+                num_sampled_nodes=num_sampled_nodes_dict,
+                num_sampled_edges=num_sampled_edges_dict, metadata=metadata)
+        else:
+
+            src = seed
+
+            node = OrderedSet(
+                src.tolist()) if not self.disjoint else OrderedSet(
+                    tuple(zip(src_batch.tolist(), src.tolist())))
+            node_with_dupl = []
+            batch_with_dupl = []
+            edge = []
+
+            sampled_nbrs_per_node = []
+            num_sampled_nodes = [seed.numel()]
+            num_sampled_edges = [0]
+
+            # loop over the layers
+            for one_hop_num in self.num_neighbors:
+                out = await self.sample_one_hop(src, one_hop_num, seed_time,
+                                                src_batch)
+
+                # remove duplicates
+                # TODO: find better method to remove duplicates
+                node_wo_dupl = OrderedSet(
+                    (out.node).tolist()) if not self.disjoint else OrderedSet(
+                        zip((out.batch).tolist(), (out.node).tolist()))
+                if len(node_wo_dupl) == 0:
+                    # no neighbors were sampled
+                    break
+                duplicates = node.intersection(node_wo_dupl)
+                node_wo_dupl.difference_update(duplicates)
+                src = Tensor(node_wo_dupl if not self.disjoint else list(
+                    zip(*node_wo_dupl))[1]).type(torch.int64)
+                node.update(node_wo_dupl)
+
+                node_with_dupl.append(out.node)
+                edge.append(out.edge)
+
+                if self.disjoint:
+                    src_batch = Tensor(list(zip(*node_wo_dupl))[0]).type(
+                        torch.int64)
+                    batch_with_dupl.append(out.batch)
+
+                num_sampled_nodes.append(len(src))
+                num_sampled_edges.append(len(out.node))
+                sampled_nbrs_per_node += out.metadata
+
+            row, col = torch.ops.pyg.relabel_neighborhood(
+                seed, torch.cat(node_with_dupl), sampled_nbrs_per_node,
+                self._sampler.num_nodes,
+                torch.cat(batch_with_dupl) if self.disjoint else None,
+                self.csc, self.disjoint)
+
+            node = Tensor(node).type(torch.int64)
+
+            batch, node = node.t().contiguous() if self.disjoint else (None,
+                                                                       node)
+
+            sampler_output = SamplerOutput(
+                node=node, row=row, col=col, edge=torch.cat(edge),
+                batch=batch if self.disjoint else None,
+                num_sampled_nodes=num_sampled_nodes,
+                num_sampled_edges=num_sampled_edges, metadata=metadata)
+
+        if self.subgraph_type == SubgraphType.bidirectional:
+            sampler_output = sampler_output.to_bidirectional()
+
+        return sampler_output
+
+    def get_local_sampler_output(
+        self,
+        outputs: List[SamplerOutput],
+        seed_size: int,
+    ) -> SamplerOutput:
+        r""" Used when seed nodes belongs only to a local partition. It's
+        purpose is to remove seed nodes from sampled nodes and calculates
+        how many neighbors were sampled by each src node based on the
+        :obj:`cumm_sampled_nbrs_per_node`.
+        Returns updated sampler output.
+        """
+        p_id = self.dist_graph.partition_idx
+
+        # do not include seed
+        outputs[p_id].node = outputs[p_id].node[seed_size:]
+        if self.disjoint:
+            outputs[p_id].batch = outputs[p_id].batch[seed_size:]
+
+        cumm_sampled_nbrs_per_node = outputs[p_id].metadata
+
+        begin = np.array(cumm_sampled_nbrs_per_node[1:])
+        end = np.array(cumm_sampled_nbrs_per_node[0:-1])
+
+        sampled_nbrs_per_node = list(np.subtract(begin, end))
+
+        outputs[p_id].metadata = (sampled_nbrs_per_node)
+
+        return outputs[p_id]
+
+    def merge_sampler_outputs(
+        self,
+        partition_ids: Tensor,
+        partition_orders: Tensor,
+        outputs: List[SamplerOutput],
+        one_hop_num: int,
+    ) -> SamplerOutput:
+        r""" Merges samplers outputs from different partitions, so that they
+        are sorted according to the sampling order. Removes seed nodes from
+        sampled nodes and calculates how many neighbors were sampled by each
+        src node based on the :obj:`cumm_sampled_nbrs_per_node`. Leverages the
+        :obj:`pyg-lib` :obj:`merge_sampler_outputs` function.
+
+        Args:
+            partition_ids (torch.Tensor): Contains information on which
+                partition seeds nodes are located on.
+            partition_orders (torch.Tensor): Contains information about the
+                order of seed nodes in each partition.
+            outputs (List[SamplerOutput]): List of all samplers outputs.
+            one_hop_num (int): Max number of neighbors sampled in the current
+                layer.
+
+        Returns :obj:`SamplerOutput` containing all merged outputs.
+        """
+        sampled_nodes_with_dupl = [
+            o.node if o is not None else None for o in outputs
+        ]
+        edge_ids = [o.edge if o is not None else None for o in outputs]
+        batch = [o.batch if o is not None else None
+                 for o in outputs] if self.disjoint else None
+        cumm_sampled_nbrs_per_node = [
+            o.metadata if o is not None else None for o in outputs
+        ]
+
+        partition_ids = partition_ids.tolist()
+        partition_orders = partition_orders.tolist()
+
+        partitions_num = self.dist_graph.meta['num_parts']
+
+        out = torch.ops.pyg.merge_sampler_outputs(
+            sampled_nodes_with_dupl, cumm_sampled_nbrs_per_node, partition_ids,
+            partition_orders, partitions_num, one_hop_num, edge_ids, batch,
+            self.disjoint, self.with_edge)
+        (out_node_with_dupl, out_edge, out_batch,
+         out_sampled_nbrs_per_node) = out
+
+        return SamplerOutput(out_node_with_dupl, None, None, out_edge,
+                             out_batch if self.disjoint else None,
+                             metadata=(out_sampled_nbrs_per_node))
+
+    async def sample_one_hop(
+        self,
+        srcs: Tensor,
+        one_hop_num: int,
+        seed_time: Optional[Tensor] = None,
+        batch: OptTensor = None,
+        etype: Optional[EdgeType] = None,
+    ) -> SamplerOutput:
+        r""" Sample one-hop neighbors for a :obj:`srcs`. If src node is located
+        on a local partition, evaluates the :obj:`_sample_one_hop` function on
+        a current machine. If src node is from a remote partition, send a
+        request to a remote machine that contains this partition.
+
+        Returns merged samplers outputs from local / remote machines.
+        """
+        src_ntype = (etype[0] if not self.csc else
+                     etype[2]) if etype is not None else None
+
+        partition_ids = self.dist_graph.get_partition_ids_from_nids(
+            srcs, src_ntype)
+        partition_orders = torch.zeros(len(partition_ids), dtype=torch.long)
+
+        p_outputs: List[SamplerOutput] = [None
+                                          ] * self.dist_graph.meta['num_parts']
+        futs: List[torch.futures.Future] = []
+
+        local_only = True
+
+        for i in range(self.dist_graph.num_partitions):
+            p_id = ((self.dist_graph.partition_idx + i) %
+                    self.dist_graph.num_partitions)
+            p_mask = (partition_ids == p_id)
+            p_srcs = torch.masked_select(srcs, p_mask)
+            p_batch = torch.masked_select(
+                batch, p_mask) if batch is not None else None
+            p_seed_time = torch.masked_select(
+                seed_time, p_mask) if seed_time is not None else None
+
+            p_indices = torch.arange(len(p_srcs), dtype=torch.long)
+            partition_orders[p_mask] = p_indices
+
+            if p_srcs.shape[0] > 0:
+                if p_id == self.dist_graph.partition_idx:
+                    # sample on local machine
+                    p_nbr_out = self._sampler._sample_one_hop(
+                        p_srcs, one_hop_num, p_seed_time, p_batch, self.csc,
+                        etype)
+                    p_outputs.pop(p_id)
+                    p_outputs.insert(p_id, p_nbr_out)
+                else:
+                    # sample on remote machine
+                    local_only = False
+                    to_worker = self.rpc_router.get_to_worker(p_id)
+                    futs.append(
+                        rpc_async(
+                            to_worker, self.rpc_sample_callee_id,
+                            args=(p_srcs, one_hop_num, p_seed_time, p_batch,
+                                  etype)))
+
+        # All src nodes are local
+        if local_only:
+            return self.get_local_sampler_output(p_outputs, len(srcs))
+
+        # Src nodes are remote
+        res_fut_list = await wrap_torch_future(torch.futures.collect_all(futs))
+        for i, res_fut in enumerate(res_fut_list):
+            p_outputs.pop(p_id)
+            p_outputs.insert(p_id, res_fut.wait())
+
+        return self.merge_sampler_outputs(partition_ids, partition_orders,
+                                          p_outputs, one_hop_num)
+
+    async def _colloate_fn(
+        self, output: Union[SamplerOutput, HeteroSamplerOutput]
+    ) -> Union[SamplerOutput, HeteroSamplerOutput]:
+        pass
+
+
+# Sampling Utilities ##########################################################
+
+
+def close_sampler(worker_id, sampler):
+    # Make sure that mp.Queue is empty at exit and RAM is cleared
+    try:
+        sampler.event_loop.shutdown_loop()
+    except AttributeError:
+        pass
+    shutdown_rpc(graceful=True)

--- a/torch_geometric/distributed/event_loop.py
+++ b/torch_geometric/distributed/event_loop.py
@@ -1,0 +1,88 @@
+import asyncio
+import logging
+from threading import BoundedSemaphore, Thread
+
+import torch
+
+
+def wrap_torch_future(f: torch.futures.Future) -> asyncio.futures.Future:
+    r""" Convert a torch future to a standard asyncio future."""
+    loop = asyncio.get_event_loop()
+    aio_future = loop.create_future()
+
+    def on_done(*_):
+        try:
+            result = f.wait()
+        except Exception as e:
+            loop.call_soon_threadsafe(aio_future.set_exception, e)
+        else:
+            loop.call_soon_threadsafe(aio_future.set_result, result)
+
+    f.add_done_callback(on_done)
+    return aio_future
+
+
+class ConcurrentEventLoop(object):
+    r""" Concurrent event loop context.
+
+    Args:
+        concurrency: max processing concurrency.
+    """
+    def __init__(self, concurrency):
+        self._concurrency = concurrency
+        self._sem = BoundedSemaphore(concurrency)
+        self._loop = asyncio.new_event_loop()
+        self._runner_t = Thread(target=self._run_loop)
+        self._runner_t.daemon = True
+
+    def start_loop(self):
+        if not self._runner_t.is_alive():
+            self._runner_t.start()
+
+    def shutdown_loop(self):
+        self.wait_all()
+        if self._runner_t.is_alive():
+            self._loop.stop()
+            self._runner_t.join(timeout=1)
+
+    def wait_all(self):
+        r""" Wait all pending tasks to be finished."""
+        for _ in range(self._concurrency):
+            self._sem.acquire()
+        for _ in range(self._concurrency):
+            self._sem.release()
+
+    def add_task(self, coro, callback=None):
+        r""" Add an asynchronized coroutine task to run.
+
+        Args:
+        coro: the async coroutine func.
+        callback: the callback func applied on the returned results
+            after the coroutine task is finished.
+
+        Note that any results returned by `callback` func will be ignored,
+        so it is preferable to handle all in your `callback` func and do
+        not return any results.
+        """
+        def on_done(f: asyncio.futures.Future):
+            try:
+                res = f.result()
+                if callback is not None:
+                    callback(res)
+            except Exception as e:
+                logging.error("coroutine task failed: %s", e)
+            self._sem.release()
+
+        self._sem.acquire()
+        fut = asyncio.run_coroutine_threadsafe(coro, self._loop)
+        fut.add_done_callback(on_done)
+
+    def run_task(self, coro):
+        r""" Run a coroutine task synchronously.
+        """
+        with self._sem:
+            fut = asyncio.run_coroutine_threadsafe(coro, self._loop)
+            return fut.result()
+
+    def _run_loop(self):
+        self._loop.run_forever()

--- a/torch_geometric/distributed/local_graph_store.py
+++ b/torch_geometric/distributed/local_graph_store.py
@@ -89,6 +89,7 @@ class LocalGraphStore(GraphStore):
         edge_id: Tensor,
         edge_index: Tensor,
         num_nodes: int,
+        is_sorted: Optional[bool] = False,
     ) -> 'LocalGraphStore':
         r"""Creates a local graph store from a homogeneous :pyg:`PyG` graph.
 
@@ -101,6 +102,7 @@ class LocalGraphStore(GraphStore):
             edge_type=None,
             layout='coo',
             size=(num_nodes, num_nodes),
+            is_sorted=is_sorted,
         )
 
         graph_store = cls()
@@ -114,6 +116,7 @@ class LocalGraphStore(GraphStore):
         edge_id_dict: Dict[EdgeType, Tensor],
         edge_index_dict: Dict[EdgeType, Tensor],
         num_nodes_dict: Dict[NodeType, int],
+        is_sorted_dict: Dict[NodeType, bool],
     ) -> 'LocalGraphStore':
         r"""Creates a local graph store from a heterogeneous :pyg:`PyG` graph.
 
@@ -132,6 +135,7 @@ class LocalGraphStore(GraphStore):
                 edge_type=edge_type,
                 layout='coo',
                 size=(num_nodes_dict[src], num_nodes_dict[dst]),
+                is_sorted=is_sorted_dict[dst],
             )
 
         graph_store = cls()

--- a/torch_geometric/distributed/utils.py
+++ b/torch_geometric/distributed/utils.py
@@ -1,11 +1,12 @@
+from dataclasses import dataclass
+from typing import Dict, List, Union
+
 import torch
+from ordered_set import OrderedSet
 from torch import Tensor
 
-from ordered_set import OrderedSet
-from dataclasses import dataclass
-
-from typing import Dict, List, Union
 from torch_geometric.typing import Dict, NodeType
+
 
 @dataclass
 class NodeDict:

--- a/torch_geometric/distributed/utils.py
+++ b/torch_geometric/distributed/utils.py
@@ -1,0 +1,55 @@
+import torch
+from torch import Tensor
+
+from ordered_set import OrderedSet
+from dataclasses import dataclass
+
+from typing import Dict, List, Union
+from torch_geometric.typing import Dict, NodeType
+
+@dataclass
+class NodeDict:
+    r""" Class used during hetero sampling. It contains fields that refer to
+    NodeDict in three situations:
+    1) the nodes are to serve as srcs in the next layer,
+    2) nodes with duplicates, that are further needed to create COO output
+       matrix,
+    3) output nodes without duplicates.
+    """
+    def __init__(self, node_types):
+        self.src: Dict[NodeType, Tensor] = {}
+        self.with_dupl: Dict[NodeType, Tensor] = {}
+        self.out: Union[OrderedSet[List[int]], Dict[NodeType, Tensor]] = {}
+
+        for ntype in node_types:
+            self.src.update({ntype: torch.empty(0, dtype=torch.int64)})
+            self.with_dupl.update({ntype: torch.empty(0, dtype=torch.int64)})
+            self.out.update({ntype: OrderedSet([])})
+
+
+@dataclass
+class BatchDict:
+    r""" Class used during disjoint hetero sampling. It contains fields that
+    refer to BatchDict in three situations:
+    1) the batch is to serve as initial subgraph ids for src nodes in the next
+       layer,
+    2) subgraph ids with duplicates, that are further needed to create COO
+       output matrix,
+    3) output subgraph ids without duplicates.
+    """
+    def __init__(self, node_types, disjoint):
+        self.src: Dict[NodeType, Tensor] = {}
+        self.with_dupl: Dict[NodeType, Tensor] = {}
+        self.out: Dict[NodeType, Tensor] = {}
+        self.disjoint = disjoint
+
+        if not self.disjoint:
+            for ntype in node_types:
+                self.src.update({ntype: torch.empty(0, dtype=torch.int64)})
+                self.with_dupl.update(
+                    {ntype: torch.empty(0, dtype=torch.int64)})
+                self.out.update({ntype: torch.empty(0, dtype=torch.int64)})
+        else:
+            self.src = None
+            self.with_dupl = None
+            self.out = None

--- a/torch_geometric/sampler/__init__.py
+++ b/torch_geometric/sampler/__init__.py
@@ -1,10 +1,10 @@
 from .base import (BaseSampler, NodeSamplerInput, EdgeSamplerInput,
                    SamplerOutput, HeteroSamplerOutput, NegativeSampling,
                    NumNeighbors)
-from .neighbor_sampler import NeighborSampler
+from .neighbor_sampler import NeighborSampler, edge_sample_async
 from .hgt_sampler import HGTSampler
 
-__all__ = classes = [
+classes = [
     'BaseSampler',
     'NodeSamplerInput',
     'EdgeSamplerInput',
@@ -15,3 +15,9 @@ __all__ = classes = [
     'NeighborSampler',
     'HGTSampler',
 ]
+
+functions = [
+    'edge_sample_async',
+]
+
+__all__ = classes + functions

--- a/torch_geometric/sampler/base.py
+++ b/torch_geometric/sampler/base.py
@@ -93,6 +93,17 @@ class NodeSamplerInput(CastMixin):
             self.input_type,
         )
 
+    def __len__(self):
+        return self.node.numel()
+
+    def share_memory(self):
+        self.node.share_memory_()
+        return self
+
+    def to(self, device: torch.device):
+        self.node.to(device)
+        return self
+
 
 @dataclass(init=False)
 class EdgeSamplerInput(CastMixin):
@@ -157,6 +168,23 @@ class EdgeSamplerInput(CastMixin):
             self.time[index] if self.time is not None else None,
             self.input_type,
         )
+
+    def __len__(self):
+        return self.row.numel()
+
+    def share_memory(self):
+        self.row.share_memory_()
+        self.col.share_memory_()
+        if self.label is not None:
+            self.label.share_memory_()
+        return self
+
+    def to(self, device: torch.device):
+        self.row.to(device)
+        self.col.to(device)
+        if self.label is not None:
+            self.label.to(device)
+        return self
 
 
 @dataclass

--- a/torch_geometric/sampler/neighbor_sampler.py
+++ b/torch_geometric/sampler/neighbor_sampler.py
@@ -1,3 +1,4 @@
+import asyncio
 import copy
 import math
 import sys
@@ -47,6 +48,7 @@ class NeighborSampler(BaseSampler):
         share_memory: bool = False,
         # Deprecated:
         directed: bool = True,
+        is_hetero: bool = None,
     ):
         if not directed:
             subgraph_type = SubgraphType.induced
@@ -93,25 +95,18 @@ class NeighborSampler(BaseSampler):
 
         else:  # self.data_type == DataType.remote
             feature_store, graph_store = data
-
-            # Obtain graph metadata:
             node_attrs = feature_store.get_all_tensor_attrs()
-            self.node_types = list(set(attr.group_name for attr in node_attrs))
-
             edge_attrs = graph_store.get_all_edge_attrs()
-            self.edge_types = list(set(attr.edge_type for attr in edge_attrs))
 
-            self.num_nodes = {
-                node_type: remote_backend_utils.size(*data, node_type)
-                for node_type in self.node_types
-            }
+            # infere hetero or homo - backwards compatibility hotfix
+            # (test failing)
+            try:
+                self.is_hetero = graph_store.meta["is_hetero"]
+            except AttributeError:
+                # assume default is_hetero = True
+                self.is_hetero = True
 
-            self.node_time: Optional[Dict[str, Tensor]] = None
             if time_attr is not None:
-                # If the `time_attr` is present, we expect that `GraphStore`
-                # holds all edges sorted by destination, and within local
-                # neighborhoods, node indices should be sorted by time.
-                # TODO (matthias, manan) Find an alternative way to ensure.
                 for edge_attr in edge_attrs:
                     if edge_attr.layout == EdgeLayout.CSR:
                         raise ValueError(
@@ -122,30 +117,64 @@ class NeighborSampler(BaseSampler):
                             "Temporal sampling requires that edges are "
                             "sorted by destination, and by source time "
                             "within local neighborhoods")
-
                 # We obtain all features with `node_attr.name=time_attr`:
                 time_attrs = [
                     copy.copy(attr) for attr in node_attrs
                     if attr.attr_name == time_attr
                 ]
-                for attr in time_attrs:  # Reset the index to obtain full data.
-                    attr.index = None
-                time_tensors = feature_store.multi_get_tensor(time_attrs)
-                self.node_time = {
-                    time_attr.group_name: time_tensor
-                    for time_attr, time_tensor in zip(time_attrs, time_tensors)
+
+            # Obtain graph metadata:
+            self.node_types = list(
+                set(attr.group_name for attr in node_attrs
+                    if type(attr.group_name) == NodeType))
+            self.edge_types = list(set(attr.edge_type for attr in edge_attrs))
+
+            if self.is_hetero is False:
+
+                self.num_nodes = max(edge_attrs[0].size)
+                self.node_time: Optional[Tensor] = None
+
+                if time_attr is not None:
+                    if len(time_attrs) != 1:
+                        raise ValueError(
+                            "There should be one time attr in case of homo "
+                            "data")
+                    # Reset the index to obtain full data.
+                    time_attrs[0].index = None
+                    time_tensor = feature_store.get_tensor(time_attrs[0])
+                    self.node_time = time_tensor
+
+                self.row, self.colptr, self.perm = graph_store.csc()
+
+            elif self.is_hetero is True:
+
+                self.num_nodes = {
+                    node_type: remote_backend_utils.size(*data, node_type)
+                    for node_type in self.node_types
                 }
 
-            # Conversion to/from C++ string type (see above):
-            self.to_rel_type = {k: '__'.join(k) for k in self.edge_types}
-            self.to_edge_type = {v: k for k, v in self.to_rel_type.items()}
+                self.node_time: Optional[Dict[str, Tensor]] = None
+                if time_attr is not None:
+                    # Reset the index to obtain full data.
+                    for attr in time_attrs:
+                        attr.index = None
+                    time_tensors = feature_store.multi_get_tensor(time_attrs)
+                    self.node_time = {
+                        time_attr.group_name: time_tensor
+                        for time_attr, time_tensor in zip(
+                            time_attrs, time_tensors)
+                    }
 
-            # Convert the graph data into CSC format for sampling:
-            row_dict, colptr_dict, self.perm = graph_store.csc()
-            self.row_dict = remap_keys(row_dict, self.to_rel_type)
-            self.colptr_dict = remap_keys(colptr_dict, self.to_rel_type)
+                # Conversion to/from C++ string type (see above):
+                self.to_rel_type = {k: '__'.join(k) for k in self.edge_types}
+                self.to_edge_type = {v: k for k, v in self.to_rel_type.items()}
+                # Convert the graph data into CSC format for sampling:
+                row_dict, colptr_dict, self.perm = graph_store.csc()
+                self.row_dict = remap_keys(row_dict, self.to_rel_type)
+                self.colptr_dict = remap_keys(colptr_dict, self.to_rel_type)
 
         self.num_neighbors = num_neighbors
+        self.num_hops = self.num_neighbors.num_hops
         self.replace = replace
         self.subgraph_type = SubgraphType(subgraph_type)
         self.disjoint = disjoint
@@ -354,6 +383,53 @@ class NeighborSampler(BaseSampler):
                 num_sampled_edges=num_sampled_edges,
             )
 
+    def _sample_one_hop(self, srcs: Tensor, one_hop_num: int,
+                        seed_time: Optional[Tensor] = None,
+                        batch: OptTensor = None, csc: bool = True,
+                        edge_type: EdgeType = None) -> SamplerOutput:
+        r""" Implements one-hop neighbor sampling for a :obj:`srcs`
+        leveraging a :obj:`neighbor_sample` function from :obj:`pyg-lib`.
+        """
+        rel_type = '__'.join(edge_type) if self.is_hetero else None
+
+        colptr = self.colptr if not self.is_hetero else self.colptr_dict[
+            rel_type]
+        row = self.row if not self.is_hetero else self.row_dict[rel_type]
+
+        if self.node_time is not None:
+            node_time = self.node_time if not self.is_hetero else \
+                self.node_time[edge_type[0] if not csc else edge_type[0]]
+        else:
+            node_time = None
+
+        seed = srcs
+
+        out = torch.ops.pyg.neighbor_sample(
+            colptr,
+            row,
+            seed.to(colptr.dtype),
+            [one_hop_num],
+            node_time,
+            seed_time,
+            batch,
+            csc,
+            self.replace,
+            self.subgraph_type != SubgraphType.induced,
+            self.disjoint,
+            self.temporal_strategy,
+            True,  # return_edge_id
+            True,  # distributed
+        )
+        _, _, node, edge, batch = out[:4] + (None, )
+
+        cumm_sum_nbrs_per_node = out[6]
+
+        if self.disjoint:
+            batch, node = node.t().contiguous()
+
+        return SamplerOutput(node=node, row=None, col=None, edge=edge,
+                             batch=batch, metadata=(cumm_sum_nbrs_per_node))
+
 
 # Sampling Utilities ##########################################################
 
@@ -387,6 +463,20 @@ def edge_sample(
     disjoint: bool,
     node_time: Optional[Union[Tensor, Dict[str, Tensor]]] = None,
     neg_sampling: Optional[NegativeSampling] = None,
+) -> Union[SamplerOutput, HeteroSamplerOutput]:
+    return asyncio.run(
+        edge_sample_async(inputs, sample_fn, num_nodes, disjoint, node_time,
+                          neg_sampling))
+
+
+async def edge_sample_async(
+    inputs: EdgeSamplerInput,
+    sample_fn: Callable,
+    num_nodes: Union[int, Dict[NodeType, int]],
+    disjoint: bool,
+    node_time: Optional[Union[Tensor, Dict[str, Tensor]]] = None,
+    neg_sampling: Optional[NegativeSampling] = None,
+    distributed: bool = False,
 ) -> Union[SamplerOutput, HeteroSamplerOutput]:
     r"""Performs sampling from an edge sampler input, leveraging a sampling
     function of the same signature as `node_sample`."""
@@ -566,7 +656,12 @@ def edge_sample(
         if edge_label_time is not None:  # Always disjoint.
             seed_time = torch.cat([src_time, dst_time])
 
-        out = sample_fn(seed, seed_time)
+        if distributed:
+            out = await sample_fn(
+                NodeSamplerInput(inputs.input_id, seed, seed_time,
+                                 input_type=None))
+        else:
+            out = sample_fn(seed, seed_time)
 
         # Enhance `out` by label information ##################################
         if neg_sampling is None or neg_sampling.is_binary():


### PR DESCRIPTION
This code belongs to the part of the whole distributed training for PyG.

`DistNeighborSampler` leverages the `NeighborSampler` class from `pytorch_geometric` and the `neighbor_sample` function from `pyg-lib`. However, due to the fact that in case of distributed training it is required to synchronise the results between machines after each layer, the part of the code responsible for sampling was implemented in python.

Added suport for the following sampling methods:
- node, edge, negative, disjoint, temporal

**TODOs:**
- finish hetero part
- subgraph sampling

**Other distributed PRs:**
pytorch_geometric: [#7869](https://github.com/pyg-team/pytorch_geometric/pull/7869)
pyg-lib: [#246](https://github.com/pyg-team/pyg-lib/pull/246)