### PR TITLE
minor correction: `args.device` --> `device`

### DIFF
--- a/examples/hetero/hierarchical_sage.py
+++ b/examples/hetero/hierarchical_sage.py
@@ -63,7 +63,7 @@ model = HierarchicalHeteroGraphSage(
     hidden_channels=64,
     out_channels=dataset.num_classes,
     num_layers=2,
-).to(args.device)
+).to(device)
 
 optimizer = torch.optim.Adam(model.parameters(), lr=0.01)
 


### PR DESCRIPTION
This is a minor correction (args.device --> device) to support cpu execution of hierarchical_sage.py example, otherwise running only if gpu available. 
Being a non-notable change, I have not updated CHANGELOG.md