### PR TITLE
[BUG] Fixing Bug in Version Handling

### DIFF
--- a/torch_geometric/testing/decorators.py
+++ b/torch_geometric/testing/decorators.py
@@ -7,6 +7,7 @@ from typing import Callable
 
 import torch
 from packaging.requirements import Requirement
+from packaging.version import Version
 
 from torch_geometric.typing import WITH_METIS, WITH_PYG_LIB, WITH_TORCH_SPARSE
 from torch_geometric.visualization.graph import has_graphviz
@@ -180,12 +181,7 @@ def has_package(package: str) -> bool:
     if not hasattr(module, '__version__'):
         return True
 
-    version = module.__version__
-    # `req.specifier` does not support `.dev` suffixes, e.g., for
-    # `pyg_lib==0.1.0.dev*`, so we manually drop them:
-    if '.dev' in version:
-        version = '.'.join(version.split('.dev')[:-1])
-
+    version = Version(module.__version__).base_version
     return version in req.specifier
 
 


### PR DESCRIPTION
I've noticed that the tests with the `withPackage` test decorators
```
@withPackage("torch>=1.12.0")
def test_some_test(...):
    . . .
 ```
are not being executed,
```
SKIPPED [2] test/nn/conv/test_heat_conv.py:10: Package torch>=1.12.0 not found
SKIPPED [2] test/nn/conv/test_hetero_conv.py:181: Package torch>=2.1.0 not found
SKIPPED [1] test/nn/conv/test_hgt_conv.py:12: Package torch>=1.12.0 not found
SKIPPED [1] test/nn/conv/test_hgt_conv.py:63: Package torch>=1.12.0 not found
SKIPPED [1] test/nn/conv/test_hgt_conv.py:114: Package torch>=1.12.0 not found
```
 even though I have torch=2.4.0 installed on my machine. To be precise, I am using Torch version `2.4.0a0+f70bd71a48.nv24.06` which has an unexpected version ID format for the for `pytorch_geometric` .

The proposed PR uses standard [Python version handling](https://packaging.python.org/en/latest/specifications/version-specifiers/), which covers the dev case previously treated separately.

**NOTES:**

- I found and fixed a similar issue in `pytorch_frame`, see [PR#410](https://github.com/pyg-team/pytorch-frame/pull/410).
- When testing the fix for the current PR,  I noticed that 113  (=600-483) more tests were run from the `test` directory
```
Befor:========== 5926 passed, 600 skipped, 503 warnings in 535.56s (0:08:55)
After:========== 13 failed, 6030 passed, 483 skipped, 521 warnings  in 596.27s  (0:09:56)
``` 
and 13 of them failed. Similar failures may occur in your CI environment. Please consider this during the PR review.


