### PR TITLE
Sparse version of `nn.dense.DMoNPooling`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Added a `ogbn-mag240m` example ([#8249](https://github.com/pyg-team/pytorch_geometric/pull/8249))
 - Added `EdgeIndex.sparse_resize_` functionality ([#8983](https://github.com/pyg-team/pytorch_geometric/pull/8983))
 - Added approximate `faiss`-based KNN-search ([#8952](https://github.com/pyg-team/pytorch_geometric/pull/8952))
+- Added `SparseDMoNPooling`, sparse version of `DMoNPooling` ([#9254](https://github.com/pyg-team/pytorch_geometric/pull/9254))
 
 ### Changed
 

--- a/test/nn/pool/test_dmon.py
+++ b/test/nn/pool/test_dmon.py
@@ -1,12 +1,10 @@
 import math
 
-# import numpy as np
+import numpy as np
 import torch
 
-# from torch_geometric.nn import dense_dmon
+from torch_geometric.nn.dense import DMoNPooling as DenseDMoNPooling
 from torch_geometric.nn.pool.dmon import SparseDMoNPooling
-
-# from torch_geometric.testing import is_full_test
 
 
 class TestDmoNPooling:
@@ -21,58 +19,60 @@ class TestDmoNPooling:
             # a matrix with expected sparsity = 0.2
             (torch.rand((self.batch_size, self.num_nodes, self.num_nodes))
              <= self.sparsity).type(torch.float).to_sparse())
-        s = torch.randn((self.batch_size, self.num_nodes, self.num_clusters))
         mask = torch.randint(0, 2, (self.batch_size, self.num_nodes),
                              dtype=torch.bool)
 
-        return x, adj, s, mask
+        return x, adj, mask
 
     def test_output_shape_and_range(self):
-        x, adj, s, mask = self.create_input()
+        x, adj, mask = self.create_input()
         pool = SparseDMoNPooling([self.channels, self.channels],
                                  self.num_clusters)
         s, x, adj, spectral_loss, ortho_loss, cluster_loss = pool(x, adj, mask)
-        assert s.size() == (2, 20, 10)
-        assert x.size() == (2, 10, 16)
-        assert adj.size() == (2, 10, 10)
+        assert s.size() == (self.batch_size, self.num_nodes, self.num_clusters)
+        assert x.size() == (self.batch_size, self.num_clusters, self.channels)
+        assert adj.size() == (2, self.num_clusters, self.num_clusters)
         assert -1 <= spectral_loss <= 0.5
         assert 0 <= ortho_loss <= math.sqrt(2)
         assert 0 <= cluster_loss <= math.sqrt(self.num_clusters) - 1
 
-        # if is_full_test():
-        #     jit = torch.jit.script(mincut_pool)
+    def test_output_vs_dense_dmon(self):
+        """Check the output matches that of the dense DMoNPooling."""
+        x, adj, mask = self.create_input()
 
-        #     x_jit, adj_jit, mincut_loss, ortho_loss = jit(x, adj, s, mask)
-        #     assert x_jit.size() == (self.batch_size, self.num_clusters,
-        #                             self.channels)
-        #     assert adj_jit.size() == (
-        #         self.batch_size,
-        #         self.num_clusters,
-        #         self.num_clusters,
-        #     )
-        #     assert -1 <= mincut_loss <= 0
-        #     assert 0 <= ortho_loss <= math.sqrt(2)
+        dense_pool = DenseDMoNPooling([self.channels, self.channels],
+                                      self.num_clusters)
+        dense_output = dense_pool(x, adj.to_dense(), mask)
 
-    # def test_output_vs_dense_mincut(self):
-    #     """Check the output matches that of the dense_mincut_pool."""
-    #     x, adj, s, mask = self.create_input()
+        sparse_pool = SparseDMoNPooling([self.channels, self.channels],
+                                        self.num_clusters)
+        # copy the model parameters
+        sparse_pool.load_state_dict(dense_pool.state_dict())
 
-    #     (
-    #         expected_x_out,
-    #         expected_adj_out,
-    #         expected_mincut_loss,
-    #         expected_ortho_loss,
-    #     ) = dense_mincut_pool(x, adj.to_dense(), s, mask)
+        sparse_output = sparse_pool(x, adj, mask)
 
-    #     actual_x_out, actual_adj_out, actual_mincut_loss,
-    # actual_ortho_loss = (
-    #         mincut_pool(x, adj, s, mask))
+        # convert to numpy
+        (
+            expected_s,
+            expected_x,
+            expected_adj,
+            expected_spectral_loss,
+            expected_ortho_loss,
+            expected_cluster_loss,
+            actual_s,
+            actual_x,
+            actual_adj,
+            actual_spectral_loss,
+            actual_ortho_loss,
+            actual_cluster_loss,
+        ) = map(lambda v: v.detach().numpy(), dense_output + sparse_output)
 
-    #     np.testing.assert_allclose(expected_x_out, actual_x_out,
-    #                                rtol=self.RTOL)
-    #     np.testing.assert_allclose(expected_adj_out, actual_adj_out,
-    #                                rtol=self.RTOL)
-    #     np.testing.assert_allclose(expected_mincut_loss, actual_mincut_loss,
-    #                                rtol=self.RTOL)
-    #     np.testing.assert_allclose(expected_ortho_loss, actual_ortho_loss,
-    #                                rtol=self.RTOL)
+        np.testing.assert_allclose(expected_s, actual_s, rtol=self.RTOL)
+        np.testing.assert_allclose(expected_x, actual_x, rtol=self.RTOL)
+        np.testing.assert_allclose(expected_adj, actual_adj, rtol=self.RTOL)
+        np.testing.assert_allclose(expected_spectral_loss,
+                                   actual_spectral_loss, rtol=self.RTOL)
+        np.testing.assert_allclose(expected_ortho_loss, actual_ortho_loss,
+                                   rtol=self.RTOL)
+        np.testing.assert_allclose(expected_cluster_loss, actual_cluster_loss,
+                                   rtol=self.RTOL)

--- a/test/nn/pool/test_dmon.py
+++ b/test/nn/pool/test_dmon.py
@@ -1,0 +1,78 @@
+import math
+
+# import numpy as np
+import torch
+
+# from torch_geometric.nn import dense_dmon
+from torch_geometric.nn.pool.dmon import SparseDMoNPooling
+
+# from torch_geometric.testing import is_full_test
+
+
+class TestDmoNPooling:
+    RTOL = 1e-6  # relative tolerance
+
+    batch_size, num_nodes, channels, num_clusters = (2, 20, 16, 10)
+    sparsity = 0.2
+
+    def create_input(self):
+        x = torch.randn((self.batch_size, self.num_nodes, self.channels))
+        adj = (
+            # a matrix with expected sparsity = 0.2
+            (torch.rand((self.batch_size, self.num_nodes, self.num_nodes))
+             <= self.sparsity).type(torch.float).to_sparse())
+        s = torch.randn((self.batch_size, self.num_nodes, self.num_clusters))
+        mask = torch.randint(0, 2, (self.batch_size, self.num_nodes),
+                             dtype=torch.bool)
+
+        return x, adj, s, mask
+
+    def test_output_shape_and_range(self):
+        x, adj, s, mask = self.create_input()
+        pool = SparseDMoNPooling([self.channels, self.channels],
+                                 self.num_clusters)
+        s, x, adj, spectral_loss, ortho_loss, cluster_loss = pool(x, adj, mask)
+        assert s.size() == (2, 20, 10)
+        assert x.size() == (2, 10, 16)
+        assert adj.size() == (2, 10, 10)
+        assert -1 <= spectral_loss <= 0.5
+        assert 0 <= ortho_loss <= math.sqrt(2)
+        assert 0 <= cluster_loss <= math.sqrt(self.num_clusters) - 1
+
+        # if is_full_test():
+        #     jit = torch.jit.script(mincut_pool)
+
+        #     x_jit, adj_jit, mincut_loss, ortho_loss = jit(x, adj, s, mask)
+        #     assert x_jit.size() == (self.batch_size, self.num_clusters,
+        #                             self.channels)
+        #     assert adj_jit.size() == (
+        #         self.batch_size,
+        #         self.num_clusters,
+        #         self.num_clusters,
+        #     )
+        #     assert -1 <= mincut_loss <= 0
+        #     assert 0 <= ortho_loss <= math.sqrt(2)
+
+    # def test_output_vs_dense_mincut(self):
+    #     """Check the output matches that of the dense_mincut_pool."""
+    #     x, adj, s, mask = self.create_input()
+
+    #     (
+    #         expected_x_out,
+    #         expected_adj_out,
+    #         expected_mincut_loss,
+    #         expected_ortho_loss,
+    #     ) = dense_mincut_pool(x, adj.to_dense(), s, mask)
+
+    #     actual_x_out, actual_adj_out, actual_mincut_loss,
+    # actual_ortho_loss = (
+    #         mincut_pool(x, adj, s, mask))
+
+    #     np.testing.assert_allclose(expected_x_out, actual_x_out,
+    #                                rtol=self.RTOL)
+    #     np.testing.assert_allclose(expected_adj_out, actual_adj_out,
+    #                                rtol=self.RTOL)
+    #     np.testing.assert_allclose(expected_mincut_loss, actual_mincut_loss,
+    #                                rtol=self.RTOL)
+    #     np.testing.assert_allclose(expected_ortho_loss, actual_ortho_loss,
+    #                                rtol=self.RTOL)

--- a/torch_geometric/nn/pool/dmon.py
+++ b/torch_geometric/nn/pool/dmon.py
@@ -1,0 +1,175 @@
+from typing import List, Optional, Tuple, Union
+
+import torch
+import torch.nn.functional as F
+from torch import Tensor
+
+from torch_geometric.nn.dense.mincut_pool import _rank3_trace
+
+EPS = 1e-15
+
+
+def _bmm(t2: Tensor, t3: Tensor) -> Tensor:
+    r"""Batched matrix multiplication.
+    Multiply a 2D dense tensor with a 3D sparse coo tensor.
+    """
+    dim1 = t3.shape[0]
+    return torch.stack(
+        [torch.matmul(t2.transpose(1, 2)[i], t3[i]) for i in range(dim1)],
+        dim=0,
+    )
+
+
+class SparseDMoNPooling(torch.nn.Module):
+    r"""Sparse version of nn.dense.dmon_pool.DMoNPooling.
+
+    .. math::
+        \mathbf{X}^{\prime} &= {\mathrm{softmax}(\mathbf{S})}^{\top} \cdot
+        \mathbf{X}
+
+        \mathbf{A}^{\prime} &= {\mathrm{softmax}(\mathbf{S})}^{\top} \cdot
+        \mathbf{A} \cdot \mathrm{softmax}(\mathbf{S})
+
+    based on dense learned assignments :math:`\mathbf{S} \in \mathbb{R}^{B
+    \times N \times C}`.
+    Returns the learned cluster assignment matrix, the pooled node feature
+    matrix, the coarsened symmetrically normalized adjacency matrix, and three
+    auxiliary objectives: (1) The spectral loss
+
+    .. math::
+        \mathcal{L}_s = - \frac{1}{2m}
+        \cdot{\mathrm{Tr}(\mathbf{S}^{\top} \mathbf{B} \mathbf{S})}
+
+    where :math:`\mathbf{B}` is the modularity matrix, (2) the orthogonality
+    loss
+
+    .. math::
+        \mathcal{L}_o = {\left\| \frac{\mathbf{S}^{\top} \mathbf{S}}
+        {{\|\mathbf{S}^{\top} \mathbf{S}\|}_F} -\frac{\mathbf{I}_C}{\sqrt{C}}
+        \right\|}_F
+
+    where :math:`C` is the number of clusters, and (3) the cluster loss
+
+    .. math::
+        \mathcal{L}_c = \frac{\sqrt{C}}{n}
+        {\left\|\sum_i\mathbf{C_i}^{\top}\right\|}_F - 1.
+
+    .. note::
+
+        For an example of using :class:`DMoNPooling`, see
+        `examples/proteins_dmon_pool.py
+        <https://github.com/pyg-team/pytorch_geometric/blob
+        /master/examples/proteins_dmon_pool.py>`_.
+
+    Args:
+        channels (int or List[int]): Size of each input sample. If given as a
+            list, will construct an MLP based on the given feature sizes.
+        k (int): The number of clusters.
+        dropout (float, optional): Dropout probability. (default: :obj:`0.0`)
+    """
+    def __init__(self, channels: Union[int, List[int]], k: int,
+                 dropout: float = 0.0):
+        super().__init__()
+
+        if isinstance(channels, int):
+            channels = [channels]
+
+        from torch_geometric.nn.models.mlp import MLP
+        self.mlp = MLP(channels + [k], act=None, norm=None)
+
+        self.dropout = dropout
+
+        self.reset_parameters()
+
+    def reset_parameters(self):
+        r"""Resets all learnable parameters of the module."""
+        self.mlp.reset_parameters()
+
+    def forward(
+        self,
+        x: Tensor,
+        adj: Tensor,
+        mask: Optional[Tensor] = None,
+    ) -> Tuple[Tensor, Tensor, Tensor, Tensor, Tensor, Tensor]:
+        r"""Forward pass.
+
+        Args:
+            x (torch.Tensor): Node feature tensor
+                :math:`\mathbf{X} \in \mathbb{R}^{B \times N \times F}`, with
+                batch-size :math:`B`, (maximum) number of nodes :math:`N` for
+                each graph, and feature dimension :math:`F`.
+                Note that the cluster assignment matrix
+                :math:`\mathbf{S} \in \mathbb{R}^{B \times N \times C}` is
+                being created within this method.
+            adj (torch.Tensor): Adjacency tensor
+                :math:`\mathbf{A} \in \mathbb{R}^{B \times N \times N}`.
+            mask (torch.Tensor, optional): Mask matrix
+                :math:`\mathbf{M} \in {\{ 0, 1 \}}^{B \times N}` indicating
+                the valid nodes for each graph. (default: :obj:`None`)
+
+        :rtype: (:class:`torch.Tensor`, :class:`torch.Tensor`,
+            :class:`torch.Tensor`, :class:`torch.Tensor`,
+            :class:`torch.Tensor`, :class:`torch.Tensor`)
+        """
+        x = x.unsqueeze(0) if x.dim() == 2 else x
+        adj = adj.unsqueeze(0) if adj.dim() == 2 else adj
+        s = self.mlp(x)
+        s = F.dropout(s, self.dropout, training=self.training)
+        s = torch.softmax(s, dim=-1)
+
+        (batch_size, num_nodes, _), C = x.size(), s.size(-1)
+
+        print("C: {}".format(C))
+        if mask is None:
+            mask = torch.ones(batch_size, num_nodes, dtype=torch.bool,
+                              device=x.device)
+
+        mask = mask.view(batch_size, num_nodes, 1).to(x.dtype)
+        x, s = x * mask, s * mask
+
+        out = F.selu(torch.matmul(s.transpose(1, 2), x))
+        # out_adj = torch.matmul(torch.matmul(s.transpose(1, 2), adj), s)
+        out_adj = _bmm(s, adj)
+
+        # Spectral loss:
+        degrees = torch.einsum('ijk->ij', adj)  # B X N
+        degrees = degrees.unsqueeze(-1) * mask  # B x N x 1
+        degrees_t = degrees.transpose(1, 2)  # B x 1 x N
+
+        m = torch.einsum('ijk->i', degrees) / 2  # B
+        m_expand = m.view(-1, 1, 1).expand(-1, C, C)  # B x C x C
+
+        ca = torch.matmul(s.transpose(1, 2), degrees)  # B x C x 1
+        cb = torch.matmul(degrees_t, s)  # B x 1 x C
+
+        normalizer = torch.matmul(ca, cb) / 2 / m_expand
+        decompose = out_adj - normalizer
+        spectral_loss = -_rank3_trace(decompose) / 2 / m
+        spectral_loss = spectral_loss.mean()
+
+        # Orthogonality regularization:
+        ss = torch.matmul(s.transpose(1, 2), s)
+        i_s = torch.eye(C).type_as(ss)
+        ortho_loss = torch.norm(
+            ss / torch.norm(ss, dim=(-1, -2), keepdim=True) -
+            i_s / torch.norm(i_s), dim=(-1, -2))
+        ortho_loss = ortho_loss.mean()
+
+        # Cluster loss:
+        cluster_size = torch.einsum('ijk->ik', s)  # B x C
+        cluster_loss = torch.norm(input=cluster_size, dim=1)
+        cluster_loss = cluster_loss / mask.sum(dim=1) * torch.norm(i_s) - 1
+        cluster_loss = cluster_loss.mean()
+
+        # Fix and normalize coarsened adjacency matrix:
+        ind = torch.arange(C, device=out_adj.device)
+        out_adj[:, ind, ind] = 0
+        d = torch.einsum('ijk->ij', out_adj)
+        d = torch.sqrt(d)[:, None] + EPS
+        out_adj = (out_adj / d) / d.transpose(1, 2)
+
+        return s, out, out_adj, spectral_loss, ortho_loss, cluster_loss
+
+    def __repr__(self) -> str:
+        return (f'{self.__class__.__name__}({self.mlp.in_channels}, '
+                f'num_clusters={self.mlp.out_channels})')

--- a/torch_geometric/nn/pool/dmon.py
+++ b/torch_geometric/nn/pool/dmon.py
@@ -119,7 +119,6 @@ class SparseDMoNPooling(torch.nn.Module):
 
         (batch_size, num_nodes, _), C = x.size(), s.size(-1)
 
-        print("C: {}".format(C))
         if mask is None:
             mask = torch.ones(batch_size, num_nodes, dtype=torch.bool,
                               device=x.device)
@@ -129,10 +128,10 @@ class SparseDMoNPooling(torch.nn.Module):
 
         out = F.selu(torch.matmul(s.transpose(1, 2), x))
         # out_adj = torch.matmul(torch.matmul(s.transpose(1, 2), adj), s)
-        out_adj = _bmm(s, adj)
+        out_adj = torch.matmul(_bmm(s, adj), s)
 
         # Spectral loss:
-        degrees = torch.einsum('ijk->ij', adj)  # B X N
+        degrees = torch.einsum('ijk->ij', adj).to_dense()  # B X N
         degrees = degrees.unsqueeze(-1) * mask  # B x N x 1
         degrees_t = degrees.transpose(1, 2)  # B x 1 x N
 


### PR DESCRIPTION
# What and why

- `nn.dense.DMoNPooling` requires the input adjacency matrix to be dense, which does not scale to large graphs.
- This PR adds the "sparse" version of `DMoNPooling`