### PR TITLE
Raise error if `len(DynamicBatchSampler())` is ambiguous

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -117,6 +117,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
+- Fixed the assumption of `DynamicBatchSampler.__len__` being the same as its provided dataset ([#8137](https://github.com/pyg-team/pytorch_geometric/pull/8137))
 - Enabled pickling of `DimeNet` models ([#8019](https://github.com/pyg-team/pytorch_geometric/pull/8019))
 - Changed the `trim_to_layer` function to filter out non-reachable node and edge types when operating on heterogeneous graphs ([#7942](https://github.com/pyg-team/pytorch_geometric/pull/7942))
 - Accelerated and simplified `top_k` computation in `TopKPooling` ([#7737](https://github.com/pyg-team/pytorch_geometric/pull/7737))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -117,7 +117,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
-- Fixed the assumption of `DynamicBatchSampler.__len__` being the same as its provided dataset ([#8137](https://github.com/pyg-team/pytorch_geometric/pull/8137))
+- Fix `DynamicBatchSampler.__len__` to raise an error in case `num_steps` is undefined ([#8137](https://github.com/pyg-team/pytorch_geometric/pull/8137))
 - Enabled pickling of `DimeNet` models ([#8019](https://github.com/pyg-team/pytorch_geometric/pull/8019))
 - Changed the `trim_to_layer` function to filter out non-reachable node and edge types when operating on heterogeneous graphs ([#7942](https://github.com/pyg-team/pytorch_geometric/pull/7942))
 - Accelerated and simplified `top_k` computation in `TopKPooling` ([#7737](https://github.com/pyg-team/pytorch_geometric/pull/7737))

--- a/test/loader/test_dynamic_batch_sampler.py
+++ b/test/loader/test_dynamic_batch_sampler.py
@@ -33,20 +33,6 @@ def test_dataloader_with_dynamic_batches():
         num_nodes_total += data.num_nodes
     assert num_nodes_total == 404
 
-    # Test warning
-    batch_sampler = DynamicBatchSampler(data_list, 300, skip_too_big=False,
-                                        num_steps=2)
-    loader = DataLoader(data_list, batch_sampler=batch_sampler)
-
-    with pytest.warns(UserWarning, match="is larger than 300 nodes"):
-        num_nodes_total = 0
-        for data in loader:
-            num_nodes_total += data.num_nodes
-        assert num_nodes_total == 601
-
-    with pytest.raises(
-            ValueError,
-            match="The length of a DynamicBatchSampler is undefined"):
-        len(DynamicBatchSampler(data_list, max_num=300, num_steps=None))
-
+    with pytest.raises(ValueError, match="length of 'DynamicBatchSampler'"):
+        len(DynamicBatchSampler(data_list, max_num=300))
     assert len(DynamicBatchSampler(data_list, max_num=300, num_steps=2)) == 2

--- a/test/loader/test_dynamic_batch_sampler.py
+++ b/test/loader/test_dynamic_batch_sampler.py
@@ -43,3 +43,8 @@ def test_dataloader_with_dynamic_batches():
         for data in loader:
             num_nodes_total += data.num_nodes
         assert num_nodes_total == 601
+
+    with pytest.raises(ValueError, match="The length of a DynamicBatchSampler is undefined"):
+        len(DynamicBatchSampler(data_list, max_num=300, num_steps=None))
+
+    assert len(DynamicBatchSampler(data_list, max_num=300, num_steps=2)) == 2

--- a/test/loader/test_dynamic_batch_sampler.py
+++ b/test/loader/test_dynamic_batch_sampler.py
@@ -44,7 +44,9 @@ def test_dataloader_with_dynamic_batches():
             num_nodes_total += data.num_nodes
         assert num_nodes_total == 601
 
-    with pytest.raises(ValueError, match="The length of a DynamicBatchSampler is undefined"):
+    with pytest.raises(
+            ValueError,
+            match="The length of a DynamicBatchSampler is undefined"):
         len(DynamicBatchSampler(data_list, max_num=300, num_steps=None))
 
     assert len(DynamicBatchSampler(data_list, max_num=300, num_steps=2)) == 2

--- a/torch_geometric/loader/dynamic_batch_sampler.py
+++ b/torch_geometric/loader/dynamic_batch_sampler.py
@@ -1,4 +1,3 @@
-import warnings
 from typing import Iterator, List, Optional
 
 import torch
@@ -38,17 +37,23 @@ class DynamicBatchSampler(torch.utils.data.sampler.Sampler):
         num_steps (int, optional): The number of mini-batches to draw for a
             single epoch. If set to :obj:`None`, will iterate through all the
             underlying examples, but :meth:`__len__` will be :obj:`None` since
-            it is be ambiguous. (default: :obj:`None`)
+            it is ambiguous. (default: :obj:`None`)
     """
-    def __init__(self, dataset: Dataset, max_num: int, mode: str = 'node',
-                 shuffle: bool = False, skip_too_big: bool = False,
-                 num_steps: Optional[int] = None):
-        if not isinstance(max_num, int) or max_num <= 0:
-            raise ValueError("`max_num` should be a positive integer value "
-                             "(got {max_num}).")
+    def __init__(
+        self,
+        dataset: Dataset,
+        max_num: int,
+        mode: str = 'node',
+        shuffle: bool = False,
+        skip_too_big: bool = False,
+        num_steps: Optional[int] = None,
+    ):
+        if max_num <= 0:
+            raise ValueError(f"`max_num` should be a positive integer value "
+                             f"(got {max_num})")
         if mode not in ['node', 'edge']:
-            raise ValueError("`mode` choice should be either "
-                             f"'node' or 'edge' (got '{mode}').")
+            raise ValueError(f"`mode` choice should be either "
+                             f"'node' or 'edge' (got '{mode}')")
 
         self.dataset = dataset
         self.max_num = max_num
@@ -59,52 +64,44 @@ class DynamicBatchSampler(torch.utils.data.sampler.Sampler):
         self.max_steps = num_steps or len(dataset)
 
     def __iter__(self) -> Iterator[List[int]]:
-        batch = []
-        batch_n = 0
-        num_steps = 0
-        num_processed = 0
-
         if self.shuffle:
-            indices = torch.randperm(len(self.dataset), dtype=torch.long)
+            indices = torch.randperm(len(self.dataset)).tolist()
         else:
-            indices = torch.arange(len(self.dataset), dtype=torch.long)
+            indices = range(len(self.dataset))
+
+        samples: List[int] = []
+        current_num: int = 0
+        num_steps: int = 0
+        num_processed: int = 0
 
         while (num_processed < len(self.dataset)
                and num_steps < self.max_steps):
-            # Fill batch
-            for idx in indices[num_processed:]:
-                # Size of sample
-                data = self.dataset[idx]
-                n = data.num_nodes if self.mode == 'node' else data.num_edges
 
-                if batch_n + n > self.max_num:
-                    if batch_n == 0:
+            for i in indices[num_processed:]:
+                data = self.dataset[i]
+                num = data.num_nodes if self.mode == 'node' else data.num_edges
+
+                if current_num + num > self.max_num:
+                    if current_num == 0:
                         if self.skip_too_big:
                             continue
-                        else:
-                            warnings.warn("Size of data sample at index "
-                                          f"{idx} is larger than "
-                                          f"{self.max_num} {self.mode}s "
-                                          f"(got {n} {self.mode}s.")
-                    else:
-                        # Mini-batch filled
+                    else:  # Mini-batch filled:
                         break
 
-                # Add sample to current batch
-                batch.append(idx.item())
+                samples.append(i)
                 num_processed += 1
-                batch_n += n
+                current_num += num
 
-            yield batch
-            batch = []
-            batch_n = 0
+            yield samples
+            samples: List[int] = []
+            current_num = 0
             num_steps += 1
 
-    def __len__(self) -> Optional[int]:
-        if self.num_steps is not None:
-            return self.num_steps
+    def __len__(self) -> int:
+        if self.num_steps is None:
+            raise ValueError(f"The length of '{self.__class__.__name__}' is "
+                             f"undefined since the number of steps per epoch "
+                             f"is ambiguous. Either specify `num_steps` or "
+                             f"use a static batch sampler.")
 
-        raise ValueError("The length of a DynamicBatchSampler is undefined "
-                         "since the number of steps per epoch is ambiguous. "
-                         "Either specify `num_steps` or use a static batch "
-                         "sampler.")
+        return self.num_steps

--- a/torch_geometric/loader/dynamic_batch_sampler.py
+++ b/torch_geometric/loader/dynamic_batch_sampler.py
@@ -101,6 +101,3 @@ class DynamicBatchSampler(torch.utils.data.sampler.Sampler):
             batch = []
             batch_n = 0
             num_steps += 1
-
-    def __len__(self) -> int:
-        return self.num_steps


### PR DESCRIPTION
Part of a fix for #7724.

Assuming `len(DynamicBatchSampler(dataset)) == len(dataset)` is wrong in AFAIK all cases `max_num>1`, which can lead to undesired behaviour in 3rd party libraries like PyTorch Lightning as reported in the linked issue.