### PR TITLE
Use socket as context in tests including RPC to ensure better closing behaviors (CI fix)

### DIFF
--- a/test/distributed/test_dist_link_neighbor_loader.py
+++ b/test/distributed/test_dist_link_neighbor_loader.py
@@ -65,7 +65,7 @@ def dist_link_neighbor_loader_homo(
     )
 
     edge_label_index = part_data[1].get_edge_index(None, 'coo')
-    edge_label = torch.randint(high=2, size=(edge_label_index.size(1),))
+    edge_label = torch.randint(high=2, size=(edge_label_index.size(1), ))
 
     loader = DistLinkNeighborLoader(
         data=part_data,
@@ -90,7 +90,7 @@ def dist_link_neighbor_loader_homo(
 
     for batch in loader:
         assert isinstance(batch, Data)
-        assert batch.n_id.size() == (batch.num_nodes,)
+        assert batch.n_id.size() == (batch.num_nodes, )
         assert batch.input_id.numel() == batch.batch_size == 10
         assert batch.edge_index.min() >= 0
         assert batch.edge_index.max() < batch.num_nodes
@@ -117,7 +117,7 @@ def dist_link_neighbor_loader_hetero(
     )
 
     edge_label_index = part_data[1].get_edge_index(edge_type, 'coo')
-    edge_label = torch.randint(high=2, size=(edge_label_index.size(1),))
+    edge_label = torch.randint(high=2, size=(edge_label_index.size(1), ))
 
     loader = DistLinkNeighborLoader(
         data=part_data,
@@ -142,11 +142,8 @@ def dist_link_neighbor_loader_hetero(
 
     for batch in loader:
         assert isinstance(batch, HeteroData)
-        assert (
-            batch[edge_type].input_id.numel()
-            == batch[edge_type].batch_size
-            == 10
-        )
+        assert (batch[edge_type].input_id.numel() ==
+                batch[edge_type].batch_size == 10)
 
         assert len(batch.node_types) == 2
         for node_type in batch.node_types:
@@ -156,9 +153,8 @@ def dist_link_neighbor_loader_hetero(
 
         assert len(batch.edge_types) == 4
         for edge_type in batch.edge_types:
-            assert batch[edge_type].edge_attr.size(0) == batch[
-                edge_type
-            ].edge_index.size(1)
+            assert batch[edge_type].edge_attr.size(
+                0) == batch[edge_type].edge_index.size(1)
 
 
 @onlyLinux

--- a/test/distributed/test_dist_link_neighbor_loader.py
+++ b/test/distributed/test_dist_link_neighbor_loader.py
@@ -4,6 +4,7 @@ from typing import Tuple
 import pytest
 import torch
 import torch.multiprocessing as mp
+from contextlib import closing
 
 from torch_geometric.data import Data, HeteroData
 from torch_geometric.datasets import FakeDataset, FakeHeteroDataset
@@ -65,7 +66,7 @@ def dist_link_neighbor_loader_homo(
     )
 
     edge_label_index = part_data[1].get_edge_index(None, 'coo')
-    edge_label = torch.randint(high=2, size=(edge_label_index.size(1), ))
+    edge_label = torch.randint(high=2, size=(edge_label_index.size(1),))
 
     loader = DistLinkNeighborLoader(
         data=part_data,
@@ -90,7 +91,7 @@ def dist_link_neighbor_loader_homo(
 
     for batch in loader:
         assert isinstance(batch, Data)
-        assert batch.n_id.size() == (batch.num_nodes, )
+        assert batch.n_id.size() == (batch.num_nodes,)
         assert batch.input_id.numel() == batch.batch_size == 10
         assert batch.edge_index.min() >= 0
         assert batch.edge_index.max() < batch.num_nodes
@@ -117,7 +118,7 @@ def dist_link_neighbor_loader_hetero(
     )
 
     edge_label_index = part_data[1].get_edge_index(edge_type, 'coo')
-    edge_label = torch.randint(high=2, size=(edge_label_index.size(1), ))
+    edge_label = torch.randint(high=2, size=(edge_label_index.size(1),))
 
     loader = DistLinkNeighborLoader(
         data=part_data,
@@ -142,8 +143,11 @@ def dist_link_neighbor_loader_hetero(
 
     for batch in loader:
         assert isinstance(batch, HeteroData)
-        assert (batch[edge_type].input_id.numel() ==
-                batch[edge_type].batch_size == 10)
+        assert (
+            batch[edge_type].input_id.numel()
+            == batch[edge_type].batch_size
+            == 10
+        )
 
         assert len(batch.node_types) == 2
         for node_type in batch.node_types:
@@ -153,8 +157,9 @@ def dist_link_neighbor_loader_hetero(
 
         assert len(batch.edge_types) == 4
         for edge_type in batch.edge_types:
-            assert (batch[edge_type].edge_attr.size(0) ==
-                    batch[edge_type].edge_index.size(1))
+            assert batch[edge_type].edge_attr.size(0) == batch[
+                edge_type
+            ].edge_index.size(1)
 
 
 @onlyLinux
@@ -171,12 +176,12 @@ def test_dist_link_neighbor_loader_homo(
     async_sampling,
     neg_ratio,
 ):
+    addr = '127.0.0.1'
     mp_context = torch.multiprocessing.get_context('spawn')
-    s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-    s.bind(('127.0.0.1', 0))
-    port = s.getsockname()[1]
-    s.close()
-    addr = 'localhost'
+    with closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as sock:
+        sock.settimeout(1)
+        sock.bind((addr, 0))
+        port = sock.getsockname()[1]
 
     data = FakeDataset(
         num_graphs=1,
@@ -189,14 +194,30 @@ def test_dist_link_neighbor_loader_homo(
 
     w0 = mp_context.Process(
         target=dist_link_neighbor_loader_homo,
-        args=(tmp_path, num_parts, 0, addr, port, num_workers, async_sampling,
-              neg_ratio),
+        args=(
+            tmp_path,
+            num_parts,
+            0,
+            addr,
+            port,
+            num_workers,
+            async_sampling,
+            neg_ratio,
+        ),
     )
 
     w1 = mp_context.Process(
         target=dist_link_neighbor_loader_homo,
-        args=(tmp_path, num_parts, 1, addr, port, num_workers, async_sampling,
-              neg_ratio),
+        args=(
+            tmp_path,
+            num_parts,
+            1,
+            addr,
+            port,
+            num_workers,
+            async_sampling,
+            neg_ratio,
+        ),
     )
 
     w0.start()
@@ -222,11 +243,11 @@ def test_dist_link_neighbor_loader_hetero(
     edge_type,
 ):
     mp_context = torch.multiprocessing.get_context('spawn')
-    s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-    s.bind(('127.0.0.1', 0))
-    port = s.getsockname()[1]
-    s.close()
-    addr = 'localhost'
+    addr = '127.0.0.1'
+    with closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as sock:
+        sock.settimeout(1)
+        sock.bind((addr, 0))
+        port = sock.getsockname()[1]
 
     data = FakeHeteroDataset(
         num_graphs=1,
@@ -241,14 +262,32 @@ def test_dist_link_neighbor_loader_hetero(
 
     w0 = mp_context.Process(
         target=dist_link_neighbor_loader_hetero,
-        args=(tmp_path, num_parts, 0, addr, port, num_workers, async_sampling,
-              neg_ratio, edge_type),
+        args=(
+            tmp_path,
+            num_parts,
+            0,
+            addr,
+            port,
+            num_workers,
+            async_sampling,
+            neg_ratio,
+            edge_type,
+        ),
     )
 
     w1 = mp_context.Process(
         target=dist_link_neighbor_loader_hetero,
-        args=(tmp_path, num_parts, 1, addr, port, num_workers, async_sampling,
-              neg_ratio, edge_type),
+        args=(
+            tmp_path,
+            num_parts,
+            1,
+            addr,
+            port,
+            num_workers,
+            async_sampling,
+            neg_ratio,
+            edge_type,
+        ),
     )
 
     w0.start()

--- a/test/distributed/test_dist_link_neighbor_loader.py
+++ b/test/distributed/test_dist_link_neighbor_loader.py
@@ -4,7 +4,6 @@ from typing import Tuple
 import pytest
 import torch
 import torch.multiprocessing as mp
-from contextlib import closing
 
 from torch_geometric.data import Data, HeteroData
 from torch_geometric.datasets import FakeDataset, FakeHeteroDataset
@@ -178,7 +177,7 @@ def test_dist_link_neighbor_loader_homo(
 ):
     addr = '127.0.0.1'
     mp_context = torch.multiprocessing.get_context('spawn')
-    with closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as sock:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
         sock.settimeout(1)
         sock.bind((addr, 0))
         port = sock.getsockname()[1]
@@ -244,7 +243,7 @@ def test_dist_link_neighbor_loader_hetero(
 ):
     mp_context = torch.multiprocessing.get_context('spawn')
     addr = '127.0.0.1'
-    with closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as sock:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
         sock.settimeout(1)
         sock.bind((addr, 0))
         port = sock.getsockname()[1]

--- a/test/distributed/test_dist_neighbor_loader.py
+++ b/test/distributed/test_dist_neighbor_loader.py
@@ -3,7 +3,6 @@ import socket
 import pytest
 import torch
 import torch.multiprocessing as mp
-from contextlib import closing
 
 from torch_geometric.data import Data, HeteroData
 from torch_geometric.datasets import FakeDataset, FakeHeteroDataset
@@ -178,7 +177,7 @@ def test_dist_neighbor_loader_homo(
 ):
     mp_context = torch.multiprocessing.get_context('spawn')
     addr = '127.0.0.1'
-    with closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as sock:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
         sock.settimeout(1)
         sock.bind((addr, 0))
         port = sock.getsockname()[1]
@@ -222,7 +221,7 @@ def test_dist_neighbor_loader_hetero(
 ):
     mp_context = torch.multiprocessing.get_context('spawn')
     addr = '127.0.0.1'
-    with closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as sock:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
         sock.settimeout(1)
         sock.bind((addr, 0))
         port = sock.getsockname()[1]

--- a/test/distributed/test_dist_neighbor_loader.py
+++ b/test/distributed/test_dist_neighbor_loader.py
@@ -86,7 +86,7 @@ def dist_neighbor_loader_homo(
 
     for batch in loader:
         assert isinstance(batch, Data)
-        assert batch.n_id.size() == (batch.num_nodes,)
+        assert batch.n_id.size() == (batch.num_nodes, )
         assert batch.input_id.numel() == batch.batch_size == 10
         assert batch.edge_index.min() >= 0
         assert batch.edge_index.max() < batch.num_nodes

--- a/test/distributed/test_dist_neighbor_sampler.py
+++ b/test/distributed/test_dist_neighbor_sampler.py
@@ -1,7 +1,6 @@
 import atexit
 import socket
 from typing import Optional
-from contextlib import closing
 
 import pytest
 import torch
@@ -227,7 +226,7 @@ def dist_neighbor_sampler_temporal(
 @pytest.mark.parametrize('disjoint', [False, True])
 def test_dist_neighbor_sampler(disjoint):
     mp_context = torch.multiprocessing.get_context('spawn')
-    with closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as sock:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
         sock.settimeout(1)
         sock.bind(('127.0.0.1', 0))
         port = sock.getsockname()[1]
@@ -255,7 +254,7 @@ def test_dist_neighbor_sampler(disjoint):
 @pytest.mark.parametrize('temporal_strategy', ['uniform'])
 def test_dist_neighbor_sampler_temporal(seed_time, temporal_strategy):
     mp_context = torch.multiprocessing.get_context('spawn')
-    with closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as sock:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
         sock.settimeout(1)
         sock.bind(('127.0.0.1', 0))
         port = sock.getsockname()[1]
@@ -288,7 +287,7 @@ def test_dist_neighbor_sampler_edge_level_temporal(
     seed_time = torch.tensor(seed_time)
 
     mp_context = torch.multiprocessing.get_context('spawn')
-    with closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as sock:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
         sock.settimeout(1)
         sock.bind(('127.0.0.1', 0))
         port = sock.getsockname()[1]

--- a/test/distributed/test_dist_neighbor_sampler.py
+++ b/test/distributed/test_dist_neighbor_sampler.py
@@ -21,20 +21,16 @@ from torch_geometric.testing import onlyLinux, withPackage
 def create_data(rank: int, world_size: int, time_attr: Optional[str] = None):
     if rank == 0:  # Partition 0:
         node_id = torch.tensor([0, 1, 2, 3, 4, 5, 9])
-        edge_index = torch.tensor(
-            [  # Sorted by destination.
-                [1, 2, 3, 4, 5, 0, 0],
-                [0, 1, 2, 3, 4, 4, 9],
-            ]
-        )
+        edge_index = torch.tensor([  # Sorted by destination.
+            [1, 2, 3, 4, 5, 0, 0],
+            [0, 1, 2, 3, 4, 4, 9],
+        ])
     else:  # Partition 1:
         node_id = torch.tensor([0, 4, 5, 6, 7, 8, 9])
-        edge_index = torch.tensor(
-            [  # Sorted by destination.
-                [5, 6, 7, 8, 9, 5, 0],
-                [4, 5, 6, 7, 8, 9, 9],
-            ]
-        )
+        edge_index = torch.tensor([  # Sorted by destination.
+            [5, 6, 7, 8, 9, 5, 0],
+            [4, 5, 6, 7, 8, 9, 9],
+        ])
     feature_store = LocalFeatureStore.from_data(node_id)
     graph_store = LocalGraphStore.from_data(
         edge_id=None,
@@ -48,19 +44,16 @@ def create_data(rank: int, world_size: int, time_attr: Optional[str] = None):
     graph_store.partition_idx = rank
     graph_store.num_partitions = world_size
 
-    edge_index = torch.tensor(
-        [  # Create reference data:
-            [1, 2, 3, 4, 5, 0, 5, 6, 7, 8, 9, 0],
-            [0, 1, 2, 3, 4, 4, 9, 5, 6, 7, 8, 9],
-        ]
-    )
+    edge_index = torch.tensor([  # Create reference data:
+        [1, 2, 3, 4, 5, 0, 5, 6, 7, 8, 9, 0],
+        [0, 1, 2, 3, 4, 4, 9, 5, 6, 7, 8, 9],
+    ])
     data = Data(x=None, y=None, edge_index=edge_index, num_nodes=10)
 
     if time_attr == 'time':  # Create node-level time data:
         data.time = torch.tensor([5, 0, 1, 3, 3, 4, 4, 4, 4, 4])
-        feature_store.put_tensor(
-            data.time, group_name=None, attr_name=time_attr
-        )
+        feature_store.put_tensor(data.time, group_name=None,
+                                 attr_name=time_attr)
 
     elif time_attr == 'edge_time':  # Create edge-level time data:
         data.edge_time = torch.tensor([0, 1, 2, 3, 4, 5, 7, 7, 7, 7, 7, 11])
@@ -70,9 +63,8 @@ def create_data(rank: int, world_size: int, time_attr: Optional[str] = None):
         if rank == 1:
             edge_time = torch.tensor([4, 7, 7, 7, 7, 7, 11])
 
-        feature_store.put_tensor(
-            edge_time, group_name=None, attr_name=time_attr
-        )
+        feature_store.put_tensor(edge_time, group_name=None,
+                                 attr_name=time_attr)
 
     return (feature_store, graph_store), data
 
@@ -123,8 +115,7 @@ def dist_neighbor_sampler(
 
     # Evaluate distributed node sample function:
     out_dist = dist_sampler.event_loop.run_task(
-        coro=dist_sampler.node_sample(inputs)
-    )
+        coro=dist_sampler.node_sample(inputs))
 
     sampler = NeighborSampler(
         data=data,
@@ -199,8 +190,7 @@ def dist_neighbor_sampler_temporal(
 
     # Evaluate distributed node sample function:
     out_dist = dist_sampler.event_loop.run_task(
-        coro=dist_sampler.node_sample(inputs)
-    )
+        coro=dist_sampler.node_sample(inputs))
     sampler = NeighborSampler(
         data=data,
         num_neighbors=num_neighbors,

--- a/test/distributed/test_rpc.py
+++ b/test/distributed/test_rpc.py
@@ -1,4 +1,3 @@
-from contextlib import closing
 import socket
 from typing import Dict, List
 
@@ -112,7 +111,7 @@ def test_dist_feature_lookup():
     feature1.put_tensor(cpu_tensor1, group_name=None, attr_name='x')
 
     mp_context = torch.multiprocessing.get_context('spawn')
-    with closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as sock:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
         sock.settimeout(1)
         sock.bind(('127.0.0.1', 0))
         port = sock.getsockname()[1]

--- a/test/distributed/test_rpc.py
+++ b/test/distributed/test_rpc.py
@@ -36,8 +36,7 @@ def run_rpc_feature_test(
 
     # 2) Collect all workers:
     partition_to_workers = rpc.rpc_partition_to_workers(
-        current_ctx, world_size, rank
-    )
+        current_ctx, world_size, rank)
 
     assert partition_to_workers == [
         ['dist-feature-test-0'],
@@ -94,12 +93,10 @@ def test_dist_feature_lookup():
     global_id1 = torch.arange(128 * 2) + 128 * 2
 
     # Set the partition book for two features (partition 0 and 1):
-    partition_book = torch.cat(
-        [
-            torch.zeros(128 * 2, dtype=torch.long),
-            torch.ones(128 * 2, dtype=torch.long),
-        ]
-    )
+    partition_book = torch.cat([
+        torch.zeros(128 * 2, dtype=torch.long),
+        torch.ones(128 * 2, dtype=torch.long),
+    ])
 
     # Put the test tensor into the different feature stores with IDs:
     feature0 = LocalFeatureStore()
@@ -116,12 +113,10 @@ def test_dist_feature_lookup():
         sock.bind(('127.0.0.1', 0))
         port = sock.getsockname()[1]
 
-    w0 = mp_context.Process(
-        target=run_rpc_feature_test, args=(2, 0, feature0, partition_book, port)
-    )
-    w1 = mp_context.Process(
-        target=run_rpc_feature_test, args=(2, 1, feature1, partition_book, port)
-    )
+    w0 = mp_context.Process(target=run_rpc_feature_test,
+                            args=(2, 0, feature0, partition_book, port))
+    w1 = mp_context.Process(target=run_rpc_feature_test,
+                            args=(2, 1, feature1, partition_book, port))
 
     w0.start()
     w1.start()


### PR DESCRIPTION
We've observed that removing DDP in #8563 helped to solve DDP-related issues, however some RPC-related connection issues remain. This could be due to `socket` module leaving the port open and `torch.rpc` finding the port busy.
Using the socket as context to retrieve open port ID can help to solve this.
Tested with CI 'Full testing' : https://github.com/pyg-team/pytorch_geometric/actions/runs/7141727138/attempts/1
All attempts pass Linux-based tests. Tested 3 times.
Error msg:
```
[W socket.cpp:401] [c10d] The server socket has failed to bind to [::]:51262 (errno: 98 - Address already in use).
[W socket.cpp:401] [c10d] The server socket has failed to bind to 0.0.0.0:51262 (errno: 98 - Address already in use).
[E socket.cpp:435] [c10d] The server socket has failed to listen on any local network address.
Process SpawnProcess-15:
Traceback (most recent call last):
  File "/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/multiprocessing/process.py", line 315, in _bootstrap
    self.run()
  File "/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/multiprocessing/process.py", line 108, in run
    self._target(*self._args, **self._kwargs)
  File "/home/runner/work/pytorch_geometric/pytorch_geometric/test/distributed/test_dist_neighbor_sampler.py", line 202, in dist_neighbor_sampler_temporal
    init_rpc(
  File "/home/runner/work/pytorch_geometric/pytorch_geometric/torch_geometric/distributed/rpc.py", line 65, in init_rpc
    rpc.init_rpc(
  File "/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages/torch/distributed/rpc/__init__.py", line 176, in init_rpc
    store, _, _ = next(rendezvous_iterator)
  File "/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages/torch/distributed/rendezvous.py", line 212, in _tcp_rendezvous_handler
    store = _create_c10d_store(result.hostname, result.port, rank, world_size, timeout)
  File "/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages/torch/distributed/rendezvous.py", line 188, in _create_c10d_store
    return TCPStore(
RuntimeError: The server socket has failed to listen on any local network address. The server socket has failed to bind to [::]:51262 (errno: 98 - Address already in use). The server socket has failed to bind to 0.0.0.0:51262 (errno: 98 - Address already in use).
```