### PR TITLE
Skip tests that require torch-cluster to be installed when it's not available

### DIFF
--- a/test/nn/models/test_dimenet.py
+++ b/test/nn/models/test_dimenet.py
@@ -27,6 +27,7 @@ def test_dimenet_modules():
 
 @withPackage('sympy')
 @withPackage('torch_sparse')  # TODO `triplet` requires `SparseTensor` for now.
+@withPackage('torch-cluster')
 @pytest.mark.parametrize('Model', [DimeNet, DimeNetPlusPlus])
 def test_dimenet(Model):
     z = torch.randint(1, 10, (20, ))

--- a/test/nn/models/test_gnnff.py
+++ b/test/nn/models/test_gnnff.py
@@ -5,6 +5,7 @@ from torch_geometric.testing import is_full_test, withPackage
 
 
 @withPackage('torch_sparse')  # TODO `triplet` requires `SparseTensor` for now.
+@withPackage('torch-cluster')
 def test_gnnff():
     z = torch.randint(1, 10, (20, ))
     pos = torch.randn(20, 3)


### PR DESCRIPTION
These changes enable us to prevent the following test failures:
```
FAILED test/nn/models/test_dimenet.py::test_dimenet[DimeNet] - ImportError: 'radius_graph' requires 'torch-cluster'
FAILED test/nn/models/test_dimenet.py::test_dimenet[DimeNetPlusPlus] - ImportError: 'radius_graph' requires 'torch-cluster'
FAILED test/nn/models/test_gnnff.py::test_gnnff - ImportError: 'radius_graph' requires 'torch-cluster'
```