### PR TITLE
Introduce `auto-skip-changelog`

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -54,5 +54,5 @@ benchmark:
   - changed-files:
       - any-glob-to-any-file: ["benchmark/**/*", "torch_geometric/profile/**/*"]
 
-skip-changelog:
+auto-skip-changelog:
   - head-branch: ['^skip', '^pre-commit-ci']

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -13,4 +13,4 @@ jobs:
       - name: Enforce changelog entry
         uses: dangoslen/changelog-enforcer@v3
         with:
-          skipLabels: 'skip-changelog', 'auto-skip-changelog'
+          skipLabels: skip-changelog, auto-skip-changelog

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -13,4 +13,4 @@ jobs:
       - name: Enforce changelog entry
         uses: dangoslen/changelog-enforcer@v3
         with:
-          skipLabels: 'skip-changelog'
+          skipLabels: 'skip-changelog', 'auto-skip-changelog'


### PR DESCRIPTION
Currently, CI will reset `skip-changelog` label if it is manually specified. Separate the two into different labels.