### PR TITLE
Added an assertion in `MetaPath2Vec` to ensure valid metapath input

### DIFF
--- a/torch_geometric/nn/models/metapath2vec.py
+++ b/torch_geometric/nn/models/metapath2vec.py
@@ -82,8 +82,13 @@ class MetaPath2Vec(torch.nn.Module):
             self.col_dict[keys] = col
             self.rowcount_dict[keys] = rowptr[1:] - rowptr[:-1]
 
-        for i in range(1, len(metapath)):
-            assert metapath[i - 1][-1] == metapath[i][0]
+        for edge_type1, edge_type2 in zip(metapath[:-1], metapath[1:]):
+            if edge_type1[-1] != edge_type2[0]:
+                raise ValueError(
+                    "Found invalid metapath. Ensure that the destination node "
+                    "type matches with the source node type across all "
+                    "consecutive edge types.")
+
         assert walk_length + 1 >= context_size
         if walk_length > len(metapath) and metapath[0][0] != metapath[-1][-1]:
             raise AttributeError(

--- a/torch_geometric/nn/models/metapath2vec.py
+++ b/torch_geometric/nn/models/metapath2vec.py
@@ -82,6 +82,8 @@ class MetaPath2Vec(torch.nn.Module):
             self.col_dict[keys] = col
             self.rowcount_dict[keys] = rowptr[1:] - rowptr[:-1]
 
+        for i in range(1, len(metapath)):
+            assert metapath[i - 1][-1] == metapath[i][0]
         assert walk_length + 1 >= context_size
         if walk_length > len(metapath) and metapath[0][0] != metapath[-1][-1]:
             raise AttributeError(


### PR DESCRIPTION
This PR adds an assertion in `MetaPath2Vec` to ensure valid metapath input and avoid the `IndexError` as in #8205.
Specifically, a valid metapath for `MetaPath2Vec` must fulfill the requirement that the end of the last edge type should be the start of the next edge type.