### PR TITLE
Allow users to modify dataset summary table format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
+- Added the `fmt` arg to `Dataset.get_summary` ([#9408](https://github.com/pyg-team/pytorch_geometric/pull/9408))
 - Skipped zero atom molecules in `MoleculeNet` ([#9318](https://github.com/pyg-team/pytorch_geometric/pull/9318))
 - Ensure proper parallelism in `OnDiskDataset` for multi-threaded `get` calls ([#9140](https://github.com/pyg-team/pytorch_geometric/pull/9140))
 - Allow `None` outputs in `FeatureStore.get_tensor()` - `KeyError` should now be raised based on the implementation in `FeatureStore._get_tensor()` ([#9102](https://github.com/pyg-team/pytorch_geometric/pull/9102))

--- a/torch_geometric/data/dataset.py
+++ b/torch_geometric/data/dataset.py
@@ -362,14 +362,27 @@ class Dataset(torch.utils.data.Dataset):
         arg_repr = str(len(self)) if len(self) > 1 else ''
         return f'{self.__class__.__name__}({arg_repr})'
 
-    def get_summary(self) -> Any:
-        r"""Collects summary statistics for the dataset."""
-        from torch_geometric.data.summary import Summary
-        return Summary.from_dataset(self)
+    def get_summary(self, fmt: str = "psql") -> Any:
+        r"""Collects summary statistics for the dataset.
 
-    def print_summary(self) -> None:
-        r"""Prints summary statistics of the dataset to the console."""
-        print(str(self.get_summary()))
+        Args:
+            fmt (str, optional): Summary tables format. Available table formats
+                can be found `here <https://github.com/astanin/python-tabulate?
+                tab=readme-ov-file#table-format>`__. (default: :obj:`psql`)
+        """
+        from torch_geometric.data.summary import Summary
+        return Summary.from_dataset(self, fmt=fmt)
+
+    def print_summary(self, fmt: str = "psql") -> None:
+        r"""Prints summary statistics of the dataset to the console.
+
+
+        Args:
+            fmt (str, optional): Summary tables format. Available table formats
+                can be found `here <https://github.com/astanin/python-tabulate?
+                tab=readme-ov-file#table-format>`__. (default: :obj:`psql`)
+        """
+        print(str(self.get_summary(fmt=fmt)))
 
     def to_datapipe(self) -> Any:
         r"""Converts the dataset into a :class:`torch.utils.data.DataPipe`.

--- a/torch_geometric/data/dataset.py
+++ b/torch_geometric/data/dataset.py
@@ -362,27 +362,20 @@ class Dataset(torch.utils.data.Dataset):
         arg_repr = str(len(self)) if len(self) > 1 else ''
         return f'{self.__class__.__name__}({arg_repr})'
 
-    def get_summary(self, fmt: str = "psql") -> Any:
-        r"""Collects summary statistics for the dataset.
-
-        Args:
-            fmt (str, optional): Summary tables format. Available table formats
-                can be found `here <https://github.com/astanin/python-tabulate?
-                tab=readme-ov-file#table-format>`__. (default: :obj:`psql`)
-        """
+    def get_summary(self) -> Any:
+        r"""Collects summary statistics for the dataset."""
         from torch_geometric.data.summary import Summary
-        return Summary.from_dataset(self, fmt=fmt)
+        return Summary.from_dataset(self)
 
     def print_summary(self, fmt: str = "psql") -> None:
         r"""Prints summary statistics of the dataset to the console.
 
-
         Args:
             fmt (str, optional): Summary tables format. Available table formats
                 can be found `here <https://github.com/astanin/python-tabulate?
-                tab=readme-ov-file#table-format>`__. (default: :obj:`psql`)
+                tab=readme-ov-file#table-format>`__. (default: :obj:`"psql"`)
         """
-        print(str(self.get_summary(fmt=fmt)))
+        print(self.get_summary().format(fmt=fmt))
 
     def to_datapipe(self) -> Any:
         r"""Converts the dataset into a :class:`torch.utils.data.DataPipe`.

--- a/torch_geometric/data/summary.py
+++ b/torch_geometric/data/summary.py
@@ -42,6 +42,7 @@ class Stats:
 
 @dataclass(repr=False)
 class Summary:
+    fmt: str
     name: str
     num_graphs: int
     num_nodes: Stats
@@ -55,6 +56,7 @@ class Summary:
         dataset: Dataset,
         progress_bar: Optional[bool] = None,
         per_type: bool = True,
+        fmt: str = "psql",
     ) -> Self:
         r"""Creates a summary of a :class:`~torch_geometric.data.Dataset`
         object.
@@ -68,6 +70,9 @@ class Summary:
             per_type (bool, optional): If set to :obj:`True`, will separate
                 statistics per node and edge type (only applicable in
                 heterogeneous graph datasets). (default: :obj:`True`)
+            fmt (str, optional): Summary tables format. Available table formats
+                can be found `here <https://github.com/astanin/python-tabulate?
+                tab=readme-ov-file#table-format>`__. (default: :obj:`psql`)
         """
         name = dataset.__class__.__name__
 
@@ -109,6 +114,7 @@ class Summary:
             }
 
         return cls(
+            fmt=fmt,
             name=name,
             num_graphs=len(dataset),
             num_nodes=Stats.from_data(num_nodes),
@@ -127,7 +133,7 @@ class Summary:
         for field in Stats.__dataclass_fields__:
             row = [field] + [f'{getattr(s, field):.1f}' for s in stats]
             content.append(row)
-        body += tabulate(content, headers='firstrow', tablefmt='psql')
+        body += tabulate(content, headers='firstrow', tablefmt=self.fmt)
 
         if self.num_nodes_per_type is not None:
             content = [['']]
@@ -140,7 +146,7 @@ class Summary:
                 ]
                 content.append(row)
             body += "\nNumber of nodes per node type:\n"
-            body += tabulate(content, headers='firstrow', tablefmt='psql')
+            body += tabulate(content, headers='firstrow', tablefmt=self.fmt)
 
         if self.num_edges_per_type is not None:
             content = [['']]
@@ -156,6 +162,6 @@ class Summary:
                 ]
                 content.append(row)
             body += "\nNumber of edges per edge type:\n"
-            body += tabulate(content, headers='firstrow', tablefmt='psql')
+            body += tabulate(content, headers='firstrow', tablefmt=self.fmt)
 
         return body

--- a/torch_geometric/data/summary.py
+++ b/torch_geometric/data/summary.py
@@ -42,7 +42,6 @@ class Stats:
 
 @dataclass(repr=False)
 class Summary:
-    fmt: str
     name: str
     num_graphs: int
     num_nodes: Stats
@@ -56,7 +55,6 @@ class Summary:
         dataset: Dataset,
         progress_bar: Optional[bool] = None,
         per_type: bool = True,
-        fmt: str = "psql",
     ) -> Self:
         r"""Creates a summary of a :class:`~torch_geometric.data.Dataset`
         object.
@@ -70,9 +68,6 @@ class Summary:
             per_type (bool, optional): If set to :obj:`True`, will separate
                 statistics per node and edge type (only applicable in
                 heterogeneous graph datasets). (default: :obj:`True`)
-            fmt (str, optional): Summary tables format. Available table formats
-                can be found `here <https://github.com/astanin/python-tabulate?
-                tab=readme-ov-file#table-format>`__. (default: :obj:`psql`)
         """
         name = dataset.__class__.__name__
 
@@ -114,7 +109,6 @@ class Summary:
             }
 
         return cls(
-            fmt=fmt,
             name=name,
             num_graphs=len(dataset),
             num_nodes=Stats.from_data(num_nodes),
@@ -123,7 +117,14 @@ class Summary:
             num_edges_per_type=num_edges_per_type,
         )
 
-    def __repr__(self) -> str:
+    def format(self, fmt: str = "psql") -> str:
+        r"""Formats summary statistics of the dataset.
+
+        Args:
+            fmt (str, optional): Summary tables format. Available table formats
+                can be found `here <https://github.com/astanin/python-tabulate?
+                tab=readme-ov-file#table-format>`__. (default: :obj:`"psql"`)
+        """
         from tabulate import tabulate
 
         body = f'{self.name} (#graphs={self.num_graphs}):\n'
@@ -133,7 +134,7 @@ class Summary:
         for field in Stats.__dataclass_fields__:
             row = [field] + [f'{getattr(s, field):.1f}' for s in stats]
             content.append(row)
-        body += tabulate(content, headers='firstrow', tablefmt=self.fmt)
+        body += tabulate(content, headers='firstrow', tablefmt=fmt)
 
         if self.num_nodes_per_type is not None:
             content = [['']]
@@ -146,7 +147,7 @@ class Summary:
                 ]
                 content.append(row)
             body += "\nNumber of nodes per node type:\n"
-            body += tabulate(content, headers='firstrow', tablefmt=self.fmt)
+            body += tabulate(content, headers='firstrow', tablefmt=fmt)
 
         if self.num_edges_per_type is not None:
             content = [['']]
@@ -162,6 +163,9 @@ class Summary:
                 ]
                 content.append(row)
             body += "\nNumber of edges per edge type:\n"
-            body += tabulate(content, headers='firstrow', tablefmt=self.fmt)
+            body += tabulate(content, headers='firstrow', tablefmt=fmt)
 
         return body
+
+    def __repr__(self) -> str:
+        return self.format()


### PR DESCRIPTION
Currently dataset summary is generated in `psql` table format with no way to modify it. 

This PR allows users to modify the format of a generated dataset summary. 

I have also added a link to the [available table formats](https://github.com/astanin/python-tabulate?tab=readme-ov-file#table-format),  I'm not sure if this change requires additional testing, but let me know if it does along with any other changes needed.

Thank you.