### PR TITLE
Drop `import torch.mps` in benchmark

### DIFF
--- a/benchmark/citation/train_eval.py
+++ b/benchmark/citation/train_eval.py
@@ -60,7 +60,6 @@ def run_train(dataset, model, runs, epochs, lr, weight_decay, early_stopping,
         elif hasattr(torch.backends,
                      'mps') and torch.backends.mps.is_available():
             try:
-                import torch.mps
                 torch.mps.synchronize()
             except ImportError:
                 pass
@@ -98,7 +97,6 @@ def run_train(dataset, model, runs, epochs, lr, weight_decay, early_stopping,
         elif hasattr(torch.backends,
                      'mps') and torch.backends.mps.is_available():
             try:
-                import torch.mps
                 torch.mps.synchronize()
             except ImportError:
                 pass

--- a/benchmark/kernel/train_eval.py
+++ b/benchmark/kernel/train_eval.py
@@ -46,7 +46,6 @@ def cross_validation_with_val_set(dataset, model, folds, epochs, batch_size,
         elif hasattr(torch.backends,
                      'mps') and torch.backends.mps.is_available():
             try:
-                import torch.mps
                 torch.mps.synchronize()
             except ImportError:
                 pass

--- a/benchmark/points/train_eval.py
+++ b/benchmark/points/train_eval.py
@@ -31,7 +31,6 @@ def run_train(train_dataset, test_dataset, model, epochs, batch_size,
             torch.cuda.synchronize()
         elif (hasattr(torch.backends, 'mps')
               and torch.backends.mps.is_available()):
-            import torch.mps
             torch.mps.synchronize()
 
         t_start = time.perf_counter()
@@ -43,7 +42,6 @@ def run_train(train_dataset, test_dataset, model, epochs, batch_size,
             torch.cuda.synchronize()
         elif (hasattr(torch.backends, 'mps')
               and torch.backends.mps.is_available()):
-            import torch.mps
             torch.mps.synchronize()
 
         t_end = time.perf_counter()
@@ -87,6 +85,7 @@ def run(train_dataset, test_dataset, model, epochs, batch_size, lr,
         lr_decay_factor, lr_decay_step_size, weight_decay, inference,
         profiling, bf16, use_compile):
     if not inference:
+        print(torch)
         run_train(train_dataset, test_dataset, model, epochs, batch_size,
                   use_compile, lr, lr_decay_factor, lr_decay_step_size,
                   weight_decay)

--- a/benchmark/points/train_eval.py
+++ b/benchmark/points/train_eval.py
@@ -85,7 +85,6 @@ def run(train_dataset, test_dataset, model, epochs, batch_size, lr,
         lr_decay_factor, lr_decay_step_size, weight_decay, inference,
         profiling, bf16, use_compile):
     if not inference:
-        print(torch)
         run_train(train_dataset, test_dataset, model, epochs, batch_size,
                   use_compile, lr, lr_decay_factor, lr_decay_step_size,
                   weight_decay)

--- a/benchmark/runtime/dgl/train.py
+++ b/benchmark/runtime/dgl/train.py
@@ -19,7 +19,6 @@ def train_runtime(model, data, epochs, device):
     if torch.cuda.is_available():
         torch.cuda.synchronize()
     elif hasattr(torch.backends, 'mps') and torch.backends.mps.is_available():
-        import torch.mps
         torch.mps.synchronize()
     t_start = time.perf_counter()
 

--- a/benchmark/runtime/train.py
+++ b/benchmark/runtime/train.py
@@ -15,7 +15,6 @@ def train_runtime(model, data, epochs, device):
     if torch.cuda.is_available():
         torch.cuda.synchronize()
     elif hasattr(torch.backends, 'mps') and torch.backends.mps.is_available():
-        import torch.mps
         torch.mps.synchronize()
     t_start = time.perf_counter()
 


### PR DESCRIPTION
Not needed. If kept, results in
```
UnboundLocalError: local variable 'torch' referenced before assignment