### PR TITLE
Version bump for singularity container

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -14,11 +14,11 @@ If you encounter any problems, please feel free to contact <liangshengwen@ict.ac
 You can run PyG inside a singularity image. An example singularity file can be found in this folder. You might have to modify the script as versions keep getting updated.
 
 The versions specified in the script were last updated in December 2023. The script installs:
+
 - cuda 12.1 (requires compute capability 5.0 as provided since Maxwell, i.e. Geforce GTX 9xx and newer)
 - python 3.11.7 (3.12 was not yet supported by pytorch)
 - pytorch 2.1.0 (pytorch 2.1.1 was out but not yet supported by pyg_lib)
-- pytorch geometric 
-
+- pytorch geometric
 
 ## Building and Using the Container
 
@@ -26,7 +26,7 @@ To build the container, run
 
 `sudo singularity build geometric.sif singularity`
 
-then wait. 
+then wait.
 The container needs to be built on a machine with an NVIDIA GPU in order to install cuda bindings. Otherwise, the CPU version will be installed. (and there is no easy fix to avoid that..)
 Once finished, you can run the GAT example in the folder you built the image in by calling
 
@@ -50,7 +50,6 @@ singularity exec geometric.sif python3 gat.py
 
 in case you have to resort to using the CPU.
 
-
 ## Troubleshooting and additional comments
 
 **Temporary files:** If your harddisk runs full after multiple builds, this is known and apparently working as intended; delete the `/tmp/sbuild-XXXXXXXXX` files.
@@ -61,8 +60,6 @@ in case you have to resort to using the CPU.
 
 **Deprecation Notice:** NVIDIA only supports the latest CUDA subversion of each docker image. If you receive a deprecation notice, consider increasing the CUDA version of the base docker file from 12.1.1 to 12.1.x.
 
