### PR TITLE
Add note for `edge_size` coefficient in `GNNExplainer`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,6 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
-- Added a note in `GNNExplainer` about using default values for edge_size coefficient([#8211](https://github.com/pyg-team/pytorch_geometric/pull/8211))
 - Added the `RCDD` dataset ([#8196](https://github.com/pyg-team/pytorch_geometric/pull/8196))
 - Added distributed `GAT + ogbn-products` example targeting XPU device ([#8032](https://github.com/pyg-team/pytorch_geometric/pull/8032))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- Added a note in `GNNExplainer` about using default values for edge_size coefficient([#8211](https://github.com/pyg-team/pytorch_geometric/pull/8211))
 - Added the `RCDD` dataset ([#8196](https://github.com/pyg-team/pytorch_geometric/pull/8196))
 - Added distributed `GAT + ogbn-products` example targeting XPU device ([#8032](https://github.com/pyg-team/pytorch_geometric/pull/8032))
 

--- a/torch_geometric/explain/algorithm/gnn_explainer.py
+++ b/torch_geometric/explain/algorithm/gnn_explainer.py
@@ -29,6 +29,14 @@ class GNNExplainer(ExplainerAlgorithm):
         gnn_explainer_link_pred.py <https://github.com/pyg-team/
         pytorch_geometric/blob/master/examples/explain/gnn_explainer_link_pred.py>`_.
 
+        Please consider adjusting the `edge_size` coefficient according to
+        the average number of edges per node, especially if this value is bigger than 
+        in the datasets used in the original paper. The coefficient `edge_size` is
+        multiplied by the number of nodes in the explanation at every iteration, and 
+        the resulting value is added to the loss (a regularization term), with the
+        goal of producing compact explanations. A higher value will push the 
+        algorithm towards explanations with less elements.
+
     Args:
         epochs (int, optional): The number of epochs to train.
             (default: :obj:`100`)

--- a/torch_geometric/explain/algorithm/gnn_explainer.py
+++ b/torch_geometric/explain/algorithm/gnn_explainer.py
@@ -29,14 +29,17 @@ class GNNExplainer(ExplainerAlgorithm):
         gnn_explainer_link_pred.py <https://github.com/pyg-team/
         pytorch_geometric/blob/master/examples/explain/gnn_explainer_link_pred.py>`_.
 
-        Please consider adjusting the `edge_size` coefficient according to
-        the average number of edges per node, especially if this value is
-        bigger than in the datasets used in the original paper. The
-        coefficient `edge_size` is  multiplied by the number of nodes in the
-        explanation at every iteration, and the resulting value is added to
-        the loss (a regularization term), with the goal of producing compact
-        explanations. A higher value will push the algorithm towards
-        explanations with less elements.
+    .. note::
+
+        The :obj:`edge_size` coefficient is multiplied by the number of nodes
+        in the explanation at every iteration, and the resulting value is added
+        to the loss as a regularization term, with the goal of producing
+        compact explanations.
+        A higher value will push the algorithm towards explanations with less
+        elements.
+        Consider adjusting the :obj:`edge_size` coefficient according to the
+        average node degree in the dataset, especially if this value is bigger
+        than in the datasets used in the original paper.
 
     Args:
         epochs (int, optional): The number of epochs to train.

--- a/torch_geometric/explain/algorithm/gnn_explainer.py
+++ b/torch_geometric/explain/algorithm/gnn_explainer.py
@@ -30,12 +30,12 @@ class GNNExplainer(ExplainerAlgorithm):
         pytorch_geometric/blob/master/examples/explain/gnn_explainer_link_pred.py>`_.
 
         Please consider adjusting the `edge_size` coefficient according to
-        the average number of edges per node, especially if this value is 
-        bigger than in the datasets used in the original paper. The 
+        the average number of edges per node, especially if this value is
+        bigger than in the datasets used in the original paper. The
         coefficient `edge_size` is  multiplied by the number of nodes in the
         explanation at every iteration, and the resulting value is added to
         the loss (a regularization term), with the goal of producing compact
-        explanations. A higher value will push the algorithm towards 
+        explanations. A higher value will push the algorithm towards
         explanations with less elements.
 
     Args:

--- a/torch_geometric/explain/algorithm/gnn_explainer.py
+++ b/torch_geometric/explain/algorithm/gnn_explainer.py
@@ -30,11 +30,11 @@ class GNNExplainer(ExplainerAlgorithm):
         pytorch_geometric/blob/master/examples/explain/gnn_explainer_link_pred.py>`_.
 
         Please consider adjusting the `edge_size` coefficient according to
-        the average number of edges per node, especially if this value is bigger than 
+        the average number of edges per node, especially if this value is bigger than
         in the datasets used in the original paper. The coefficient `edge_size` is
-        multiplied by the number of nodes in the explanation at every iteration, and 
+        multiplied by the number of nodes in the explanation at every iteration, and
         the resulting value is added to the loss (a regularization term), with the
-        goal of producing compact explanations. A higher value will push the 
+        goal of producing compact explanations. A higher value will push the
         algorithm towards explanations with less elements.
 
     Args:

--- a/torch_geometric/explain/algorithm/gnn_explainer.py
+++ b/torch_geometric/explain/algorithm/gnn_explainer.py
@@ -30,12 +30,13 @@ class GNNExplainer(ExplainerAlgorithm):
         pytorch_geometric/blob/master/examples/explain/gnn_explainer_link_pred.py>`_.
 
         Please consider adjusting the `edge_size` coefficient according to
-        the average number of edges per node, especially if this value is bigger than
-        in the datasets used in the original paper. The coefficient `edge_size` is
-        multiplied by the number of nodes in the explanation at every iteration, and
-        the resulting value is added to the loss (a regularization term), with the
-        goal of producing compact explanations. A higher value will push the
-        algorithm towards explanations with less elements.
+        the average number of edges per node, especially if this value is 
+        bigger than in the datasets used in the original paper. The 
+        coefficient `edge_size` is  multiplied by the number of nodes in the
+        explanation at every iteration, and the resulting value is added to
+        the loss (a regularization term), with the goal of producing compact
+        explanations. A higher value will push the algorithm towards 
+        explanations with less elements.
 
     Args:
         epochs (int, optional): The number of epochs to train.


### PR DESCRIPTION
Following from https://github.com/pyg-team/pytorch_geometric/issues/1985

The default value of edge_size coefficient is suitable for many networks, but at the end it is tightly related with the number of edges. It is useful to reevaluate if we want to use this number based on our objective of "compactness" of the explanation. 

I consider that this value is not properly announced (my feeling is that normally it is just ignored) and with this PR I try to raise awareness about it with a note in the comments of the class.