### PR TITLE
Fix `torch_geometric.nn.aggr` article note link

### DIFF
--- a/docs/source/modules/nn.rst
+++ b/docs/source/modules/nn.rst
@@ -147,7 +147,7 @@ Finally, we added full support for customization of aggregations into the :class
 
 .. note::
 
-   You can read more about the :class:`torch_geometric.nn.aggr` package in this [blog post](https://medium.com/@pytorch_geometric/a-principled-approach-to-aggregations-983c086b10b3).
+   You can read more about the :class:`torch_geometric.nn.aggr` package in this `blog post <https://medium.com/@pytorch_geometric/a-principled-approach-to-aggregations-983c086b10b3>`__.
 
 .. autosummary::
    :nosignatures:


### PR DESCRIPTION
Hi, 

I have come across  a link being formatted incorrectly in the docs for [Aggregation Operators](https://pytorch-geometric.readthedocs.io/en/latest/modules/nn.html#aggregation-operators). The incorrect link appears in the note section, as shown in this screenshot:
![image](https://github.com/pyg-team/pytorch_geometric/assets/33166525/879c8b79-52d7-45ce-a978-29608b66c70d)

This PR fixes the link formatting to ensure it's rendered properly.

Thank you.
