### PR TITLE
Remove warning generated in few examples

### DIFF
--- a/examples/mem_pool.py
+++ b/examples/mem_pool.py
@@ -11,7 +11,7 @@ from torch_geometric.nn import DeepGCNLayer, GATConv, MemPooling
 
 path = osp.join(osp.dirname(osp.realpath(__file__)), '..', 'data', 'TUD')
 dataset = TUDataset(path, name="PROTEINS_full", use_node_attr=True)
-dataset.data.x = dataset.data.x[:, :-3]  # only use non-binary features.
+dataset._data.x = dataset._data.x[:, :-3]  # only use non-binary features.
 dataset = dataset.shuffle()
 
 n = (len(dataset)) // 10

--- a/examples/proteins_dmon_pool.py
+++ b/examples/proteins_dmon_pool.py
@@ -13,7 +13,7 @@ from torch_geometric.utils import to_dense_adj, to_dense_batch
 
 path = osp.join(osp.dirname(osp.realpath(__file__)), '..', 'data', 'PROTEINS')
 dataset = TUDataset(path, name='PROTEINS').shuffle()
-avg_num_nodes = int(dataset.data.x.size(0) / len(dataset))
+avg_num_nodes = int(dataset._data.x.size(0) / len(dataset))
 n = (len(dataset) + 9) // 10
 test_dataset = dataset[:n]
 val_dataset = dataset[n:2 * n]

--- a/examples/proteins_mincut_pool.py
+++ b/examples/proteins_mincut_pool.py
@@ -13,7 +13,7 @@ from torch_geometric.utils import to_dense_adj, to_dense_batch
 
 path = osp.join(osp.dirname(osp.realpath(__file__)), '..', 'data', 'PROTEINS')
 dataset = TUDataset(path, name='PROTEINS').shuffle()
-average_nodes = int(dataset._data.x.size(0) / len(dataset))
+avg_num_nodes = int(dataset._data.x.size(0) / len(dataset))
 n = (len(dataset) + 9) // 10
 test_dataset = dataset[:n]
 val_dataset = dataset[n:2 * n]
@@ -28,7 +28,7 @@ class Net(torch.nn.Module):
         super().__init__()
 
         self.conv1 = GCNConv(in_channels, hidden_channels)
-        num_nodes = ceil(0.5 * average_nodes)
+        num_nodes = ceil(0.5 * avg_num_nodes)
         self.pool1 = Linear(hidden_channels, num_nodes)
 
         self.conv2 = DenseGraphConv(hidden_channels, hidden_channels)

--- a/examples/proteins_mincut_pool.py
+++ b/examples/proteins_mincut_pool.py
@@ -13,7 +13,7 @@ from torch_geometric.utils import to_dense_adj, to_dense_batch
 
 path = osp.join(osp.dirname(osp.realpath(__file__)), '..', 'data', 'PROTEINS')
 dataset = TUDataset(path, name='PROTEINS').shuffle()
-average_nodes = int(dataset.data.x.size(0) / len(dataset))
+average_nodes = int(dataset._data.x.size(0) / len(dataset))
 n = (len(dataset) + 9) // 10
 test_dataset = dataset[:n]
 val_dataset = dataset[n:2 * n]

--- a/examples/seal_link_pred.py
+++ b/examples/seal_link_pred.py
@@ -20,7 +20,7 @@ from torch_geometric.utils import k_hop_subgraph, to_scipy_sparse_matrix
 
 class SEALDataset(InMemoryDataset):
     def __init__(self, dataset, num_hops, split='train'):
-        self._data = dataset[0]
+        self.data = dataset[0]
         self.num_hops = num_hops
         super().__init__(dataset.root)
         index = ['train', 'val', 'test'].index(split)
@@ -33,7 +33,7 @@ class SEALDataset(InMemoryDataset):
     def process(self):
         transform = RandomLinkSplit(num_val=0.05, num_test=0.1,
                                     is_undirected=True, split_labels=True)
-        train_data, val_data, test_data = transform(self._data)
+        train_data, val_data, test_data = transform(self.data)
 
         self._max_z = 0
 
@@ -83,7 +83,7 @@ class SEALDataset(InMemoryDataset):
             z = self.drnl_node_labeling(sub_edge_index, src, dst,
                                         num_nodes=sub_nodes.size(0))
 
-            data = Data(x=self._data.x[sub_nodes], z=z,
+            data = Data(x=self.data.x[sub_nodes], z=z,
                         edge_index=sub_edge_index, y=y)
             data_list.append(data)
 

--- a/examples/seal_link_pred.py
+++ b/examples/seal_link_pred.py
@@ -20,7 +20,7 @@ from torch_geometric.utils import k_hop_subgraph, to_scipy_sparse_matrix
 
 class SEALDataset(InMemoryDataset):
     def __init__(self, dataset, num_hops, split='train'):
-        self.data = dataset[0]
+        self._data = dataset[0]
         self.num_hops = num_hops
         super().__init__(dataset.root)
         index = ['train', 'val', 'test'].index(split)
@@ -33,7 +33,7 @@ class SEALDataset(InMemoryDataset):
     def process(self):
         transform = RandomLinkSplit(num_val=0.05, num_test=0.1,
                                     is_undirected=True, split_labels=True)
-        train_data, val_data, test_data = transform(self.data)
+        train_data, val_data, test_data = transform(self._data)
 
         self._max_z = 0
 
@@ -83,7 +83,7 @@ class SEALDataset(InMemoryDataset):
             z = self.drnl_node_labeling(sub_edge_index, src, dst,
                                         num_nodes=sub_nodes.size(0))
 
-            data = Data(x=self.data.x[sub_nodes], z=z,
+            data = Data(x=self._data.x[sub_nodes], z=z,
                         edge_index=sub_edge_index, y=y)
             data_list.append(data)
 


### PR DESCRIPTION
With this fix, the following warnings:
```
/usr/local/lib/python3.10/dist-packages/torch_geometric/data/in_memory_dataset.py:301: UserWarning: It is not recommended 
to directly access the internal storage format `data` of an 'InMemoryDataset'. If you are absolutely certain what you 
are doing, access the internal storage via `InMemoryDataset._data` instead to suppress this warning. Alternatively, 
you can access stacked individual attributes of every graph via `dataset.{attr_name}`.
```
will no longer be generated in `mem_pool.py`, `proteins_dmon_pool.py`, `proteins_mincut_pool.py`, `seal_link_pred.py` examples.

