### PR TITLE
[nit] Remove unnecessary codes in `AddRandomWalkPE`

### DIFF
--- a/torch_geometric/transforms/add_positional_encoding.py
+++ b/torch_geometric/transforms/add_positional_encoding.py
@@ -147,8 +147,6 @@ class AddRandomWalkPE(BaseTransform):
         pe_list = [get_self_loop_attr(*to_edge_index(out), num_nodes=N)]
         for _ in range(self.walk_length - 1):
             out = out @ adj
-            if out.layout == torch.sparse_coo:
-                out = out._coalesced_(True)
             pe_list.append(get_self_loop_attr(*to_edge_index(out), N))
         pe = torch.stack(pe_list, dim=-1)
 


### PR DESCRIPTION
A follow-up of #8225. We will do `_coalesced_` in `to_edge_index`.