### PR TITLE
Add note on network interface in distributed examples README

### DIFF
--- a/examples/distributed/pyg/README.md
+++ b/examples/distributed/pyg/README.md
@@ -101,16 +101,18 @@ In this case, the interface used for multi-node communication needs to be specif
 Assuming that `$MASTER_ADDR` is set the the IP of `node#0`.
 
 On the `node#0`:
+
 ```bash
 export TP_SOCKET_IFNAME=$(ip addr | grep "$MASTER_ADDR" | awk '{print $NF}')
 export GLOO_SOCKET_IFNAME=$TP_SOCKET_IFNAME
 ```
+
 On the other nodes:
+
 ```bash
 export TP_SOCKET_IFNAME=$(ip route get $MASTER_ADDR | grep -oP '(?<=dev )[^ ]+')
 export GLOO_SOCKET_IFNAME=$TP_SOCKET_IFNAME
 ```
-
 
 #### Option B: Launch Script
 

--- a/examples/distributed/pyg/README.md
+++ b/examples/distributed/pyg/README.md
@@ -80,7 +80,7 @@ The `dataset_root_dir` should point to the head directory where your partition i
 ```bash
 # Node 0:
 python node_ogb_cpu.py \
-  --dataset=ogbn-products
+  --dataset=ogbn-products \
   --dataset_root_dir=<partition folder directory> \
   --num_nodes=2 \
   --node_rank=0 \
@@ -88,12 +88,29 @@ python node_ogb_cpu.py \
 
 # Node 1:
 python node_obg_cpu.py \
-  --dataset=ogbn-products
+  --dataset=ogbn-products \
   --dataset_root_dir=<partition folder directory> \
   --num_nodes=2 \
   --node_rank=1 \
   --master_addr=<master ip>
 ```
+
+In some configurations, the network interface used for multi-node communication may be different not the default one.
+In this case, the interface used for multi-node communication needs to be specified to Gloo.
+
+Assuming that `$MASTER_ADDR` is set the the IP of `node#0`.
+
+On the `node#0`:
+```bash
+export TP_SOCKET_IFNAME=$(ip addr | grep "$MASTER_ADDR" | awk '{print $NF}')
+export GLOO_SOCKET_IFNAME=$TP_SOCKET_IFNAME
+```
+On the other nodes:
+```bash
+export TP_SOCKET_IFNAME=$(ip route get $MASTER_ADDR | grep -oP '(?<=dev )[^ ]+')
+export GLOO_SOCKET_IFNAME=$TP_SOCKET_IFNAME
+```
+
 
 #### Option B: Launch Script
 

--- a/examples/distributed/pyg/README.md
+++ b/examples/distributed/pyg/README.md
@@ -98,7 +98,7 @@ python node_obg_cpu.py \
 In some configurations, the network interface used for multi-node communication may be different than the default one.
 In this case, the interface used for multi-node communication needs to be specified to Gloo.
 
-Assuming that `$MASTER_ADDR` is set the the IP of `node#0`.
+Assuming that `$MASTER_ADDR` is set to the IP of `node#0`.
 
 On the `node#0`:
 

--- a/examples/distributed/pyg/README.md
+++ b/examples/distributed/pyg/README.md
@@ -95,7 +95,7 @@ python node_obg_cpu.py \
   --master_addr=<master ip>
 ```
 
-In some configurations, the network interface used for multi-node communication may be different not the default one.
+In some configurations, the network interface used for multi-node communication may be different than the default one.
 In this case, the interface used for multi-node communication needs to be specified to Gloo.
 
 Assuming that `$MASTER_ADDR` is set the the IP of `node#0`.


### PR DESCRIPTION
This PR updates the README in the distributed example to explain how to ensure that the right network interface is used for multi-node communication.