### PR TITLE
Fix typo in docstring of sequential.py

### DIFF
--- a/torch_geometric/nn/sequential.py
+++ b/torch_geometric/nn/sequential.py
@@ -69,7 +69,7 @@ def Sequential(
 
     Args:
         input_args (str): The input arguments of the model.
-        modules ([(str, Callable) or Callable]): A list of modules (with
+        modules ([(Callable, str) or Callable]): A list of modules (with
             optional function header definitions). Alternatively, an
             :obj:`OrderedDict` of modules (and function header definitions) can
             be passed.


### PR DESCRIPTION
There was a small error in the docstring of sequential. The ordering of the (model, function header) tuple was inconsistent.