### PR TITLE
refactor(testing): simplify withCUDA decorator

### DIFF
--- a/torch_geometric/testing/decorators.py
+++ b/torch_geometric/testing/decorators.py
@@ -196,17 +196,6 @@ def withCUDA(func: Callable) -> Callable:
     if torch.cuda.is_available():
         devices.append(pytest.param(torch.device('cuda:0'), id='cuda:0'))
 
-    # Additional devices can be registered through environment variables:
-    device = os.getenv('TORCH_DEVICE')
-    if device:
-        backend = os.getenv('TORCH_BACKEND')
-        if backend is None:
-            warnings.warn(f"Please specify the backend via 'TORCH_BACKEND' in"
-                          f"order to test against '{device}'")
-        else:
-            import_module(backend)
-            devices.append(pytest.param(torch.device(device), id=device))
-
     return pytest.mark.parametrize('device', devices)(func)
 
 


### PR DESCRIPTION
Remove environment variable checks and addition of devices for TORCH_BACKEND and TORCH_DEVICE.

The original implementation of the withCUDA decorator included addition of device testing using TORCH_BACKEND and TORCH_DEVICE environment variables. However, these checks were causing confusion as they mixed the concepts of device and backend, which are distinct in PyTorch. This commit removes these checks to simplify the decorator and make its purpose clearer.