### PR TITLE
Rectify the default attention mode "node" of the `nn.HypergraphConv` layer

### DIFF
--- a/torch_geometric/nn/conv/hypergraph_conv.py
+++ b/torch_geometric/nn/conv/hypergraph_conv.py
@@ -174,9 +174,9 @@ class HypergraphConv(MessagePassing):
             alpha = (torch.cat([x_i, x_j], dim=-1) * self.att).sum(dim=-1)
             alpha = F.leaky_relu(alpha, self.negative_slope)
             if self.attention_mode == 'node':
-                alpha = softmax(alpha, hyperedge_index[1], num_nodes=x.size(0))
+                alpha = softmax(alpha, hyperedge_index[1], num_nodes=num_edges)
             else:
-                alpha = softmax(alpha, hyperedge_index[0], num_nodes=x.size(0))
+                alpha = softmax(alpha, hyperedge_index[0], num_nodes=num_nodes)
             alpha = F.dropout(alpha, p=self.dropout, training=self.training)
 
         D = scatter(hyperedge_weight[hyperedge_index[1]], hyperedge_index[0],


### PR DESCRIPTION
Greetings, esteemed individuals.

While acquainting myself with the utilization of the nn.HypergraphConv layer through the application of mock inputs, I have encountered an issue with the default attention mode, namely "node," which disrupts the functionality of the forward function.

Upon examining the source code, I have identified a potential problem with the num_nodes parameter within the softmax function at line 177. From my perspective, when attempting to compute attention scores for nodes within a hyperedge, the number of hyperedges should be considered as num_nodes.

Therefore, I have modified the value of num_nodes to correspond to the pre-calculated quantity of num_edges. As a result, the issue has been resolved, and the functionality has been restored harmoniously.

Warmest regards.