### PR TITLE
Fix the URL to the Karate Club paper in karate.py

### DIFF
--- a/torch_geometric/datasets/karate.py
+++ b/torch_geometric/datasets/karate.py
@@ -8,8 +8,9 @@ from torch_geometric.data import Data, InMemoryDataset
 class KarateClub(InMemoryDataset):
     r"""Zachary's karate club network from the `"An Information Flow Model for
     Conflict and Fission in Small Groups"
-    <http://www1.ind.ku.dk/complexLearning/zachary1977.pdf>`_ paper, containing
-    34 nodes, connected by 156 (undirected and unweighted) edges.
+    <https://www.journals.uchicago.edu/doi/abs/10.1086/jar.33.4.3629752>`_
+    paper, containing 34 nodes,
+    connected by 156 (undirected and unweighted) edges.
     Every node is labeled by one of four classes obtained via modularity-based
     clustering, following the `"Semi-supervised Classification with Graph
     Convolutional Networks" <https://arxiv.org/abs/1609.02907>`_ paper.


### PR DESCRIPTION
Hello.
There was the broken link to the “An Information Flow Model for Conflict and Fission in Small Groups” paper in [this](https://pytorch-geometric.readthedocs.io/en/latest/generated/torch_geometric.datasets.KarateClub.html#torch_geometric.datasets.KarateClub) documentation.

I changed the link from

http://www1.ind.ku.dk/complexLearning/zachary1977.pdf

to

https://www.journals.uchicago.edu/doi/abs/10.1086/jar.33.4.3629752.

Ref: #9225 