### PR TITLE
Implemented the Learnable Communitive Monoid Aggregation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
-- Added `LCMAggregation`, an implementation of the Learnable Communitive Monoid for GNN's ([#7976](https://github.com/pyg-team/pytorch_geometric/pull/7976))
+- Added `LCMAggregation`, an implementation of Learnable Communitive Monoids ([#7976](https://github.com/pyg-team/pytorch_geometric/pull/7976))
 - Added a warning for isolated/non-existing node types in `HeteroData.validate()` ([#7995](https://github.com/pyg-team/pytorch_geometric/pull/7995))
 - Added `utils.cumsum` implementation ([#7994](https://github.com/pyg-team/pytorch_geometric/pull/7994))
 - Added the `BrcaTcga` dataset ([#7905](https://github.com/pyg-team/pytorch_geometric/pull/7905))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,7 +93,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Added unbatching logic for `torch.sparse` tensors ([#7037](https://github.com/pyg-team/pytorch_geometric/pull/7037))
 - Added the `RotatE` KGE model ([#7026](https://github.com/pyg-team/pytorch_geometric/pull/7026))
 - Added support for Apple silicon GPU acceleration in some main examples ([#7770](https://github.com/pyg-team/pytorch_geometric/pull/7770), [#7711](https://github.com/pyg-team/pytorch_geometric/pull/7711), [#7784](https://github.com/pyg-team/pytorch_geometric/pull/7784), [#7785](https://github.com/pyg-team/pytorch_geometric/pull/7785))
-- Added `LCMAggregation`, an implementation of the Learnable Communitive Monoid for GNN's ([#7574](https://github.com/pyg-team/pytorch_geometric/issues/7574))
+- Added `LCMAggregation`, an implementation of the Learnable Communitive Monoid for GNN's ([#7976](https://github.com/pyg-team/pytorch_geometric/pull/7976))
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Added unbatching logic for `torch.sparse` tensors ([#7037](https://github.com/pyg-team/pytorch_geometric/pull/7037))
 - Added the `RotatE` KGE model ([#7026](https://github.com/pyg-team/pytorch_geometric/pull/7026))
 - Added support for Apple silicon GPU acceleration in some main examples ([#7770](https://github.com/pyg-team/pytorch_geometric/pull/7770), [#7711](https://github.com/pyg-team/pytorch_geometric/pull/7711), [#7784](https://github.com/pyg-team/pytorch_geometric/pull/7784), [#7785](https://github.com/pyg-team/pytorch_geometric/pull/7785))
+- Added `LCMAggregation`, an implementation of the Learnable Communitive Monoid for GNN's ([#7574](https://github.com/pyg-team/pytorch_geometric/issues/7574))
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- Added `LCMAggregation`, an implementation of the Learnable Communitive Monoid for GNN's ([#7976](https://github.com/pyg-team/pytorch_geometric/pull/7976))
 - Added a warning for isolated/non-existing node types in `HeteroData.validate()` ([#7995](https://github.com/pyg-team/pytorch_geometric/pull/7995))
 - Added `utils.cumsum` implementation ([#7994](https://github.com/pyg-team/pytorch_geometric/pull/7994))
 - Added the `BrcaTcga` dataset ([#7905](https://github.com/pyg-team/pytorch_geometric/pull/7905))
@@ -93,7 +94,6 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Added unbatching logic for `torch.sparse` tensors ([#7037](https://github.com/pyg-team/pytorch_geometric/pull/7037))
 - Added the `RotatE` KGE model ([#7026](https://github.com/pyg-team/pytorch_geometric/pull/7026))
 - Added support for Apple silicon GPU acceleration in some main examples ([#7770](https://github.com/pyg-team/pytorch_geometric/pull/7770), [#7711](https://github.com/pyg-team/pytorch_geometric/pull/7711), [#7784](https://github.com/pyg-team/pytorch_geometric/pull/7784), [#7785](https://github.com/pyg-team/pytorch_geometric/pull/7785))
-- Added `LCMAggregation`, an implementation of the Learnable Communitive Monoid for GNN's ([#7976](https://github.com/pyg-team/pytorch_geometric/pull/7976))
 
 ### Changed
 

--- a/test/nn/aggr/test_lcm.py
+++ b/test/nn/aggr/test_lcm.py
@@ -1,3 +1,4 @@
+import pytest
 import torch
 
 from torch_geometric.nn.aggr.lcm import LCMAggregation
@@ -26,9 +27,5 @@ def test_lcm_aggregation2():
 
 
 def test_lcm_aggregation3():
-    try:
+    with pytest.raises(ValueError):
         LCMAggregation(16, 32, project=False)
-    except ValueError:
-        return
-
-    assert False

--- a/test/nn/aggr/test_lcm.py
+++ b/test/nn/aggr/test_lcm.py
@@ -1,10 +1,10 @@
 import pytest
 import torch
 
-from torch_geometric.nn.aggr.lcm import LCMAggregation
+from torch_geometric.nn import LCMAggregation
 
 
-def test_lcm_aggregation1():
+def test_lcm_aggregation_with_project():
     x = torch.randn(6, 16)
     index = torch.tensor([0, 0, 1, 1, 1, 2])
 
@@ -15,7 +15,7 @@ def test_lcm_aggregation1():
     assert out.size() == (3, 32)
 
 
-def test_lcm_aggregation2():
+def test_lcm_aggregation_without_project():
     x = torch.randn(6, 16)
     index = torch.tensor([0, 0, 1, 1, 1, 2])
 
@@ -26,6 +26,6 @@ def test_lcm_aggregation2():
     assert out.size() == (3, 16)
 
 
-def test_lcm_aggregation3():
-    with pytest.raises(ValueError):
+def test_lcm_aggregation_error_handling():
+    with pytest.raises(ValueError, match="must be projected"):
         LCMAggregation(16, 32, project=False)

--- a/test/nn/aggr/test_lcm.py
+++ b/test/nn/aggr/test_lcm.py
@@ -1,0 +1,34 @@
+import torch
+
+from torch_geometric.nn.aggr.lcm import LCMAggregation
+
+
+def test_lcm_aggregation1():
+    x = torch.randn(6, 16)
+    index = torch.tensor([0, 0, 1, 1, 1, 2])
+
+    aggr = LCMAggregation(16, 32)
+    assert str(aggr) == 'LCMAggregation(16, 32, project=True)'
+
+    out = aggr(x, index)
+    assert out.size() == (3, 32)
+
+
+def test_lcm_aggregation2():
+    x = torch.randn(6, 16)
+    index = torch.tensor([0, 0, 1, 1, 1, 2])
+
+    aggr = LCMAggregation(16, 16, project=False)
+    assert str(aggr) == 'LCMAggregation(16, 16, project=False)'
+
+    out = aggr(x, index)
+    assert out.size() == (3, 16)
+
+
+def test_lcm_aggregation3():
+    try:
+        LCMAggregation(16, 32, project=False)
+    except ValueError:
+        return
+
+    assert False

--- a/torch_geometric/nn/aggr/__init__.py
+++ b/torch_geometric/nn/aggr/__init__.py
@@ -23,6 +23,7 @@ from .attention import AttentionalAggregation
 from .mlp import MLPAggregation
 from .deep_sets import DeepSetsAggregation
 from .set_transformer import SetTransformerAggregation
+from .lcm import LCMAggregation
 
 __all__ = classes = [
     'Aggregation',
@@ -49,4 +50,5 @@ __all__ = classes = [
     'MLPAggregation',
     'DeepSetsAggregation',
     'SetTransformerAggregation',
+    'LCMAggregation',
 ]

--- a/torch_geometric/nn/aggr/lcm.py
+++ b/torch_geometric/nn/aggr/lcm.py
@@ -77,8 +77,9 @@ class LCMAggregation(Aggregation):
         depth = ceil(log2(x.shape[0]))
         for _ in range(depth):
             x = [
-                self.bin_op(x[2 * i], x[2 * i + 1]) if 2 * i +
-                1 < len(x) else x[2 * i] for i in range(ceil(len(x) / 2))
+                self.bin_op(x[2 * i], x[2 * i + 1]) if
+                (2 * i + 1) < len(x) else x[2 * i]
+                for i in range(ceil(len(x) / 2))
             ]
 
         assert len(x) == 1

--- a/torch_geometric/nn/aggr/lcm.py
+++ b/torch_geometric/nn/aggr/lcm.py
@@ -1,0 +1,90 @@
+from math import ceil, log2
+from typing import Optional
+
+from torch import Tensor
+from torch.nn import GRUCell, Linear
+
+from torch_geometric.experimental import disable_dynamic_shapes
+from torch_geometric.nn.aggr import Aggregation
+
+
+class LCMAggregation(Aggregation):
+    r"""Performs LCM aggregation in which the elements are aggregated using a
+    binary tree reduction with $O(\log V)$ depth, as described in the
+    `"Learnable Commutative Monoids for Graph Neural Networks"
+    <https://arxiv.org/abs/2212.08541>`_ paper.
+
+    .. note::
+
+        :class:`LCMAggregation` requires sorted indices :obj:`index` as input.
+        Specifically, if you use this aggregation as part of
+        :class:`~torch_geometric.nn.conv.MessagePassing`, ensure that
+        :obj:`edge_index` is sorted by destination nodes, either by manually
+        sorting edge indices via :meth:`~torch_geometric.utils.sort_edge_index`
+        or by calling :meth:`torch_geometric.data.Data.sort`.
+
+    .. warning::
+
+        :class:`LCMAggregation` is not a permutation-invariant operator.
+
+    Args:
+        in_channels (int): Size of each input sample.
+        out_channels (int): Size of each output sample.
+        project (bool, optional): If set to :obj:`True`, the layer will apply a
+            linear transformation followed by an activation function before
+            aggregation. (default: :obj:`True`)
+    """
+    def __init__(self, in_channels: int, out_channels: int,
+                 project: Optional[bool] = True):
+        super().__init__()
+        if in_channels != out_channels and not project:
+            raise ValueError("input must be projected if"
+                             "`in_channels != out_channels`")
+
+        self.in_channels = in_channels
+        self.out_channels = out_channels
+        self.project = project
+        if project:
+            self.lin = Linear(in_channels, out_channels, bias=True)
+
+        self.gru_cell = GRUCell(out_channels, out_channels)
+
+        self.bin_op = lambda x, y: \
+            (self.gru_cell(x, y) + self.gru_cell(y, x)) / 2
+
+    def reset_parameters(self):
+        self.gru_cell.reset_parameters()
+        if self.project:
+            self.lin.reset_parameters()
+
+    @disable_dynamic_shapes(required_args=['dim_size', 'max_num_elements'])
+    def forward(
+        self,
+        x: Tensor,
+        index: Optional[Tensor] = None,
+        ptr: Optional[Tensor] = None,
+        dim_size: Optional[int] = None,
+        dim: int = -2,
+        max_num_elements: Optional[int] = None,
+    ):
+        x, _ = self.to_dense_batch(x, index, ptr, dim_size, dim,
+                                   max_num_elements=max_num_elements)
+
+        if self.project:
+            x = self.lin(x).relu()
+        x = x.permute(1, 0, 2)
+
+        depth = ceil(log2(x.shape[0]))
+        for _ in range(depth):
+            x = [
+                self.bin_op(x[2 * i], x[2 * i + 1]) if 2 * i +
+                1 < len(x) else x[2 * i] for i in range(ceil(len(x) / 2))
+            ]
+
+        assert len(x) == 1
+        return x[0]
+
+    def __repr__(self) -> str:
+        return (f'{self.__class__.__name__}({self.in_channels}, '
+                f'{self.out_channels}, '
+                f'project={self.project})')

--- a/torch_geometric/nn/aggr/lcm.py
+++ b/torch_geometric/nn/aggr/lcm.py
@@ -35,7 +35,7 @@ class LCMAggregation(Aggregation):
             aggregation. (default: :obj:`True`)
     """
     def __init__(self, in_channels: int, out_channels: int,
-                 project: Optional[bool] = True):
+                 project: bool = True):
         super().__init__()
         if in_channels != out_channels and not project:
             raise ValueError("input must be projected if"

--- a/torch_geometric/nn/aggr/lcm.py
+++ b/torch_geometric/nn/aggr/lcm.py
@@ -9,10 +9,11 @@ from torch_geometric.nn.aggr import Aggregation
 
 
 class LCMAggregation(Aggregation):
-    r"""Performs LCM aggregation in which the elements are aggregated using a
-    binary tree reduction with $O(\log V)$ depth, as described in the
+    r"""The Learnable Commutative Monoid aggregation from the
     `"Learnable Commutative Monoids for Graph Neural Networks"
-    <https://arxiv.org/abs/2212.08541>`_ paper.
+    <https://arxiv.org/abs/2212.08541>`_ paper, in which the elements are
+    aggregated using a binary tree reduction with
+    :math:`\mathcal{O}(\log |\mathcal{V}|)` depth.
 
     .. note::
 
@@ -34,28 +35,36 @@ class LCMAggregation(Aggregation):
             linear transformation followed by an activation function before
             aggregation. (default: :obj:`True`)
     """
-    def __init__(self, in_channels: int, out_channels: int,
-                 project: bool = True):
+    def __init__(
+        self,
+        in_channels: int,
+        out_channels: int,
+        project: bool = True,
+    ):
         super().__init__()
+
         if in_channels != out_channels and not project:
-            raise ValueError("input must be projected if"
-                             "`in_channels != out_channels`")
+            raise ValueError(f"Inputs of '{self.__class__.__name__}' must be "
+                             f"projected if `in_channels != out_channels`")
 
         self.in_channels = in_channels
         self.out_channels = out_channels
         self.project = project
-        if project:
-            self.lin = Linear(in_channels, out_channels, bias=True)
+
+        if self.project:
+            self.lin = Linear(in_channels, out_channels)
+        else:
+            self.lin = None
 
         self.gru_cell = GRUCell(out_channels, out_channels)
 
-        self.bin_op = lambda x, y: \
-            (self.gru_cell(x, y) + self.gru_cell(y, x)) / 2
-
     def reset_parameters(self):
-        self.gru_cell.reset_parameters()
-        if self.project:
+        if self.lin is not None:
             self.lin.reset_parameters()
+        self.gru_cell.reset_parameters()
+
+    def binary_op(self, left: Tensor, right: Tensor) -> Tensor:
+        return (self.gru_cell(left, right) + self.gru_cell(right, left)) / 2.0
 
     @disable_dynamic_shapes(required_args=['dim_size', 'max_num_elements'])
     def forward(
@@ -67,17 +76,19 @@ class LCMAggregation(Aggregation):
         dim: int = -2,
         max_num_elements: Optional[int] = None,
     ) -> Tensor:
-        x, _ = self.to_dense_batch(x, index, ptr, dim_size, dim,
-                                   max_num_elements=max_num_elements)
 
         if self.project:
             x = self.lin(x).relu()
-        x = x.permute(1, 0, 2)
 
-        depth = ceil(log2(x.shape[0]))
+        x, _ = self.to_dense_batch(x, index, ptr, dim_size, dim,
+                                   max_num_elements=max_num_elements)
+
+        x = x.permute(1, 0, 2)  # [num_neighbors, num_nodes, num_features]
+
+        depth = ceil(log2(x.size(0)))
         for _ in range(depth):
             x = [
-                self.bin_op(x[2 * i], x[2 * i + 1]) if
+                self.binary_op(x[2 * i], x[2 * i + 1]) if
                 (2 * i + 1) < len(x) else x[2 * i]
                 for i in range(ceil(len(x) / 2))
             ]
@@ -87,5 +98,4 @@ class LCMAggregation(Aggregation):
 
     def __repr__(self) -> str:
         return (f'{self.__class__.__name__}({self.in_channels}, '
-                f'{self.out_channels}, '
-                f'project={self.project})')
+                f'{self.out_channels}, project={self.project})')

--- a/torch_geometric/nn/aggr/lcm.py
+++ b/torch_geometric/nn/aggr/lcm.py
@@ -59,7 +59,7 @@ class LCMAggregation(Aggregation):
         self.gru_cell = GRUCell(out_channels, out_channels)
 
     def reset_parameters(self):
-        if self.lin is not None:
+        if self.project:
             self.lin.reset_parameters()
         self.gru_cell.reset_parameters()
 

--- a/torch_geometric/nn/aggr/lcm.py
+++ b/torch_geometric/nn/aggr/lcm.py
@@ -66,7 +66,7 @@ class LCMAggregation(Aggregation):
         dim_size: Optional[int] = None,
         dim: int = -2,
         max_num_elements: Optional[int] = None,
-    ):
+    ) -> Tensor:
         x, _ = self.to_dense_batch(x, index, ptr, dim_size, dim,
                                    max_num_elements=max_num_elements)
 


### PR DESCRIPTION
Initial version of the LCM aggregation, requested in issue #7574. A possible feature to incorporate is for `forward` to additionally compute and return an associativity loss, as described in the paper. 