### PR TITLE
Add alternative edge indices shape to `GCNConv` input description

### DIFF
--- a/torch_geometric/nn/conv/gcn_conv.py
+++ b/torch_geometric/nn/conv/gcn_conv.py
@@ -159,7 +159,8 @@ class GCNConv(MessagePassing):
     Shapes:
         - **input:**
           node features :math:`(|\mathcal{V}|, F_{in})`,
-          edge indices :math:`(2, |\mathcal{E}|)`,
+          edge indices :math:`(2, |\mathcal{E}|)`
+          or :math:`(|\mathcal{V}|, |\mathcal{V}|)` *(sparse)*,
           edge weights :math:`(|\mathcal{E}|)` *(optional)*
         - **output:** node features :math:`(|\mathcal{V}|, F_{out})`
     """

--- a/torch_geometric/nn/conv/gcn_conv.py
+++ b/torch_geometric/nn/conv/gcn_conv.py
@@ -160,7 +160,7 @@ class GCNConv(MessagePassing):
         - **input:**
           node features :math:`(|\mathcal{V}|, F_{in})`,
           edge indices :math:`(2, |\mathcal{E}|)`
-          or :math:`(|\mathcal{V}|, |\mathcal{V}|)` *(sparse)*,
+          or sparse matrix :math:`(|\mathcal{V}|, |\mathcal{V}|)`,
           edge weights :math:`(|\mathcal{E}|)` *(optional)*
         - **output:** node features :math:`(|\mathcal{V}|, F_{out})`
     """


### PR DESCRIPTION
<img width="752" alt="Screenshot 2023-10-26 at 1 05 22 PM" src="https://github.com/pyg-team/pytorch_geometric/assets/54658925/fa7d55b6-30ac-4036-baf3-1133e5c47257">
According to the implementation https://github.com/pyg-team/pytorch_geometric/blob/master/torch_geometric/nn/conv/gcn_conv.py#L49, sparse adjacency matrix of shape |V|*|V| can also be used as edge_indices.