### PR TITLE
Make `batch` optional in the global pooling layers

### DIFF
--- a/torch_geometric/nn/pool/glob.py
+++ b/torch_geometric/nn/pool/glob.py
@@ -5,7 +5,7 @@ from torch import Tensor
 from torch_geometric.utils import scatter
 
 
-def global_add_pool(x: Tensor, batch: Optional[Tensor],
+def global_add_pool(x: Tensor, batch: Optional[Tensor] = None,
                     size: Optional[int] = None) -> Tensor:
     r"""Returns batch-wise graph-level-outputs by adding node features
     across the node dimension.
@@ -34,7 +34,7 @@ def global_add_pool(x: Tensor, batch: Optional[Tensor],
     return scatter(x, batch, dim=dim, dim_size=size, reduce='sum')
 
 
-def global_mean_pool(x: Tensor, batch: Optional[Tensor],
+def global_mean_pool(x: Tensor, batch: Optional[Tensor] = None,
                      size: Optional[int] = None) -> Tensor:
     r"""Returns batch-wise graph-level-outputs by averaging node features
     across the node dimension.
@@ -63,7 +63,7 @@ def global_mean_pool(x: Tensor, batch: Optional[Tensor],
     return scatter(x, batch, dim=dim, dim_size=size, reduce='mean')
 
 
-def global_max_pool(x: Tensor, batch: Optional[Tensor],
+def global_max_pool(x: Tensor, batch: Optional[Tensor] = None,
                     size: Optional[int] = None) -> Tensor:
     r"""Returns batch-wise graph-level-outputs by taking the channel-wise
     maximum across the node dimension.


### PR DESCRIPTION
Currently, `batch=None` has to be mandatorily passed to the global pooling layers in `torch_geometric/nn/pool/glob.py`. This PR makes it optional, as the type annotations assume.

I can update the [tests](https://github.com/pyg-team/pytorch_geometric/blob/master/test/nn/pool/test_glob.py) too, if needed.