### PR TITLE
feat(benchmark): switch to `global_add_pool`

### DIFF
--- a/benchmark/kernel/graph_sage.py
+++ b/benchmark/kernel/graph_sage.py
@@ -2,7 +2,7 @@ import torch
 import torch.nn.functional as F
 from torch.nn import Linear
 
-from torch_geometric.nn import JumpingKnowledge, SAGEConv, global_mean_pool
+from torch_geometric.nn import JumpingKnowledge, SAGEConv, global_add_pool
 
 
 class GraphSAGE(torch.nn.Module):
@@ -27,7 +27,7 @@ class GraphSAGE(torch.nn.Module):
         x = F.relu(self.conv1(x, edge_index))
         for conv in self.convs:
             x = F.relu(conv(x, edge_index))
-        x = global_mean_pool(x, batch)
+        x = global_add_pool(x, batch)
         x = F.relu(self.lin1(x))
         x = F.dropout(x, p=0.5, training=self.training)
         x = self.lin2(x)
@@ -67,7 +67,7 @@ class GraphSAGEWithJK(torch.nn.Module):
             x = F.relu(conv(x, edge_index))
             xs += [x]
         x = self.jump(xs)
-        x = global_mean_pool(x, batch)
+        x = global_add_pool(x, batch)
         x = F.relu(self.lin1(x))
         x = F.dropout(x, p=0.5, training=self.training)
         x = self.lin2(x)


### PR DESCRIPTION
Similar to #7955 

This PR aims to update the GraphSAGE implementation in the kernel benchmarks to use `global_add_pool` as opposed to `global_mean_pool`. Based on experiments reported in [Does readout matter in GraphSAGE](https://wandb.ai/sauravmaheshkar/GraphSAGE/reports/Does-readout-matter-in-GraphSAGE--Vmlldzo2NTQ1Mjc4)

Attached below is one such graph comparing the Average Precision on the test set for Multi-label graph classification on the Peptides Functional Dataset from the LRGB dataset group averaged over 2 random seeds. 

![Screenshot 2024-01-20 at 10 34 14 PM](https://github.com/pyg-team/pytorch_geometric/assets/61241031/f4414a68-e7a5-4afc-81dc-253191057696)

* Based on the last PR I've skipped making changes to the `CHANGELOG` as the `skip-changelog` logo was used last time.

Request for Review: @rusty1s 
