### PR TITLE
CS224W: Added filtered evaluation setting to KGEModel

### DIFF
--- a/torch_geometric/nn/kge/base.py
+++ b/torch_geometric/nn/kge/base.py
@@ -18,6 +18,7 @@ class KGEModel(torch.nn.Module):
         sparse (bool, optional): If set to :obj:`True`, gradients w.r.t. to the
             embedding matrices will be sparse. (default: :obj:`False`)
     """
+
     def __init__(
         self,
         num_nodes: int,
@@ -113,15 +114,15 @@ class KGEModel(torch.nn.Module):
                 (default: :obj:`10`)
             log (bool, optional): If set to :obj:`False`, will not print a
                 progress bar to the console. (default: :obj:`True`)
-            filtered (bool, optional): If set to :obj:`True`, does evaluation 
-                in the filtered setting, as described in 
-                [Bordes et al, 2013](https://dl.acm.org/doi/10.5555/2999792.2999923). 
-                This mode filters out all tails present in the training, validation, 
-                or test set for any (head,relation) from the candidate set of tails 
+            filtered (bool, optional): If set to :obj:`True`, does evaluation
+                in the filtered setting, as described in
+                [Bordes et al, 2013](https://dl.acm.org/doi/10.5555/2999792.2999923).
+                This mode filters out all tails present in the training, validation,
+                or test set for any (head,relation) from the candidate set of tails
                 while computing the rank. (default: :obj:`False`)
-            neighbors (List[List[List[int]]], optional): List of tails present in the 
-                training, validation or test set for any (head,relation) pair in the 
-                dataset. Specifically, if :math:`(h,r,t)` is present in the dataset, 
+            neighbors (List[List[List[int]]], optional): List of tails present in the
+                training, validation or test set for any (head,relation) pair in the
+                dataset. Specifically, if :math:`(h,r,t)` is present in the dataset,
                 :math:`t` is present in :math:`neighbors[h][r]`. (default: :obj:`None`)
         """
         arange = range(head_index.numel())
@@ -144,7 +145,8 @@ class KGEModel(torch.nn.Module):
                         # Do not filter out the gold answer
                         continue
                     mask_indices.append(e_id)
-                mask_indices = torch.LongTensor(mask_indices).to(head_index.device)
+                mask_indices = torch.LongTensor(
+                    mask_indices).to(head_index.device)
                 flattened_scores.index_fill_(0, mask_indices, -100)
             rank = int((flattened_scores.argsort(
                 descending=True) == t).nonzero().view(-1))

--- a/torch_geometric/nn/kge/base.py
+++ b/torch_geometric/nn/kge/base.py
@@ -145,7 +145,7 @@ class KGEModel(torch.nn.Module):
                         continue
                     mask_indices.append(e_id)
                 mask_indices = torch.LongTensor(mask_indices).to(head_index.device)
-                flattened_scores.index_fill_(0, mask_indices, -1)
+                flattened_scores.index_fill_(0, mask_indices, -100)
             rank = int((flattened_scores.argsort(
                 descending=True) == t).nonzero().view(-1))
             mean_ranks.append(rank)

