### PR TITLE
Add transformation with a chronological split

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- Added transformation with a chronological split ([#8979](https://github.com/pyg-team/pytorch_geometric/pull/8979))
 - Added support for `EdgeIndex` in `MessagePassing` ([#9007](https://github.com/pyg-team/pytorch_geometric/pull/9007))
 - Added support for `torch.compile` in combination with `EdgeIndex` ([#9007](https://github.com/pyg-team/pytorch_geometric/pull/9007))
 - Added a `ogbn-mag240m` example ([#8249](https://github.com/pyg-team/pytorch_geometric/pull/8249))

--- a/test/data/test_data.py
+++ b/test/data/test_data.py
@@ -548,14 +548,14 @@ def test_data_time_handling(num_nodes, num_edges):
     assert not data.is_node_attr('time')
     assert data.is_sorted_by_time()
 
-    out = data.up_to(5)
+    out = data.up_to(6)
     assert out.num_edges == 6
     assert torch.allclose(out.x, data.x)
     assert torch.equal(out.edge_index, data.edge_index[:, :6])
     assert torch.allclose(out.edge_attr, data.edge_attr[:6])
     assert torch.equal(out.time, data.time[:6])
 
-    out = data.snapshot(2, 5)
+    out = data.snapshot(2, 6)
     assert out.num_edges == 4
     assert torch.allclose(out.x, data.x)
     assert torch.equal(out.edge_index, data.edge_index[:, 2:6])

--- a/test/transforms/test_chronological_split.py
+++ b/test/transforms/test_chronological_split.py
@@ -1,0 +1,45 @@
+import pytest
+import torch
+
+from torch_geometric.data import Data, HeteroData
+from torch_geometric.testing import get_random_edge_index
+from torch_geometric.transforms import ChronologicalSplit
+
+
+@pytest.mark.parametrize('val_ratio', [0.15, 0.2])
+@pytest.mark.parametrize('test_ratio', [0.15, 0.2])
+def test_chronological_split_on_data(val_ratio, test_ratio):
+    num_nodes = 32
+    num_edges = 100
+    data = Data(x=torch.randn(num_nodes, 12),
+                edge_index=torch.randint(0, num_nodes, (2, num_edges)),
+                time=torch.randint(0, 100, (num_edges, )), num_nodes=num_nodes)
+    transform = ChronologicalSplit(val_ratio=val_ratio, test_ratio=test_ratio)
+    train_data, val_data, test_data = transform(data)
+
+    assert train_data.time.max() < val_data.time.min()
+    assert val_data.time.max() < test_data.time.min()
+
+
+@pytest.mark.parametrize('val_ratio', [0.15, 0.2])
+@pytest.mark.parametrize('test_ratio', [0.15, 0.2])
+def test_chronological_split_on_hetero_data(val_ratio, test_ratio):
+    num_paper_nodes = 32
+    num_author_nodes = 64
+    num_edges = 100
+    data = HeteroData()
+    data['paper'].x = torch.randn(num_paper_nodes, 16)
+    data['paper'].time = torch.randint(0, 100, (num_paper_nodes, ))
+    data['author'].x = torch.randn(num_author_nodes, 16)
+    data['author'].time = torch.randint(100, 200, (num_author_nodes, ))
+    data['paper',
+         'author'].edge_index = get_random_edge_index(num_paper_nodes,
+                                                      num_author_nodes,
+                                                      num_edges)
+    data['paper', 'author'].time = torch.randint(200, 300, (num_edges, ))
+    transform = ChronologicalSplit(val_ratio=val_ratio, test_ratio=test_ratio)
+    train_data, val_data, test_data = transform(data)
+
+    for key in ['paper', 'author', ('paper', 'author')]:
+        assert train_data[key].time.max() < val_data[key].time.min()
+        assert val_data[key].time.max() < test_data[key].time.min()

--- a/torch_geometric/data/data.py
+++ b/torch_geometric/data/data.py
@@ -292,7 +292,7 @@ class BaseData:
         end_time: Union[float, int],
     ) -> Self:
         r"""Returns a snapshot of :obj:`data` to only hold events that occurred
-        in period :obj:`[start_time, end_time]`.
+        in period :obj:`<start_time, end_time)`.
         """
         out = copy.copy(self)
         for store in out.stores:
@@ -301,7 +301,7 @@ class BaseData:
 
     def up_to(self, end_time: Union[float, int]) -> Self:
         r"""Returns a snapshot of :obj:`data` to only hold events that occurred
-        up to :obj:`end_time` (inclusive of :obj:`edge_time`).
+        before :obj:`end_time`.
         """
         out = copy.copy(self)
         for store in out.stores:

--- a/torch_geometric/data/storage.py
+++ b/torch_geometric/data/storage.py
@@ -372,7 +372,7 @@ class BaseStorage(MutableMapping):
         end_time: Union[float, int],
     ) -> Self:
         if 'time' in self:
-            mask = (self.time >= start_time) & (self.time <= end_time)
+            mask = (self.time >= start_time) & (self.time < end_time)
 
             if self.is_node_attr('time'):
                 keys = self.node_attrs()

--- a/torch_geometric/transforms/__init__.py
+++ b/torch_geometric/transforms/__init__.py
@@ -11,6 +11,7 @@ from .remove_training_classes import RemoveTrainingClasses
 from .random_node_split import RandomNodeSplit
 from .random_link_split import RandomLinkSplit
 from .node_property_split import NodePropertySplit
+from .chronological_split import ChronologicalSplit
 from .mask import IndexToMask, MaskToIndex
 from .pad import Pad
 
@@ -75,6 +76,7 @@ general_transforms = [
     'RandomNodeSplit',
     'RandomLinkSplit',
     'NodePropertySplit',
+    'ChronologicalSplit',
     'IndexToMask',
     'MaskToIndex',
     'Pad',

--- a/torch_geometric/transforms/chronological_split.py
+++ b/torch_geometric/transforms/chronological_split.py
@@ -1,12 +1,12 @@
 import copy
-from itertools import chain
-from typing import Optional, Tuple, Union
+from typing import List, Tuple, Union
 
 import numpy as np
 
 from torch_geometric.data import Data, HeteroData
 from torch_geometric.data.datapipes import functional_transform
 from torch_geometric.transforms import BaseTransform
+from torch_geometric.typing import NodeOrEdgeType
 
 
 @functional_transform('chronological_split')
@@ -26,8 +26,8 @@ class ChronologicalSplit(BaseTransform):
         test_ratio (float, optional): The proportion (in percents) of the
             dataset to include in the test split. (default: :obj:`0.15`)
     """
-    def __init__(self, val_ratio: Optional[float] = 0.15,
-                 test_ratio: Optional[float] = 0.15) -> None:
+    def __init__(self, val_ratio: float = 0.15,
+                 test_ratio: float = 0.15) -> None:
         assert 0. <= val_ratio <= 1.
         assert 0. <= test_ratio <= 1.
         assert val_ratio + test_ratio < 1.
@@ -44,30 +44,38 @@ class ChronologicalSplit(BaseTransform):
             Union[Data, HeteroData],
     ]:
         if isinstance(data, Data):
-            assert hasattr(data, self.key)
-
-            val_time, test_time = np.quantile(
-                data.time.numpy(),
-                [1 - self.val_ratio - self.test_ratio, 1 - self.test_ratio])
-            train_data = data.snapshot(0, val_time)
-            val_data = data.snapshot(val_time, test_time)
-            test_data = data.snapshot(test_time, data.time.max() + 1)
-
-            return train_data, val_data, test_data
+            return self._forward_data(data)
         else:  # HeteroData
-            train_data = copy.copy(data)
-            val_data = copy.copy(data)
-            test_data = copy.copy(data)
+            return self._forward_hetero_data(data)
 
-            for key in chain(data.node_types, data.edge_types):
-                if hasattr(data[key], self.key):
-                    val_time, test_time = np.quantile(data[key].time.numpy(), [
-                        1 - self.val_ratio - self.test_ratio,
-                        1 - self.test_ratio
-                    ])
-                    train_data[key].snapshot(0, val_time)
-                    val_data[key].snapshot(val_time, test_time)
-                    test_data[key].snapshot(test_time,
-                                            data[key].time.max() + 1)
+    def _forward_data(self, data: Data) -> Tuple[Data, Data, Data]:
+        assert hasattr(data, self.key)
 
-            return train_data, val_data, test_data
+        val_time, test_time = np.quantile(
+            data[self.key].numpy(),
+            [1 - self.val_ratio - self.test_ratio, 1 - self.test_ratio])
+        train_data = data.snapshot(0, val_time)
+        val_data = data.snapshot(val_time, test_time)
+        test_data = data.snapshot(test_time, data[self.key].max().item() + 1)
+
+        return train_data, val_data, test_data
+
+    def _forward_hetero_data(
+            self,
+            data: HeteroData) -> Tuple[HeteroData, HeteroData, HeteroData]:
+        train_data = copy.copy(data)
+        val_data = copy.copy(data)
+        test_data = copy.copy(data)
+
+        all_types: List[NodeOrEdgeType] = data.node_types + data.edge_types
+        for key in all_types:
+            if hasattr(data[key], self.key):
+                val_time, test_time = np.quantile(data[key].time.numpy(), [
+                    1 - self.val_ratio - self.test_ratio, 1 - self.test_ratio
+                ])
+                train_data[key].snapshot(0, val_time)
+                val_data[key].snapshot(val_time, test_time)
+                test_data[key].snapshot(test_time,
+                                        data[key].time.max().item() + 1)
+
+        return train_data, val_data, test_data

--- a/torch_geometric/transforms/chronological_split.py
+++ b/torch_geometric/transforms/chronological_split.py
@@ -1,0 +1,73 @@
+import copy
+from itertools import chain
+from typing import Optional, Tuple, Union
+
+import numpy as np
+
+from torch_geometric.data import Data, HeteroData
+from torch_geometric.data.datapipes import functional_transform
+from torch_geometric.transforms import BaseTransform
+
+
+@functional_transform('chronological_split')
+class ChronologicalSplit(BaseTransform):
+    r"""Performs a chronological split into training, validation and test sets
+    of a :class:`~torch_geometric.data.Data` or a
+    :class:`~torch_geometric.data.HeteroData` object
+    (functional name: :obj:`chronological_split`).
+
+    Chronological split satisfies the following relationship:
+    max(train_time) < min(val_time) && max(val_time) < min(test_time)
+
+    Args:
+        val_ratio (float, optional): The proportion (in percents) of the
+            dataset to include in the validation split.
+            (default: :obj:`0.15`)
+        test_ratio (float, optional): The proportion (in percents) of the
+            dataset to include in the test split. (default: :obj:`0.15`)
+    """
+    def __init__(self, val_ratio: Optional[float] = 0.15,
+                 test_ratio: Optional[float] = 0.15) -> None:
+        assert 0. <= val_ratio <= 1.
+        assert 0. <= test_ratio <= 1.
+        assert val_ratio + test_ratio < 1.
+        self.val_ratio = val_ratio
+        self.test_ratio = test_ratio
+        self.key = 'time'
+
+    def forward(
+        self,
+        data: Union[Data, HeteroData],
+    ) -> Tuple[
+            Union[Data, HeteroData],
+            Union[Data, HeteroData],
+            Union[Data, HeteroData],
+    ]:
+        if isinstance(data, Data):
+            assert hasattr(data, self.key)
+
+            val_time, test_time = np.quantile(
+                data.time.numpy(),
+                [1 - self.val_ratio - self.test_ratio, 1 - self.test_ratio])
+            train_data = data.snapshot(0, val_time)
+            val_data = data.snapshot(val_time, test_time)
+            test_data = data.snapshot(test_time, data.time.max() + 1)
+
+            return train_data, val_data, test_data
+        else:  # HeteroData
+            train_data = copy.copy(data)
+            val_data = copy.copy(data)
+            test_data = copy.copy(data)
+
+            for key in chain(data.node_types, data.edge_types):
+                if hasattr(data[key], self.key):
+                    val_time, test_time = np.quantile(data[key].time.numpy(), [
+                        1 - self.val_ratio - self.test_ratio,
+                        1 - self.test_ratio
+                    ])
+                    train_data[key].snapshot(0, val_time)
+                    val_data[key].snapshot(val_time, test_time)
+                    test_data[key].snapshot(test_time,
+                                            data[key].time.max() + 1)
+
+            return train_data, val_data, test_data


### PR DESCRIPTION
This PR adds the `ChronologicalSplit` transformation, which splits the data into training, validation, and test parts, satisfying the following relationship:
```
max(train_time) < min(val_time) && max(val_time) < min(test_time)
```

Related issues: #3230 #8454 