### PR TITLE
Fix bug in `to_scipy_sparse_matrix`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- Fixed bug in `to_scipy_sparse_matrix` when cuda is set as default torch device ([#9146](https://github.com/pyg-team/pytorch_geometric/pull/9146))
 - Fixed `MetaPath2Vec` in case the last node is isolated ([#9145](https://github.com/pyg-team/pytorch_geometric/pull/9145))
 - Ensure backward compatibility in `MessagePassing` via `torch.load` ([#9105](https://github.com/pyg-team/pytorch_geometric/pull/9105))
 - Prevent model compilation on custom `propagate` functions ([#9079](https://github.com/pyg-team/pytorch_geometric/pull/9079))

--- a/torch_geometric/utils/convert.py
+++ b/torch_geometric/utils/convert.py
@@ -37,7 +37,7 @@ def to_scipy_sparse_matrix(
     row, col = edge_index.cpu()
 
     if edge_attr is None:
-        edge_attr = torch.ones(row.size(0))
+        edge_attr = torch.ones(row.size(0), device="cpu")
     else:
         edge_attr = edge_attr.view(-1).cpu()
         assert edge_attr.size(0) == row.size(0)


### PR DESCRIPTION
Setting the default device in PyTorch to "cuda" can cause a bug in the `to_scipy_sparse_matrix` function.

Code to reproduce:
```python
import torch

from torch_geometric.utils import to_scipy_sparse_matrix

torch.set_default_device("cuda")

edge_index = torch.tensor([
    [0, 1, 1, 2, 2, 3],
    [1, 0, 2, 1, 3, 2],
])

to_scipy_sparse_matrix(edge_index)
```

All tensor input to the function is always copied to the CPU for further processing. However, if `edge_attr` argument is **not** given to the `to_scipy_sparse_matrix` function, a tensor of ones is created instead. No device argument is specified currently for the creation of this tensor, causing it to be created on the GPU if that is the default setting. Almost directly after, `edge_attr.numpy()` is called, causing the following error:
```
TypeError: can't convert cuda:0 device type tensor to numpy. Use Tensor.cpu() to copy the tensor to host memory first.
```

This pull request simply adds the `device="cpu"` argument to the creation of the `edge_attr` tensor to prevent this.