### PR TITLE
Full repr string for `BatchNorm`

### DIFF
--- a/test/nn/norm/test_batch_norm.py
+++ b/test/nn/norm/test_batch_norm.py
@@ -13,7 +13,8 @@ def test_batch_norm(device, conf):
     norm = BatchNorm(16, affine=conf, track_running_stats=conf).to(device)
     norm.reset_running_stats()
     norm.reset_parameters()
-    assert str(norm) == 'BatchNorm(16)'
+    assert str(norm) == (f'BatchNorm(16, eps=1e-05, momentum=0.1, '
+                         f'affine={conf}, track_running_stats={conf})')
 
     if is_full_test():
         torch.jit.script(norm)

--- a/torch_geometric/nn/norm/batch_norm.py
+++ b/torch_geometric/nn/norm/batch_norm.py
@@ -88,7 +88,7 @@ class BatchNorm(torch.nn.Module):
         return self.module(x)
 
     def __repr__(self):
-        return f'{self.__class__.__name__}({self.module.num_features})'
+        return f'{self.__class__.__name__}({self.module.extra_repr()})'
 
 
 class HeteroBatchNorm(torch.nn.Module):


### PR DESCRIPTION
Rely on PyTorch's `extra_repr` to get more info in PyG's `BatchNorm`