### PR TITLE
Ignore `edge_label` and `edge_label_index` in `ToSparseTensor()` transform

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- Fixed incorrect treatment of `edge_label` and `edge_label_index` in `ToSparseTensor` transform ([#9199](https://github.com/pyg-team/pytorch_geometric/pull/9199))
 - Fixed `EgoData` processing in `SnapDataset` in case filenames are unsorted ([#9195](https://github.com/pyg-team/pytorch_geometric/pull/9195))
 - Fixed empty graph and isolated node handling in `to_dgl` ([#9188](https://github.com/pyg-team/pytorch_geometric/pull/9188))
 - Fixed bug in `to_scipy_sparse_matrix` when cuda is set as default torch device ([#9146](https://github.com/pyg-team/pytorch_geometric/pull/9146))

--- a/test/transforms/test_random_link_split.py
+++ b/test/transforms/test_random_link_split.py
@@ -7,7 +7,7 @@ from torch_geometric.testing import (
     onlyFullTest,
     onlyOnline,
 )
-from torch_geometric.transforms import RandomLinkSplit
+from torch_geometric.transforms import RandomLinkSplit, ToSparseTensor
 from torch_geometric.utils import is_undirected, to_undirected
 
 
@@ -83,6 +83,20 @@ def test_random_link_split():
     assert train_data.edge_attr.size() == (3, 3)
     assert train_data.edge_label_index.size(1) == 6
     assert train_data.edge_label.size(0) == 6
+
+
+def test_random_link_split_with_to_sparse_tensor():
+    edge_index = torch.tensor([[0, 1, 1, 2, 2, 3, 3, 4, 4, 5],
+                               [1, 0, 2, 1, 3, 2, 4, 3, 5, 4]])
+    data = Data(edge_index=edge_index, num_nodes=6)
+
+    transform = RandomLinkSplit(num_val=2, num_test=2, neg_sampling_ratio=0.0)
+    train_data1, _, _ = transform(data)
+    assert train_data1.edge_index.size(1) == train_data1.edge_label.size(0)
+
+    train_data2 = ToSparseTensor()(train_data1)
+    assert train_data1.edge_label.equal(train_data2.edge_label)
+    assert train_data1.edge_label_index.equal(train_data2.edge_label_index)
 
 
 def test_random_link_split_with_label():

--- a/torch_geometric/transforms/to_sparse_tensor.py
+++ b/torch_geometric/transforms/to_sparse_tensor.py
@@ -79,7 +79,7 @@ class ToSparseTensor(BaseTransform):
 
             keys, values = [], []
             for key, value in store.items():
-                if key == 'edge_index':
+                if key in {'edge_index', 'edge_label', 'edge_label_index'}:
                     continue
 
                 if store.is_edge_attr(key):


### PR DESCRIPTION
Fixes https://github.com/pyg-team/pytorch_geometric/issues/9196