### PR TITLE
Merge `TemporalData` with `Data`/`HeteroData` [2/n]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,7 +46,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Added the `num_graphs` option to the `StochasticBlockModelDataset` ([#8648](https://github.com/pyg-team/pytorch_geometric/pull/8648))
 - Added noise scheduler utility for diffusion based graph generative models ([#8347](https://github.com/pyg-team/pytorch_geometric/pull/8347))
 - Added the equivariant `ViSNet` model ([#8287](https://github.com/pyg-team/pytorch_geometric/pull/8287))
-- Added temporal-related capabilities to `Data` ([#8454](https://github.com/pyg-team/pytorch_geometric/pull/8454))
+- Added temporal-related capabilities to `Data` and `HeteroData` ([#8454](https://github.com/pyg-team/pytorch_geometric/pull/8454), [#8739](https://github.com/pyg-team/pytorch_geometric/pull/8739))
 - Added support for returning multi graphs in `to_networkx` ([#8575](https://github.com/pyg-team/pytorch_geometric/pull/8575))
 - Added support for XPU device in `profileit` decorator ([#8532](https://github.com/pyg-team/pytorch_geometric/pull/8532))
 - Added `KNNIndex` exclusion logic ([#8573](https://github.com/pyg-team/pytorch_geometric/pull/8573))

--- a/test/data/test_hetero_data.py
+++ b/test/data/test_hetero_data.py
@@ -608,14 +608,14 @@ def test_hetero_data_time_handling():
     assert not data.is_sorted_by_time([rel2])
     assert not data.is_sorted_by_time([rel3])
 
-    out = data.up_to([rel1], 49)
+    out = data.up_to(49, [rel1])
     assert out[rel1].num_edges == 50
     assert torch.allclose(out['paper'].x, data['paper'].x)
     assert torch.allclose(out['author'].x, data['author'].x)
     assert torch.equal(out[rel1].edge_index, data[rel1].edge_index[:, :50])
     assert torch.equal(out[rel1].time, data[rel1].time[:50])
 
-    out = data.snapshot([rel1], 10, 49)
+    out = data.snapshot(10, 49, [rel1])
     assert out[rel1].num_edges == 40
     assert torch.allclose(out['paper'].x, data['paper'].x)
     assert torch.allclose(out['author'].x, data['author'].x)

--- a/torch_geometric/data/data.py
+++ b/torch_geometric/data/data.py
@@ -39,6 +39,7 @@ from torch_geometric.typing import (
     OptTensor,
     SparseTensor,
     TensorFrame,
+    TimeType,
 )
 from torch_geometric.utils import is_sparse, select, subgraph
 
@@ -288,8 +289,8 @@ class BaseData:
 
     def snapshot(
         self,
-        start_time: Union[float, int],
-        end_time: Union[float, int],
+        start_time: TimeType,
+        end_time: TimeType,
     ) -> Self:
         r"""Returns a snapshot of :obj:`data` to only hold events that occurred
         in period :obj:`[start_time, end_time]`.
@@ -299,7 +300,7 @@ class BaseData:
             store.snapshot(start_time, end_time)
         return out
 
-    def up_to(self, end_time: Union[float, int]) -> Self:
+    def up_to(self, end_time: TimeType) -> Self:
         r"""Returns a snapshot of :obj:`data` to only hold events that occurred
         up to :obj:`end_time` (inclusive of :obj:`edge_time`).
         """

--- a/torch_geometric/data/hetero_data.py
+++ b/torch_geometric/data/hetero_data.py
@@ -789,14 +789,15 @@ class HeteroData(BaseData, FeatureStore, GraphStore):
         return out
 
     def is_sorted_by_time(
-            self, types: Union[List[EdgeType], List[NodeType]]) -> bool:
+            self, types: Optional[List[NodeOrEdgeType]] = None) -> bool:
         r"""Returns :obj:`True` if :obj:`time` exists and is sorted for all
-        :obj:`types` (either edge types or node types).
+        :obj:`types`. If :obj:`types` is set to :obj:`None`, will check all
+        currently hold types.
         """
         if not types:
-            return False
+            types = self.node_types + self.edge_types
 
-        for t in [self._to_canonical(t) for t in types]:
+        for t in types:
             if 'time' not in self[t]:
                 return False
             if not self[t].is_sorted_by_time():
@@ -804,46 +805,45 @@ class HeteroData(BaseData, FeatureStore, GraphStore):
 
         return True
 
-    def sort_by_time(self, types: Union[List[EdgeType],
-                                        List[NodeType]]) -> Self:
+    def sort_by_time(self,
+                     types: Optional[List[NodeOrEdgeType]] = None) -> Self:
         r"""Sorts data associated with :obj:`time` according to :obj:`time` for
-        all :obj:`types` (either edge types or node types).
+        all :obj:`types`. If :obj:`types` is set to :obj:`None`, will sort all
+        currently hold types.
         """
         if not types:
-            return self
+            types = self.node_types + self.edge_types
 
         out = copy.copy(self)
-        # TODO: should we limit `out` to be a [edge|node]_type_subgraph?
-        for t in [self._to_canonical(t) for t in types]:
+        for t in types:
             out[t].sort_by_time()
         return out
 
-    def snapshot(self, types: Union[List[EdgeType], List[NodeType]],
-                 start_time: TimeType, end_time: TimeType) -> Self:
+    def snapshot(self, start_time: TimeType, end_time: TimeType,
+                 types: Optional[List[NodeOrEdgeType]] = None) -> Self:
         r"""Returns a snapshot restricted by :obj:`start_time` and
-        :obj:`end_time` for all :obj:`types` (either edge types or node
-        types).
+        :obj:`end_time` for all :obj:`types`. If :obj:`types` is set to
+        :obj:`None`, will apply to all currently hold types.
         """
         if not types:
-            return self
+            types = self.node_types + self.edge_types
 
         out = copy.copy(self)
-        # TODO: should we limit `out` to be a [edge|node]_type_subgraph?
-        for t in [self._to_canonical(t) for t in types]:
+        for t in types:
             out[t].snapshot(start_time, end_time)
         return out
 
-    def up_to(self, types: Union[List[EdgeType], List[NodeType]],
-              end_time: TimeType) -> Self:
+    def up_to(self, end_time: TimeType,
+              types: Optional[List[NodeOrEdgeType]] = None) -> Self:
         r"""Returns a snapshot restricted by :obj:`end_time` for all
-        :obj:`types` (either edge types or node).
+        :obj:`types`. If :obj:`types` is set to :obj:`None`, will apply to
+        all currently hold types.
         """
         if not types:
-            return self
+            types = self.node_types + self.edge_types
 
         out = copy.copy(self)
-        # TODO: should we limit `out` to be a [edge|node]_type_subgraph?
-        for t in [self._to_canonical(t) for t in types]:
+        for t in types:
             out[t].up_to(end_time)
         return out
 

--- a/torch_geometric/data/storage.py
+++ b/torch_geometric/data/storage.py
@@ -31,6 +31,7 @@ from torch_geometric.typing import (
     NodeType,
     SparseTensor,
     TensorFrame,
+    TimeType,
 )
 from torch_geometric.utils import (
     coalesce,
@@ -368,8 +369,8 @@ class BaseStorage(MutableMapping):
 
     def snapshot(
         self,
-        start_time: Union[float, int],
-        end_time: Union[float, int],
+        start_time: TimeType,
+        end_time: TimeType,
     ) -> Self:
         if 'time' in self:
             mask = (self.time >= start_time) & (self.time <= end_time)
@@ -386,7 +387,7 @@ class BaseStorage(MutableMapping):
 
         return self
 
-    def up_to(self, time: Union[float, int]) -> Self:
+    def up_to(self, time: TimeType) -> Self:
         if 'time' in self:
             return self.snapshot(self.time.min().item(), time)
         return self

--- a/torch_geometric/typing.py
+++ b/torch_geometric/typing.py
@@ -276,6 +276,8 @@ class MockTorchCSCTensor:
 
 # Types for accessing data ####################################################
 
+TimeType = Union[float, int]
+
 # Node-types are denoted by a single string, e.g.: `data['paper']`:
 NodeType = str
 


### PR DESCRIPTION
This PR attempts to merge `TemporalData` into `HeteroData`.
Currently, one can perform time-related modification/query using a specific node or edge type:
```Python
# bad: usage based on `BaseStorage` methods
for e in hetero_data.edge_types:
    hetero_data[e].up_to(10)
res = all([hetero_data[e].is_sorted_by_time() for e in hetero_data.edge_types])
```
This is possible because `BaseStorage` implements those functionalities. For better usability, however,
these functions should be exposed in the `HeteroData` API directly. Such an approach would also allow us to
perform operations on many node or edge types at once:
```Python
# good: usage based on `HeteroData` API
out = hetero_data.up_to(hetero_data.edge_types, 10)
res = hetero_data.is_sorted_by_time(hetero_data.edge_types)
```

Related: #3230, #8454