### PR TITLE
Add faster `mask_select` method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
+- Update `utils.mask.mask_select` with faster method ([#8369](https://github.com/pyg-team/pytorch_geometric/pull/8369))
 - Update `DistNeighborSampler` for homogeneous graphs ([#8209](https://github.com/pyg-team/pytorch_geometric/pull/8209), [#8367](https://github.com/pyg-team/pytorch_geometric/pull/8367))
 - Update `GraphStore` and `FeatureStore` to support distributed training ([#8083](https://github.com/pyg-team/pytorch_geometric/pull/8083))
 - Disallow the usage of `add_self_loops=True` in `GCNConv(normalize=False)` ([#8210](https://github.com/pyg-team/pytorch_geometric/pull/8210))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- Made `utils.mask.mask_select` faster ([#8369](https://github.com/pyg-team/pytorch_geometric/pull/8369))
 - Added `force_reload` option to `Dataset` and `InMemoryDataset` to reload datasets ([#8352](https://github.com/pyg-team/pytorch_geometric/pull/8352), [#8357](https://github.com/pyg-team/pytorch_geometric/pull/8357))
 - Added support for `torch.compile` in `MultiAggregation` ([#8345](https://github.com/pyg-team/pytorch_geometric/pull/8345))
 - Added support for `torch.compile` in `HeteroConv` ([#8344](https://github.com/pyg-team/pytorch_geometric/pull/8344))
@@ -23,7 +24,6 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
-- Update `utils.mask.mask_select` with faster method ([#8369](https://github.com/pyg-team/pytorch_geometric/pull/8369))
 - Update `DistNeighborSampler` for homogeneous graphs ([#8209](https://github.com/pyg-team/pytorch_geometric/pull/8209), [#8367](https://github.com/pyg-team/pytorch_geometric/pull/8367))
 - Update `GraphStore` and `FeatureStore` to support distributed training ([#8083](https://github.com/pyg-team/pytorch_geometric/pull/8083))
 - Disallow the usage of `add_self_loops=True` in `GCNConv(normalize=False)` ([#8210](https://github.com/pyg-team/pytorch_geometric/pull/8210))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,6 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
-- Made `utils.mask.mask_select` faster ([#8369](https://github.com/pyg-team/pytorch_geometric/pull/8369))
 - Added `force_reload` option to `Dataset` and `InMemoryDataset` to reload datasets ([#8352](https://github.com/pyg-team/pytorch_geometric/pull/8352), [#8357](https://github.com/pyg-team/pytorch_geometric/pull/8357))
 - Added support for `torch.compile` in `MultiAggregation` ([#8345](https://github.com/pyg-team/pytorch_geometric/pull/8345))
 - Added support for `torch.compile` in `HeteroConv` ([#8344](https://github.com/pyg-team/pytorch_geometric/pull/8344))
@@ -24,6 +23,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
+- Made `utils.mask.mask_select` faster ([#8369](https://github.com/pyg-team/pytorch_geometric/pull/8369))
 - Update `DistNeighborSampler` for homogeneous graphs ([#8209](https://github.com/pyg-team/pytorch_geometric/pull/8209), [#8367](https://github.com/pyg-team/pytorch_geometric/pull/8367))
 - Update `GraphStore` and `FeatureStore` to support distributed training ([#8083](https://github.com/pyg-team/pytorch_geometric/pull/8083))
 - Disallow the usage of `add_self_loops=True` in `GCNConv(normalize=False)` ([#8210](https://github.com/pyg-team/pytorch_geometric/pull/8210))

--- a/torch_geometric/utils/mask.py
+++ b/torch_geometric/utils/mask.py
@@ -27,13 +27,14 @@ def mask_select(src: Tensor, dim: int, mask: Tensor) -> Tensor:
     dim = dim + src.dim() if dim < 0 else dim
     assert dim >= 0 and dim < src.dim()
 
-    if dim != 0:
-        src = src.transpose(0, dim)
-
+    # Applying a 1-dimensional mask in the first dimension is significantly
+    # faster than broadcasting the mask and utilizing `masked_select`.
+    # As such, we transpose in the first dimension, perform the masking, and
+    # then transpose back to the original shape.
+    src = src.transpose(0, dim) if dim != 0 else src
     out = src[mask]
+    out = out.transpose(0, dim) if dim != 0 else out
 
-    if dim != 0:
-        out = out.transpose(0, dim)
     return out
 
 

--- a/torch_geometric/utils/mask.py
+++ b/torch_geometric/utils/mask.py
@@ -27,15 +27,14 @@ def mask_select(src: Tensor, dim: int, mask: Tensor) -> Tensor:
     dim = dim + src.dim() if dim < 0 else dim
     assert dim >= 0 and dim < src.dim()
 
-    size = [1] * src.dim()
-    size[dim] = mask.numel()
+    if dim != 0:
+        src = src.transpose(0, dim)
 
-    out = src.masked_select(mask.view(size))
+    out = src[mask]
 
-    size = list(src.size())
-    size[dim] = -1
-
-    return out.view(size)
+    if dim != 0:
+        out = out.transpose(0, dim)
+    return out
 
 
 def index_to_mask(index: Tensor, size: Optional[int] = None) -> Tensor:


### PR DESCRIPTION
This PR addresses a minor performance issue with the `utils.mask.mask_select` method.

The previous implementation unsqueezed the mask to be broadcastable along all dimensions.
This broadcasted masking is significantly slower in torch than applying a 1-dimensional mask to the first dimension of a tensor.
The new implementation simply transposes the tensor such that the masked dimension comes first and later undoes this.

This mainly affects the methods for computing subgraphs which are needlessly slow on bigger graphs with many features.

Here is a code example to illustrate the difference:
```python
import torch
from torch_geometric.data import Data
from timeit import timeit


N = 1000000
E = 10000000

data = Data(
    x=torch.randn((N, 200)),
    edge_index=torch.randint(0, N, (2, E)),
    edge_attr=torch.randn((E, 200), dtype=torch.float16)
)

subset_bool = torch.rand((N,)) < 0.5
time_bool = timeit(lambda: data.subgraph(subset_bool), number=1)
print(f'Time: {time_bool:.4f}s')
```

The prior version yields:
```bash
Time: 13.7826s
```
The updated version yields:
```bash
Time:  0.3541s
```

So more than a 30-fold speedup. We thought this may be helpful to accelerate workflows involving subgraph extraction.