### PR TITLE
Remove future warnings generated in `argva_node_clustering.py` example

### DIFF
--- a/examples/argva_node_clustering.py
+++ b/examples/argva_node_clustering.py
@@ -94,7 +94,7 @@ def test(data):
 
     # Cluster embedded values using k-means.
     kmeans_input = z.cpu().numpy()
-    kmeans = KMeans(n_clusters=7, random_state=0).fit(kmeans_input)
+    kmeans = KMeans(n_clusters=7, random_state=0, n_init='auto').fit(kmeans_input)
     pred = kmeans.predict(kmeans_input)
 
     labels = data.y.cpu().numpy()

--- a/examples/argva_node_clustering.py
+++ b/examples/argva_node_clustering.py
@@ -94,7 +94,8 @@ def test(data):
 
     # Cluster embedded values using k-means.
     kmeans_input = z.cpu().numpy()
-    kmeans = KMeans(n_clusters=7, random_state=0, n_init='auto').fit(kmeans_input)
+    kmeans = KMeans(n_clusters=7, random_state=0,
+                    n_init='auto').fit(kmeans_input)
     pred = kmeans.predict(kmeans_input)
 
     labels = data.y.cpu().numpy()


### PR DESCRIPTION
With this fix, the next warning that appears for each epoch:
```
/usr/local/lib/python3.10/dist-packages/sklearn/cluster/_kmeans.py:870: FutureWarning: The default value of `n_init` will change from 10 to 'auto' in 1.4. Set the value of `n_init` explicitly to suppress the warning
  warnings.warn(
```
will no longer be generated.