-**Outdated Host NVIDIA driver:** CUDA 12.1 requires a relatively up-to-date nvidia driver on the host. It is not necessary that the exact CUDA versions match as long as the driver is recent enough. 
+**Outdated Host NVIDIA driver:** CUDA 12.1 requires a relatively up-to-date nvidia driver on the host. It is not necessary that the exact CUDA versions match as long as the driver is recent enough.
 
 **Compute Capabilities:** If you run it on multiply systems (likely, with singularity), ensure that the device is supported by the CUDA version. If you have the cuda samples installed, check the compute capabilities with (for example) `/usr/local/cuda-10.1/extras/demo_suite/deviceQuery | grep 'CUDA Capability'`; if not, check [here](https://en.wikipedia.org/wiki/CUDA#GPUs_supported). CUDA 12.x relies com compute capability 5.0 and up, which includes GTX 9xx cards and newer.
-
-

--- a/docker/README.md
+++ b/docker/README.md
@@ -11,17 +11,14 @@ If you encounter any problems, please feel free to contact <liangshengwen@ict.ac
 
 # Singularity
 
-You can run PyG inside a singularity image. An example singularity file can be found in this folder.
+You can run PyG inside a singularity image. An example singularity file can be found in this folder. You might have to modify the script as versions keep getting updated.
 
-You might have to modify the script; depending on your needs, modify the following:
+The versions specified in the script were last updated in December 2023. The script installs:
+- cuda 12.1 (requires compute capability 5.0 as provided since Maxwell, i.e. Geforce GTX 9xx and newer)
+- python 3.11.7 (3.12 was not yet supported by pytorch)
+- pytorch 2.1.0 (pytorch 2.1.1 was out but not yet supported by pyg_lib)
+- pytorch geometric 
 
-- **cuda version 10.1**: If you need another version, change `From: nvidia/cuda:10.1-cudnn7-devel-ubuntu16.04` to the corresponding tag from <https://hub.docker.com/r/nvidia/cuda>. Same if you want to use anything but Ubuntu 16.04. Your host has to have at least this cuda version!
-- **python version 3.7.2**: If you need another version, change `pyenv install 3.7.2` and the following lines to the corresponding version.
-- **pytorch version 1.3.0**: If you need another version, change `pip install torch==1.3.0`.
-- **pytorch_geometric versions**: This uses specific versions for each of the `pytorch_geometric` requirements (scatter: 1.4.0, sparse: 0.4.3, cluster: 1.4.5, geometric 1.3.2). To change these, change the corresponding `git checkout` lines near the bottom.
-- **cuda compute capability 5.0 and 6.1**: If you run it on multiply systems (likely, with singularity), ensure that all compute capabilities are listed here. If you have the cuda samples installed, check it with (for example) `/usr/local/cuda-10.1/extras/demo_suite/deviceQuery | grep 'CUDA Capability'`; if not, check [here](https://en.wikipedia.org/wiki/CUDA#GPUs_supported).
-
-Note: If your harddisk runs full after multiple builds, this is known and apparently working as intended; delete the `/tmp/sbuild-XXXXXXXXX` files.
 
 ## Building and Using the Container
 
@@ -29,7 +26,9 @@ To build the container, run
 
 `sudo singularity build geometric.sif singularity`
 
-then wait. Once finished, you can run the GAT example in the folder you built the image in by calling
+then wait. 
+The container needs to be built on a machine with an NVIDIA GPU in order to install cuda bindings. Otherwise, the CPU version will be installed. (and there is no easy fix to avoid that..)
+Once finished, you can run the GAT example in the folder you built the image in by calling
 
 ```
 wget https://raw.githubusercontent.com/pyg-team/pytorch_geometric/master/examples/gat.py
@@ -40,13 +39,30 @@ wget https://raw.githubusercontent.com/pyg-team/pytorch_geometric/master/example
 then
 
 ```
-singularity exec geometric.sif python3 gat.py
-```
-
-to run on the CPU, or
-
-```
 singularity exec --nv geometric.sif python3 gat.py
 ```
 
-to run on the GPU.
+to run on the GPU, or
+
+```
+singularity exec geometric.sif python3 gat.py
+```
+
+in case you have to resort to using the CPU.
+
+
+## Troubleshooting and additional comments
+
+**Temporary files:** If your harddisk runs full after multiple builds, this is known and apparently working as intended; delete the `/tmp/sbuild-XXXXXXXXX` files.
+
+**Paths:** when running singularity (e.g. `singularity run --nv geometric.sif`) it will load your local .bashrc which can modify you PATH variable. Adding the `--no-home` flag can avoid this behavior.
+
+**Only CPU version:** Check that the `--nv` flag is set when running the container. Also make sure that the machine on which the container is built is equipped with an NVIDIA GPU.
+
+**Deprecation Notice:** NVIDIA only supports the latest CUDA subversion of each docker image. If you receive a deprecation notice, consider increasing the CUDA version of the base docker file from 12.1.1 to 12.1.x.
+
+**Outdated Host NVIDIA driver:** CUDA 12.1 requires a relatively up-to-date nvidia driver on the host. It is not necessary that the exact CUDA versions match as long as the driver is recent enough. 
+
+**Compute Capabilities:** If you run it on multiply systems (likely, with singularity), ensure that the device is supported by the CUDA version. If you have the cuda samples installed, check the compute capabilities with (for example) `/usr/local/cuda-10.1/extras/demo_suite/deviceQuery | grep 'CUDA Capability'`; if not, check [here](https://en.wikipedia.org/wiki/CUDA#GPUs_supported). CUDA 12.x relies com compute capability 5.0 and up, which includes GTX 9xx cards and newer.
+
+

--- a/docker/singularity
+++ b/docker/singularity
@@ -1,5 +1,6 @@
 Bootstrap: docker
-From: nvidia/cuda:10.1-cudnn7-devel-ubuntu18.04
+# From: nvidia/cuda:11.6.1-cudnn8-devel-ubuntu20.04
+From: nvidia/cuda:12.1.1-cudnn8-devel-ubuntu22.04
 
 %post
   CURDIR=$(pwd)
@@ -36,40 +37,19 @@ From: nvidia/cuda:10.1-cudnn7-devel-ubuntu18.04
   export PYENV_ROOT=/opt/pyenv
   export PATH="/opt/pyenv/bin:$PATH"
   curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash
-  pyenv install 3.7.2
-  echo 'export PATH=/opt/pyenv/versions/3.7.2/bin/:$PATH' >> $SINGULARITY_ENVIRONMENT
-  export PATH=/opt/pyenv/versions/3.7.2/bin/:$PATH
+  pyenv install 3.11.7
+  echo 'export PATH=/opt/pyenv/versions/3.11.7/bin/:$PATH' >> $SINGULARITY_ENVIRONMENT
+  export PATH=/opt/pyenv/versions/3.11.7/bin/:$PATH
 
-  pip install torch==1.3.0
+  # pip install torch==2.1.0
+  pip install torch==2.1.0 torchvision torchaudio --index-url https://download.pytorch.org/whl/cu121
 
-  mkdir -p $SINGULARITY_ROOTFS/tmp/sing_build_cuda
-  cd $SINGULARITY_ROOTFS/tmp/sing_build_cuda
+  pip install tabulate
+  pip install ogb
 
-  export TORCH_CUDA_ARCH_LIST="5.0 6.1"
+  pip install torch_geometric
 
-  git clone https://github.com/rusty1s/pytorch_scatter.git && \
-    cd ./pytorch_scatter && \
-    git checkout 1.4.0 && \
-    python3 -m pip install . && \
-    cd ..
+  # Optional dependencies:
+  pip install pyg_lib torch_scatter torch_sparse torch_cluster torch_spline_conv -f https://data.pyg.org/whl/torch-2.1.0+cu121.html
 
-  git clone https://github.com/rusty1s/pytorch_sparse.git && \
-    cd ./pytorch_sparse && \
-    git checkout 0.4.3 && \
-    python3 -m pip install . && \
-    cd ..
 
-  git clone https://github.com/rusty1s/pytorch_cluster.git && \
-    cd ./pytorch_cluster && \
-    git checkout 1.4.5 && \
-    python3 -m pip install . && \
-    cd ..
-
-  git clone https://github.com/pyg-team/pytorch_geometric.git && \
-    cd ./pytorch_geometric && \
-    git checkout 1.3.2 && \
-    python3 -m pip install . && \
-    cd ..
-
-  cd $CURDIR
-  rm -rf $SINGULARITY_ROOTFS/tmp/sing_build_cuda

--- a/docker/singularity
+++ b/docker/singularity
@@ -51,5 +51,3 @@ From: nvidia/cuda:12.1.1-cudnn8-devel-ubuntu22.04
 
   # Optional dependencies:
   pip install pyg_lib torch_scatter torch_sparse torch_cluster torch_spline_conv -f https://data.pyg.org/whl/torch-2.1.0+cu121.html
-
-


### PR DESCRIPTION
The old definition of the singularity container was quite outdated and did not work anymore (at least for me). The updated singularity file now builds upon the most recent (compatible) versions of pytorch, pyg, cuda, python, and Ubuntu LTS.