### PR TITLE
Fix RPC timeout issues caused by premature worker closing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Added the option to skip explanations of certain message passing layers via `conv.explain = False` ([#8216](https://github.com/pyg-team/pytorch_geometric/pull/8216))
 
 ### Changed
-
+- Fixed RPC timeout due to worker closing in `DistLoader` with `atexit` not executed correctly in `worker_init_fn` ([#8605](https://github.com/pyg-team/pytorch_geometric/pull/8605))
 - `ExplainerDataset` will now contain node labels for any motif generator ([#8519](https://github.com/pyg-team/pytorch_geometric/pull/8519))
 - Made `utils.softmax` faster via `softmax_csr` ([#8399](https://github.com/pyg-team/pytorch_geometric/pull/8399))
 - Made `utils.mask.mask_select` faster ([#8369](https://github.com/pyg-team/pytorch_geometric/pull/8369))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Added the option to skip explanations of certain message passing layers via `conv.explain = False` ([#8216](https://github.com/pyg-team/pytorch_geometric/pull/8216))
 
 ### Changed
+
 - Fixed RPC timeout due to worker closing in `DistLoader` with `atexit` not executed correctly in `worker_init_fn` ([#8605](https://github.com/pyg-team/pytorch_geometric/pull/8605))
 - `ExplainerDataset` will now contain node labels for any motif generator ([#8519](https://github.com/pyg-team/pytorch_geometric/pull/8519))
 - Made `utils.softmax` faster via `softmax_csr` ([#8399](https://github.com/pyg-team/pytorch_geometric/pull/8399))

--- a/test/distributed/test_dist_link_neighbor_loader.py
+++ b/test/distributed/test_dist_link_neighbor_loader.py
@@ -65,7 +65,7 @@ def dist_link_neighbor_loader_homo(
     )
 
     edge_label_index = part_data[1].get_edge_index(None, 'coo')
-    edge_label = torch.randint(high=2, size=(edge_label_index.size(1),))
+    edge_label = torch.randint(high=2, size=(edge_label_index.size(1), ))
 
     loader = DistLinkNeighborLoader(
         data=part_data,
@@ -89,7 +89,7 @@ def dist_link_neighbor_loader_homo(
 
     for batch in loader:
         assert isinstance(batch, Data)
-        assert batch.n_id.size() == (batch.num_nodes,)
+        assert batch.n_id.size() == (batch.num_nodes, )
         assert batch.input_id.numel() == batch.batch_size == 10
         assert batch.edge_index.min() >= 0
         assert batch.edge_index.max() < batch.num_nodes
@@ -117,7 +117,7 @@ def dist_link_neighbor_loader_hetero(
     )
 
     edge_label_index = part_data[1].get_edge_index(edge_type, 'coo')
-    edge_label = torch.randint(high=2, size=(edge_label_index.size(1),))
+    edge_label = torch.randint(high=2, size=(edge_label_index.size(1), ))
 
     loader = DistLinkNeighborLoader(
         data=part_data,
@@ -152,7 +152,7 @@ def dist_link_neighbor_loader_hetero(
 
         assert len(batch.edge_types) == 4
         for edge_type in batch.edge_types:
-            assert (batch[edge_type].edge_attr.size(0) == 
+            assert (batch[edge_type].edge_attr.size(0) ==
                     batch[edge_type].edge_index.size(1))
     assert loader.channel.empty()
 

--- a/test/distributed/test_dist_link_neighbor_loader.py
+++ b/test/distributed/test_dist_link_neighbor_loader.py
@@ -65,7 +65,7 @@ def dist_link_neighbor_loader_homo(
     )
 
     edge_label_index = part_data[1].get_edge_index(None, 'coo')
-    edge_label = torch.randint(high=2, size=(edge_label_index.size(1), ))
+    edge_label = torch.randint(high=2, size=(edge_label_index.size(1),))
 
     loader = DistLinkNeighborLoader(
         data=part_data,
@@ -77,7 +77,6 @@ def dist_link_neighbor_loader_homo(
         master_addr=master_addr,
         master_port=master_port,
         current_ctx=current_ctx,
-        rpc_worker_names={},
         concurrency=10,
         drop_last=True,
         async_sampling=async_sampling,
@@ -85,15 +84,16 @@ def dist_link_neighbor_loader_homo(
 
     assert str(loader).startswith('DistLinkNeighborLoader')
     assert str(mp.current_process().pid) in str(loader)
-    assert isinstance(loader.neighbor_sampler, DistNeighborSampler)
+    assert isinstance(loader.dist_sampler, DistNeighborSampler)
     assert not part_data[0].meta['is_hetero']
 
     for batch in loader:
         assert isinstance(batch, Data)
-        assert batch.n_id.size() == (batch.num_nodes, )
+        assert batch.n_id.size() == (batch.num_nodes,)
         assert batch.input_id.numel() == batch.batch_size == 10
         assert batch.edge_index.min() >= 0
         assert batch.edge_index.max() < batch.num_nodes
+    assert loader.channel.empty()
 
 
 def dist_link_neighbor_loader_hetero(
@@ -117,7 +117,7 @@ def dist_link_neighbor_loader_hetero(
     )
 
     edge_label_index = part_data[1].get_edge_index(edge_type, 'coo')
-    edge_label = torch.randint(high=2, size=(edge_label_index.size(1), ))
+    edge_label = torch.randint(high=2, size=(edge_label_index.size(1),))
 
     loader = DistLinkNeighborLoader(
         data=part_data,
@@ -129,7 +129,6 @@ def dist_link_neighbor_loader_hetero(
         master_addr=master_addr,
         master_port=master_port,
         current_ctx=current_ctx,
-        rpc_worker_names={},
         concurrency=10,
         drop_last=True,
         async_sampling=async_sampling,
@@ -137,7 +136,7 @@ def dist_link_neighbor_loader_hetero(
 
     assert str(loader).startswith('DistLinkNeighborLoader')
     assert str(mp.current_process().pid) in str(loader)
-    assert isinstance(loader.neighbor_sampler, DistNeighborSampler)
+    assert isinstance(loader.dist_sampler, DistNeighborSampler)
     assert part_data[0].meta['is_hetero']
 
     for batch in loader:
@@ -153,8 +152,9 @@ def dist_link_neighbor_loader_hetero(
 
         assert len(batch.edge_types) == 4
         for edge_type in batch.edge_types:
-            assert (batch[edge_type].edge_attr.size(0) ==
+            assert (batch[edge_type].edge_attr.size(0) == 
                     batch[edge_type].edge_index.size(1))
+    assert loader.channel.empty()
 
 
 @onlyLinux

--- a/test/distributed/test_dist_neighbor_loader.py
+++ b/test/distributed/test_dist_neighbor_loader.py
@@ -85,7 +85,7 @@ def dist_neighbor_loader_homo(
 
     for batch in loader:
         assert isinstance(batch, Data)
-        assert batch.n_id.size() == (batch.num_nodes,)
+        assert batch.n_id.size() == (batch.num_nodes, )
         assert batch.input_id.numel() == batch.batch_size == 10
         assert batch.edge_index.min() >= 0
         assert batch.edge_index.max() < batch.num_nodes

--- a/test/distributed/test_dist_neighbor_loader.py
+++ b/test/distributed/test_dist_neighbor_loader.py
@@ -71,7 +71,6 @@ def dist_neighbor_loader_homo(
         master_addr=master_addr,
         master_port=master_port,
         current_ctx=current_ctx,
-        rpc_worker_names={},
         concurrency=10,
         drop_last=True,
         async_sampling=async_sampling,
@@ -81,12 +80,12 @@ def dist_neighbor_loader_homo(
 
     assert str(loader).startswith('DistNeighborLoader')
     assert str(mp.current_process().pid) in str(loader)
-    assert isinstance(loader.neighbor_sampler, DistNeighborSampler)
+    assert isinstance(loader.dist_sampler, DistNeighborSampler)
     assert not part_data[0].meta['is_hetero']
 
     for batch in loader:
         assert isinstance(batch, Data)
-        assert batch.n_id.size() == (batch.num_nodes, )
+        assert batch.n_id.size() == (batch.num_nodes,)
         assert batch.input_id.numel() == batch.batch_size == 10
         assert batch.edge_index.min() >= 0
         assert batch.edge_index.max() < batch.num_nodes
@@ -94,6 +93,7 @@ def dist_neighbor_loader_homo(
             batch.n_id[batch.edge_index],
             edge_index[:, batch.e_id],
         )
+    assert loader.channel.empty()
 
 
 def dist_neighbor_loader_hetero(
@@ -124,7 +124,6 @@ def dist_neighbor_loader_hetero(
         master_addr=master_addr,
         master_port=master_port,
         current_ctx=current_ctx,
-        rpc_worker_names={},
         concurrency=10,
         drop_last=True,
         async_sampling=async_sampling,
@@ -132,7 +131,7 @@ def dist_neighbor_loader_hetero(
 
     assert str(loader).startswith('DistNeighborLoader')
     assert str(mp.current_process().pid) in str(loader)
-    assert isinstance(loader.neighbor_sampler, DistNeighborSampler)
+    assert isinstance(loader.dist_sampler, DistNeighborSampler)
     assert part_data[0].meta['is_hetero']
 
     for batch in loader:
@@ -159,6 +158,7 @@ def dist_neighbor_loader_hetero(
                 ], dim=0)
                 global_edge_index_2 = edge_index[:, batch[edge_type].e_id]
                 assert torch.equal(global_edge_index_1, global_edge_index_2)
+    assert loader.channel.empty()
 
 
 @onlyLinux

--- a/test/distributed/test_dist_neighbor_sampler.py
+++ b/test/distributed/test_dist_neighbor_sampler.py
@@ -6,13 +6,9 @@ import pytest
 import torch
 
 from torch_geometric.data import Data
-from torch_geometric.distributed import (
-    DistNeighborSampler,
-    LocalFeatureStore,
-    LocalGraphStore,
-)
 from torch_geometric.datasets import FakeHeteroDataset
 from torch_geometric.distributed import (
+    DistNeighborSampler,
     LocalFeatureStore,
     LocalGraphStore,
     Partitioner,
@@ -90,9 +86,8 @@ def create_hetero_data(tmp_path: str, rank: int):
     graph_store.partition_idx = feature_store.partition_idx = partition_idx
     graph_store.num_partitions = feature_store.num_partitions = num_partitions
     graph_store.node_pb = feature_store.node_feat_pb = node_pb
-    graph_store.edge_pb =  feature_store.edge_feat_pb = edge_pb
+    graph_store.edge_pb = feature_store.edge_feat_pb = edge_pb
     graph_store.meta = feature_store.meta = meta
-
 
     return feature_store, graph_store
 
@@ -142,8 +137,7 @@ def dist_neighbor_sampler(
 
     # Evaluate distributed node sample function:
     out_dist = dist_sampler.event_loop.run_task(
-        coro=dist_sampler.node_sample(inputs)
-    )
+        coro=dist_sampler.node_sample(inputs))
 
     sampler = NeighborSampler(
         data=data,
@@ -218,8 +212,7 @@ def dist_neighbor_sampler_temporal(
 
     # Evaluate distributed node sample function:
     out_dist = dist_sampler.event_loop.run_task(
-        coro=dist_sampler.node_sample(inputs)
-    )
+        coro=dist_sampler.node_sample(inputs))
 
     sampler = NeighborSampler(
         data=data,
@@ -298,8 +291,7 @@ def dist_neighbor_sampler_hetero(
 
     # Evaluate distributed node sample function:
     out_dist = dist_sampler.event_loop.run_task(
-        coro=dist_sampler.node_sample(inputs)
-    )
+        coro=dist_sampler.node_sample(inputs))
 
     sampler = NeighborSampler(
         data=data,

--- a/test/distributed/test_rpc.py
+++ b/test/distributed/test_rpc.py
@@ -1,11 +1,10 @@
 import socket
-from typing import Dict, List
 
 import torch
 
 import torch_geometric.distributed.rpc as rpc
 from torch_geometric.distributed import LocalFeatureStore
-from torch_geometric.distributed.dist_context import DistContext, DistRole
+from torch_geometric.distributed.dist_context import DistContext
 from torch_geometric.distributed.rpc import RPCRouter
 from torch_geometric.testing import onlyLinux
 
@@ -25,11 +24,9 @@ def run_rpc_feature_test(
         global_world_size=world_size,
         group_name='dist-feature-test',
     )
-    rpc_worker_names: Dict[DistRole, List[str]] = {}
 
     rpc.init_rpc(
         current_ctx=current_ctx,
-        rpc_worker_names=rpc_worker_names,
         master_addr='localhost',
         master_port=master_port,
     )

--- a/torch_geometric/distributed/dist_link_neighbor_loader.py
+++ b/torch_geometric/distributed/dist_link_neighbor_loader.py
@@ -8,7 +8,7 @@ from torch_geometric.distributed import (
     LocalFeatureStore,
     LocalGraphStore,
 )
-from torch_geometric.distributed.dist_context import DistContext, DistRole
+from torch_geometric.distributed.dist_context import DistContext
 from torch_geometric.loader import LinkLoader
 from torch_geometric.sampler.base import NegativeSampling, SubgraphType
 from torch_geometric.typing import EdgeType, InputEdges, OptTensor
@@ -31,7 +31,6 @@ class DistLinkNeighborLoader(LinkLoader, DistLoader):
             the master node.
         current_ctx (DistContext): Distributed context information of the
             current process.
-        rpc_worker_names (Dict[DistRole, List[str]]): RPC workers identifiers.
         concurrency (int, optional): RPC concurrency used for defining the
             maximum size of the asynchronous processing queue.
             (default: :obj:`1`)
@@ -46,11 +45,10 @@ class DistLinkNeighborLoader(LinkLoader, DistLoader):
         master_addr: str,
         master_port: Union[int, str],
         current_ctx: DistContext,
-        rpc_worker_names: Dict[DistRole, List[str]],
         edge_label_index: InputEdges = None,
         edge_label: OptTensor = None,
         edge_label_time: OptTensor = None,
-        neighbor_sampler: Optional[DistNeighborSampler] = None,
+        dist_sampler: Optional[DistNeighborSampler] = None,
         replace: bool = False,
         subgraph_type: Union[SubgraphType, str] = "directional",
         disjoint: bool = False,
@@ -80,11 +78,10 @@ class DistLinkNeighborLoader(LinkLoader, DistLoader):
 
         channel = torch.multiprocessing.Queue() if async_sampling else None
 
-        if neighbor_sampler is None:
-            neighbor_sampler = DistNeighborSampler(
+        if dist_sampler is None:
+            dist_sampler = DistNeighborSampler(
                 data=data,
                 current_ctx=current_ctx,
-                rpc_worker_names=rpc_worker_names,
                 num_neighbors=num_neighbors,
                 replace=replace,
                 subgraph_type=subgraph_type,
@@ -96,21 +93,19 @@ class DistLinkNeighborLoader(LinkLoader, DistLoader):
                 concurrency=concurrency,
             )
 
-        self.neighbor_sampler = neighbor_sampler
-
         DistLoader.__init__(
             self,
             channel=channel,
             master_addr=master_addr,
             master_port=master_port,
             current_ctx=current_ctx,
-            rpc_worker_names=rpc_worker_names,
+            dist_sampler=dist_sampler,
             **kwargs,
         )
         LinkLoader.__init__(
             self,
             data=data,
-            link_sampler=neighbor_sampler,
+            link_sampler=dist_sampler,
             edge_label_index=edge_label_index,
             edge_label=edge_label,
             neg_sampling=neg_sampling,

--- a/torch_geometric/distributed/dist_loader.py
+++ b/torch_geometric/distributed/dist_loader.py
@@ -1,13 +1,18 @@
 import atexit
 import logging
 import os
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Optional, Union
 
 import torch.multiprocessing as mp
 
-from torch_geometric.distributed.dist_context import DistContext, DistRole
-from torch_geometric.distributed.dist_neighbor_sampler import close_sampler
-from torch_geometric.distributed.rpc import global_barrier, init_rpc
+from torch_geometric.distributed import DistNeighborSampler
+from torch_geometric.distributed.dist_context import DistContext
+from torch_geometric.distributed.rpc import (
+    global_barrier,
+    init_rpc,
+    shutdown_rpc,
+)
+from torch_geometric.loader.base import DataLoaderIterator
 
 
 class DistLoader:
@@ -16,7 +21,6 @@ class DistLoader:
     Args:
         current_ctx (DistContext): Distributed context info of the current
             process.
-        rpc_worker_names (Dict[DistRole, List[str]]): RPC workers identifiers.
         master_addr (str, optional): RPC address for distributed loader
             communication.
             Refers to the IP address of the master node. (default: :obj:`None`)
@@ -37,57 +41,74 @@ class DistLoader:
             :meth:`~torch.distributed.rpc.rpc_async` if necessary.
             (default: :obj:`180`)
     """
+
     def __init__(
         self,
         current_ctx: DistContext,
-        rpc_worker_names: Dict[DistRole, List[str]],
         master_addr: Optional[str] = None,
         master_port: Optional[Union[int, str]] = None,
         channel: Optional[mp.Queue] = None,
         num_rpc_threads: int = 16,
         rpc_timeout: int = 180,
+        dist_sampler: DistNeighborSampler = None,
         **kwargs,
     ):
         if master_addr is None and os.environ.get('MASTER_ADDR') is not None:
             master_addr = os.environ['MASTER_ADDR']
         if master_addr is None:
-            raise ValueError(f"Missing master address for RPC communication "
-                             f"in '{self.__class__.__name__}'. Try to provide "
-                             f"it or set it via the 'MASTER_ADDR' environment "
-                             f"variable.")
+            raise ValueError(
+                f"Missing master address for RPC communication "
+                f"in '{self.__class__.__name__}'. Try to provide "
+                f"it or set it via the 'MASTER_ADDR' environment "
+                f"variable."
+            )
 
         if master_port is None and os.environ.get('MASTER_PORT') is not None:
-            master_port = int(os.environ['MASTER_PORT'])
+            # Select next port to MASTER_PORT used for DDP.
+            # If multiple loaders are launched in the same script, please
+            # provide distinct ports for each.
+            master_port = int(os.environ['MASTER_PORT']) + 1
         if master_port is None:
-            raise ValueError(f"Missing master port for RPC communication in "
-                             f"'{self.__class__.__name__}'. Try to provide it "
-                             f"or set it via the 'MASTER_ADDR' environment "
-                             f"variable.")
+            raise ValueError(
+                f"Missing master port for RPC communication in "
+                f"'{self.__class__.__name__}'. Try to provide it "
+                f"or set it via the 'MASTER_ADDR' environment "
+                f"variable."
+            )
 
         assert num_rpc_threads > 0
         assert rpc_timeout > 0
 
+        self.dist_sampler = dist_sampler
         self.current_ctx = current_ctx
-        self.rpc_worker_names = rpc_worker_names
         self.master_addr = master_addr
         self.master_port = master_port
-        self.channel = channel or mp.Queue()
+        self.channel = channel
         self.pid = mp.current_process().pid
         self.num_rpc_threads = num_rpc_threads
         self.rpc_timeout = rpc_timeout
         self.num_workers = kwargs.get('num_workers', 0)
 
-        logging.info(f"[{self}] MASTER_ADDR={master_addr}, "
-                     f"MASTER_PORT={master_port}")
+        logging.info(
+            f"[{self}] MASTER_ADDR={master_addr}, " f"MASTER_PORT={master_port}"
+        )
 
         if self.num_workers == 0:  # Initialize RPC in main process:
             self.worker_init_fn(0)
 
     def channel_get(self, out: Any) -> Any:
-        if self.channel is not None:
+        if self.channel:
             out = self.channel.get()
             logging.debug(f"[{self}] Retrieved message")
         return out
+
+    def reset_channel(self, channel=None):
+        # clean remaining queue items and restart new queue
+        logging.debug(f'{self} Resetting msg channel')
+        while not self.channel.empty():
+            self.channel.get_nowait()
+        self.channel = channel or mp.Queue()
+        self.dist_sampler.channel = self.channel
 
     def worker_init_fn(self, worker_id: int):
         try:
@@ -95,31 +116,45 @@ class DistLoader:
             self.current_ctx_worker = DistContext(
                 world_size=self.current_ctx.world_size * num_sampler_proc,
                 rank=self.current_ctx.rank * num_sampler_proc + worker_id,
-                global_world_size=self.current_ctx.world_size *
-                num_sampler_proc,
-                global_rank=self.current_ctx.rank * num_sampler_proc +
-                worker_id,
+                global_world_size=self.current_ctx.world_size
+                * num_sampler_proc,
+                global_rank=self.current_ctx.rank * num_sampler_proc
+                + worker_id,
                 group_name='mp_sampling_worker',
             )
 
             init_rpc(
                 current_ctx=self.current_ctx_worker,
-                rpc_worker_names={},
                 master_addr=self.master_addr,
                 master_port=self.master_port,
                 num_rpc_threads=self.num_rpc_threads,
                 rpc_timeout=self.rpc_timeout,
             )
-            assert hasattr(self, 'neighbor_sampler')
-            self.neighbor_sampler.register_sampler_rpc()
-            self.neighbor_sampler.init_event_loop()
-            # close RPC & worker group at exit:
-            atexit.register(close_sampler, worker_id, self.neighbor_sampler)
+            logging.info(
+                f"RPC initiated in worker-{worker_id} "
+                f"(current_ctx_worker={self.current_ctx_worker.worker_name})"
+            )
+            self.dist_sampler.init_sampler_instance()
+            self.dist_sampler.register_sampler_rpc()
             global_barrier(timeout=10)  # Wait for all workers to initialize.
 
+            # close RPC & worker group at exit:
+            atexit.register(shutdown_rpc, self.current_ctx_worker.worker_name)
+
         except RuntimeError:
-            raise RuntimeError(f"`{self}.init_fn()` could not initialize the "
-                               f"worker loop of the neighbor sampler")
+            raise RuntimeError(
+                f"`{self}.init_fn()` could not initialize the "
+                f"worker loop of the neighbor sampler"
+            )
 
     def __repr__(self) -> str:
         return f'{self.__class__.__name__}(pid={self.pid})'
+
+    def __enter__(self) -> DataLoaderIterator:
+        self._iterator = self._get_iterator()
+        return self._iterator
+
+    def __exit__(self, *args) -> None:
+        del self._iterator
+        if self.channel:
+            self.reset_channel()

--- a/torch_geometric/distributed/dist_loader.py
+++ b/torch_geometric/distributed/dist_loader.py
@@ -41,7 +41,6 @@ class DistLoader:
             :meth:`~torch.distributed.rpc.rpc_async` if necessary.
             (default: :obj:`180`)
     """
-
     def __init__(
         self,
         current_ctx: DistContext,
@@ -56,12 +55,10 @@ class DistLoader:
         if master_addr is None and os.environ.get('MASTER_ADDR') is not None:
             master_addr = os.environ['MASTER_ADDR']
         if master_addr is None:
-            raise ValueError(
-                f"Missing master address for RPC communication "
-                f"in '{self.__class__.__name__}'. Try to provide "
-                f"it or set it via the 'MASTER_ADDR' environment "
-                f"variable."
-            )
+            raise ValueError(f"Missing master address for RPC communication "
+                             f"in '{self.__class__.__name__}'. Try to provide "
+                             f"it or set it via the 'MASTER_ADDR' environment "
+                             f"variable.")
 
         if master_port is None and os.environ.get('MASTER_PORT') is not None:
             # Select next port to MASTER_PORT used for DDP.
@@ -69,12 +66,10 @@ class DistLoader:
             # provide distinct ports for each.
             master_port = int(os.environ['MASTER_PORT']) + 1
         if master_port is None:
-            raise ValueError(
-                f"Missing master port for RPC communication in "
-                f"'{self.__class__.__name__}'. Try to provide it "
-                f"or set it via the 'MASTER_ADDR' environment "
-                f"variable."
-            )
+            raise ValueError(f"Missing master port for RPC communication in "
+                             f"'{self.__class__.__name__}'. Try to provide it "
+                             f"or set it via the 'MASTER_ADDR' environment "
+                             f"variable.")
 
         assert num_rpc_threads > 0
         assert rpc_timeout > 0
@@ -89,9 +84,8 @@ class DistLoader:
         self.rpc_timeout = rpc_timeout
         self.num_workers = kwargs.get('num_workers', 0)
 
-        logging.info(
-            f"[{self}] MASTER_ADDR={master_addr}, " f"MASTER_PORT={master_port}"
-        )
+        logging.info(f"[{self}] MASTER_ADDR={master_addr}, "
+                     f"MASTER_PORT={master_port}")
 
         if self.num_workers == 0:  # Initialize RPC in main process:
             self.worker_init_fn(0)
@@ -116,10 +110,10 @@ class DistLoader:
             self.current_ctx_worker = DistContext(
                 world_size=self.current_ctx.world_size * num_sampler_proc,
                 rank=self.current_ctx.rank * num_sampler_proc + worker_id,
-                global_world_size=self.current_ctx.world_size
-                * num_sampler_proc,
-                global_rank=self.current_ctx.rank * num_sampler_proc
-                + worker_id,
+                global_world_size=self.current_ctx.world_size *
+                num_sampler_proc,
+                global_rank=self.current_ctx.rank * num_sampler_proc +
+                worker_id,
                 group_name='mp_sampling_worker',
             )
 
@@ -132,8 +126,7 @@ class DistLoader:
             )
             logging.info(
                 f"RPC initiated in worker-{worker_id} "
-                f"(current_ctx_worker={self.current_ctx_worker.worker_name})"
-            )
+                f"(current_ctx_worker={self.current_ctx_worker.worker_name})")
             self.dist_sampler.init_sampler_instance()
             self.dist_sampler.register_sampler_rpc()
             global_barrier(timeout=10)  # Wait for all workers to initialize.
@@ -142,10 +135,8 @@ class DistLoader:
             atexit.register(shutdown_rpc, self.current_ctx_worker.worker_name)
 
         except RuntimeError:
-            raise RuntimeError(
-                f"`{self}.init_fn()` could not initialize the "
-                f"worker loop of the neighbor sampler"
-            )
+            raise RuntimeError(f"`{self}.init_fn()` could not initialize the "
+                               f"worker loop of the neighbor sampler")
 
     def __repr__(self) -> str:
         return f'{self.__class__.__name__}(pid={self.pid})'

--- a/torch_geometric/distributed/dist_neighbor_loader.py
+++ b/torch_geometric/distributed/dist_neighbor_loader.py
@@ -38,7 +38,6 @@ class DistNeighborLoader(NodeLoader, DistLoader):
         All other arguments follow the interface of
         :class:`torch_geometric.loader.NeighborLoader`.
     """
-
     def __init__(
         self,
         data: Tuple[LocalFeatureStore, LocalGraphStore],
@@ -66,11 +65,9 @@ class DistNeighborLoader(NodeLoader, DistLoader):
         assert concurrency >= 1, "RPC concurrency must be greater than 1"
 
         if input_time is not None and time_attr is None:
-            raise ValueError(
-                "Received conflicting 'input_time' and "
-                "'time_attr' arguments: 'input_time' is set "
-                "while 'time_attr' is not set."
-            )
+            raise ValueError("Received conflicting 'input_time' and "
+                             "'time_attr' arguments: 'input_time' is set "
+                             "while 'time_attr' is not set.")
 
         channel = torch.multiprocessing.Queue() if async_sampling else None
 

--- a/torch_geometric/distributed/dist_neighbor_sampler.py
+++ b/torch_geometric/distributed/dist_neighbor_sampler.py
@@ -43,7 +43,6 @@ class RPCSamplingCallee(RPCCallBase):
     r"""A wrapper for RPC callee that will perform RPC sampling from remote
     processes.
     """
-
     def __init__(self, sampler: NeighborSampler):
         super().__init__()
         self.sampler = sampler
@@ -59,7 +58,6 @@ class DistNeighborSampler:
     r"""An implementation of a distributed and asynchronised neighbor sampler
     used by :class:`~torch_geometric.distributed.DistNeighborLoader`.
     """
-
     def __init__(
         self,
         current_ctx: DistContext,

--- a/torch_geometric/distributed/dist_neighbor_sampler.py
+++ b/torch_geometric/distributed/dist_neighbor_sampler.py
@@ -1,6 +1,5 @@
 import itertools
 import logging
-from collections import defaultdict
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 import numpy as np
@@ -133,7 +132,7 @@ class DistNeighborSampler:
         if self.event_loop is None:
             self.event_loop = ConcurrentEventLoop(self.concurrency)
             self.event_loop.start_loop()
-            logging.info(f"{self} uses {self.event_loop}")
+            logging.info(f'{self} uses {self.event_loop}')
 
         if self.channel is None:
             # synchronous sampling

--- a/torch_geometric/distributed/event_loop.py
+++ b/torch_geometric/distributed/event_loop.py
@@ -2,12 +2,12 @@ import asyncio
 import logging
 from threading import BoundedSemaphore, Thread
 from typing import Callable, Optional
-
+import atexit
 import torch
 
-# This code is taken from alibaba graphlearn-for-pytorch repository:
+# Based on graphlearn-for-pytorch repository python/distributed/event_loop.py
 # https://github.com/alibaba/graphlearn-for-pytorch/blob/main/graphlearn_torch/
-# python/distributed/event_loop.py
+# LICENSE: Apache v2
 
 
 def to_asyncio_future(future: torch.futures.Future) -> asyncio.futures.Future:
@@ -34,6 +34,7 @@ class ConcurrentEventLoop:
     Args:
         concurrency: max processing concurrency.
     """
+
     def __init__(self, concurrency: int):
         self._concurrency = concurrency
         self._sem = BoundedSemaphore(concurrency)
@@ -41,15 +42,21 @@ class ConcurrentEventLoop:
         self._runner_t = Thread(target=self._run_loop)
         self._runner_t.daemon = True
 
+        def cleanup():
+            for _ in range(self._concurrency):
+                self._sem.acquire()
+            for _ in range(self._concurrency):
+                self._sem.release()
+            if self._runner_t.is_alive():
+                self._loop.stop()
+                self._runner_t.join(timeout=1)
+                logging.info(f'{self}: Closed `ConcurrentEventLoop`')
+                
+        atexit.register(cleanup)
+
     def start_loop(self):
         if not self._runner_t.is_alive():
             self._runner_t.start()
-
-    def shutdown_loop(self):
-        self.wait_all()
-        if self._runner_t.is_alive():
-            self._loop.stop()
-            self._runner_t.join(timeout=1)
 
     def wait_all(self):
         r"""Wait for all pending tasks to be finished."""
@@ -69,6 +76,7 @@ class ConcurrentEventLoop:
 
         Note that any result returned by :obj:`callback` will be ignored.
         """
+
         def on_done(f: asyncio.futures.Future):
             try:
                 res = f.result()

--- a/torch_geometric/distributed/event_loop.py
+++ b/torch_geometric/distributed/event_loop.py
@@ -1,8 +1,9 @@
 import asyncio
+import atexit
 import logging
 from threading import BoundedSemaphore, Thread
 from typing import Callable, Optional
-import atexit
+
 import torch
 
 # Based on graphlearn-for-pytorch repository python/distributed/event_loop.py
@@ -34,7 +35,6 @@ class ConcurrentEventLoop:
     Args:
         concurrency: max processing concurrency.
     """
-
     def __init__(self, concurrency: int):
         self._concurrency = concurrency
         self._sem = BoundedSemaphore(concurrency)
@@ -50,8 +50,8 @@ class ConcurrentEventLoop:
             if self._runner_t.is_alive():
                 self._loop.stop()
                 self._runner_t.join(timeout=1)
-                logging.info(f'{self}: Closed `ConcurrentEventLoop`')
-                
+                logging.debug(f'{self}: Closed `ConcurrentEventLoop`')
+
         atexit.register(cleanup)
 
     def start_loop(self):
@@ -76,7 +76,6 @@ class ConcurrentEventLoop:
 
         Note that any result returned by :obj:`callback` will be ignored.
         """
-
         def on_done(f: asyncio.futures.Future):
             try:
                 res = f.result()

--- a/torch_geometric/distributed/rpc.py
+++ b/torch_geometric/distributed/rpc.py
@@ -35,7 +35,7 @@ def global_barrier(timeout: Optional[int] = None) -> None:
     try:
         global_all_gather(obj=None, timeout=timeout)
     except RuntimeError:
-        logging.error("Failed to respond to global barrier")
+        logging.error('Failed to respond to global barrier')
 
 
 def init_rpc(
@@ -75,12 +75,11 @@ def shutdown_rpc(id: str = None, graceful: bool = True,
                  timeout: float = 240.0):
     with _rpc_init_lock:
         if rpc_is_initialized():
-            logging.info(f"Shutdown rpc start {id} (graceful={graceful})")
             global_barrier(timeout=timeout)
             rpc.shutdown(graceful, timeout)
-            logging.info(f"Closed RPC in {id} (graceful={graceful})")
+            logging.debug(f'Closed RPC in {id} (graceful={graceful})')
         else:
-            logging.info(f"RPC isn't initialized.")
+            logging.error(f'RPC in {id} not initialized.')
 
 
 class RPCRouter:
@@ -88,7 +87,7 @@ class RPCRouter:
     def __init__(self, partition_to_workers: List[List[str]]):
         for pid, rpc_worker_list in enumerate(partition_to_workers):
             if len(rpc_worker_list) == 0:
-                raise ValueError("No RPC worker is in worker list")
+                raise ValueError('No RPC worker is in worker list')
         self.partition_to_workers = partition_to_workers
         self.rpc_worker_indices = [0 for _ in range(len(partition_to_workers))]
 

--- a/torch_geometric/distributed/rpc.py
+++ b/torch_geometric/distributed/rpc.py
@@ -1,19 +1,17 @@
-import atexit
 import logging
 import threading
 from abc import ABC, abstractmethod
-from typing import Callable, Dict, List, Optional
+from typing import Any, Callable, Dict, List, Optional
 
 from torch.distributed import rpc
+from torch._C._distributed_rpc import _is_current_rpc_agent_set
 
-import torch_geometric.typing
 from torch_geometric.distributed.dist_context import DistContext, DistRole
 
 _rpc_init_lock = threading.RLock()
 
 
 def rpc_is_initialized() -> bool:
-    from torch._C._distributed_rpc import _is_current_rpc_agent_set
     return _is_current_rpc_agent_set()
 
 
@@ -24,7 +22,7 @@ def rpc_require_initialized(func: Callable) -> Callable:
 
 
 @rpc_require_initialized
-def global_all_gather(obj, timeout: Optional[int] = None):
+def global_all_gather(obj, timeout: Optional[int] = None) -> Any:
     r"""Gathers objects from all groups in a list."""
     if timeout is None:
         return rpc.api._all_gather(obj)
@@ -32,7 +30,7 @@ def global_all_gather(obj, timeout: Optional[int] = None):
 
 
 @rpc_require_initialized
-def global_barrier(timeout: Optional[int] = None):
+def global_barrier(timeout: Optional[int] = None) -> None:
     r"""Block until all local and remote RPC processes."""
     try:
         global_all_gather(obj=None, timeout=timeout)
@@ -42,11 +40,11 @@ def global_barrier(timeout: Optional[int] = None):
 
 def init_rpc(
     current_ctx: DistContext,
-    rpc_worker_names: Dict[DistRole, List[str]],
     master_addr: str,
     master_port: int,
     num_rpc_threads: int = 16,
-    rpc_timeout: int = 240,
+    rpc_timeout: float = 240.0,
+    rpc_worker_names: Optional[Dict[DistRole, List[str]]] = {},
 ):
     with _rpc_init_lock:
         if rpc_is_initialized():
@@ -70,37 +68,23 @@ def init_rpc(
             rpc_backend_options=options,
         )
 
-        gathered_results = global_all_gather(
-            obj=(current_ctx.role, current_ctx.world_size, current_ctx.rank),
-            timeout=rpc_timeout,
-        )
-
-        for worker_name, (role, world_size, rank) in gathered_results.items():
-            worker_list = rpc_worker_names.get(role, None)
-            if worker_list is None:
-                worker_list = [None for _ in range(world_size)]
-            else:
-                if len(worker_list) != world_size:
-                    raise RuntimeError(f"Inconsistent world size found in "
-                                       f"'init_rpc' (got {len(worker_list)})")
-
-            worker_list[rank] = worker_name
-            rpc_worker_names[role] = worker_list
-
         global_barrier(timeout=rpc_timeout)
 
 
-def shutdown_rpc(graceful: bool = True):
-    if rpc_is_initialized():
-        rpc.shutdown(graceful)
-
-
-if not torch_geometric.typing.WITH_WINDOWS:
-    atexit.register(shutdown_rpc, False)
+def shutdown_rpc(id: str = None, graceful: bool = True, timeout: float = 240.0):
+    with _rpc_init_lock:
+        if rpc_is_initialized():
+            logging.info(f"Shutdown rpc start {id} (graceful={graceful})")
+            global_barrier(timeout=timeout)
+            rpc.shutdown(graceful, timeout)
+            logging.info(f"Closed RPC in {id} (graceful={graceful})")
+        else:
+            logging.info(f"RPC isn't initialized.")
 
 
 class RPCRouter:
     r"""A router to get the worker based on the partition ID."""
+
     def __init__(self, partition_to_workers: List[List[str]]):
         for pid, rpc_worker_list in enumerate(partition_to_workers):
             if len(rpc_worker_list) == 0:
@@ -112,8 +96,9 @@ class RPCRouter:
         rpc_worker_list = self.partition_to_workers[partition_idx]
         worker_idx = self.rpc_worker_indices[partition_idx]
         router_worker = rpc_worker_list[worker_idx]
-        self.rpc_worker_indices[partition_idx] = ((worker_idx + 1) %
-                                                  len(rpc_worker_list))
+        self.rpc_worker_indices[partition_idx] = (worker_idx + 1) % len(
+            rpc_worker_list
+        )
         return router_worker
 
 
@@ -129,7 +114,8 @@ def rpc_partition_to_workers(
     ctx = current_ctx
     partition_to_workers = [[] for _ in range(num_partitions)]
     gathered_results = global_all_gather(
-        (ctx.role, num_partitions, current_partition_idx))
+        (ctx.role, num_partitions, current_partition_idx)
+    )
     for worker_name, (role, nparts, idx) in gathered_results.items():
         partition_to_workers[idx].append(worker_name)
     return partition_to_workers
@@ -137,6 +123,7 @@ def rpc_partition_to_workers(
 
 class RPCCallBase(ABC):
     r"""A wrapper base class for RPC calls in remote processes."""
+
     @abstractmethod
     def rpc_sync(self, *args, **kwargs):
         pass

--- a/torch_geometric/distributed/rpc.py
+++ b/torch_geometric/distributed/rpc.py
@@ -95,8 +95,8 @@ class RPCRouter:
         rpc_worker_list = self.partition_to_workers[partition_idx]
         worker_idx = self.rpc_worker_indices[partition_idx]
         router_worker = rpc_worker_list[worker_idx]
-        self.rpc_worker_indices[partition_idx] = ((worker_idx +
-                                                  1) % len(rpc_worker_list))
+        self.rpc_worker_indices[partition_idx] = ((worker_idx + 1) %
+                                                  len(rpc_worker_list))
         return router_worker
 
 

--- a/torch_geometric/distributed/rpc.py
+++ b/torch_geometric/distributed/rpc.py
@@ -44,7 +44,7 @@ def init_rpc(
     master_port: int,
     num_rpc_threads: int = 16,
     rpc_timeout: float = 240.0,
-    rpc_worker_names: Optional[Dict[DistRole, List[str]]] = {},
+    rpc_worker_names: Optional[Dict[DistRole, List[str]]] = None,
 ):
     with _rpc_init_lock:
         if rpc_is_initialized():

--- a/torch_geometric/distributed/rpc.py
+++ b/torch_geometric/distributed/rpc.py
@@ -95,8 +95,8 @@ class RPCRouter:
         rpc_worker_list = self.partition_to_workers[partition_idx]
         worker_idx = self.rpc_worker_indices[partition_idx]
         router_worker = rpc_worker_list[worker_idx]
-        self.rpc_worker_indices[partition_idx] = (worker_idx +
-                                                  1) % len(rpc_worker_list)
+        self.rpc_worker_indices[partition_idx] = ((worker_idx +
+                                                  1) % len(rpc_worker_list))
         return router_worker
 
 

--- a/torch_geometric/distributed/rpc.py
+++ b/torch_geometric/distributed/rpc.py
@@ -3,8 +3,8 @@ import threading
 from abc import ABC, abstractmethod
 from typing import Any, Callable, Dict, List, Optional
 
-from torch.distributed import rpc
 from torch._C._distributed_rpc import _is_current_rpc_agent_set
+from torch.distributed import rpc
 
 from torch_geometric.distributed.dist_context import DistContext, DistRole
 
@@ -71,7 +71,8 @@ def init_rpc(
         global_barrier(timeout=rpc_timeout)
 
 
-def shutdown_rpc(id: str = None, graceful: bool = True, timeout: float = 240.0):
+def shutdown_rpc(id: str = None, graceful: bool = True,
+                 timeout: float = 240.0):
     with _rpc_init_lock:
         if rpc_is_initialized():
             logging.info(f"Shutdown rpc start {id} (graceful={graceful})")
@@ -84,7 +85,6 @@ def shutdown_rpc(id: str = None, graceful: bool = True, timeout: float = 240.0):
 
 class RPCRouter:
     r"""A router to get the worker based on the partition ID."""
-
     def __init__(self, partition_to_workers: List[List[str]]):
         for pid, rpc_worker_list in enumerate(partition_to_workers):
             if len(rpc_worker_list) == 0:
@@ -96,9 +96,8 @@ class RPCRouter:
         rpc_worker_list = self.partition_to_workers[partition_idx]
         worker_idx = self.rpc_worker_indices[partition_idx]
         router_worker = rpc_worker_list[worker_idx]
-        self.rpc_worker_indices[partition_idx] = (worker_idx + 1) % len(
-            rpc_worker_list
-        )
+        self.rpc_worker_indices[partition_idx] = (worker_idx +
+                                                  1) % len(rpc_worker_list)
         return router_worker
 
 
@@ -114,8 +113,7 @@ def rpc_partition_to_workers(
     ctx = current_ctx
     partition_to_workers = [[] for _ in range(num_partitions)]
     gathered_results = global_all_gather(
-        (ctx.role, num_partitions, current_partition_idx)
-    )
+        (ctx.role, num_partitions, current_partition_idx))
     for worker_name, (role, nparts, idx) in gathered_results.items():
         partition_to_workers[idx].append(worker_name)
     return partition_to_workers
@@ -123,7 +121,6 @@ def rpc_partition_to_workers(
 
 class RPCCallBase(ABC):
     r"""A wrapper base class for RPC calls in remote processes."""
-
     @abstractmethod
     def rpc_sync(self, *args, **kwargs):
         pass

--- a/torch_geometric/loader/base.py
+++ b/torch_geometric/loader/base.py
@@ -1,6 +1,9 @@
 from typing import Any, Callable
 
-from torch.utils.data.dataloader import _BaseDataLoaderIter
+from torch.utils.data.dataloader import (
+    _BaseDataLoaderIter,
+    _MultiProcessingDataLoaderIter,
+)
 
 
 class DataLoaderIterator:
@@ -19,6 +22,7 @@ class DataLoaderIterator:
       with full parallelization power (which usually executes faster).
     * It lets us naturally support data already being present on the GPU.
     """
+
     def __init__(self, iterator: _BaseDataLoaderIter, transform_fn: Callable):
         self.iterator = iterator
         self.transform_fn = transform_fn
@@ -34,3 +38,7 @@ class DataLoaderIterator:
 
     def __next__(self) -> Any:
         return self.transform_fn(next(self.iterator))
+
+    def __del__(self) -> Any:
+        if isinstance(self.iterator, _MultiProcessingDataLoaderIter):
+            self.iterator.__del__()

--- a/torch_geometric/loader/base.py
+++ b/torch_geometric/loader/base.py
@@ -22,7 +22,6 @@ class DataLoaderIterator:
       with full parallelization power (which usually executes faster).
     * It lets us naturally support data already being present on the GPU.
     """
-
     def __init__(self, iterator: _BaseDataLoaderIter, transform_fn: Callable):
         self.iterator = iterator
         self.transform_fn = transform_fn


### PR DESCRIPTION
This PR fixes RPC-related errors caused by premature worker shutdown. 
Closed #8605 and opened this PR to align with changes in #8503.

The cause were multiple `atexit` statements defined both in `worker_loop` and in `rpc.py` that lead to unpredicatable behaviors resulting in errors, when the `ConcurrentEventLoop` shutdown was lagging behind.
```
RuntimeError: EPIPE: broken pipe (this error originated at tensorpipe/transport/uv/connection_impl.cc:157)
[W tensorpipe_agent.cpp:725] RPC agent for mp_sampling_worker-13 encountered error when reading incoming request from mp_sampling_worker-6: pipe closed (this error originated at tensorpipe/core/pipe_impl.cc:356)
```
Also I've removed `rpc_workers_names` from loader args as we're not using that in current implementation.
Updated tests for the sampler.