### PR TITLE
Make `Data` attributes cache non shareable

### DIFF
--- a/test/data/test_data.py
+++ b/test/data/test_data.py
@@ -179,14 +179,14 @@ def test_data_attr_cache():
 
 def test_data_attr_cache_not_shared():
     x = torch.rand((4, 4))
-    edge_index = torch.tensor([[0, 1, 2, 3, 0, 1], [0, 1, 2, 3, 0, 1]],
-                              dtype=torch.long)
-    time = torch.tensor([0., 1., 2., 3., 4., 5.])
+    edge_index = torch.tensor([[0, 1, 2, 3, 0, 1], [0, 1, 2, 3, 0, 1]])
+    time = torch.arange(edge_index.size(1))
     data = Data(x=x, edge_index=edge_index, time=time)
-
     assert data.is_node_attr('x')
 
     out = data.up_to(3.5)
+    # This is expected behavior due to the ambiguity of between node-level and
+    # edge-level tensors when they share the same number of nodes/edges.
     assert out.is_node_attr('time')
     assert not data.is_node_attr('time')
 

--- a/test/data/test_data.py
+++ b/test/data/test_data.py
@@ -177,6 +177,20 @@ def test_data_attr_cache():
     assert 'y' in data._store._cached_attr[AttrType.OTHER]
 
 
+def test_data_attr_cache_not_shared():
+    x = torch.rand((4, 4))
+    edge_index = torch.tensor([[0, 1, 2, 3, 0, 1], [0, 1, 2, 3, 0, 1]],
+                              dtype=torch.long)
+    time = torch.tensor([0., 1., 2., 3., 4., 5.])
+    data = Data(x=x, edge_index=edge_index, time=time)
+
+    assert data.is_node_attr('x')
+
+    out = data.up_to(3.5)
+    assert out.is_node_attr('time')
+    assert not data.is_node_attr('time')
+
+
 def test_to_heterogeneous_empty_edge_index():
     data = Data(
         x=torch.randn(5, 10),

--- a/torch_geometric/data/storage.py
+++ b/torch_geometric/data/storage.py
@@ -135,7 +135,8 @@ class BaseStorage(MutableMapping):
     def __copy__(self) -> Self:
         out = self.__class__.__new__(self.__class__)
         for key, value in self.__dict__.items():
-            out.__dict__[key] = value
+            if key != '_cached_attr':
+                out.__dict__[key] = value
         out._mapping = copy.copy(out._mapping)
         return out
 


### PR DESCRIPTION
When `Data` object has non-empty `_attr_cache`, after creating copy of `Data`, both objects will share `_attr_cache`, which may result in wrong attribute classification. For example:
```python
x = torch.rand((4, 4))
edge_index = torch.tensor([[0, 1, 2, 3, 0, 1], [0, 1, 2, 3, 0, 1]], dtype=torch.long)
time = torch.tensor([0., 1., 2., 3., 4., 5.])
data = Data(x=x, edge_index=edge_index, time=time)

# this will implicitly fill _attr_cache
assert data.is_node_attr('x')

out = data.up_to(3.5)
assert out.is_node_attr('time')
# before this PR, assert will fail, producing the wrong attribute classification, as time should be an edge attribute
assert not data.is_node_attr('time')
```