### PR TITLE
Add `group_cat` functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
-- Added `scatter_concat` functionality ([#9029](https://github.com/pyg-team/pytorch_geometric/pull/9029))
+- Added `group_cat` functionality ([#9029](https://github.com/pyg-team/pytorch_geometric/pull/9029))
 - Added support for `EdgeIndex` in `MessagePassing` ([#9007](https://github.com/pyg-team/pytorch_geometric/pull/9007))
 - Added support for `torch.compile` in combination with `EdgeIndex` ([#9007](https://github.com/pyg-team/pytorch_geometric/pull/9007))
 - Added a `ogbn-mag240m` example ([#8249](https://github.com/pyg-team/pytorch_geometric/pull/8249))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- Added `scatter_concat` functionality ([#9029](https://github.com/pyg-team/pytorch_geometric/pull/9029))
 - Added support for `EdgeIndex` in `MessagePassing` ([#9007](https://github.com/pyg-team/pytorch_geometric/pull/9007))
 - Added support for `torch.compile` in combination with `EdgeIndex` ([#9007](https://github.com/pyg-team/pytorch_geometric/pull/9007))
 - Added a `ogbn-mag240m` example ([#8249](https://github.com/pyg-team/pytorch_geometric/pull/8249))

--- a/test/utils/test_scatter.py
+++ b/test/utils/test_scatter.py
@@ -113,23 +113,24 @@ def test_scatter_argmax(device):
 
 @withCUDA
 def test_scatter_concat(device):
-    x1 = torch.tensor([[0.2716, 0.4233, 0.2658, 0.8284],
-                       [0.3166, 0.0142, 0.1700, 0.2944],
-                       [0.2371, 0.3839, 0.7193, 0.2954],
-                       [0.4100, 0.0012, 0.5114, 0.3353]],device=device)
-    x2 = torch.tensor([[0.3752, 0.5782, 0.7105, 0.4002],
-                       [0.7757, 0.5999, 0.7898, 0.0753]],device=device)
-    x1_index = torch.LongTensor([0,0,1,2],device=device)
-    x2_index = torch.LongTensor([0,2],device=device)
-    expected = torch.tensor([[0.2716, 0.4233, 0.2658, 0.8284],
-                             [0.3166, 0.0142, 0.1700, 0.2944],
-                             [0.3752, 0.5782, 0.7105, 0.4002],
-                             [0.2371, 0.3839, 0.7193, 0.2954],
-                             [0.4100, 0.0012, 0.5114, 0.3353],
-                             [0.7757, 0.5999, 0.7898, 0.0753]],device=device)
-    out, index_out = scatter_concat((x1,x2), (x1_index,x2_index), 0, return_index=True)
+    x1 = torch.tensor(
+        [[0.2716, 0.4233, 0.2658, 0.8284], [0.3166, 0.0142, 0.1700, 0.2944],
+         [0.2371, 0.3839, 0.7193, 0.2954], [0.4100, 0.0012, 0.5114, 0.3353]],
+        device=device)
+    x2 = torch.tensor(
+        [[0.3752, 0.5782, 0.7105, 0.4002], [0.7757, 0.5999, 0.7898, 0.0753]],
+        device=device)
+    x1_index = torch.LongTensor([0, 0, 1, 2], device=device)
+    x2_index = torch.LongTensor([0, 2], device=device)
+    expected = torch.tensor(
+        [[0.2716, 0.4233, 0.2658, 0.8284], [0.3166, 0.0142, 0.1700, 0.2944],
+         [0.3752, 0.5782, 0.7105, 0.4002], [0.2371, 0.3839, 0.7193, 0.2954],
+         [0.4100, 0.0012, 0.5114, 0.3353], [0.7757, 0.5999, 0.7898, 0.0753]],
+        device=device)
+    out, index_out = scatter_concat((x1, x2), (x1_index, x2_index), 0,
+                                    return_index=True)
     assert torch.equal(out, expected)
-    assert torch.equal(index_out, torch.LongTensor([0,0,0,1,2,2]))
+    assert torch.equal(index_out, torch.LongTensor([0, 0, 0, 1, 2, 2]))
 
 
 if __name__ == '__main__':

--- a/test/utils/test_scatter.py
+++ b/test/utils/test_scatter.py
@@ -6,7 +6,7 @@ import torch
 import torch_geometric.typing
 from torch_geometric.profile import benchmark
 from torch_geometric.testing import withCUDA, withPackage
-from torch_geometric.utils import group_argsort, scatter, scatter_concat
+from torch_geometric.utils import group_argsort, group_cat, scatter
 from torch_geometric.utils._scatter import scatter_argmax
 
 
@@ -112,25 +112,22 @@ def test_scatter_argmax(device):
 
 
 @withCUDA
-def test_scatter_concat(device):
-    x1 = torch.tensor(
-        [[0.2716, 0.4233, 0.2658, 0.8284], [0.3166, 0.0142, 0.1700, 0.2944],
-         [0.2371, 0.3839, 0.7193, 0.2954], [0.4100, 0.0012, 0.5114, 0.3353]],
-        device=device)
-    x2 = torch.tensor(
-        [[0.3752, 0.5782, 0.7105, 0.4002], [0.7757, 0.5999, 0.7898, 0.0753]],
-        device=device)
-    x1_index = torch.LongTensor([0, 0, 1, 2], device=device)
-    x2_index = torch.LongTensor([0, 2], device=device)
-    expected = torch.tensor(
-        [[0.2716, 0.4233, 0.2658, 0.8284], [0.3166, 0.0142, 0.1700, 0.2944],
-         [0.3752, 0.5782, 0.7105, 0.4002], [0.2371, 0.3839, 0.7193, 0.2954],
-         [0.4100, 0.0012, 0.5114, 0.3353], [0.7757, 0.5999, 0.7898, 0.0753]],
-        device=device)
-    out, index_out = scatter_concat((x1, x2), (x1_index, x2_index), 0,
-                                    return_index=True)
+def test_group_cat(device):
+    x1 = torch.randn(4, 4, device=device)
+    x2 = torch.randn(2, 4, device=device)
+    index1 = torch.tensor([0, 0, 1, 2], device=device)
+    index2 = torch.tensor([0, 2], device=device)
+
+    expected = torch.cat([x1[:2], x2[:1], x1[2:4], x2[1:]], dim=0)
+
+    out, index = group_cat(
+        [x1, x2],
+        [index1, index2],
+        dim=0,
+        return_index=True,
+    )
     assert torch.equal(out, expected)
-    assert torch.equal(index_out, torch.LongTensor([0, 0, 0, 1, 2, 2]))
+    assert index.tolist() == [0, 0, 0, 1, 2, 2]
 
 
 if __name__ == '__main__':

--- a/test/utils/test_scatter.py
+++ b/test/utils/test_scatter.py
@@ -6,7 +6,7 @@ import torch
 import torch_geometric.typing
 from torch_geometric.profile import benchmark
 from torch_geometric.testing import withCUDA, withPackage
-from torch_geometric.utils import group_argsort, scatter
+from torch_geometric.utils import group_argsort, scatter, scatter_concat
 from torch_geometric.utils._scatter import scatter_argmax
 
 
@@ -109,6 +109,27 @@ def test_scatter_argmax(device):
     argmax = scatter_argmax(src, index, dim_size=6)
     torch_geometric.typing.WITH_TORCH_SCATTER = old_state
     assert argmax.tolist() == [3, 5, 1, 4, 5, 5]
+
+
+@withCUDA
+def test_scatter_concat(device):
+    x1 = torch.tensor([[0.2716, 0.4233, 0.2658, 0.8284],
+                       [0.3166, 0.0142, 0.1700, 0.2944],
+                       [0.2371, 0.3839, 0.7193, 0.2954],
+                       [0.4100, 0.0012, 0.5114, 0.3353]],device=device)
+    x2 = torch.tensor([[0.3752, 0.5782, 0.7105, 0.4002],
+                       [0.7757, 0.5999, 0.7898, 0.0753]],device=device)
+    x1_index = torch.LongTensor([0,0,1,2],device=device)
+    x2_index = torch.LongTensor([0,2],device=device)
+    expected = torch.tensor([[0.2716, 0.4233, 0.2658, 0.8284],
+                             [0.3166, 0.0142, 0.1700, 0.2944],
+                             [0.3752, 0.5782, 0.7105, 0.4002],
+                             [0.2371, 0.3839, 0.7193, 0.2954],
+                             [0.4100, 0.0012, 0.5114, 0.3353],
+                             [0.7757, 0.5999, 0.7898, 0.0753]],device=device)
+    out, index_out = scatter_concat((x1,x2), (x1_index,x2_index), 0, return_index=True)
+    assert torch.equal(out, expected)
+    assert torch.equal(index_out, torch.LongTensor([0,0,0,1,2,2]))
 
 
 if __name__ == '__main__':

--- a/torch_geometric/utils/__init__.py
+++ b/torch_geometric/utils/__init__.py
@@ -2,7 +2,7 @@ r"""Utility package."""
 
 import copy
 
-from ._scatter import scatter, group_argsort
+from ._scatter import scatter, group_argsort, scatter_concat
 from ._segment import segment
 from ._index_sort import index_sort
 from .functions import cumsum
@@ -60,6 +60,7 @@ from ._train_test_split_edges import train_test_split_edges
 __all__ = [
     'scatter',
     'group_argsort',
+    'scatter_concat',
     'segment',
     'index_sort',
     'cumsum',

--- a/torch_geometric/utils/__init__.py
+++ b/torch_geometric/utils/__init__.py
@@ -2,7 +2,7 @@ r"""Utility package."""
 
 import copy
 
-from ._scatter import scatter, group_argsort, scatter_concat
+from ._scatter import scatter, group_argsort, group_cat
 from ._segment import segment
 from ._index_sort import index_sort
 from .functions import cumsum
@@ -60,7 +60,7 @@ from ._train_test_split_edges import train_test_split_edges
 __all__ = [
     'scatter',
     'group_argsort',
-    'scatter_concat',
+    'group_cat',
     'segment',
     'index_sort',
     'cumsum',

--- a/torch_geometric/utils/_scatter.py
+++ b/torch_geometric/utils/_scatter.py
@@ -1,13 +1,12 @@
-from typing import Optional
+from typing import List, Optional, Tuple, Union
 
 import torch
-from torch import Tensor, LongTensor
+from torch import LongTensor, Tensor
 
 import torch_geometric.typing
 from torch_geometric import is_compiling, warnings
 from torch_geometric.typing import torch_scatter
 from torch_geometric.utils.functions import cumsum
-from typing import Union, Tuple, List
 
 if torch_geometric.typing.WITH_PT112:  # pragma: no cover
 
@@ -287,16 +286,16 @@ def group_argsort(
 
 
 def scatter_concat(
-    tensors: Union[Tuple[Tensor],List[Tensor]],
-    index: Union[Tuple[LongTensor],List[LongTensor]],
-    dim: Optional[int] = 0,
-    return_index: Optional[bool] = False
-) -> Union[Tensor,Tuple[Tensor,Tensor]]:
-    r"""Concatenates the given sequence of tensors :obj:`tensors` in the given 
+    tensors: Union[Tuple[Tensor],
+                   List[Tensor]], index: Union[Tuple[LongTensor],
+                                               List[LongTensor]],
+    dim: Optional[int] = 0, return_index: Optional[bool] = False
+) -> Union[Tensor, Tuple[Tensor, Tensor]]:
+    r"""Concatenates the given sequence of tensors :obj:`tensors` in the given
     dimension :obj:`dim`.
     Differ from :meth:`torch.cat`, values along the concatenating dimension
     are grouped according to the indicies defined in the :obj:`index` tensors.
-    All tensors must either have the same shape (except in the concatenating 
+    All tensors must either have the same shape (except in the concatenating
     dimension) or be empty and all index tensors must in the same sequence as
     in :obj:`tensors`.
 
@@ -328,5 +327,5 @@ def scatter_concat(
     assert len(tensors) == len(index)
     val, loc = torch.sort(torch.concatenate(index), stable=True)
     if return_index:
-        return torch.concat(tensors, dim=dim).index_select(dim,loc), val
-    return torch.concat(tensors, dim=dim).index_select(dim,loc)
+        return torch.concat(tensors, dim=dim).index_select(dim, loc), val
+    return torch.concat(tensors, dim=dim).index_select(dim, loc)

--- a/torch_geometric/utils/_scatter.py
+++ b/torch_geometric/utils/_scatter.py
@@ -1,7 +1,7 @@
-from typing import List, Optional, Sequence, Tuple, Union
+from typing import Optional, Sequence, Tuple, Union
 
 import torch
-from torch import LongTensor, Tensor
+from torch import Tensor
 
 import torch_geometric.typing
 from torch_geometric import is_compiling, warnings
@@ -287,7 +287,7 @@ def group_argsort(
 
 def group_cat(
     tensors: Sequence[Tensor],
-    index: Sequence[LongTensor],
+    index: Sequence[Tensor],
     dim: int = 0,
     return_index: bool = False,
 ) -> Union[Tensor, Tuple[Tensor, Tensor]]:


### PR DESCRIPTION
Concatenates the given sequence of `tensors` in the given dimension `dim`. Differ from `torch.cat`, values along the concatenating dimension are grouped according to the indicies defined in the `index` tensors. 

All tensors must either have the same shape (except in the concatenating dimension) or be empty and all index tensors must in the same sequence as in `tensors`.

Examples:
```
>>> x1 = torch.tensor([[0.2716, 0.4233, 0.2658, 0.8284],
...                    [0.3166, 0.0142, 0.1700, 0.2944],
...                    [0.2371, 0.3839, 0.7193, 0.2954],
...                    [0.4100, 0.0012, 0.5114, 0.3353]])
>>> x2 = torch.tensor([[0.3752, 0.5782, 0.7105, 0.4002],
...                    [0.7757, 0.5999, 0.7898, 0.0753]])

>>> x1_index = torch.LongTensor([0,0,1,2])
>>> x2_index = torch.LongTensor([0,2])

>>> scatter_concat([x1,x2], [x1_index,x2_index], 0)
tensor([[0.2716, 0.4233, 0.2658, 0.8284],
              [0.3166, 0.0142, 0.1700, 0.2944],
              [0.3752, 0.5782, 0.7105, 0.4002],
              [0.2371, 0.3839, 0.7193, 0.2954],
              [0.4100, 0.0012, 0.5114, 0.3353],
              [0.7757, 0.5999, 0.7898, 0.0753]])
```