### PR TITLE
Revert `EdgeIndex` usage in `Planetoid` datasets

### DIFF
--- a/examples/compile/gcn.py
+++ b/examples/compile/gcn.py
@@ -47,7 +47,7 @@ model = GCN(
     out_channels=dataset.num_classes,
 ).to(device)
 
-# Compile the model into an optimized version and enforce zero graph breaks:
+# Compile the model into an optimized version:
 model = torch_geometric.compile(model, dynamic=False)
 
 optimizer = torch.optim.Adam([

--- a/examples/compile/gin.py
+++ b/examples/compile/gin.py
@@ -56,7 +56,7 @@ model = GIN(
     num_layers=5,
 ).to(device)
 
-# Compile the model into an optimized version and enforce zero graph breaks:
+# Compile the model into an optimized version:
 model = torch_geometric.compile(model, dynamic=True)
 
 optimizer = torch.optim.Adam(model.parameters(), lr=0.01)

--- a/test/datasets/test_planetoid.py
+++ b/test/datasets/test_planetoid.py
@@ -1,4 +1,3 @@
-from torch_geometric import EdgeIndex
 from torch_geometric.loader import DataLoader
 from torch_geometric.testing import onlyOnline
 
@@ -51,10 +50,11 @@ def test_citeseer_with_random_split(get_dataset):
         num_test=41,
     )
     data = dataset[0]
-    assert isinstance(data.edge_index, EdgeIndex)
-    assert data.edge_index.sparse_size() == (data.num_nodes, data.num_nodes)
-    assert data.edge_index.is_undirected
-    assert data.edge_index.is_sorted_by_col
+    # from torch_geometric import EdgeIndex
+    # assert isinstance(data.edge_index, EdgeIndex)
+    # assert data.edge_index.sparse_size() == (data.num_nodes, data.num_nodes)
+    # assert data.edge_index.is_undirected
+    # assert data.edge_index.is_sorted_by_col
 
     assert data.train_mask.sum() == dataset.num_classes * 11
     assert data.val_mask.sum() == 29


### PR DESCRIPTION
`EdgeIndex` is not yet compatible with `torch.compile`