### PR TITLE
feat(ci/labeler): bump `actions/labeler` and add `skip-changelog` label

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,54 +1,54 @@
 documentation:
-- changed-files:
-  - any-glob-to-any-file: "docs/**/*"
+  - changed-files:
+      - any-glob-to-any-file: "docs/**/*"
 
 example:
-- changed-files:
-  - any-glob-to-any-file: "examples/**/*"
+  - changed-files:
+      - any-glob-to-any-file: "examples/**/*"
 
 data:
-- changed-files:
-  - any-glob-to-any-file: "torch_geometric/data/**/*"
+  - changed-files:
+      - any-glob-to-any-file: "torch_geometric/data/**/*"
 
 dataset:
-- changed-files:
-  - any-glob-to-any-file: [ "torch_geometric/io/**/*", "torch_geometric/datasets/**/*" ]
+  - changed-files:
+      - any-glob-to-any-file: ["torch_geometric/io/**/*", "torch_geometric/datasets/**/*"]
 
 sampler:
-- changed-files:
-  - any-glob-to-any-file: "torch_geometric/sampler/**/*"
+  - changed-files:
+      - any-glob-to-any-file: "torch_geometric/sampler/**/*"
 
 loader:
-- changed-files:
-  - any-glob-to-any-file: "torch_geometric/loader/**/*"
+  - changed-files:
+      - any-glob-to-any-file: "torch_geometric/loader/**/*"
 
 nn:
-- changed-files:
-  - any-glob-to-any-file: "torch_geometric/nn/**/*"
+  - changed-files:
+      - any-glob-to-any-file: "torch_geometric/nn/**/*"
 
 explain:
-- changed-files:
-  - any-glob-to-any-file: "torch_geometric/explain/**/*"
+  - changed-files:
+      - any-glob-to-any-file: "torch_geometric/explain/**/*"
 
 transform:
-- changed-files:
-  - any-glob-to-any-file: "torch_geometric/transforms/**/*"
+  - changed-files:
+      - any-glob-to-any-file: "torch_geometric/transforms/**/*"
 
 utils:
-- changed-files:
-  - any-glob-to-any-file: "torch_geometric/utils/**/*"
+  - changed-files:
+      - any-glob-to-any-file: "torch_geometric/utils/**/*"
 
 contrib:
-- changed-files:
-  - any-glob-to-any-file: "torch_geometric/contrib/**/*"
+  - changed-files:
+      - any-glob-to-any-file: "torch_geometric/contrib/**/*"
 
 graphgym:
-- changed-files:
-  - any-glob-to-any-file: [ "graphgym/**/*", "torch_geometric/graphgym/**/*" ]
+  - changed-files:
+      - any-glob-to-any-file: ["graphgym/**/*", "torch_geometric/graphgym/**/*"]
 
 benchmark:
-- changed-files:
-  - any-glob-to-any-file: [ "benchmark/**/*", "torch_geometric/profile/**/*" ]
+  - changed-files:
+      - any-glob-to-any-file: ["benchmark/**/*", "torch_geometric/profile/**/*"]
 
 skip-changelog:
- - head-branch: ['^skip']
+  - head-branch: ['^skip']

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,41 +1,54 @@
 documentation:
-  - docs/**/*
+- changed-files:
+  - any-glob-to-any-file: "docs/**/*"
 
 example:
-  - examples/**/*
+- changed-files:
+  - any-glob-to-any-file: "examples/**/*"
 
 data:
-  - torch_geometric/data/**/*
+- changed-files:
+  - any-glob-to-any-file: "torch_geometric/data/**/*"
 
 dataset:
-  - torch_geometric/io/**/*
-  - torch_geometric/datasets/**/*
+- changed-files:
+  - any-glob-to-any-file: [ "torch_geometric/io/**/*", "torch_geometric/datasets/**/*" ]
 
 sampler:
-  - torch_geometric/sampler/**/*
+- changed-files:
+  - any-glob-to-any-file: "torch_geometric/sampler/**/*"
 
 loader:
-  - torch_geometric/loader/**/*
+- changed-files:
+  - any-glob-to-any-file: "torch_geometric/loader/**/*"
 
 nn:
-  - torch_geometric/nn/**/*
+- changed-files:
+  - any-glob-to-any-file: "torch_geometric/nn/**/*"
 
 explain:
-  - torch_geometric/explain/**/*
+- changed-files:
+  - any-glob-to-any-file: "torch_geometric/explain/**/*"
 
 transform:
-  - torch_geometric/transforms/**/*
+- changed-files:
+  - any-glob-to-any-file: "torch_geometric/transforms/**/*"
 
 utils:
-  - torch_geometric/utils/**/*
+- changed-files:
+  - any-glob-to-any-file: "torch_geometric/utils/**/*"
 
 contrib:
-  - torch_geometric/contrib/**/*
+- changed-files:
+  - any-glob-to-any-file: "torch_geometric/contrib/**/*"
 
 graphgym:
-  - graphgym/**/*
-  - torch_geometric/graphgym/**/*
+- changed-files:
+  - any-glob-to-any-file: [ "graphgym/**/*", "torch_geometric/graphgym/**/*" ]
 
 benchmark:
-  - benchmark/**/*
-  - torch_geometric/profile/**/*
+- changed-files:
+  - any-glob-to-any-file: [ "benchmark/**/*", "torch_geometric/profile/**/*" ]
+
+skip-changelog:
+ - head-branch: ['^skip']

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Add PR labels
-        uses: actions/labeler@v4
+        uses: actions/labeler@v5
         continue-on-error: true
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,7 +1,7 @@
 name: PR Labeler
 
 on:  # yamllint disable-line rule:truthy
-  pull_request:
+  pull_request_target:
 
 jobs:
 


### PR DESCRIPTION
This PR aims to make the CI process better for contributors by adding the ability to auto-assign the `skip-changelog` label by naming the branch `skip*`. With the [new version of `actions/labeler` we can specify a list of regex expressions](https://github.com/actions/labeler?tab=readme-ov-file#match-object) to match with for the head branch.

This will prevent failing CI in case where updating the `CHANGELOG` isn't considered necessary. 

Perhaps this should also be reflected in the docs somewhere, most likely the contributing guide. More than happy to update the docs as well.

Request for Review: @rusty1s 