### PR TITLE
style: update ruff `quote-style` to single

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -140,6 +140,12 @@ include_trailing_comma = true
 skip = [".gitignore", "__init__.py"]
 
 [tool.ruff]  # https://docs.astral.sh/ruff/rules
+src = ["torch_geometric"]
+line-length = 80
+indent-width = 4
+target-version = "py38"
+
+[tool.ruff.lint]
 select = [
     "D",  # pydocstyle
 ]
@@ -153,10 +159,9 @@ ignore = [
     "D107",  # Ignore "Missing docstring in __init__"
     "D205",  # Ignore "blank line required between summary line and description"
 ]
-src = ["torch_geometric"]
-line-length = 80
-indent-width = 4
-target-version = "py38"
+
+[tool.ruff.format]
+quote-style = "single"
 
 [tool.ruff.lint.pydocstyle]
 convention = "google"


### PR DESCRIPTION
Ref: #9153

Also fixes `ruff` warning, viz.

```lang-bash
warning: The top-level linter settings are deprecated in favour of their counterparts in the `lint` section. Please update the following options in `pyproject.toml`:
  - 'ignore' -> 'lint.ignore'
  - 'select' -> 'lint.select'
```

This PR doesn't include the actual changes `ruff` might yield, just the change to configuration. 

Request for Review: @rusty1s 