### PR TITLE
Do not modify `node_offsets` in-place

### DIFF
--- a/torch_geometric/data/data.py
+++ b/torch_geometric/data/data.py
@@ -204,7 +204,7 @@ class BaseData:
         offset: int = 0
         for store in self.node_stores:
             out[store._key] = offset
-            offset += store.num_nodes
+            offset = offset + store.num_nodes
         return out
 
     def generate_ids(self):


### PR DESCRIPTION
Yields incorrect results in case `num_nodes` is a tensor.

Fixes https://github.com/pyg-team/pytorch_geometric/discussions/8412.