### PR TITLE
Update `torch_geometric.testing.withCUDA`

### DIFF
--- a/torch_geometric/testing/decorators.py
+++ b/torch_geometric/testing/decorators.py
@@ -173,9 +173,9 @@ def withCUDA(func: Callable):
     r"""A decorator to test both on CPU and CUDA (if available)."""
     import pytest
 
-    devices = [torch.device('cpu')]
+    devices = [pytest.param(torch.device('cpu'), id='cpu')]
     if torch.cuda.is_available():
-        devices.append(torch.device('cuda:0'))
+        devices.append(pytest.param(torch.device('cuda:0'), id='cuda:0'))
 
     # Additional devices can be registered through environment variables:
     device = os.getenv('TORCH_DEVICE')
@@ -186,7 +186,7 @@ def withCUDA(func: Callable):
                           f"order to test against '{device}'")
         else:
             import_module(backend)
-            devices.append(torch.device(device))
+            devices.append(pytest.param(torch.device(device), id=device))
 
     return pytest.mark.parametrize('device', devices)(func)
 


### PR DESCRIPTION
This PR will make the pytest logs look like this:
```diff
- test_something.py::test_a[device0] PASSED
- test_something.py::test_a[device1] PASSED
+ test_something.py::test_a[cpu] PASSED
+ test_something.py::test_a[cuda:0] PASSED
```