### PR TITLE
Remove warnings generated in `test_graphmask_explainer.py` and `test_laplacian_lambda_max.py`

### DIFF
--- a/torch_geometric/explain/algorithm/graphmask_explainer.py
+++ b/torch_geometric/explain/algorithm/graphmask_explainer.py
@@ -1,7 +1,6 @@
 import math
 from typing import List, Optional, Tuple, Union
 
-import numpy as np
 import torch
 import torch.nn.functional as F
 from torch import Tensor
@@ -162,7 +161,7 @@ class GraphMaskExplainer(ExplainerAlgorithm):
                 (torch.log(u) - torch.log(1 - u) + input_element) / beta)
 
             penalty = torch.sigmoid(input_element -
-                                    beta * np.math.log(-gamma / zeta))
+                                    beta * math.log(-gamma / zeta))
         else:
             s = torch.sigmoid(input_element)
             penalty = torch.zeros_like(input_element)

--- a/torch_geometric/transforms/laplacian_lambda_max.py
+++ b/torch_geometric/transforms/laplacian_lambda_max.py
@@ -1,7 +1,6 @@
 from typing import Optional
+
 import numpy
-
-
 from scipy.sparse.linalg import eigs, eigsh
 
 from torch_geometric.data import Data

--- a/torch_geometric/transforms/laplacian_lambda_max.py
+++ b/torch_geometric/transforms/laplacian_lambda_max.py
@@ -1,4 +1,6 @@
 from typing import Optional
+import numpy
+
 
 from scipy.sparse.linalg import eigs, eigsh
 
@@ -62,7 +64,7 @@ class LaplacianLambdaMax(BaseTransform):
             eig_fn = eigsh
 
         lambda_max = eig_fn(L, k=1, which='LM', return_eigenvectors=False)
-        data.lambda_max = float(lambda_max.real)
+        data.lambda_max = float(numpy.ndarray.item(lambda_max.real))
 
         return data
 

--- a/torch_geometric/transforms/laplacian_lambda_max.py
+++ b/torch_geometric/transforms/laplacian_lambda_max.py
@@ -1,6 +1,5 @@
 from typing import Optional
 
-import numpy
 from scipy.sparse.linalg import eigs, eigsh
 
 from torch_geometric.data import Data
@@ -63,7 +62,7 @@ class LaplacianLambdaMax(BaseTransform):
             eig_fn = eigsh
 
         lambda_max = eig_fn(L, k=1, which='LM', return_eigenvectors=False)
-        data.lambda_max = float(numpy.ndarray.item(lambda_max.real))
+        data.lambda_max = lambda_max.real.item()
 
         return data
 


### PR DESCRIPTION
With this fix, the following warning:
```
test/explain/algorithm/test_graphmask_explainer.py: 12960 warnings
  /usr/local/lib/python3.10/dist-packages/torch_geometric/explain/algorithm/graphmask_explainer.py:165: DeprecationWarning: `np.math` is a deprecated alias for the standard library `math` module (Deprecated Numpy 1.25). Replace usages of `np.math` with `math`
    beta * np.math.log(-gamma / zeta))


test/transforms/test_laplacian_lambda_max.py::test_laplacian_lambda_max
test/transforms/test_laplacian_lambda_max.py::test_laplacian_lambda_max
test/transforms/test_laplacian_lambda_max.py::test_laplacian_lambda_max
test/transforms/test_laplacian_lambda_max.py::test_laplacian_lambda_max
  /usr/local/lib/python3.10/dist-packages/torch_geometric/transforms/laplacian_lambda_max.py:65: DeprecationWarning: Conversion of an array with ndim > 0 to a scalar is deprecated, and will error in future. Ensure you extract a single element from your array before performing this operation. (Deprecated NumPy 1.25.)
    data.lambda_max = float(lambda_max.real)
```
will no longer be generated.