### PR TITLE
Remove DDP init from `test_dist_neighbor_sampler` causing CI to break

### DIFF
--- a/test/distributed/test_dist_neighbor_sampler.py
+++ b/test/distributed/test_dist_neighbor_sampler.py
@@ -21,16 +21,20 @@ from torch_geometric.testing import onlyLinux, withPackage
 def create_data(rank: int, world_size: int, time_attr: Optional[str] = None):
     if rank == 0:  # Partition 0:
         node_id = torch.tensor([0, 1, 2, 3, 4, 5, 9])
-        edge_index = torch.tensor([  # Sorted by destination.
-            [1, 2, 3, 4, 5, 0, 0],
-            [0, 1, 2, 3, 4, 4, 9],
-        ])
+        edge_index = torch.tensor(
+            [  # Sorted by destination.
+                [1, 2, 3, 4, 5, 0, 0],
+                [0, 1, 2, 3, 4, 4, 9],
+            ]
+        )
     else:  # Partition 1:
         node_id = torch.tensor([0, 4, 5, 6, 7, 8, 9])
-        edge_index = torch.tensor([  # Sorted by destination.
-            [5, 6, 7, 8, 9, 5, 0],
-            [4, 5, 6, 7, 8, 9, 9],
-        ])
+        edge_index = torch.tensor(
+            [  # Sorted by destination.
+                [5, 6, 7, 8, 9, 5, 0],
+                [4, 5, 6, 7, 8, 9, 9],
+            ]
+        )
     feature_store = LocalFeatureStore.from_data(node_id)
     graph_store = LocalGraphStore.from_data(
         edge_id=None,
@@ -44,16 +48,19 @@ def create_data(rank: int, world_size: int, time_attr: Optional[str] = None):
     graph_store.partition_idx = rank
     graph_store.num_partitions = world_size
 
-    edge_index = torch.tensor([  # Create reference data:
-        [1, 2, 3, 4, 5, 0, 5, 6, 7, 8, 9, 0],
-        [0, 1, 2, 3, 4, 4, 9, 5, 6, 7, 8, 9],
-    ])
+    edge_index = torch.tensor(
+        [  # Create reference data:
+            [1, 2, 3, 4, 5, 0, 5, 6, 7, 8, 9, 0],
+            [0, 1, 2, 3, 4, 4, 9, 5, 6, 7, 8, 9],
+        ]
+    )
     data = Data(x=None, y=None, edge_index=edge_index, num_nodes=10)
 
     if time_attr == 'time':  # Create node-level time data:
         data.time = torch.tensor([5, 0, 1, 3, 3, 4, 4, 4, 4, 4])
-        feature_store.put_tensor(data.time, group_name=None,
-                                 attr_name=time_attr)
+        feature_store.put_tensor(
+            data.time, group_name=None, attr_name=time_attr
+        )
 
     elif time_attr == 'edge_time':  # Create edge-level time data:
         data.edge_time = torch.tensor([0, 1, 2, 3, 4, 5, 7, 7, 7, 7, 7, 11])
@@ -63,8 +70,9 @@ def create_data(rank: int, world_size: int, time_attr: Optional[str] = None):
         if rank == 1:
             edge_time = torch.tensor([4, 7, 7, 7, 7, 7, 11])
 
-        feature_store.put_tensor(edge_time, group_name=None,
-                                 attr_name=time_attr)
+        feature_store.put_tensor(
+            edge_time, group_name=None, attr_name=time_attr
+        )
 
     return (feature_store, graph_store), data
 
@@ -85,14 +93,6 @@ def dist_neighbor_sampler(
         group_name='dist-sampler-test',
     )
 
-    # Initialize training process group of PyTorch:
-    torch.distributed.init_process_group(
-        backend='gloo',
-        rank=current_ctx.rank,
-        world_size=current_ctx.world_size,
-        init_method=f'tcp://localhost:{master_port}',
-    )
-
     dist_sampler = DistNeighborSampler(
         data=dist_data,
         current_ctx=current_ctx,
@@ -101,7 +101,9 @@ def dist_neighbor_sampler(
         shuffle=False,
         disjoint=disjoint,
     )
-
+    # Close RPC & worker group at exit:
+    atexit.register(close_sampler, 0, dist_sampler)
+    
     init_rpc(
         current_ctx=current_ctx,
         rpc_worker_names={},
@@ -112,10 +114,6 @@ def dist_neighbor_sampler(
     dist_sampler.register_sampler_rpc()
     dist_sampler.init_event_loop()
 
-    # Close RPC & worker group at exit:
-    atexit.register(close_sampler, 0, dist_sampler)
-    torch.distributed.barrier()
-
     if rank == 0:  # Seed nodes:
         input_node = torch.tensor([1, 6])
     else:
@@ -125,9 +123,8 @@ def dist_neighbor_sampler(
 
     # Evaluate distributed node sample function:
     out_dist = dist_sampler.event_loop.run_task(
-        coro=dist_sampler.node_sample(inputs))
-
-    torch.distributed.barrier()
+        coro=dist_sampler.node_sample(inputs)
+    )
 
     sampler = NeighborSampler(
         data=data,
@@ -146,9 +143,6 @@ def dist_neighbor_sampler(
         assert torch.equal(out_dist.batch, out.batch)
     assert out_dist.num_sampled_nodes == out.num_sampled_nodes
     assert out_dist.num_sampled_edges == out.num_sampled_edges
-
-    torch.distributed.barrier()
-    torch.distributed.destroy_process_group()
 
 
 def dist_neighbor_sampler_temporal(
@@ -169,14 +163,6 @@ def dist_neighbor_sampler_temporal(
         group_name='dist-sampler-test',
     )
 
-    # Initialize training process group of PyTorch:
-    torch.distributed.init_process_group(
-        backend='gloo',
-        rank=current_ctx.rank,
-        world_size=current_ctx.world_size,
-        init_method=f'tcp://localhost:{master_port}',
-    )
-
     num_neighbors = [-1, -1] if temporal_strategy == 'uniform' else [1, 1]
     dist_sampler = DistNeighborSampler(
         data=dist_data,
@@ -188,6 +174,8 @@ def dist_neighbor_sampler_temporal(
         temporal_strategy=temporal_strategy,
         time_attr=time_attr,
     )
+    # Close RPC & worker group at exit:
+    atexit.register(close_sampler, 0, dist_sampler)
 
     init_rpc(
         current_ctx=current_ctx,
@@ -195,13 +183,8 @@ def dist_neighbor_sampler_temporal(
         master_addr='localhost',
         master_port=master_port,
     )
-
     dist_sampler.register_sampler_rpc()
     dist_sampler.init_event_loop()
-
-    # Close RPC & worker group at exit:
-    atexit.register(close_sampler, 0, dist_sampler)
-    torch.distributed.barrier()
 
     if rank == 0:  # Seed nodes:
         input_node = torch.tensor([1, 6], dtype=torch.int64)
@@ -216,10 +199,8 @@ def dist_neighbor_sampler_temporal(
 
     # Evaluate distributed node sample function:
     out_dist = dist_sampler.event_loop.run_task(
-        coro=dist_sampler.node_sample(inputs))
-
-    torch.distributed.barrier()
-
+        coro=dist_sampler.node_sample(inputs)
+    )
     sampler = NeighborSampler(
         data=data,
         num_neighbors=num_neighbors,
@@ -238,9 +219,6 @@ def dist_neighbor_sampler_temporal(
     assert torch.equal(out_dist.batch, out.batch)
     assert out_dist.num_sampled_nodes == out.num_sampled_nodes
     assert out_dist.num_sampled_edges == out.num_sampled_edges
-
-    torch.distributed.barrier()
-    torch.distributed.destroy_process_group()
 
 
 @onlyLinux

--- a/test/distributed/test_dist_neighbor_sampler.py
+++ b/test/distributed/test_dist_neighbor_sampler.py
@@ -21,20 +21,16 @@ from torch_geometric.testing import onlyLinux, withPackage
 def create_data(rank: int, world_size: int, time_attr: Optional[str] = None):
     if rank == 0:  # Partition 0:
         node_id = torch.tensor([0, 1, 2, 3, 4, 5, 9])
-        edge_index = torch.tensor(
-            [  # Sorted by destination.
-                [1, 2, 3, 4, 5, 0, 0],
-                [0, 1, 2, 3, 4, 4, 9],
-            ]
-        )
+        edge_index = torch.tensor([  # Sorted by destination.
+            [1, 2, 3, 4, 5, 0, 0],
+            [0, 1, 2, 3, 4, 4, 9],
+        ])
     else:  # Partition 1:
         node_id = torch.tensor([0, 4, 5, 6, 7, 8, 9])
-        edge_index = torch.tensor(
-            [  # Sorted by destination.
-                [5, 6, 7, 8, 9, 5, 0],
-                [4, 5, 6, 7, 8, 9, 9],
-            ]
-        )
+        edge_index = torch.tensor([  # Sorted by destination.
+            [5, 6, 7, 8, 9, 5, 0],
+            [4, 5, 6, 7, 8, 9, 9],
+        ])
     feature_store = LocalFeatureStore.from_data(node_id)
     graph_store = LocalGraphStore.from_data(
         edge_id=None,
@@ -48,19 +44,16 @@ def create_data(rank: int, world_size: int, time_attr: Optional[str] = None):
     graph_store.partition_idx = rank
     graph_store.num_partitions = world_size
 
-    edge_index = torch.tensor(
-        [  # Create reference data:
-            [1, 2, 3, 4, 5, 0, 5, 6, 7, 8, 9, 0],
-            [0, 1, 2, 3, 4, 4, 9, 5, 6, 7, 8, 9],
-        ]
-    )
+    edge_index = torch.tensor([  # Create reference data:
+        [1, 2, 3, 4, 5, 0, 5, 6, 7, 8, 9, 0],
+        [0, 1, 2, 3, 4, 4, 9, 5, 6, 7, 8, 9],
+    ])
     data = Data(x=None, y=None, edge_index=edge_index, num_nodes=10)
 
     if time_attr == 'time':  # Create node-level time data:
         data.time = torch.tensor([5, 0, 1, 3, 3, 4, 4, 4, 4, 4])
-        feature_store.put_tensor(
-            data.time, group_name=None, attr_name=time_attr
-        )
+        feature_store.put_tensor(data.time, group_name=None,
+                                 attr_name=time_attr)
 
     elif time_attr == 'edge_time':  # Create edge-level time data:
         data.edge_time = torch.tensor([0, 1, 2, 3, 4, 5, 7, 7, 7, 7, 7, 11])
@@ -70,9 +63,8 @@ def create_data(rank: int, world_size: int, time_attr: Optional[str] = None):
         if rank == 1:
             edge_time = torch.tensor([4, 7, 7, 7, 7, 7, 11])
 
-        feature_store.put_tensor(
-            edge_time, group_name=None, attr_name=time_attr
-        )
+        feature_store.put_tensor(edge_time, group_name=None,
+                                 attr_name=time_attr)
 
     return (feature_store, graph_store), data
 
@@ -103,7 +95,7 @@ def dist_neighbor_sampler(
     )
     # Close RPC & worker group at exit:
     atexit.register(close_sampler, 0, dist_sampler)
-    
+
     init_rpc(
         current_ctx=current_ctx,
         rpc_worker_names={},
@@ -123,8 +115,7 @@ def dist_neighbor_sampler(
 
     # Evaluate distributed node sample function:
     out_dist = dist_sampler.event_loop.run_task(
-        coro=dist_sampler.node_sample(inputs)
-    )
+        coro=dist_sampler.node_sample(inputs))
 
     sampler = NeighborSampler(
         data=data,
@@ -199,8 +190,7 @@ def dist_neighbor_sampler_temporal(
 
     # Evaluate distributed node sample function:
     out_dist = dist_sampler.event_loop.run_task(
-        coro=dist_sampler.node_sample(inputs)
-    )
+        coro=dist_sampler.node_sample(inputs))
     sampler = NeighborSampler(
         data=data,
         num_neighbors=num_neighbors,

--- a/test/distributed/test_rpc.py
+++ b/test/distributed/test_rpc.py
@@ -36,8 +36,7 @@ def run_rpc_feature_test(
 
     # 2) Collect all workers:
     partition_to_workers = rpc.rpc_partition_to_workers(
-        current_ctx, world_size, rank
-    )
+        current_ctx, world_size, rank)
 
     assert partition_to_workers == [
         ['dist-feature-test-0'],
@@ -94,12 +93,10 @@ def test_dist_feature_lookup():
     global_id1 = torch.arange(128 * 2) + 128 * 2
 
     # Set the partition book for two features (partition 0 and 1):
-    partition_book = torch.cat(
-        [
-            torch.zeros(128 * 2, dtype=torch.long),
-            torch.ones(128 * 2, dtype=torch.long),
-        ]
-    )
+    partition_book = torch.cat([
+        torch.zeros(128 * 2, dtype=torch.long),
+        torch.ones(128 * 2, dtype=torch.long),
+    ])
 
     # Put the test tensor into the different feature stores with IDs:
     feature0 = LocalFeatureStore()
@@ -116,12 +113,10 @@ def test_dist_feature_lookup():
     port = s.getsockname()[1]
     s.close()
 
-    w0 = mp_context.Process(
-        target=run_rpc_feature_test, args=(2, 0, feature0, partition_book, port)
-    )
-    w1 = mp_context.Process(
-        target=run_rpc_feature_test, args=(2, 1, feature1, partition_book, port)
-    )
+    w0 = mp_context.Process(target=run_rpc_feature_test,
+                            args=(2, 0, feature0, partition_book, port))
+    w1 = mp_context.Process(target=run_rpc_feature_test,
+                            args=(2, 1, feature1, partition_book, port))
 
     w0.start()
     w1.start()

--- a/test/distributed/test_rpc.py
+++ b/test/distributed/test_rpc.py
@@ -80,7 +80,7 @@ def run_rpc_feature_test(
     assert torch.allclose(cpu_tensor1, tensor1.wait())
 
     rpc.shutdown_rpc()
-    
+
     assert rpc.rpc_is_initialized() == False
 
 

--- a/test/distributed/test_rpc.py
+++ b/test/distributed/test_rpc.py
@@ -80,6 +80,8 @@ def run_rpc_feature_test(
     assert torch.allclose(cpu_tensor1, tensor1.wait())
 
     rpc.shutdown_rpc()
+    
+    assert rpc.rpc_is_initialized() == False
 
 
 @onlyLinux

--- a/test/distributed/test_rpc.py
+++ b/test/distributed/test_rpc.py
@@ -36,7 +36,8 @@ def run_rpc_feature_test(
 
     # 2) Collect all workers:
     partition_to_workers = rpc.rpc_partition_to_workers(
-        current_ctx, world_size, rank)
+        current_ctx, world_size, rank
+    )
 
     assert partition_to_workers == [
         ['dist-feature-test-0'],
@@ -53,7 +54,7 @@ def run_rpc_feature_test(
         'edge_types': None,
         'is_hetero': False,
         'node_types': None,
-        'num_parts': 2
+        'num_parts': 2,
     }
 
     feature.num_partitions = world_size
@@ -80,8 +81,7 @@ def run_rpc_feature_test(
     assert torch.allclose(cpu_tensor1, tensor1.wait())
 
     rpc.shutdown_rpc()
-
-    assert rpc.rpc_is_initialized() == False
+    assert rpc.rpc_is_initialized() is False
 
 
 @onlyLinux
@@ -94,10 +94,12 @@ def test_dist_feature_lookup():
     global_id1 = torch.arange(128 * 2) + 128 * 2
 
     # Set the partition book for two features (partition 0 and 1):
-    partition_book = torch.cat([
-        torch.zeros(128 * 2, dtype=torch.long),
-        torch.ones(128 * 2, dtype=torch.long)
-    ])
+    partition_book = torch.cat(
+        [
+            torch.zeros(128 * 2, dtype=torch.long),
+            torch.ones(128 * 2, dtype=torch.long),
+        ]
+    )
 
     # Put the test tensor into the different feature stores with IDs:
     feature0 = LocalFeatureStore()
@@ -114,10 +116,12 @@ def test_dist_feature_lookup():
     port = s.getsockname()[1]
     s.close()
 
-    w0 = mp_context.Process(target=run_rpc_feature_test,
-                            args=(2, 0, feature0, partition_book, port))
-    w1 = mp_context.Process(target=run_rpc_feature_test,
-                            args=(2, 1, feature1, partition_book, port))
+    w0 = mp_context.Process(
+        target=run_rpc_feature_test, args=(2, 0, feature0, partition_book, port)
+    )
+    w1 = mp_context.Process(
+        target=run_rpc_feature_test, args=(2, 1, feature1, partition_book, port)
+    )
 
     w0.start()
     w1.start()


### PR DESCRIPTION
DDP isn't necessary for the RPC-based feature retrieval in `DistNeighborSampler` tests.
Added a simple test in `test_rpc.py` to check if `close_rpc()` shuts down the connection.