### PR TITLE
Fix or add missing specification for code blocks in documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Fixed `OSError` on read-only file systems within `MessagePassing` ([#9032](https://github.com/pyg-team/pytorch_geometric/pull/9032))
 - Fixed metaclass conflict in `Dataset` ([#8999](https://github.com/pyg-team/pytorch_geometric/pull/8999))
 - Fixed import errors on `MessagePassing` modules with nested inheritance ([#8973](https://github.com/pyg-team/pytorch_geometric/pull/8973))
+- Fixed or added missing syntax highlight specification for code blocks in documentation [#9326](https://github.com/pyg-team/pytorch_geometric/pull/9326)
 
 ### Removed
 

--- a/docs/source/tutorial/distributed_pyg.rst
+++ b/docs/source/tutorial/distributed_pyg.rst
@@ -79,7 +79,7 @@ Later on, each node in the cluster then owns a single partition of this graph.
 
 The resulting structure of partitioning for a two-part split on the homogeneous :obj:`ogbn-products` is shown below:
 
-.. code-block::
+.. code-block:: none
 
     partitions
     └─ obgn-products

--- a/torch_geometric/data/lightning/datamodule.py
+++ b/torch_geometric/data/lightning/datamodule.py
@@ -221,7 +221,7 @@ class LightningDataset(LightningDataModule):
         speed.html>`__ are supported in order to correctly share data across
         all devices/processes:
 
-        .. code-block::
+        .. code-block:: python
 
             import pytorch_lightning as pl
             trainer = pl.Trainer(strategy="ddp_spawn", accelerator="gpu",

--- a/torch_geometric/distributed/partition.py
+++ b/torch_geometric/distributed/partition.py
@@ -23,7 +23,7 @@ class Partitioner:
 
     **Homogeneous graphs:**
 
-    .. code-block::
+    .. code-block:: none
 
         root/
         |-- META.json
@@ -40,7 +40,7 @@ class Partitioner:
 
     **Heterogeneous graphs:**
 
-    .. code-block::
+    .. code-block:: none
 
         root/
         |-- META.json

--- a/torch_geometric/nn/aggr/base.py
+++ b/torch_geometric/nn/aggr/base.py
@@ -25,7 +25,7 @@ class Aggregation(torch.nn.Module):
     Notably, :obj:`index` does not have to be sorted (for most aggregation
     operators):
 
-    .. code-block::
+    .. code-block:: python
 
        # Feature matrix holding 10 elements with 64 features each:
        x = torch.randn(10, 64)
@@ -39,7 +39,7 @@ class Aggregation(torch.nn.Module):
     called :obj:`ptr`. Here, elements within the same set need to be grouped
     together in the input, and :obj:`ptr` defines their boundaries:
 
-    .. code-block::
+    .. code-block:: python
 
        # Feature matrix holding 10 elements with 64 features each:
        x = torch.randn(10, 64)

--- a/torch_geometric/transforms/node_property_split.py
+++ b/torch_geometric/transforms/node_property_split.py
@@ -45,7 +45,6 @@ class NodePropertySplit(BaseTransform):
             property are considered to be OOD (default: :obj:`True`)
 
     Example:
-
     .. code-block:: python
 
         from torch_geometric.transforms import NodePropertySplit

--- a/torch_geometric/transforms/node_property_split.py
+++ b/torch_geometric/transforms/node_property_split.py
@@ -45,6 +45,7 @@ class NodePropertySplit(BaseTransform):
             property are considered to be OOD (default: :obj:`True`)
 
     Example:
+
     .. code-block:: python
 
         from torch_geometric.transforms import NodePropertySplit

--- a/torch_geometric/transforms/pad.py
+++ b/torch_geometric/transforms/pad.py
@@ -270,7 +270,6 @@ class Pad(BaseTransform):
     value of :obj:`1.5`.
 
     Example:
-
     .. code-block:: python
 
         num_nodes = {'v0': 10, 'v1': 20, 'v2':30}

--- a/torch_geometric/transforms/pad.py
+++ b/torch_geometric/transforms/pad.py
@@ -270,7 +270,8 @@ class Pad(BaseTransform):
     value of :obj:`1.5`.
 
     Example:
-    .. code-block::
+
+    .. code-block:: python
 
         num_nodes = {'v0': 10, 'v1': 20, 'v2':30}
         num_edges = {('v0', 'e0', 'v1'): 80}

--- a/torch_geometric/transforms/random_link_split.py
+++ b/torch_geometric/transforms/random_link_split.py
@@ -23,7 +23,7 @@ class RandomLinkSplit(BaseTransform):
     in validation and test splits; and the validation split does not include
     edges in the test split.
 
-    .. code-block::
+    .. code-block:: python
 
         from torch_geometric.transforms import RandomLinkSplit
 


### PR DESCRIPTION
Simply makes some adjustments to the docstrings to (1) add missing syntax highlighting and (2) fix spacing issues.

For example, the code block in the documentation of [transforms.NodePropertySplit](https://pytorch-geometric.readthedocs.io/en/latest/generated/torch_geometric.transforms.NodePropertySplit.html#torch_geometric.transforms.NodePropertySplit) is currently not rendered as code.