### PR TITLE
Remove warnings generated in `test_cugraph_[gat/sage/rgcn]_conv.py`.

### DIFF
--- a/torch_geometric/nn/conv/cugraph/base.py
+++ b/torch_geometric/nn/conv/cugraph/base.py
@@ -7,10 +7,7 @@ from torch_geometric import EdgeIndex
 
 try:  # pragma: no cover
     LEGACY_MODE = False
-    from pylibcugraphops.pytorch import (
-        CSC,
-        HeteroCSC,
-    )
+    from pylibcugraphops.pytorch import CSC, HeteroCSC
     HAS_PYLIBCUGRAPHOPS = True
 except ImportError:
     HAS_PYLIBCUGRAPHOPS = False

--- a/torch_geometric/nn/conv/cugraph/base.py
+++ b/torch_geometric/nn/conv/cugraph/base.py
@@ -8,10 +8,8 @@ from torch_geometric import EdgeIndex
 try:  # pragma: no cover
     LEGACY_MODE = False
     from pylibcugraphops.pytorch import (
-        SampledCSC,
-        SampledHeteroCSC,
-        StaticCSC,
-        StaticHeteroCSC,
+        CSC,
+        HeteroCSC,
     )
     HAS_PYLIBCUGRAPHOPS = True
 except ImportError:
@@ -79,12 +77,13 @@ class CuGraphModule(torch.nn.Module):  # pragma: no cover
                 return make_mfg_csr(dst_nodes, colptr, row, max_num_neighbors,
                                     num_src_nodes)
 
-            return SampledCSC(colptr, row, max_num_neighbors, num_src_nodes)
+            return CSC(colptr, row, num_src_nodes,
+                       dst_max_in_degree=max_num_neighbors)
 
         if LEGACY_MODE:
             return make_fg_csr(colptr, row)
 
-        return StaticCSC(colptr, row)
+        return CSC(colptr, row, num_src_nodes=num_src_nodes)
 
     def get_typed_cugraph(
         self,
@@ -135,15 +134,16 @@ class CuGraphModule(torch.nn.Module):  # pragma: no cover
                                        out_node_types=None, in_node_types=None,
                                        edge_types=edge_type)
 
-            return SampledHeteroCSC(colptr, row, edge_type, max_num_neighbors,
-                                    num_src_nodes, num_edge_types)
+            return HeteroCSC(colptr, row, edge_type, num_src_nodes,
+                             num_edge_types,
+                             dst_max_in_degree=max_num_neighbors)
 
         if LEGACY_MODE:
             return make_fg_csr_hg(colptr, row, n_node_types=0,
                                   n_edge_types=num_edge_types, node_types=None,
                                   edge_types=edge_type)
 
-        return StaticHeteroCSC(colptr, row, edge_type, num_edge_types)
+        return HeteroCSC(colptr, row, edge_type, num_src_nodes, num_edge_types)
 
     def forward(
         self,


### PR DESCRIPTION
With this fix, the following warnings:
```
test/nn/conv/cugraph/test_cugraph_gat_conv.py: 24 warnings
test/nn/conv/cugraph/test_cugraph_sage_conv.py: 64 warnings
  /usr/local/lib/python3.10/dist-packages/pylibcugraphops/pytorch/graph.py:286: DeprecationWarning: SampledCSC is deprecated with the 23.08 release and will be removed in 23.10, use CSC instead.
    warnings.warn(

test/nn/conv/cugraph/test_cugraph_gat_conv.py: 24 warnings
test/nn/conv/cugraph/test_cugraph_sage_conv.py: 64 warnings
  /usr/local/lib/python3.10/dist-packages/pylibcugraphops/pytorch/graph.py:311: DeprecationWarning: StaticCSC is deprecated with the 23.08 release and will be removed in 23.10, use CSC instead.
    warnings.warn(

test/nn/conv/cugraph/test_cugraph_rgcn_conv.py: 72 warnings
  /usr/local/lib/python3.10/dist-packages/pylibcugraphops/pytorch/graph.py:338: DeprecationWarning: SampledHeteroCSC is deprecated with the 23.08 release and will be removed in 23.10, use HeteroCSC instead.
    warnings.warn(

test/nn/conv/cugraph/test_cugraph_rgcn_conv.py: 72 warnings
  /usr/local/lib/python3.10/dist-packages/pylibcugraphops/pytorch/graph.py:366: DeprecationWarning: StaticHeteroCSC is deprecated with the 23.08 release and will be removed in 23.10, use HeteroCSC instead.
    warnings.warn(
```
will no longer be generated.