### PR TITLE
Disable `torch._inductor.config.assert_indirect_indexing` in PyTorch 2.2

### DIFF
--- a/torch_geometric/compile.py
+++ b/torch_geometric/compile.py
@@ -93,7 +93,7 @@ def compile(model: Optional[Callable] = None, *args, **kwargs) -> Callable:
     model = to_jittable(model)
 
     # Do not generate device asserts which may slow down model execution:
-    if torch_geometric.tyiping.WITH_PT22:
+    if torch_geometric.typing.WITH_PT22:
         torch._inductor.config.assert_indirect_indexing = False
     elif torch_geometric.typing.WITH_PT21:
         torch._inductor.config.triton.assert_indirect_indexing = False

--- a/torch_geometric/compile.py
+++ b/torch_geometric/compile.py
@@ -93,10 +93,10 @@ def compile(model: Optional[Callable] = None, *args, **kwargs) -> Callable:
     model = to_jittable(model)
 
     # Do not generate device asserts which may slow down model execution:
-    try:
+    if torch_geometric.tyiping.WITH_PT22:
+        torch._inductor.config.assert_indirect_indexing = False
+    elif torch_geometric.typing.WITH_PT21:
         torch._inductor.config.triton.assert_indirect_indexing = False
-    except AttributeError:  # PyTorch < 2.1:
-        pass
 
     # Finally, run `torch.compile` to create an optimized version:
     out = torch.compile(model, *args, **kwargs)

--- a/torch_geometric/typing.py
+++ b/torch_geometric/typing.py
@@ -11,6 +11,7 @@ from torch import Tensor
 
 WITH_PT20 = int(torch.__version__.split('.')[0]) >= 2
 WITH_PT21 = WITH_PT20 and int(torch.__version__.split('.')[1]) >= 1
+WITH_PT22 = WITH_PT20 and int(torch.__version__.split('.')[1]) >= 2
 WITH_PT111 = WITH_PT20 or int(torch.__version__.split('.')[1]) >= 11
 WITH_PT112 = WITH_PT20 or int(torch.__version__.split('.')[1]) >= 12
 WITH_PT113 = WITH_PT20 or int(torch.__version__.split('.')[1]) >= 13


### PR DESCRIPTION
For PyTorch 2.1, #8220 disabled `assert_indirect_indexing`, but https://github.com/pytorch/pytorch/pull/108690 moved `assert_indirect_indexing` out of `triton` config, and the change should land in the next feature release, PyTorch 2.2:

```python
# PyTorch 2.2
torch._inductor.config.assert_indirect_indexing = False

# PyTorch 2.1
torch._inductor.config.triton.assert_indirect_indexing = False
```