### PR TITLE
Add support for heterogeneous workloads in multi XPU benchmarks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Added support for `torch.compile` in `MultiAggregation` ([#8345](https://github.com/pyg-team/pytorch_geometric/pull/8345))
 - Added support for `torch.compile` in `HeteroConv` ([#8344](https://github.com/pyg-team/pytorch_geometric/pull/8344))
 - Added support for weighted `sparse_cross_entropy` ([#8340](https://github.com/pyg-team/pytorch_geometric/pull/8340))
-- Added a multi GPU training benchmarks for CUDA and XPU devices ([#8288](https://github.com/pyg-team/pytorch_geometric/pull/8288), [#8386](https://github.com/pyg-team/pytorch_geometric/pull/8386))
+- Added a multi GPU training benchmarks for CUDA and XPU devices ([#8288](https://github.com/pyg-team/pytorch_geometric/pull/8288), [#8382](https://github.com/pyg-team/pytorch_geometric/pull/8382), [#8386](https://github.com/pyg-team/pytorch_geometric/pull/8386))
 - Support MRR computation in `KGEModel.test()` ([#8298](https://github.com/pyg-team/pytorch_geometric/pull/8298))
 - Added an example for model parallelism (`examples/multi_gpu/model_parallel.py`) ([#8309](https://github.com/pyg-team/pytorch_geometric/pull/8309))
 - Added a tutorial for multi-node multi-GPU training with pure PyTorch ([#8071](https://github.com/pyg-team/pytorch_geometric/pull/8071))

--- a/benchmark/multi_gpu/training/common.py
+++ b/benchmark/multi_gpu/training/common.py
@@ -193,7 +193,8 @@ def run(rank: int, world_size: int, args: argparse.ArgumentParser,
         model.forward(fake_x_dict, fake_edge_index_dict)
     if hetero and args.model == 'rgat':
         for i in range(args.num_layers):
-            # `lin_dst` from GATConv is unitialized for paper-cites-paper relation
+            # `lin_dst` from GATConv is unitialized for
+            # paper-cites-paper relation
             model.model.convs[i].paper__cites__paper.lin_dst(
                 torch.rand((32, inputs_channels), device=device))
 

--- a/benchmark/multi_gpu/training/common.py
+++ b/benchmark/multi_gpu/training/common.py
@@ -191,12 +191,6 @@ def run(rank: int, world_size: int, args: argparse.ArgumentParser,
             for k in edge_index_keys
         }
         model.forward(fake_x_dict, fake_edge_index_dict)
-    if hetero and args.model == 'rgat':
-        for i in range(args.num_layers):
-            # `lin_dst` from GATConv is unitialized for
-            # paper-cites-paper relation
-            model.model.convs[i].paper__cites__paper.lin_dst(
-                torch.rand((32, inputs_channels), device=device))
 
     model = DDP(model, device_ids=[device], find_unused_parameters=True)
     model.train()


### PR DESCRIPTION
Fix for the following error:
```
RuntimeError: Modules with uninitialized parameters can't be used with DistributedDataParallel. Run a dummy forward pass to correctly initialize the modules.
```

HeteroGAT requires additional treatment, as the `lin_dst` from each of its convolutions is not initialized for `paper-cites-paper` relation (for more details, look at [this code](https://github.com/pyg-team/pytorch_geometric/blob/HEAD/torch_geometric/nn/conv/gat_conv.py#L233)).