### PR TITLE
Enable edge based temporal sampling in `torch_geometric.distributed`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Added the `RCDD` dataset ([#8196](https://github.com/pyg-team/pytorch_geometric/pull/8196))
 - Added distributed `GAT + ogbn-products` example targeting XPU device ([#8032](https://github.com/pyg-team/pytorch_geometric/pull/8032))
 - Added the option to skip explanations of certain message passing layers via `conv.explain = False` ([#8216](https://github.com/pyg-team/pytorch_geometric/pull/8216))
+- Added support for distributed edge-level temporal sampling ([#8428](https://github.com/pyg-team/pytorch_geometric/pull/8428))
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Added `fsspec` as file system backend ([#8379](https://github.com/pyg-team/pytorch_geometric/pull/8379), [#8426](https://github.com/pyg-team/pytorch_geometric/pull/8426), [#8434](https://github.com/pyg-team/pytorch_geometric/pull/8434))
 - Added support for floating-point average degree numbers in `FakeDataset` and `FakeHeteroDataset` ([#8404](https://github.com/pyg-team/pytorch_geometric/pull/8404))
 - Added support for device conversions of `InMemoryDataset` ([#8402](https://github.com/pyg-team/pytorch_geometric/pull/8402))
-- Added support for edge-level temporal sampling in `NeighborLoader` and `LinkNeighborLoader` ([#8372](https://github.com/pyg-team/pytorch_geometric/pull/8372))
+- Added support for edge-level temporal sampling in `NeighborLoader` and `LinkNeighborLoader` ([#8372](https://github.com/pyg-team/pytorch_geometric/pull/8372), [#8428](https://github.com/pyg-team/pytorch_geometric/pull/8428))
 - Added support for `torch.compile` in `ModuleDict` and `ParameterDict` ([#8363](https://github.com/pyg-team/pytorch_geometric/pull/8363))
 - Added `force_reload` option to `Dataset` and `InMemoryDataset` to reload datasets ([#8352](https://github.com/pyg-team/pytorch_geometric/pull/8352), [#8357](https://github.com/pyg-team/pytorch_geometric/pull/8357), [#8436](https://github.com/pyg-team/pytorch_geometric/pull/8436))
 - Added support for `torch.compile` in `MultiAggregation` ([#8345](https://github.com/pyg-team/pytorch_geometric/pull/8345))
@@ -28,7 +28,6 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Added the `RCDD` dataset ([#8196](https://github.com/pyg-team/pytorch_geometric/pull/8196))
 - Added distributed `GAT + ogbn-products` example targeting XPU device ([#8032](https://github.com/pyg-team/pytorch_geometric/pull/8032))
 - Added the option to skip explanations of certain message passing layers via `conv.explain = False` ([#8216](https://github.com/pyg-team/pytorch_geometric/pull/8216))
-- Added support for distributed edge-level temporal sampling ([#8428](https://github.com/pyg-team/pytorch_geometric/pull/8428))
 
 ### Changed
 

--- a/test/distributed/test_dist_neighbor_sampler.py
+++ b/test/distributed/test_dist_neighbor_sampler.py
@@ -55,7 +55,7 @@ def create_data(rank: int, world_size: int, time_attr: Optional[str] = None):
         feature_store.put_tensor(data.time, group_name=None,
                                  attr_name=time_attr)
 
-    else:  # Create edge-level time data:
+    elif time_attr == 'edge_time':  # Create edge-level time data:
         data.edge_time = torch.tensor([0, 1, 2, 3, 4, 5, 7, 7, 7, 7, 7, 11])
 
         if rank == 0:

--- a/test/distributed/test_dist_neighbor_sampler.py
+++ b/test/distributed/test_dist_neighbor_sampler.py
@@ -1,5 +1,6 @@
 import atexit
 import socket
+from typing import Optional
 
 import pytest
 import torch
@@ -15,10 +16,9 @@ from torch_geometric.distributed.rpc import init_rpc
 from torch_geometric.sampler import NeighborSampler, NodeSamplerInput
 from torch_geometric.sampler.neighbor_sampler import node_sample
 from torch_geometric.testing import onlyLinux, withPackage
-from torch_geometric.typing import WITH_EDGE_TIME_NEIGHBOR_SAMPLE
 
 
-def create_data(rank: int, world_size: int, time_attr: str = 'time'):
+def create_data(rank: int, world_size: int, time_attr: Optional[str] = None):
     if rank == 0:  # Partition 0:
         node_id = torch.tensor([0, 1, 2, 3, 4, 5, 9])
         edge_index = torch.tensor([  # Sorted by destination.
@@ -50,18 +50,19 @@ def create_data(rank: int, world_size: int, time_attr: str = 'time'):
     ])
     data = Data(x=None, y=None, edge_index=edge_index, num_nodes=10)
 
-    if time_attr == 'time':  # Create time data:
+    if time_attr == 'time':  # Create node-level time data:
         data.time = torch.tensor([5, 0, 1, 3, 3, 4, 4, 4, 4, 4])
         feature_store.put_tensor(data.time, group_name=None,
                                  attr_name=time_attr)
 
-    else:  # time_attr = 'edge_time'
+    else:  # Create edge-level time data:
         data.edge_time = torch.tensor([0, 1, 2, 3, 4, 5, 7, 7, 7, 7, 7, 11])
 
         if rank == 0:
             edge_time = torch.tensor([0, 1, 2, 3, 4, 5, 11])
         if rank == 1:
             edge_time = torch.tensor([4, 7, 7, 7, 7, 7, 11])
+
         feature_store.put_tensor(edge_time, group_name=None,
                                  attr_name=time_attr)
 
@@ -297,16 +298,14 @@ def test_dist_neighbor_sampler_temporal(seed_time, temporal_strategy):
 
 @onlyLinux
 @withPackage('pyg_lib')
-@pytest.mark.skipif(
-    not WITH_EDGE_TIME_NEIGHBOR_SAMPLE,
-    reason="Edge-level temporal sampling requires a more recent 'pyg-lib'"
-    " installation")
-@pytest.mark.parametrize(
-    'seed_time',
-    [torch.tensor([1, 1]), torch.tensor([3, 7])])
+@pytest.mark.parametrize('seed_time', [[1, 1], [3, 7]])
 @pytest.mark.parametrize('temporal_strategy', ['uniform', 'last'])
-def test_dist_neighbor_sampler_edge_level_temporal(seed_time,
-                                                   temporal_strategy):
+def test_dist_neighbor_sampler_edge_level_temporal(
+    seed_time,
+    temporal_strategy,
+):
+    seed_time = torch.tensor(seed_time)
+
     mp_context = torch.multiprocessing.get_context('spawn')
     s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
     s.bind(('127.0.0.1', 0))

--- a/test/distributed/test_dist_neighbor_sampler.py
+++ b/test/distributed/test_dist_neighbor_sampler.py
@@ -15,9 +15,10 @@ from torch_geometric.distributed.rpc import init_rpc
 from torch_geometric.sampler import NeighborSampler, NodeSamplerInput
 from torch_geometric.sampler.neighbor_sampler import node_sample
 from torch_geometric.testing import onlyLinux, withPackage
+from torch_geometric.typing import WITH_EDGE_TIME_NEIGHBOR_SAMPLE
 
 
-def create_data(rank: int, world_size: int, temporal: bool = False):
+def create_data(rank: int, world_size: int, time_attr: str = 'time'):
     if rank == 0:  # Partition 0:
         node_id = torch.tensor([0, 1, 2, 3, 4, 5, 9])
         edge_index = torch.tensor([  # Sorted by destination.
@@ -30,7 +31,6 @@ def create_data(rank: int, world_size: int, temporal: bool = False):
             [5, 6, 7, 8, 9, 5, 0],
             [4, 5, 6, 7, 8, 9, 9],
         ])
-
     feature_store = LocalFeatureStore.from_data(node_id)
     graph_store = LocalGraphStore.from_data(
         edge_id=None,
@@ -50,9 +50,20 @@ def create_data(rank: int, world_size: int, temporal: bool = False):
     ])
     data = Data(x=None, y=None, edge_index=edge_index, num_nodes=10)
 
-    if temporal:  # Create time data:
+    if time_attr == 'time':  # Create time data:
         data.time = torch.tensor([5, 0, 1, 3, 3, 4, 4, 4, 4, 4])
-        feature_store.put_tensor(data.time, group_name=None, attr_name='time')
+        feature_store.put_tensor(data.time, group_name=None,
+                                 attr_name=time_attr)
+
+    else:  # time_attr = 'edge_time'
+        data.edge_time = torch.tensor([0, 1, 2, 3, 4, 5, 7, 7, 7, 7, 7, 11])
+
+        if rank == 0:
+            edge_time = torch.tensor([0, 1, 2, 3, 4, 5, 11])
+        if rank == 1:
+            edge_time = torch.tensor([4, 7, 7, 7, 7, 7, 11])
+        feature_store.put_tensor(edge_time, group_name=None,
+                                 attr_name=time_attr)
 
     return (feature_store, graph_store), data
 
@@ -144,8 +155,9 @@ def dist_neighbor_sampler_temporal(
     master_port: int,
     seed_time: torch.tensor = None,
     temporal_strategy: str = 'uniform',
+    time_attr: str = 'time',
 ):
-    dist_data, data = create_data(rank, world_size, temporal=True)
+    dist_data, data = create_data(rank, world_size, time_attr)
 
     current_ctx = DistContext(
         rank=rank,
@@ -172,7 +184,7 @@ def dist_neighbor_sampler_temporal(
         shuffle=False,
         disjoint=True,
         temporal_strategy=temporal_strategy,
-        time_attr='time',
+        time_attr=time_attr,
     )
 
     init_rpc(
@@ -211,7 +223,7 @@ def dist_neighbor_sampler_temporal(
         num_neighbors=num_neighbors,
         disjoint=True,
         temporal_strategy=temporal_strategy,
-        time_attr='time',
+        time_attr=time_attr,
     )
 
     # Evaluate node sample function:
@@ -269,12 +281,47 @@ def test_dist_neighbor_sampler_temporal(seed_time, temporal_strategy):
     world_size = 2
     w0 = mp_context.Process(
         target=dist_neighbor_sampler_temporal,
-        args=(world_size, 0, port, seed_time, temporal_strategy),
+        args=(world_size, 0, port, seed_time, temporal_strategy, 'time'),
     )
 
     w1 = mp_context.Process(
         target=dist_neighbor_sampler_temporal,
-        args=(world_size, 1, port, seed_time, temporal_strategy),
+        args=(world_size, 1, port, seed_time, temporal_strategy, 'time'),
+    )
+
+    w0.start()
+    w1.start()
+    w0.join()
+    w1.join()
+
+
+@onlyLinux
+@withPackage('pyg_lib')
+@pytest.mark.skipif(
+    not WITH_EDGE_TIME_NEIGHBOR_SAMPLE,
+    reason="Edge-level temporal sampling requires a more recent 'pyg-lib'"
+    " installation")
+@pytest.mark.parametrize(
+    'seed_time',
+    [torch.tensor([1, 1]), torch.tensor([3, 7])])
+@pytest.mark.parametrize('temporal_strategy', ['uniform', 'last'])
+def test_dist_neighbor_sampler_edge_level_temporal(seed_time,
+                                                   temporal_strategy):
+    mp_context = torch.multiprocessing.get_context('spawn')
+    s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    s.bind(('127.0.0.1', 0))
+    port = s.getsockname()[1]
+    s.close()
+
+    world_size = 2
+    w0 = mp_context.Process(
+        target=dist_neighbor_sampler_temporal,
+        args=(world_size, 0, port, seed_time, temporal_strategy, 'edge_time'),
+    )
+
+    w1 = mp_context.Process(
+        target=dist_neighbor_sampler_temporal,
+        args=(world_size, 1, port, seed_time, temporal_strategy, 'edge_time'),
     )
 
     w0.start()

--- a/torch_geometric/distributed/dist_neighbor_sampler.py
+++ b/torch_geometric/distributed/dist_neighbor_sampler.py
@@ -119,6 +119,7 @@ class DistNeighborSampler:
         self.node_types = self._sampler.node_types
         self.edge_types = self._sampler.edge_types
         self.node_time = self._sampler.node_time
+        self.edge_time = self._sampler.edge_time
 
         rpc_sample_callee = RPCSamplingCallee(self)
         self.rpc_sample_callee_id = rpc_register(rpc_sample_callee)
@@ -163,8 +164,7 @@ class DistNeighborSampler:
 
     async def node_sample(
         self,
-        inputs: Union[NodeSamplerInput, EdgeSamplerInput],
-        dst_time: Tensor = None,
+        inputs: NodeSamplerInput,
     ) -> Union[SamplerOutput, HeteroSamplerOutput]:
         r"""Performs layer by layer distributed sampling from a
         :class:`NodeSamplerInput` and returns the output of the sampling
@@ -182,34 +182,19 @@ class DistNeighborSampler:
         seed_time_dict = None
         src_batch_dict = None
 
-        if isinstance(inputs, NodeSamplerInput):
-            seed = inputs.node.to(self.device)
-            seed_time = None
-            if self.time_attr is not None:
-                if inputs.time is not None:
-                    seed_time = inputs.time.to(self.device)
-                else:
+        seed = inputs.node.to(self.device)
+        seed_time = None
+        if self.time_attr is not None:
+            if inputs.time is not None:
+                seed_time = inputs.time.to(self.device)
+            else:
+                if self.time_attr == 'time':
                     seed_time = self.node_time[seed]
-            src_batch = torch.arange(batch_size) if self.disjoint else None
-            metadata = (seed, seed_time)
+                else:  # self.time_attr == 'edge_time'
+                    raise ValueError("Seed time needs to be specified.")
 
-        elif isinstance(inputs, EdgeSamplerInput) and self.is_hetero:
-            seed_dict = {input_type[0]: inputs.row, input_type[-1]: inputs.col}
-            if dst_time is not None:
-                seed_time_dict = {
-                    input_type[0]: inputs.time,
-                    input_type[-1]: dst_time,
-                }
-
-            if self.disjoint:
-                src_batch_dict = {
-                    input_type[0]: torch.arange(batch_size),
-                    input_type[-1]: torch.arange(batch_size, batch_size * 2),
-                }
-            metadata = (seed_dict, seed_time_dict)
-
-        else:
-            raise NotImplementedError
+        src_batch = torch.arange(batch_size) if self.disjoint else None
+        metadata = (seed, seed_time)
 
         if self.is_hetero:
             if input_type is None:
@@ -374,6 +359,9 @@ class DistNeighborSampler:
                                                 src_batch)
                 if out.node.numel() == 0:
                     # no neighbors were sampled
+                    num_zero_layers = self.num_hops - i
+                    num_sampled_nodes += num_zero_layers * [0]
+                    num_sampled_edges += num_zero_layers * [0]
                     break
 
                 # remove duplicates
@@ -612,6 +600,7 @@ class DistNeighborSampler:
             colptr = self._sampler.colptr
             row = self._sampler.row
             node_time = self.node_time
+            edge_time = self.edge_time
         else:
             rel_type = '__'.join(edge_type)
             colptr = self._sampler.colptr_dict[rel_type]
@@ -625,18 +614,18 @@ class DistNeighborSampler:
             input_nodes.to(colptr.dtype),
             num_neighbors,
             node_time,
-            None,  # edge_time
+            edge_time,
             seed_time,
             None,  # TODO: edge_weight
             True,  # csc
             self.replace,
             self.subgraph_type != SubgraphType.induced,
-            self.disjoint and node_time is not None,
+            self.disjoint and self.time_attr is not None,
             self.temporal_strategy,
         )
         node, edge, cumsum_neighbors_per_node = out
 
-        if self.disjoint and node_time is not None:
+        if self.disjoint and self.time_attr is not None:
             # We create a batch during the step of merging sampler outputs.
             _, node = node.t().contiguous()
 

--- a/torch_geometric/sampler/neighbor_sampler.py
+++ b/torch_geometric/sampler/neighbor_sampler.py
@@ -212,9 +212,11 @@ class NeighborSampler(BaseSampler):
                                          "not find any temporal data")
                     time_attrs[0].index = None  # Reset index for full data.
                     time_tensor = feature_store.get_tensor(time_attrs[0])
+                    # Currently, we determine whether to use node-level or
+                    # edge-level temporal sampling based on the attribute name.
                     if time_attr == 'time':
                         self.node_time = time_tensor
-                    else:  # time_attr == 'edge_time':
+                    else:
                         self.edge_time = time_tensor
 
                 self.row, self.colptr, self.perm = graph_store.csc()
@@ -232,6 +234,7 @@ class NeighborSampler(BaseSampler):
                 self.node_time: Optional[Dict[NodeType, Tensor]] = None
                 self.edge_time: Optional[Dict[NodeType, Tensor]] = None
 
+                # TODO Add support for edge-level temporal sampling.
                 if time_attr is not None:
                     for attr in time_attrs:  # Reset index for full data.
                         attr.index = None

--- a/torch_geometric/sampler/neighbor_sampler.py
+++ b/torch_geometric/sampler/neighbor_sampler.py
@@ -165,12 +165,7 @@ class NeighborSampler(BaseSampler):
             feature_store, graph_store = data
 
             # Obtain graph metadata:
-            node_attrs = [
-                attr for attr in feature_store.get_all_tensor_attrs()
-                if isinstance(attr.group_name, NodeType)  # Heterogeneous ...
-                or attr.group_name is None  # ... or homogeneous.
-            ]
-            self.node_types = list(set(attr.group_name for attr in node_attrs))
+            attrs = [attr for attr in feature_store.get_all_tensor_attrs()]
 
             edge_attrs = graph_store.get_all_edge_attrs()
             self.edge_types = list(set(attr.edge_type for attr in edge_attrs))
@@ -199,26 +194,35 @@ class NeighborSampler(BaseSampler):
 
                 # We obtain all features with `node_attr.name=time_attr`:
                 time_attrs = [
-                    copy.copy(attr) for attr in node_attrs
+                    copy.copy(attr) for attr in attrs
                     if attr.attr_name == time_attr
                 ]
 
             if not self.is_hetero:
+                self.node_types = [None]
                 self.num_nodes = max(edge_attrs[0].size)
                 self.edge_weight: Optional[Tensor] = None
 
                 self.node_time: Optional[Tensor] = None
+                self.edge_time: Optional[Tensor] = None
+
                 if time_attr is not None:
                     if len(time_attrs) != 1:
                         raise ValueError("Temporal sampling specified but did "
                                          "not find any temporal data")
                     time_attrs[0].index = None  # Reset index for full data.
                     time_tensor = feature_store.get_tensor(time_attrs[0])
-                    self.node_time = time_tensor
+                    if time_attr == 'time':
+                        self.node_time = time_tensor
+                    else:  # time_attr == 'edge_time':
+                        self.edge_time = time_tensor
 
                 self.row, self.colptr, self.perm = graph_store.csc()
 
             else:
+                self.node_types = list(
+                    set(attr.group_name for attr in attrs
+                        if isinstance(attr.group_name, NodeType)))
                 self.num_nodes = {
                     node_type: remote_backend_utils.size(*data, node_type)
                     for node_type in self.node_types


### PR DESCRIPTION
This PR enables edge based temporal distributed training for node and link sampling.

**Comment about the edge temporal data definition:**
In the case of distributed training, it is necessary to create a separate vector for each partition that will store the time information of the edges included in the partition. (I mention this just to point out that this works differently than with node-based temporal sampling, where we can have one vector common to each partition because we operate on node ids.)
Why:
Each partition has its own unique edge_index in COO format, which is later converted to a matrix in CSR/CSC format in the neighbor sampler. Therefore, we do not have information about the global edge IDs when sampling and we would not be able to find the correct time information for a specific edge. Therefore, this information must be local.

**Changes made:**
- added support for edge_time argument
- `seed_time` needs to be specified (requirement for edge level temporal sampling)
- added unit tests
- unit tests for link sampler are in [this PR #8375](https://github.com/pyg-team/pytorch_geometric/pull/8375) 