### PR TITLE
Fix URL typo in `PCMQ4Mv2` dataset

### DIFF
--- a/torch_geometric/datasets/pcqm4m.py
+++ b/torch_geometric/datasets/pcqm4m.py
@@ -76,7 +76,7 @@ class PCQM4Mv2(OnDiskDataset):
         ]
 
     def download(self):
-        path = download_url(self.url_2d, self.raw_dir)
+        path = download_url(self.url, self.raw_dir)
         extract_zip(path, self.raw_dir)
         os.unlink(path)
 


### PR DESCRIPTION
In the `download()` method is a typo: `self.url_2d` should be named `self.url`