### PR TITLE
`Recall@k` metric for link-prediction 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- Added the `Recall@k` metric for link-prediction ([#8452](https://github.com/pyg-team/pytorch_geometric/pull/8452))
 - Added warning when calling `dataset.num_classes` on regression problems ([#8550](https://github.com/pyg-team/pytorch_geometric/pull/8550))
 - Added the `NDCG@k` metric for link-prediction ([#8326](https://github.com/pyg-team/pytorch_geometric/pull/8326))
 - Added relabel node functionality to `dropout_node` ([#8524](https://github.com/pyg-team/pytorch_geometric/pull/8524))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
-- Added the `Recall@k` metric for link-prediction ([#8452](https://github.com/pyg-team/pytorch_geometric/pull/8452))
 - Added warning when calling `dataset.num_classes` on regression problems ([#8550](https://github.com/pyg-team/pytorch_geometric/pull/8550))
-- Added the `NDCG@k` metric for link-prediction ([#8326](https://github.com/pyg-team/pytorch_geometric/pull/8326))
 - Added relabel node functionality to `dropout_node` ([#8524](https://github.com/pyg-team/pytorch_geometric/pull/8524))
 - Added support for type checking via `mypy` ([#8254](https://github.com/pyg-team/pytorch_geometric/pull/8254))
-- Added support for link-prediction retrieval metrics ([#8499](https://github.com/pyg-team/pytorch_geometric/pull/8499))
+- Added support for link-prediction retrieval metrics ([#8499](https://github.com/pyg-team/pytorch_geometric/pull/8499), [#8326](https://github.com/pyg-team/pytorch_geometric/pull/8326), [#8566](https://github.com/pyg-team/pytorch_geometric/pull/8566))
 - Added METIS partitioning with CSC/CSR format selection in `ClusterData` ([#8438](https://github.com/pyg-team/pytorch_geometric/pull/8438))
 - Added `is_torch_instance` to check against the original class of compiled models ([#8461](https://github.com/pyg-team/pytorch_geometric/pull/8461))
 - Added dense computation for `AddRandomWalkPE` ([#8431](https://github.com/pyg-team/pytorch_geometric/pull/8431))

--- a/test/nn/test_metrics.py
+++ b/test/nn/test_metrics.py
@@ -3,7 +3,11 @@ from typing import List
 import pytest
 import torch
 
-from torch_geometric.nn.metrics import LinkPredNDCG, LinkPredPrecision
+from torch_geometric.nn.metrics import (
+    LinkPredNDCG,
+    LinkPredPrecision,
+    LinkPredRecall,
+)
 
 
 @pytest.mark.parametrize('num_src_nodes', [100])
@@ -44,6 +48,51 @@ def test_precision(num_src_nodes, num_dst_nodes, num_edges, batch_size, k):
             mask = torch.isin(top_k_pred_mat[i], y_index)
             precision = float(mask.sum() / k)
             values.append(precision)
+    expected = torch.tensor(values).mean()
+    assert torch.allclose(out, expected)
+
+
+@pytest.mark.parametrize('num_src_nodes', [100])
+@pytest.mark.parametrize('num_dst_nodes', [1000])
+@pytest.mark.parametrize('num_edges', [3000])
+@pytest.mark.parametrize('batch_size', [32])
+@pytest.mark.parametrize('k', [1, 10, 100])
+@pytest.mark.parametrize('eps', [0, 1e-4, 1e-8])
+def test_recall(num_src_nodes, num_dst_nodes, num_edges, batch_size, k, eps):
+    row = torch.randint(0, num_src_nodes, (num_edges, ))
+    col = torch.randint(0, num_dst_nodes, (num_edges, ))
+    edge_label_index = torch.stack([row, col], dim=0)
+
+    pred = torch.rand(num_src_nodes, num_dst_nodes)
+    pred[row, col] += 0.3  # Offset positive links by a little.
+    top_k_pred_mat = pred.topk(k, dim=1)[1]
+
+    metric = LinkPredRecall(k, eps=eps)
+    assert str(metric) == f'LinkPredRecall({k})'
+
+    for node_id in torch.split(torch.randperm(num_src_nodes), batch_size):
+        mask = torch.isin(edge_label_index[0], node_id)
+
+        y_batch, y_index = edge_label_index[:, mask]
+
+        # Remap `y_batch` back to `[0, batch_size - 1]` range:
+        arange = torch.empty(num_src_nodes, dtype=node_id.dtype)
+        arange[node_id] = torch.arange(node_id.numel())
+        y_batch = arange[y_batch]
+
+        if y_index.numel() > 0:  # Skips 0 division.
+            metric.update(top_k_pred_mat[node_id], (y_batch, y_index))
+
+    out = metric.compute()
+    metric.reset()
+
+    values: List[float] = []
+    for i in range(num_src_nodes):  # Naive computation per node:
+        y_index = col[row == i]
+        mask = torch.isin(top_k_pred_mat[i], y_index)
+        if y_index.numel() > 0:
+            recall = float(mask.sum() / (y_index.numel() + eps))
+            values.append(recall)
     expected = torch.tensor(values).mean()
     assert torch.allclose(out, expected)
 

--- a/test/nn/test_metrics.py
+++ b/test/nn/test_metrics.py
@@ -25,7 +25,7 @@ def test_precision(num_src_nodes, num_dst_nodes, num_edges, batch_size, k):
     top_k_pred_mat = pred.topk(k, dim=1)[1]
 
     metric = LinkPredPrecision(k)
-    assert str(metric) == f'LinkPredPrecision({k})'
+    assert str(metric) == f'LinkPredPrecision(k={k})'
 
     for node_id in torch.split(torch.randperm(num_src_nodes), batch_size):
         mask = torch.isin(edge_label_index[0], node_id)
@@ -52,49 +52,16 @@ def test_precision(num_src_nodes, num_dst_nodes, num_edges, batch_size, k):
     assert torch.allclose(out, expected)
 
 
-@pytest.mark.parametrize('num_src_nodes', [100])
-@pytest.mark.parametrize('num_dst_nodes', [1000])
-@pytest.mark.parametrize('num_edges', [3000])
-@pytest.mark.parametrize('batch_size', [32])
-@pytest.mark.parametrize('k', [1, 10, 100])
-@pytest.mark.parametrize('eps', [0, 1e-4, 1e-8])
-def test_recall(num_src_nodes, num_dst_nodes, num_edges, batch_size, k, eps):
-    row = torch.randint(0, num_src_nodes, (num_edges, ))
-    col = torch.randint(0, num_dst_nodes, (num_edges, ))
-    edge_label_index = torch.stack([row, col], dim=0)
+def test_recall():
+    pred_mat = torch.tensor([[1, 0], [1, 2], [0, 2]])
+    edge_label_index = torch.tensor([[0, 0, 0, 2, 2], [0, 1, 2, 2, 1]])
 
-    pred = torch.rand(num_src_nodes, num_dst_nodes)
-    pred[row, col] += 0.3  # Offset positive links by a little.
-    top_k_pred_mat = pred.topk(k, dim=1)[1]
+    metric = LinkPredRecall(k=2)
+    assert str(metric) == f'LinkPredRecall(k={2})'
+    metric.update(pred_mat, edge_label_index)
+    result = metric.compute()
 
-    metric = LinkPredRecall(k, eps=eps)
-    assert str(metric) == f'LinkPredRecall({k})'
-
-    for node_id in torch.split(torch.randperm(num_src_nodes), batch_size):
-        mask = torch.isin(edge_label_index[0], node_id)
-
-        y_batch, y_index = edge_label_index[:, mask]
-
-        # Remap `y_batch` back to `[0, batch_size - 1]` range:
-        arange = torch.empty(num_src_nodes, dtype=node_id.dtype)
-        arange[node_id] = torch.arange(node_id.numel())
-        y_batch = arange[y_batch]
-
-        if y_index.numel() > 0:  # Skips 0 division.
-            metric.update(top_k_pred_mat[node_id], (y_batch, y_index))
-
-    out = metric.compute()
-    metric.reset()
-
-    values: List[float] = []
-    for i in range(num_src_nodes):  # Naive computation per node:
-        y_index = col[row == i]
-        mask = torch.isin(top_k_pred_mat[i], y_index)
-        if y_index.numel() > 0:
-            recall = float(mask.sum() / (y_index.numel() + eps))
-            values.append(recall)
-    expected = torch.tensor(values).mean()
-    assert torch.allclose(out, expected)
+    assert float(result) == pytest.approx(0.5 * (2 / 3 + 0.5))
 
 
 def test_ndcg():
@@ -102,6 +69,7 @@ def test_ndcg():
     edge_label_index = torch.tensor([[0, 0, 2, 2], [0, 1, 2, 1]])
 
     metric = LinkPredNDCG(k=2)
+    assert str(metric) == f'LinkPredNDCG(k={2})'
     metric.update(pred_mat, edge_label_index)
     result = metric.compute()
 

--- a/torch_geometric/nn/metrics.py
+++ b/torch_geometric/nn/metrics.py
@@ -21,9 +21,9 @@ class LinkPredMetric(BaseMetric, ABC):
     Args:
         k (int): The number of top-:math:`k` predictions to evaluate against.
     """
-    is_differentiable: Optional[bool] = None
+    is_differentiable: bool = False
+    full_state_update: bool = False
     higher_is_better: Optional[bool] = None
-    full_state_update: Optional[bool] = None
 
     def __init__(self, k: int):
         super().__init__()
@@ -140,9 +140,7 @@ class LinkPredPrecision(LinkPredMetric):
     Args:
         k (int): The number of top-:math:`k` predictions to evaluate against.
     """
-    is_differentiable: bool = False
     higher_is_better: bool = True
-    full_state_update: bool = False
 
     def _compute(self, pred_isin_mat: Tensor, y_count: Tensor) -> Tensor:
         return pred_isin_mat.sum(dim=-1) / self.k
@@ -154,9 +152,7 @@ class LinkPredRecall(LinkPredMetric):
     Args:
         k (int): The number of top-:math:`k` predictions to evaluate against.
     """
-    is_differentiable: bool = False
     higher_is_better: bool = True
-    full_state_update: bool = False
 
     def __init__(self, k: int):
         super().__init__(k)
@@ -172,9 +168,7 @@ class LinkPredNDCG(LinkPredMetric):
     Args:
         k (int): The number of top-:math:`k` predictions to evaluate against.
     """
-    is_differentiable: bool = False
     higher_is_better: bool = True
-    full_state_update: bool = False
 
     def __init__(self, k: int):
         super().__init__(k=k)

--- a/torch_geometric/nn/metrics.py
+++ b/torch_geometric/nn/metrics.py
@@ -150,6 +150,27 @@ class LinkPredPrecision(LinkPredMetric):
         return pred_isin_mat.sum(dim=-1) / self.k
 
 
+class LinkPredRecall(LinkPredMetric):
+    r"""A link prediction metric to compute Recall@:math:`k`.
+
+    Args:
+        k (int): The number of top-:math:`k` predictions to evaluate
+            against.
+        eps (float, optional): A small value to avoid division by zero
+            in recall calculation.
+    """
+    is_differentiable: bool = False
+    higher_is_better: bool = True
+    full_state_update: bool = False
+
+    def __init__(self, k: int, eps: Optional[float] = 0.0):
+        super().__init__(k)
+        self.eps = eps
+
+    def _compute(self, pred_isin_mat: Tensor, y_count: Tensor) -> Tensor:
+        return pred_isin_mat.sum(dim=1) / (y_count + self.eps)
+
+
 class LinkPredNDCG(LinkPredMetric):
     r"""A link prediction metric to compute the Normalized Discounted
     Cumulative Gain (NDCG).

--- a/torch_geometric/nn/metrics.py
+++ b/torch_geometric/nn/metrics.py
@@ -19,8 +19,7 @@ class LinkPredMetric(BaseMetric, ABC):
     r"""An abstract class for computing link prediction retrieval metrics.
 
     Args:
-        k (int): The number of top-:math:`k` predictions to evaluate
-            against.
+        k (int): The number of top-:math:`k` predictions to evaluate against.
     """
     is_differentiable: Optional[bool] = None
     higher_is_better: Optional[bool] = None
@@ -132,15 +131,14 @@ class LinkPredMetric(BaseMetric, ABC):
         raise NotImplementedError
 
     def __repr__(self) -> str:
-        return f'{self.__class__.__name__}({self.k})'
+        return f'{self.__class__.__name__}(k={self.k})'
 
 
 class LinkPredPrecision(LinkPredMetric):
     r"""A link prediction metric to compute Precision@:math`k`.
 
     Args:
-        k (int): The number of top-:math:`k` predictions to evaluate
-            against.
+        k (int): The number of top-:math:`k` predictions to evaluate against.
     """
     is_differentiable: bool = False
     higher_is_better: bool = True
@@ -154,21 +152,17 @@ class LinkPredRecall(LinkPredMetric):
     r"""A link prediction metric to compute Recall@:math:`k`.
 
     Args:
-        k (int): The number of top-:math:`k` predictions to evaluate
-            against.
-        eps (float, optional): A small value to avoid division by zero
-            in recall calculation.
+        k (int): The number of top-:math:`k` predictions to evaluate against.
     """
     is_differentiable: bool = False
     higher_is_better: bool = True
     full_state_update: bool = False
 
-    def __init__(self, k: int, eps: Optional[float] = 0.0):
+    def __init__(self, k: int):
         super().__init__(k)
-        self.eps = eps
 
     def _compute(self, pred_isin_mat: Tensor, y_count: Tensor) -> Tensor:
-        return pred_isin_mat.sum(dim=1) / (y_count + self.eps)
+        return pred_isin_mat.sum(dim=1) / y_count.clamp(min=1e-7)
 
 
 class LinkPredNDCG(LinkPredMetric):
@@ -176,8 +170,7 @@ class LinkPredNDCG(LinkPredMetric):
     Cumulative Gain (NDCG).
 
     Args:
-        k (int): The number of top-:math:`k` predictions to evaluate
-            against.
+        k (int): The number of top-:math:`k` predictions to evaluate against.
     """
     is_differentiable: bool = False
     higher_is_better: bool = True


### PR DESCRIPTION
Partly fixes #8452.

I implemented it with an optional epsilon parameter to avoid zero division.  

PS: Is it better for me to start a new issue for this specifically, as this only solves part of the issue? 