--- a/torch_geometric/nn/kge/base.py
+++ b/torch_geometric/nn/kge/base.py
@@ -18,7 +18,6 @@ class KGEModel(torch.nn.Module):
         sparse (bool, optional): If set to :obj:`True`, gradients w.r.t. to the
             embedding matrices will be sparse. (default: :obj:`False`)
     """
-
     def __init__(
         self,
         num_nodes: int,
@@ -139,8 +138,8 @@ class KGEModel(torch.nn.Module):
                         # Do not filter out the gold answer
                         continue
                     mask_indices.append(e_id)
-                mask_indices = torch.LongTensor(
-                    mask_indices).to(head_index.device)
+                mask_indices = torch.LongTensor(mask_indices).to(
+                    head_index.device)
                 flattened_scores.index_fill_(0, mask_indices, -100)
             rank = int((flattened_scores.argsort(
                 descending=True) == t).nonzero().view(-1))

--- a/torch_geometric/nn/kge/base.py
+++ b/torch_geometric/nn/kge/base.py
@@ -1,4 +1,4 @@
-from typing import Tuple, List
+from typing import List, Tuple
 
 import torch
 from torch import Tensor
@@ -91,15 +91,9 @@ class KGEModel(torch.nn.Module):
 
     @torch.no_grad()
     def test(
-        self,
-        head_index: Tensor,
-        rel_type: Tensor,
-        tail_index: Tensor,
-        batch_size: int,
-        k: int = 10,
-        log: bool = True,
-        filtered: bool = False,
-        neighbors: List[List[List[int]]] = None
+            self, head_index: Tensor, rel_type: Tensor, tail_index: Tensor,
+            batch_size: int, k: int = 10, log: bool = True,
+            filtered: bool = False, neighbors: List[List[List[int]]] = None
     ) -> Tuple[float, float, float]:
         r"""Evaluates the model quality by computing Mean Rank, MRR and
         Hits@:math:`k` across all possible tail entities.
@@ -113,15 +107,15 @@ class KGEModel(torch.nn.Module):
                 (default: :obj:`10`)
             log (bool, optional): If set to :obj:`False`, will not print a
                 progress bar to the console. (default: :obj:`True`)
-            filtered (bool, optional): If set to :obj:`True`, does evaluation 
-                in the filtered setting, as described in 
-                [Bordes et al, 2013](https://dl.acm.org/doi/10.5555/2999792.2999923). 
-                This mode filters out all tails present in the training, validation, 
-                or test set for any (head,relation) from the candidate set of tails 
+            filtered (bool, optional): If set to :obj:`True`, does evaluation
+                in the filtered setting, as described in
+                [Bordes et al, 2013](https://dl.acm.org/doi/10.5555/2999792.2999923).
+                This mode filters out all tails present in the training, validation,
+                or test set for any (head,relation) from the candidate set of tails
                 while computing the rank. (default: :obj:`False`)
-            neighbors (List[List[List[int]]], optional): List of tails present in the 
-                training, validation or test set for any (head,relation) pair in the 
-                dataset. Specifically, if :math:`(h,r,t)` is present in the dataset, 
+            neighbors (List[List[List[int]]], optional): List of tails present in the
+                training, validation or test set for any (head,relation) pair in the
+                dataset. Specifically, if :math:`(h,r,t)` is present in the dataset,
                 :math:`t` is present in :math:`neighbors[h][r]`. (default: :obj:`None`)
         """
         arange = range(head_index.numel())
@@ -144,7 +138,8 @@ class KGEModel(torch.nn.Module):
                         # Do not filter out the gold answer
                         continue
                     mask_indices.append(e_id)
-                mask_indices = torch.LongTensor(mask_indices).to(head_index.device)
+                mask_indices = torch.LongTensor(mask_indices).to(
+                    head_index.device)
                 flattened_scores.index_fill_(0, mask_indices, -100)
             rank = int((flattened_scores.argsort(
                 descending=True) == t).nonzero().view(-1))


### PR DESCRIPTION
The original implementation of KGEModel simply calculates the rank of the gold tail for any given query by considering all entities in the dataset as the candidate tail set. However, most Knowledge Graph Completion literature [Bordes et al, 2013](https://dl.acm.org/doi/10.5555/2999792.2999923) performs evaluation in a filtered setting. For any query (h,r,?), we first filter out all t from the candidate tail set such that (h,r,t) is present in the training, validation, or test split, with the exception of the gold answer to the query. The rank is then calculated on this filtered candidate set.

This PR introduces an option to turn on this mode of evaluation. If the 'filtered' argument is set to True, and a list of tails present in the training, validation, or test set for any (head,relation) pair is passed in the 'neighbors' argument, the evaluation is performed in the filtered setting. Specifically, if (h,r,t) is present in the dataset, t is present in neighbors[h][r].