### PR TITLE
[Documentation] Remove inactive Slack link from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,6 @@ ______________________________________________________________________
 It consists of various methods for deep learning on graphs and other irregular structures, also known as *[geometric deep learning](http://geometricdeeplearning.com/)*, from a variety of published papers.
 In addition, it consists of easy-to-use mini-batch loaders for operating on many small and single giant graphs, [multi GPU-support](https://github.com/pyg-team/pytorch_geometric/tree/master/examples/multi_gpu), [`torch.compile`](https://pytorch-geometric.readthedocs.io/en/latest/advanced/compile.html) support, [`DataPipe`](https://github.com/pyg-team/pytorch_geometric/blob/master/examples/datapipe.py) support, a large number of common benchmark datasets (based on simple interfaces to create your own), the [GraphGym](https://pytorch-geometric.readthedocs.io/en/latest/advanced/graphgym.html) experiment manager, and helpful transforms, both for learning on arbitrary graphs as well as on 3D meshes or point clouds.
 
-**[Click here to join our Slack community!][slack-url]**
-
 <p align="center">
   <a href="https://medium.com/stanford-cs224w"><img style="max-width=: 941px" src="https://data.pyg.org/img/cs224w_tutorials.png" /></a>
 </p>


### PR DESCRIPTION
<img width="1160" alt="Screenshot 2024-02-14 at 5 36 30 p m" src="https://github.com/pyg-team/pytorch_geometric/assets/864506/208a77d0-4777-4f70-9639-7102cd0969d6">

Remove inactive link to slack channel.
