### PR TITLE
Implement annealed Langevin dynamics sampling for graph generative models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Added the `RCDD` dataset ([#8196](https://github.com/pyg-team/pytorch_geometric/pull/8196))
 - Added distributed `GAT + ogbn-products` example targeting XPU device ([#8032](https://github.com/pyg-team/pytorch_geometric/pull/8032))
 - Added the option to skip explanations of certain message passing layers via `conv.explain = False` ([#8216](https://github.com/pyg-team/pytorch_geometric/pull/8216))
+- Added annealed Langevin dynamics sampling for diffusion based graph generative models ([#8602](https://github.com/pyg-team/pytorch_geometric/pull/8602))
 
 ### Changed
 

--- a/test/utils/test_langevin.py
+++ b/test/utils/test_langevin.py
@@ -3,13 +3,6 @@ from torch import Tensor
 
 import torch_geometric.utils.langevin as langevin
 
-if torch.cuda.is_available():
-    device = torch.device('cuda')
-elif hasattr(torch.backends, 'mps') and torch.backends.mps.is_available():
-    device = torch.device('mps')
-else:
-    device = torch.device('cpu')
-
 
 def is_symmetric(adjs):
     return torch.allclose(adjs, adjs.transpose(-1, -2))

--- a/test/utils/test_langevin.py
+++ b/test/utils/test_langevin.py
@@ -1,0 +1,98 @@
+import torch
+from torch import Tensor
+
+import torch_geometric.utils.langevin as langevin
+
+if torch.cuda.is_available():
+    device = torch.device('cuda')
+elif hasattr(torch.backends, 'mps') and torch.backends.mps.is_available():
+    device = torch.device('mps')
+else:
+    device = torch.device('cpu')
+
+
+def is_symmetric(adjs):
+    return torch.allclose(adjs, adjs.transpose(-1, -2))
+
+
+def mock_score_func(adjs: Tensor, node_flags: Tensor) -> Tensor:
+    return adjs
+
+
+def test_generate_initial_sample():
+    torch.manual_seed(12345)
+
+    batch_size = 4
+    num_nodes = 3
+    adjs, node_flags = langevin.generate_initial_sample(batch_size, num_nodes)
+
+    assert adjs.shape == (batch_size, num_nodes, num_nodes)
+    assert is_symmetric(adjs)
+    assert torch.all(adjs.ge(0))
+
+    assert node_flags.shape == (batch_size, num_nodes)
+    assert torch.all((node_flags == 0) | (node_flags == 1))
+
+
+def test_sample():
+    torch.manual_seed(12345)
+    batch_size = 4
+    num_nodes = 3
+    adjs = 0.5 + torch.randn((batch_size, num_nodes, num_nodes))
+    node_flags = torch.ones((batch_size, num_nodes))
+
+    new_adjs = langevin.sample(mock_score_func, adjs, node_flags, num_steps=10)
+    assert new_adjs.shape == adjs.shape
+
+    new_adjs = langevin.sample(mock_score_func, adjs, node_flags, num_steps=10,
+                               quantize=True)
+    assert new_adjs.shape == adjs.shape
+    assert torch.all(~torch.eq(new_adjs, adjs))  # all values are different
+
+    # check the quantization: all values are either 0 or 1
+    num_zeros = (new_adjs == 0).sum()
+    num_ones = (new_adjs == 1).sum()
+    assert num_zeros > 0
+    assert num_ones > 0
+    assert num_zeros + num_ones == batch_size * num_nodes * num_nodes
+
+
+def test_sample_step():
+    torch.manual_seed(12345)
+
+    batch_size = 4
+    num_nodes = 3
+    adjs = torch.ones((batch_size, num_nodes, num_nodes))
+    node_flags = torch.ones((batch_size, num_nodes))
+
+    new_adjs = langevin._sample_step(mock_score_func, adjs, node_flags,
+                                     noise_variance=0.1, grad_step_size=0.5)
+
+    assert new_adjs.shape == adjs.shape
+    assert torch.all(~torch.eq(new_adjs, adjs))  # all values are different
+
+
+def test_mask_adjs():
+    batch_size = 4
+    num_nodes = 3
+
+    adjs = torch.ones((batch_size, num_nodes, num_nodes))
+    node_flags = torch.ones((batch_size, num_nodes))
+
+    masked = langevin.mask_adjs(adjs, node_flags)
+    assert torch.all(masked == 1)
+
+    node_flags = torch.zeros((batch_size, num_nodes))
+    masked = langevin.mask_adjs(adjs, node_flags)
+    assert torch.all(masked == 0)
+
+    node_flags[0, :] = 1
+    node_flags[1, :2] = 1
+    node_flags[2, :1] = 1
+
+    masked = langevin.mask_adjs(adjs, node_flags)
+    # adjs[0] has 9 ones
+    # adjs[1] has 4 ones
+    # adjs[2] has 1 ones
+    # adjs[3] has 0 ones
+    assert masked.sum() == 14

--- a/torch_geometric/utils/langevin.py
+++ b/torch_geometric/utils/langevin.py
@@ -2,17 +2,16 @@
 This is used to sample score-based generative models, such as EDP-GNN.
 The method iteratively samples from a series of noise-conditional score models
 with varying noise levels.
-
-TODO: do we need to specify the device/GPU?
-TODO: do we need node_flags?
 """
+from typing import Callable, Optional
 
 import numpy as np
 import torch
 from torch import Tensor
 
 
-def gen_init_sample(batch_size: int, num_nodes: int) -> Tensor:
+def generate_initial_sample(batch_size: int, num_nodes: int,
+                            device: Optional[torch.device] = None) -> Tensor:
     """Initialize a batch of adjacency matrices.
 
     The values are continuous and drawn from a folded normal distribution.
@@ -22,75 +21,73 @@ def gen_init_sample(batch_size: int, num_nodes: int) -> Tensor:
     Args:
         batch_size (int): number of graphs (adjacency matrices)
         num_nodes (int): number of nodes in each graph
+        device (Optional[torch.device]): torch.device
 
     Returns:
-        adjs (Tensor): a batch of adjacency matrices with continuous values
+        adjs (Tensor): B x N x N, a batch of adjacency matrices with
+            continuous values
+        node_flags (Tensor): B x N, indicates whether each node exists
     """
-    # TODO: Add .to(self.dev) here if we need to specify the device/GPU:
-    # TODO: is dtype=torch.float32 correct?
     adjs = torch.randn((batch_size, num_nodes, num_nodes),
-                       dtype=torch.float32).triu(diagonal=1).abs()
+                       dtype=torch.float32).triu(diagonal=1).abs().to(device)
     adjs = (adjs + adjs.transpose(-1, -2))
-    return adjs
+    node_flags = adjs.sum(-1).squeeze(-1).gt(1e-5).to(torch.float32).to(device)
+    return adjs, node_flags
 
 
-def sample(score_func: torch.nn.Module, adjs: Tensor, num_steps: int = 100,
-           quantize=False) -> Tensor:
+def sample(score_func: Callable[[Tensor, Tensor], Tensor], adjs: Tensor,
+           node_flags: Tensor, num_steps: int = 100, quantize: bool = False,
+           grad_step_size: float = 1.0, epsilon_s: float = 0.3) -> Tensor:
     """Run annealed Langevin dynamics sampling for one noise level.
 
     Args:
-        score_func (torch.nn.Module): a noise conditional score-based
-            generative model, TODO: change the type to EDP-GNN
-        adjs (num_nodes): a batch of adjacency matrices
+        score_func (Callable[[Tensor, Tensor], Tensor]): a function that runs
+            the noise conditional score-based generative model. The inputs are
+            [adjs, node_flags]. The output is the score matrix.
+        adjs (num_nodes): B x N x N, a batch of adjacency matrices
+        node_flags (Tensor): B x N, indicates whether each node exists
         num_steps (int): the number of iterations
         quantize (bool): whether to convert the adjacency matrices to discrete
             (binary) values. This should be True only for the final noise level
+        grad_step_size (float): coefficient applied to the output of score_func
+            Algorithm 1 in https://arxiv.org/abs/2003.00638 uses alpha_i,
+            but here grad_step_size=alpha_i/2.
+        epsilon_s (float): coefficient applied to noise.
+            From https://arxiv.org/abs/2003.00638: "We add another scaling
+            coefficient epsilon_s, since it is a common practice of applying
+            Langevin dynamics"
 
     Returns:
         adjs (Tensor): a batch of adjacency matrices
     """
-    # Initialize constants
-    """
-    Algorithm 1 in https://arxiv.org/abs/2003.00638 uses alpha_i,
-    but here grad_step_size=alpha_i/2.
-    grad_step_size is the coefficient for the output of score_func.
-    """
-    grad_step_size = 1.0
-    """
-    From https://arxiv.org/abs/2003.00638:
-    "We add another scaling coefficient epsilon_s, since it is a common
-    practice of applying Langevin dynamics"
-    """
-    epsilon_s = 0.3
-    """
-    Noise is sampled from Gaussian, N(0, noise_variance)
-    """
+    # Noise is sampled from normal distribtuion with variance noise_variance
     noise_variance = epsilon_s * np.sqrt(grad_step_size * 2)
 
     for _ in range(num_steps):
-        adjs = _sample_step(score_func, adjs, noise_variance)
+        adjs = _sample_step(score_func, adjs, node_flags, noise_variance,
+                            grad_step_size)
 
     if quantize:
         # samples are in continuous space, but the graph edges are often
         # discrete, so we quantize to binary values
-        # TODO: this can probably be optimized by not materializing matrices
-        adjs = torch.where(adjs < 0.5, torch.zeros_like(adjs),
-                           torch.ones_like(adjs))
-
-    # TODO: do we need to detach from device?
+        adjs = torch.where(adjs < 0.5, 0, 1)
+    adjs = adjs.detach()
     return adjs
 
 
-def _sample_step(score_func: torch.nn.Module, adjs: Tensor,
-                 noise_variance: float, grad_step_size: float) -> Tensor:
+def _sample_step(score_func: Callable[[Tensor, Tensor], Tensor], adjs: Tensor,
+                 node_flags: Tensor, noise_variance: float,
+                 grad_step_size: float) -> Tensor:
     """Run one step of annealed Langevin dynamics sampling.
     Sample symmetric Gaussian noise, and update the adjacency matrices based
     on the score function and noise.
 
     Args:
-        score_func (torch.nn.Module): a noise conditional score-based
-            generative model, TODO: change the type to EDP-GNN
+        score_func (Callable[[Tensor, Tensor], Tensor]): a function that runs
+            the noise conditional score-based generative model. The inputs are
+            [adjs, node_flags]. The output is the score matrix.
         adjs (num_nodes): a batch of adjacency matrices
+        node_flags (Tensor): B x N, indicates whether each node exists
         noise_variance (float): variance of the Gaussian noise
         grad_step_size (float): step size coefficient for the score
 
@@ -100,7 +97,24 @@ def _sample_step(score_func: torch.nn.Module, adjs: Tensor,
     # zeros on the diagonal, so no self-loops
     noise = torch.randn_like(adjs).triu(diagonal=1) * noise_variance
     noise_symmetric = noise + noise.transpose(-1, -2)
-    score = score_func(adjs)
+    adjs_with_noise = adjs + noise_symmetric
 
-    new_adjs = adjs + grad_step_size * score + noise_symmetric
+    score = score_func(adjs_with_noise, node_flags)
+    new_adjs = adjs_with_noise + grad_step_size * score
     return new_adjs
+
+
+def mask_adjs(adjs, node_flags):
+    """Use node_flags to mask out nodes in adjs that don't exist.
+
+    Args:
+        adjs (num_nodes): B x N x N, a batch of adjacency matrices
+        node_flags (Tensor): B x N, indicates whether each node exists
+
+    Returns:
+        adjs (Tensor): a batch of adjacency matrices with values masked by
+            node_flags
+    """
+    adjs = adjs * node_flags.unsqueeze(-1)
+    adjs = adjs * node_flags.unsqueeze(-2)
+    return adjs

--- a/torch_geometric/utils/langevin.py
+++ b/torch_geometric/utils/langevin.py
@@ -13,36 +13,34 @@ from torch import Tensor
 
 
 def gen_init_sample(batch_size: int, num_nodes: int) -> Tensor:
-    """Initialize adjacency matrices.
+    """Initialize a batch of adjacency matrices.
 
     The values are continuous and drawn from a folded normal distribution.
     Each element is drawn from N(0, 1) and then the absolute value is taken.
-    The diagonal values are 0 (no self-loops)
+    The diagonal values are 0, so there are no self-loops.
 
     Args:
         batch_size (int): number of graphs (adjacency matrices)
         num_nodes (int): number of nodes in each graph
 
     Returns:
-        adjs_c (Tensor): a batch of adjacency matrices with continuous values
+        adjs (Tensor): a batch of adjacency matrices with continuous values
     """
-    # Add .to(self.dev) here if we need to specify the device/GPU:
-    adjs_c = torch.randn((batch_size, num_nodes, num_nodes),
-                         dtype=torch.float32).triu(diagonal=1).abs()
-    adjs_c = (adjs_c + adjs_c.transpose(-1, -2))
-    return adjs_c
+    # TODO: Add .to(self.dev) here if we need to specify the device/GPU:
+    # TODO: is dtype=torch.float32 correct?
+    adjs = torch.randn((batch_size, num_nodes, num_nodes),
+                       dtype=torch.float32).triu(diagonal=1).abs()
+    adjs = (adjs + adjs.transpose(-1, -2))
+    return adjs
 
 
 def sample(score_func: torch.nn.Module, adjs: Tensor, num_steps: int = 100,
            quantize=False) -> Tensor:
     """Run annealed Langevin dynamics sampling for one noise level.
 
-    TODO: documentation
-
     Args:
         score_func (torch.nn.Module): a noise conditional score-based
-            generative model
-            TODO: change the type to EDP-GNN or something else
+            generative model, TODO: change the type to EDP-GNN
         adjs (num_nodes): a batch of adjacency matrices
         num_steps (int): the number of iterations
         quantize (bool): whether to convert the adjacency matrices to discrete
@@ -51,38 +49,39 @@ def sample(score_func: torch.nn.Module, adjs: Tensor, num_steps: int = 100,
     Returns:
         adjs (Tensor): a batch of adjacency matrices
     """
+    # Initialize constants
     """
-    From the other github repo: "lambda in langevin dynamics"
-    The paper uses alpha_i, but here grad_step_size=alpha_i/2
-    grad_step_size is the coefficient for the score_func output
+    Algorithm 1 in https://arxiv.org/abs/2003.00638 uses alpha_i,
+    but here grad_step_size=alpha_i/2.
+    grad_step_size is the coefficient for the output of score_func.
     """
     grad_step_size = 1.0
     """
-    According to the paper:
+    From https://arxiv.org/abs/2003.00638:
     "We add another scaling coefficient epsilon_s, since it is a common
     practice of applying Langevin dynamics"
     """
     epsilon_s = 0.3
     """
-    noise_variance is epsilon_s * sqrt(alpha_i) from the paper
-    Noise is sampled from a Gaussian, N(mean=0, variance=noise_variance)
+    Noise is sampled from Gaussian, N(0, noise_variance)
     """
     noise_variance = epsilon_s * np.sqrt(grad_step_size * 2)
 
     for _ in range(num_steps):
-        adjs = _step_sample(score_func, adjs, noise_variance)
+        adjs = _sample_step(score_func, adjs, noise_variance)
 
     if quantize:
         # samples are in continuous space, but the graph edges are often
         # discrete, so we quantize to binary values
+        # TODO: this can probably be optimized by not materializing matrices
         adjs = torch.where(adjs < 0.5, torch.zeros_like(adjs),
                            torch.ones_like(adjs))
 
-    # TODO: detach?
+    # TODO: do we need to detach from device?
     return adjs
 
 
-def _step_sample(score_func: torch.nn.Module, adjs: Tensor,
+def _sample_step(score_func: torch.nn.Module, adjs: Tensor,
                  noise_variance: float, grad_step_size: float) -> Tensor:
     """Run one step of annealed Langevin dynamics sampling.
     Sample symmetric Gaussian noise, and update the adjacency matrices based
@@ -90,8 +89,7 @@ def _step_sample(score_func: torch.nn.Module, adjs: Tensor,
 
     Args:
         score_func (torch.nn.Module): a noise conditional score-based
-            generative model
-            TODO: change the type to EDP-GNN or something else
+            generative model, TODO: change the type to EDP-GNN
         adjs (num_nodes): a batch of adjacency matrices
         noise_variance (float): variance of the Gaussian noise
         grad_step_size (float): step size coefficient for the score
@@ -99,9 +97,10 @@ def _step_sample(score_func: torch.nn.Module, adjs: Tensor,
     Returns:
         adjs (Tensor): a batch of adjacency matrices
     """
+    # zeros on the diagonal, so no self-loops
     noise = torch.randn_like(adjs).triu(diagonal=1) * noise_variance
     noise_symmetric = noise + noise.transpose(-1, -2)
     score = score_func(adjs)
 
-    adjs = adjs + grad_step_size * score + noise_symmetric
-    return adjs
+    new_adjs = adjs + grad_step_size * score + noise_symmetric
+    return new_adjs

--- a/torch_geometric/utils/langevin.py
+++ b/torch_geometric/utils/langevin.py
@@ -3,15 +3,16 @@ This is used to sample score-based generative models, such as EDP-GNN.
 The method iteratively samples from a series of noise-conditional score models
 with varying noise levels.
 """
-from typing import Callable, Optional
+from typing import Callable, Optional, Tuple
 
 import numpy as np
 import torch
 from torch import Tensor
 
 
-def generate_initial_sample(batch_size: int, num_nodes: int,
-                            device: Optional[torch.device] = None) -> Tensor:
+def generate_initial_sample(
+        batch_size: int, num_nodes: int,
+        device: Optional[torch.device] = None) -> Tuple[Tensor, Tensor]:
     """Initialize a batch of adjacency matrices.
 
     The values are continuous and drawn from a folded normal distribution.
@@ -104,7 +105,7 @@ def _sample_step(score_func: Callable[[Tensor, Tensor], Tensor], adjs: Tensor,
     return new_adjs
 
 
-def mask_adjs(adjs, node_flags):
+def mask_adjs(adjs: Tensor, node_flags: Tensor) -> Tensor:
     """Use node_flags to mask out nodes in adjs that don't exist.
 
     Args:

--- a/torch_geometric/utils/langevin.py
+++ b/torch_geometric/utils/langevin.py
@@ -1,0 +1,98 @@
+import numpy as np
+import torch
+from torch import Tensor
+
+
+def gen_init_sample(batch_size: int, num_nodes: int) -> Tensor:
+    """Initialize adjacency matrices.
+
+    The values are continuous and drawn from a folded normal distribution.
+    Each element is drawn from N(0, 1) and then the absolute value is taken.
+    The diagonal values are 0 (no self-loops)
+
+    Args:
+        batch_size (int): number of graphs (adjacency matrices)
+        num_nodes (int): number of nodes in each graph
+
+    Returns:
+        adjs_c (Tensor): a batch of adjacency matrices with continuous values
+    """
+    # Add .to(self.dev) here if we need to specify the device/GPU:
+    adjs_c = torch.randn((batch_size, num_nodes, num_nodes),
+                         dtype=torch.float32).triu(diagonal=1).abs()
+    adjs_c = (adjs_c + adjs_c.transpose(-1, -2))
+    return adjs_c
+
+
+def sample(score_func: torch.nn.Module, adjs: Tensor, num_steps: int = 100,
+           quantize=False) -> Tensor:
+    """Run annealed Langevin dynamics sampling for one noise level.
+
+    TODO: documentation
+
+    Args:
+        score_func (torch.nn.Module): a noise conditional score-based
+            generative model
+            TODO: change the type to EDP-GNN or something else
+        adjs (num_nodes): a batch of adjacency matrices
+        num_steps (int): the number of iterations
+        quantize (bool): whether to convert the adjacency matrices to discrete
+            (binary) values. This should be True only for the final noise level
+
+    Returns:
+        adjs (Tensor): a batch of adjacency matrices
+    """
+    """
+    From the other github repo: "lambda in langevin dynamics"
+    The paper uses alpha_i, but here grad_step_size=alpha_i/2
+    grad_step_size is the coefficient for the score_func output
+    """
+    grad_step_size = 1.0
+    """
+    According to the paper:
+    "We add another scaling coefficient epsilon_s, since it is a common
+    practice of applying Langevin dynamics"
+    """
+    epsilon_s = 0.3
+    """
+    noise_variance is epsilon_s * sqrt(alpha_i) from the paper
+    Noise is sampled from a Gaussian, N(mean=0, variance=noise_variance)
+    """
+    noise_variance = epsilon_s * np.sqrt(grad_step_size * 2)
+
+    for _ in range(num_steps):
+        adjs = _step_sample(score_func, adjs, noise_variance)
+
+    if quantize:
+        # samples are in continuous space, but the graph edges are often
+        # discrete, so we quantize to binary values
+        adjs = torch.where(adjs < 0.5, torch.zeros_like(adjs),
+                           torch.ones_like(adjs))
+
+    # TODO: detach?
+    return adjs
+
+
+def _step_sample(score_func: torch.nn.Module, adjs: Tensor,
+                 noise_variance: float, grad_step_size: float) -> Tensor:
+    """Run one step of annealed Langevin dynamics sampling.
+    Sample symmetric Gaussian noise, and update the adjacency matrices based
+    on the score function and noise.
+
+    Args:
+        score_func (torch.nn.Module): a noise conditional score-based
+            generative model
+            TODO: change the type to EDP-GNN or something else
+        adjs (num_nodes): a batch of adjacency matrices
+        noise_variance (float): variance of the Gaussian noise
+        grad_step_size (float): step size coefficient for the score
+
+    Returns:
+        adjs (Tensor): a batch of adjacency matrices
+    """
+    noise = torch.randn_like(adjs).triu(diagonal=1) * noise_variance
+    noise_symmetric = noise + noise.transpose(-1, -2)
+    score = score_func(adjs)
+
+    adjs = adjs + grad_step_size * score + noise_symmetric
+    return adjs

--- a/torch_geometric/utils/langevin.py
+++ b/torch_geometric/utils/langevin.py
@@ -1,3 +1,12 @@
+"""Annealed Langevin dynamics sampling, also called Langevin Monte Carlo.
+This is used to sample score-based generative models, such as EDP-GNN.
+The method iteratively samples from a series of noise-conditional score models
+with varying noise levels.
+
+TODO: do we need to specify the device/GPU?
+TODO: do we need node_flags?
+"""
+
 import numpy as np
 import torch
 from torch import Tensor


### PR DESCRIPTION
Implement annealed Langevin dynamics sampling, as defined in Algorithm 1 in https://arxiv.org/abs/2003.00638. 
In a subsequent PR, we will implement the EDP-GNN model defined in https://arxiv.org/abs/2003.00638. The sampling procedure here will be used with the EDP-GNN model to generate graphs. 

Also see https://github.com/pyg-team/pytorch_geometric/pull/8608 and https://github.com/pyg-team/pytorch_geometric/pull/8347