### PR TITLE
Remove `@overload` in `MessagePassing`

### DIFF
--- a/torch_geometric/nn/conv/message_passing.jinja
+++ b/torch_geometric/nn/conv/message_passing.jinja
@@ -51,17 +51,13 @@ class {{cls_name}}({{parent_cls_name}}):
              'shape `[2, num_messages]` or `torch_sparse.SparseTensor` for '
              'argument `edge_index`.'))
 
-    @torch.jit._overload_method
-    def _collect(self, edge_def, size, kwargs):
-        # type: (Tensor, List[Optional[int]], Propagate_{{uid}}) -> Collect_{{uid}}
-        pass
+    def _collect(
+        self,
+        edge_def: Union[Tensor, SparseTensor],
+        size: List[Optional[int]],
+        kwargs: Propagate_{{uid}},
+    ) -> Collect_{{uid}}:
 
-    @torch.jit._overload_method
-    def _collect(self, edge_def, size, kwargs):
-        # type: (SparseTensor, List[Optional[int]], Propagate_{{uid}}) -> Collect_{{uid}}
-        pass
-
-    def _collect(self, edge_def, size, kwargs):
         init = torch.zeros(1)
         i, j = (1, 0) if self.flow == 'source_to_target' else (0, 1)
 {% for arg in user_args %}
@@ -130,17 +126,13 @@ class {{cls_name}}({{parent_cls_name}}):
         return Collect_{{uid}}({% for k in collect_types.keys() %}{{k}}={{k}}{{ ", " if not loop.last }}{% endfor %})
 
 {% if edge_updater_types|length > 0 %}
-    @torch.jit._overload_method
-    def _collect_edge(self, edge_def, size, kwargs):
-        # type: (Tensor, List[Optional[int]], EdgeUpdater_{{uid}}) -> EdgeUpdater_Collect_{{uid}}
-        pass
+    def _collect_edge(
+        self,
+        edge_def: Union[Tensor, SparseTensor],
+        size: List[Optional[int]],
+        kwargs: EdgeUpdater_{{uid}},
+    ) -> EdgeUpdater_Collect_{{uid}}:
 
-    @torch.jit._overload_method
-    def _collect_edge(self, edge_def, size, kwargs):
-        # type: (SparseTensor, List[Optional[int]], EdgeUpdater_{{uid}}) -> EdgeUpdater_Collect_{{uid}}
-        pass
-
-    def _collect_edge(self, edge_def, size, kwargs):
         init = torch.tensor(0.)
         i, j = (1, 0) if self.flow == 'source_to_target' else (0, 1)
 {% for arg in edge_user_args %}

--- a/torch_geometric/nn/conv/message_passing.py
+++ b/torch_geometric/nn/conv/message_passing.py
@@ -2,7 +2,6 @@ import inspect
 import os.path as osp
 import random
 import re
-import typing
 from inspect import Parameter
 from itertools import chain
 from typing import (
@@ -43,11 +42,6 @@ from torch_geometric.utils import (
     to_edge_index,
 )
 from torch_geometric.utils.sparse import ptr2index
-
-if typing.TYPE_CHECKING:
-    from typing import overload
-else:
-    from torch.jit import _overload_method as overload
 
 FUSE_AGGRS = {'add', 'sum', 'mean', 'min', 'max'}
 HookDict = OrderedDict[int, Callable]
@@ -203,23 +197,7 @@ class MessagePassing(torch.nn.Module):
 
     # Utilities ###############################################################
 
-    @overload
     def _check_input(
-        self,
-        edge_index: Tensor,
-        size: Size,
-    ) -> List[Optional[int]]:
-        pass
-
-    @overload
-    def _check_input(  # noqa: F811
-        self,
-        edge_index: SparseTensor,
-        size: Size,
-    ) -> List[Optional[int]]:
-        pass
-
-    def _check_input(  # noqa: F811
         self,
         edge_index: Union[Tensor, SparseTensor],
         size: Optional[Tuple[int, int]],
@@ -274,25 +252,7 @@ class MessagePassing(torch.nn.Module):
                 (f'Encountered tensor with size {src.size(self.node_dim)} in '
                  f'dimension {self.node_dim}, but expected size {the_size}.'))
 
-    @overload
     def _lift(
-        self,
-        src: Tensor,
-        edge_index: Tensor,
-        dim: int,
-    ) -> Tensor:
-        pass
-
-    @overload
-    def _lift(  # noqa: F811
-        self,
-        src: Tensor,
-        edge_index: SparseTensor,
-        dim: int,
-    ) -> Tensor:
-        pass
-
-    def _lift(  # noqa: F811
         self,
         src: Tensor,
         edge_index: Union[Tensor, SparseTensor],
@@ -364,27 +324,7 @@ class MessagePassing(torch.nn.Module):
              'shape `[2, num_messages]`, `torch_sparse.SparseTensor` '
              'or `torch.sparse.Tensor` for argument `edge_index`.'))
 
