### PR TITLE
Changes to degree normalization code

### DIFF
--- a/torch_geometric/nn/dense/mincut_pool.py
+++ b/torch_geometric/nn/dense/mincut_pool.py
@@ -99,9 +99,11 @@ def dense_mincut_pool(
     # Fix and normalize coarsened adjacency matrix.
     ind = torch.arange(k, device=out_adj.device)
     out_adj[:, ind, ind] = 0
-    d = torch.einsum('ijk->ij', out_adj)
-    d = torch.sqrt(d)[:, None] + EPS
-    out_adj = (out_adj / d) / d.transpose(1, 2)
+    # Degree normalization
+    d = torch.sum(out_adj, 2) + EPS
+    d = torch.diag_embed(d)
+    d_inv_sqrt = 1 / d.sqrt()
+    out_adj = torch.matmul(d_inv_sqrt, torch.matmul(out_adj, d_inv_sqrt))
 
     return out, out_adj, mincut_loss, ortho_loss
 


### PR DESCRIPTION
The existing code doesn't result in d being diagonal for proper degree normalization as proposed in the original paper "Spectral Clustering with Graph Neural Networks for Graph Pooling". It ends up altering the sparsity of the output adjacency matrix and it's no longer a pooling operation.