### PR TITLE
Fix output metadata processing in loaders 'filter_fn()` for multinode

### DIFF
--- a/torch_geometric/loader/node_loader.py
+++ b/torch_geometric/loader/node_loader.py
@@ -157,23 +157,20 @@ class NodeLoader(torch.utils.data.DataLoader, AffinityMixin):
                     self.node_sampler.edge_permutation)
 
             else:  # Tuple[FeatureStore, GraphStore]
+                edge_index = torch.stack([out.row, out.col])
+                data = Data(edge_index=edge_index)
+
+                # TODO Respect `custom_cls`.
+                # TODO Integrate features.
+
                 # Hack to detect whether we are in a distributed setting.
-                if self.node_sampler.__class__.__name__ == "DistNeighborSampler":
-                    # metadata entries are populated in `DistributedNeighborSampler._collate_fn()`
-                    data = Data(
-                        x=out.metadata[-3],
-                        y=out.metadata[-2],
-                        edge_attr=out.metadata[-1],
-                        edge_index=torch.stack([out.row, out.col]),
-                    )
-                else:
-                    # TODO Respect `custom_cls`.
-                    # TODO Integrate features.
-                    edge_index = torch.stack([out.row, out.col])
-                    data = Data(edge_index=edge_index)
-                    Warning(
-                        f"Custom data store requires {self}.filter_fn() to be implemented."
-                    )
+                if (self.node_sampler.__class__.__name__ ==
+                        'DistNeighborSampler'):
+                    # Metadata entries are populated in
+                    # `DistributedNeighborSampler._collate_fn()`
+                    data.x = out.metadata[-3]
+                    data.y = out.metadata[-2]
+                    data.edge_attr = out.metadata[-1]
 
             if 'n_id' not in data:
                 data.n_id = out.node


### PR DESCRIPTION
The output of `DistributedNeighborSampler._collate_fn()` includes `nfeats, nlabels, efeats` which are our `metadata[-3]`, `metadata[-2]` and `metadata[-1]`. Here: [L717C1-L718C22](https://github.com/pyg-team/pytorch_geometric/blob/88d7986b6d0a6de5895872270d2ff4fc95fae3b7/torch_geometric/distributed/dist_neighbor_sampler.py#L717C1-L718C22)