### PR TITLE
Unit tests using `@onlyXPU` should only run on XPU devices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,7 +63,6 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Fixed `OSError` on read-only file systems within `MessagePassing` ([#9032](https://github.com/pyg-team/pytorch_geometric/pull/9032))
 - Fixed metaclass conflict in `Dataset` ([#8999](https://github.com/pyg-team/pytorch_geometric/pull/8999))
 - Fixed import errors on `MessagePassing` modules with nested inheritance ([#8973](https://github.com/pyg-team/pytorch_geometric/pull/8973))
-- Fixed bug in `test_profile` @onlyXPU should only run on XPU devices ([#9396](https://github.com/pyg-team/pytorch_geometric/pull/9396))
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Fixed `OSError` on read-only file systems within `MessagePassing` ([#9032](https://github.com/pyg-team/pytorch_geometric/pull/9032))
 - Fixed metaclass conflict in `Dataset` ([#8999](https://github.com/pyg-team/pytorch_geometric/pull/8999))
 - Fixed import errors on `MessagePassing` modules with nested inheritance ([#8973](https://github.com/pyg-team/pytorch_geometric/pull/8973))
+- Fixed bug in `test_profile` @onlyXPU should only run on XPU devices ([#9396](https://github.com/pyg-team/pytorch_geometric/pull/9396))
 
 ### Removed
 

--- a/test/profile/test_profile.py
+++ b/test/profile/test_profile.py
@@ -92,9 +92,10 @@ def test_profileit_xpu(get_dataset):
     warnings.filterwarnings('ignore', '.*arguments of DataFrame.drop.*')
 
     dataset = get_dataset(name='Cora')
-    data = dataset[0].cuda()
+    device = torch.device('xpu')
+    data = dataset[0].to(device)
     model = GraphSAGE(dataset.num_features, hidden_channels=64, num_layers=3,
-                      out_channels=dataset.num_classes).cuda()
+                      out_channels=dataset.num_classes).to(device)
     optimizer = torch.optim.Adam(model.parameters(), lr=0.01)
 
     @profileit('xpu')


### PR DESCRIPTION
This PR ensure that unit tests annotated with @onlyXPU are only executed on XPU devices.  