### PR TITLE
Make train/val/test splits disjoint sets in RandomLinkSplit

### DIFF
--- a/test/transforms/test_random_link_split.py
+++ b/test/transforms/test_random_link_split.py
@@ -25,8 +25,8 @@ def test_random_link_split():
     transform = RandomLinkSplit(num_val=0.2, num_test=0.2)
     train_data, val_data, test_data = transform(data)
 
-    is_disjoint = lambda a, b: not (a[0].unsqueeze(0) == b[0].unsqueeze(1) and
-                                    a[1].unsqueeze(0) == b[1].unsqueeze(1)).any()
+    is_disjoint = lambda a, b: not (a[0].unsqueeze(0) == b[0].unsqueeze(
+        1) and a[1].unsqueeze(0) == b[1].unsqueeze(1)).any()
     assert is_disjoint(train_data.edge_index, val_data.edge_index)
     assert is_disjoint(train_data.edge_index, test_data.edge_index)
     assert is_disjoint(val_data.edge_index, test_data.edge_index)

--- a/test/transforms/test_random_link_split.py
+++ b/test/transforms/test_random_link_split.py
@@ -21,6 +21,17 @@ def test_random_link_split():
 
     data = Data(edge_index=edge_index, edge_attr=edge_attr, num_nodes=100)
 
+    # Check train, val and test splits are disjoint sets
+    transform = RandomLinkSplit(num_val=0.2, num_test=0.2)
+    train_data, val_data, test_data = transform(data)
+
+    is_disjoint = lambda a, b: not (a[0].unsqueeze(0) == b[0].unsqueeze(1) and
+                                    a[1].unsqueeze(0) == b[1].unsqueeze(1)).any()
+    assert is_disjoint(train_data.edge_index, val_data.edge_index)
+    assert is_disjoint(train_data.edge_index, test_data.edge_index)
+    assert is_disjoint(val_data.edge_index, test_data.edge_index)
+
+    train_data, val_data, test_data = transform(data)
     # No test split:
     transform = RandomLinkSplit(num_val=2, num_test=0, is_undirected=True)
     train_data, val_data, test_data = transform(data)

--- a/torch_geometric/transforms/random_link_split.py
+++ b/torch_geometric/transforms/random_link_split.py
@@ -204,7 +204,6 @@ class RandomLinkSplit(BaseTransform):
             train_edges = perm[:num_train]
             val_edges = perm[num_train:num_train + num_val]
             test_edges = perm[num_train + num_val:]
-            train_val_edges = perm[:num_train + num_val]
 
             num_disjoint = self.disjoint_train_ratio
             if isinstance(num_disjoint, float):
@@ -215,9 +214,8 @@ class RandomLinkSplit(BaseTransform):
             # Create data splits:
             self._split(train_store, train_edges[num_disjoint:], is_undirected,
                         rev_edge_type)
-            self._split(val_store, train_edges, is_undirected, rev_edge_type)
-            self._split(test_store, train_val_edges, is_undirected,
-                        rev_edge_type)
+            self._split(val_store, val_edges, is_undirected, rev_edge_type)
+            self._split(test_store, test_edges, is_undirected, rev_edge_type)
 
             # Create negative samples:
             num_neg_train = 0


### PR DESCRIPTION
It seems train split is erroneously used instead of validation split, and also I don't understand what `train_val_edges` variable is used for. So this PR is an attempt to fix this.
But some other tests are failing, so consider this as WIP, for now...