### PR TITLE
Chang SGDClassifier loss from 'log' to 'log_loss'

### DIFF
--- a/examples/graph_sage_unsup_ppi.py
+++ b/examples/graph_sage_unsup_ppi.py
@@ -79,7 +79,7 @@ def test():
     # Train classifier on training set:
     x, y = encode(train_loader)
 
-    clf = MultiOutputClassifier(SGDClassifier(loss='log', penalty='l2'))
+    clf = MultiOutputClassifier(SGDClassifier(loss='log_loss', penalty='l2'))
     clf.fit(x, y)
 
     train_f1 = f1_score(y, clf.predict(x), average='micro')


### PR DESCRIPTION
scikit-learn/scikit-learn/pull/23046 Introduces `'log_loss'` in `SGDClassifier` and deprecates `'log'`. This PR addresses this issue in the repository (no other files in the repo need to be modified for this issue)