### PR TITLE
Remove warning generated by `proteins_mincut_pool.py`

### DIFF
--- a/examples/proteins_mincut_pool.py
+++ b/examples/proteins_mincut_pool.py
@@ -13,7 +13,7 @@ from torch_geometric.utils import to_dense_adj, to_dense_batch
 
 path = osp.join(osp.dirname(osp.realpath(__file__)), '..', 'data', 'PROTEINS')
 dataset = TUDataset(path, name='PROTEINS').shuffle()
-average_nodes = int(dataset.data.x.size(0) / len(dataset))
+average_nodes = int(dataset._data.x.size(0) / len(dataset))
 n = (len(dataset) + 9) // 10
 test_dataset = dataset[:n]
 val_dataset = dataset[n:2 * n]


### PR DESCRIPTION
With this fix, the following warning:
```
/usr/local/lib/python3.10/dist-packages/torch_geometric/data/in_memory_dataset.py:301: UserWarning: It is not recommended 
to directly access the internal storage format `data` of an 'InMemoryDataset'. The given 'InMemoryDataset' only references 
a subset of examples of the full dataset, but 'data' will contain information of the full dataset. If you are absolutely 
certain what you are doing, access the internal storage via `InMemoryDataset._data` instead to suppress this warning. 
Alternatively, you can access stacked individual attributes of every graph via `dataset.{attr_name}`.
```
will no longer be generated.
