### PR TITLE
chore(pre-commit): migrate to pre-commit for line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,0 @@
-*.py text eol=lf

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,6 +11,9 @@ repos:
         name: No commits to master
       - id: end-of-file-fixer
         name: End-of-file fixer
+      - name: mixed-line-ending
+        id: mixed-line-ending
+        args: [--fix, lf]
       - id: trailing-whitespace
         name: Remove trailing whitespaces
       - id: check-toml


### PR DESCRIPTION
This PR aims to migrate to pre-commit to enforce consistent line endings. The previous approach introduced in https://github.com/pyg-team/pytorch_geometric/pull/7759 relies on using a `.gitattributes` file. Instead this PR proposes to use the `mixed-line-ending` hook to do the same.

This change was tested by running `pre-commit run --all-files`.

Request for Review: @rusty1s 

I'm skipping editing the `CHANGELOG` for now.