-    @overload
     def _collect(
-        self,
-        args: Set[str],
-        edge_index: Tensor,
-        size: List[Optional[int]],
-        kwargs: Dict[str, Any],
-    ) -> Dict[str, Any]:
-        pass
-
-    @overload
-    def _collect(  # noqa: F811
-        self,
-        args: Set[str],
-        edge_index: SparseTensor,
-        size: List[Optional[int]],
-        kwargs: Dict[str, Any],
-    ) -> Dict[str, Any]:
-        pass
-
-    def _collect(  # noqa: F811
         self,
         args: Set[str],
         edge_index: Union[Tensor, SparseTensor],

--- a/torch_geometric/utils/_subgraph.py
+++ b/torch_geometric/utils/_subgraph.py
@@ -15,9 +15,10 @@ def get_num_hops(model: torch.nn.Module) -> int:
     from.
 
     .. note::
+
         This function counts the number of message passing layers as an
         approximation of the total number of hops covered by the model.
-        Its about may not necessarily correct in case message passing layers
+        Its output may not necessarily correct in case message passing layers
         perform multi-hop aggregation, *e.g.*, as in
         :class:`~torch_geometric.nn.conv.ChebConv`.
 

--- a/torch_geometric/utils/_subgraph.py
+++ b/torch_geometric/utils/_subgraph.py
@@ -14,6 +14,13 @@ def get_num_hops(model: torch.nn.Module) -> int:
     r"""Returns the number of hops the model is aggregating information
     from.
 
+    .. note::
+        This function counts the number of message passing layers as an
+        approximation of the total number of hops covered by the model.
+        Its about may not necessarily correct in case message passing layers
+        perform multi-hop aggregation, *e.g.*, as in
+        :class:`~torch_geometric.nn.conv.ChebConv`.
+
     Example:
         >>> class GNN(torch.nn.Module):
         ...     def __init__(self):

--- a/torch_geometric/utils/_subgraph.py
+++ b/torch_geometric/utils/_subgraph.py
@@ -31,8 +31,8 @@ def get_num_hops(model: torch.nn.Module) -> int:
         ...         self.lin = Linear(16, 2)
         ...
         ...     def forward(self, x, edge_index):
-        ...         x = torch.F.relu(self.conv1(x, edge_index))
-        ...         x = self.conv2(x, edge_index)
+        ...         x = self.conv1(x, edge_index).relu()
+        ...         x = self.conv2(x, edge_index).relu()
         ...         return self.lin(x)
         >>> get_num_hops(GNN())
         2

--- a/torch_geometric/utils/_subgraph.py
+++ b/torch_geometric/utils/_subgraph.py
@@ -18,8 +18,8 @@ def get_num_hops(model: torch.nn.Module) -> int:
 
         This function counts the number of message passing layers as an
         approximation of the total number of hops covered by the model.
-        Its output may not necessarily correct in case message passing layers
-        perform multi-hop aggregation, *e.g.*, as in
+        Its output may not necessarily be correct in case message passing
+        layers perform multi-hop aggregation, *e.g.*, as in
         :class:`~torch_geometric.nn.conv.ChebConv`.
 
     Example:


### PR DESCRIPTION
TorchScript now supports `Union`. `@overload` decorators are no longer necessary.