### PR TITLE
Add Hyperbolic GCN layer of paper [Hyperbolic Graph Convolutional Neural Networks](https://arxiv.org/abs/1910.12933)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- Added `HGCNConv` layer ([#9423](https://github.com/pyg-team/pytorch_geometric/pull/9423))
 - Added the heterogeneous `HeteroJumpingKnowledge` module ([#9380](https://github.com/pyg-team/pytorch_geometric/pull/9380))
 - Started work on GNN+LLM package ([#9350](https://github.com/pyg-team/pytorch_geometric/pull/9350))
 - Added support for negative sampling in `LinkLoader` acccording to source and destination node weights ([#9316](https://github.com/pyg-team/pytorch_geometric/pull/9316))

--- a/examples/hgcn.py
+++ b/examples/hgcn.py
@@ -1,0 +1,109 @@
+import argparse
+import os.path as osp
+import time
+
+import torch
+import torch.nn.functional as F
+
+import torch_geometric.transforms as T
+from torch_geometric.datasets import Planetoid
+from torch_geometric.logging import init_wandb, log
+from torch_geometric.nn import HGCNConv
+
+parser = argparse.ArgumentParser()
+parser.add_argument('--dataset', type=str, default='Cora')
+parser.add_argument('--hidden_channels', type=int, default=128)
+parser.add_argument('--heads', type=int, default=8)
+parser.add_argument('--lr', type=float, default=0.1e-3)
+parser.add_argument('--epochs', type=int, default=100)
+parser.add_argument('--wandb', action='store_true', help='Track experiment')
+args = parser.parse_args()
+
+device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
+init_wandb(name=f'HGCN-{args.dataset}', heads=args.heads, epochs=args.epochs,
+           hidden_channels=args.hidden_channels, lr=args.lr, device=device)
+
+path = osp.join(osp.dirname(osp.realpath(__file__)), '..', 'data', 'Planetoid')
+dataset = Planetoid(path, args.dataset, transform=T.NormalizeFeatures())
+data = dataset[0].to(device)
+
+
+class LinearDecoder(torch.nn.Module):
+    """MLP Decoder for Hyperbolic/Euclidean node classification models.
+    """
+    def __init__(self, manifold, in_dim, out_dim, c):
+        super(LinearDecoder, self).__init__()
+        self.manifold = manifold
+        self.input_dim = in_dim
+        self.output_dim = out_dim
+        self.cls = torch.nn.Linear(self.input_dim, self.output_dim)
+        self.c = torch.nn.Parameter(torch.FloatTensor([c]))
+
+    def forward(self, x):
+        x = self.manifold.proj_tan0(self.manifold.logmap0(x, c=self.c),
+                                    c=self.c)
+        x = self.cls(x)
+        return x
+
+    def extra_repr(self):
+        return 'in_features={}, out_features={}, c={}'.format(
+            self.input_dim, self.output_dim, self.c)
+
+
+class HGCN(torch.nn.Module):
+    def __init__(self, in_channels, hidden_channels, out_channels):
+        super().__init__()
+        self.conv1 = HGCNConv(in_channels, hidden_channels, dropout=0.5)
+        self.decoder = LinearDecoder(self.conv1.manifold, hidden_channels,
+                                     out_channels, 1.0)
+
+    def forward(self, x, edge_index):
+        # print(x.shape, edge_index.shape)
+        x = self.conv1(x, edge_index)
+        x = F.dropout(x, p=0.6, training=self.training)
+        x = self.decoder(x)
+        x = F.log_softmax(x, dim=-1)
+        # print(x.shape)
+        # exit(0)
+        return x
+
+
+model = HGCN(dataset.num_features, args.hidden_channels,
+             dataset.num_classes).to(device)
+optimizer = torch.optim.Adam(model.parameters(), lr=1e-3, weight_decay=1e-3)
+print(model)
+
+
+def train():
+    model.train()
+    optimizer.zero_grad()
+    out = model(data.x, data.edge_index)
+    loss = F.cross_entropy(out[data.train_mask], data.y[data.train_mask])
+    loss.backward()
+    optimizer.step()
+    return float(loss)
+
+
+@torch.no_grad()
+def test():
+    model.eval()
+    pred = model(data.x, data.edge_index).argmax(dim=-1)
+
+    accs = []
+    for mask in [data.train_mask, data.val_mask, data.test_mask]:
+        accs.append(int((pred[mask] == data.y[mask]).sum()) / int(mask.sum()))
+    return accs
+
+
+times = []
+best_val_acc = final_test_acc = 0
+for epoch in range(1, args.epochs + 1):
+    start = time.time()
+    loss = train()
+    train_acc, val_acc, tmp_test_acc = test()
+    if val_acc > best_val_acc:
+        best_val_acc = val_acc
+        test_acc = tmp_test_acc
+    log(Epoch=epoch, Loss=loss, Train=train_acc, Val=val_acc, Test=test_acc)
+    times.append(time.time() - start)
+print(f"Median time per epoch: {torch.tensor(times).median():.4f}s")

--- a/examples/hgcn.py
+++ b/examples/hgcn.py
@@ -29,8 +29,7 @@ data = dataset[0].to(device)
 
 
 class LinearDecoder(torch.nn.Module):
-    """MLP Decoder for Hyperbolic/Euclidean node classification models.
-    """
+    """MLP Decoder for Hyperbolic/Euclidean node classification models."""
     def __init__(self, manifold, in_dim, out_dim, c):
         super(LinearDecoder, self).__init__()
         self.manifold = manifold

--- a/test/nn/conv/test_hgcn_conv.py
+++ b/test/nn/conv/test_hgcn_conv.py
@@ -1,0 +1,95 @@
+import pytest
+import torch
+
+from torch_geometric.nn.conv.hgcn_conv import (
+    HGCNConv,
+    HypAct,
+    Hyperboloid,
+    HypLinear,
+    PoincareBall,
+)
+from torch_geometric.utils import to_torch_csc_tensor
+
+
+def test_hgcn_conv_hyperboloid_forward():
+    x = torch.randn(4, 16)
+    edge_index = torch.tensor([[0, 0, 0, 1, 2, 3], [1, 2, 3, 0, 0, 0]])
+    value = torch.rand(edge_index.size(1))
+    adj1 = to_torch_csc_tensor(edge_index, size=(4, 4))
+    adj2 = to_torch_csc_tensor(edge_index, value, size=(4, 4))
+
+    conv = HGCNConv(16, 32, manifold='hyperboloid')
+    assert str(conv) == 'HGCNConv(16, 32)'
+
+    out1 = conv(x, edge_index)
+    assert out1.size() == (4, 32)
+    assert torch.allclose(conv(x, adj1.t()), out1, atol=1e-6)
+
+    out2 = conv(x, edge_index, value)
+    assert out2.size() == (4, 32)
+    assert torch.allclose(conv(x, adj2.t()), out2, atol=1e-6)
+    return
+
+
+def test_hgcn_conv_poincareBall_forward():
+    x = torch.randn(4, 16)
+    edge_index = torch.tensor([[0, 0, 0, 1, 2, 3], [1, 2, 3, 0, 0, 0]])
+    value = torch.rand(edge_index.size(1))
+    adj1 = to_torch_csc_tensor(edge_index, size=(4, 4))
+    adj2 = to_torch_csc_tensor(edge_index, value, size=(4, 4))
+
+    conv = HGCNConv(16, 32, manifold='poincare')
+    assert str(conv) == 'HGCNConv(16, 32)'
+
+    out1 = conv(x, edge_index)
+    assert out1.size() == (4, 32)
+    assert torch.allclose(conv(x, adj1.t()), out1, atol=1e-6)
+
+    out2 = conv(x, edge_index, value)
+    assert out2.size() == (4, 32)
+    assert torch.allclose(conv(x, adj2.t()), out2, atol=1e-6)
+    return
+
+
+def test_hgcn_linear_hyperboloid_forward():
+    x = torch.randn(4, 16)
+    manifold = Hyperboloid()
+
+    linaer = HypLinear(manifold, 16, 32, 1.0, 0.0, True)
+
+    out1 = linaer(x)
+    assert out1.size() == (4, 32)
+    return
+
+
+def test_hgcn_linear_poincareBall_forward():
+    x = torch.randn(4, 16)
+    manifold = PoincareBall()
+
+    linaer = HypLinear(manifold, 16, 32, 1.0, 0.0, True)
+
+    out1 = linaer(x)
+    assert out1.size() == (4, 32)
+    return
+
+
+def test_hypact_hyperboloid_forward():
+    x = torch.randn(4, 16)
+    manifold = Hyperboloid()
+
+    hypact = HypAct(manifold, 1.0, 1.0, None)
+
+    out1 = hypact(x)
+    assert out1.size() == (4, 16)
+    return
+
+
+def test_hypact_poincareBall_forward():
+    x = torch.randn(4, 16)
+    manifold = PoincareBall()
+
+    hypact = HypAct(manifold, 1.0, 1.0, None)
+
+    out1 = hypact(x)
+    assert out1.size() == (4, 16)
+    return

--- a/test/nn/conv/test_hgcn_conv.py
+++ b/test/nn/conv/test_hgcn_conv.py
@@ -1,4 +1,3 @@
-import pytest
 import torch
 
 from torch_geometric.nn.conv.hgcn_conv import (

--- a/torch_geometric/nn/conv/__init__.py
+++ b/torch_geometric/nn/conv/__init__.py
@@ -61,6 +61,7 @@ from .gps_conv import GPSConv
 from .antisymmetric_conv import AntiSymmetricConv
 from .dir_gnn_conv import DirGNNConv
 from .mixhop_conv import MixHopConv
+from .hgcn_conv import HGCNConv
 
 import torch_geometric.nn.conv.utils  # noqa
 
@@ -131,6 +132,7 @@ __all__ = [
     'AntiSymmetricConv',
     'DirGNNConv',
     'MixHopConv',
+    'HGCNConv',
 ]
 
 classes = __all__

--- a/torch_geometric/nn/conv/hgcn_conv.py
+++ b/torch_geometric/nn/conv/hgcn_conv.py
@@ -16,13 +16,14 @@ class HGCNConv(MessagePassing):
     r"""The hyperbolic GCN operator from the
     `"Hyperbolic Graph Convolutional Neural Networks"
     <https://arxiv.org/abs/1910.12933>`_ paper
+
     Args:
         in_channels (int): Size of each input sample.
         out_channels (int): Size of each output sample.
-        c_in (float): The hyperbolic curvature of each input sample. Equal to
-            :math:`1/K_{\ell - 1}` in the paper. (default: :obj:`1.0`)
-        c_in (float): The hyperbolic curvature of each output sample. Equal to
-            :math:`1/K_{\ell}` in the paper. (default: :obj:`1.0`)
+        c_in (float): The hyperbolic curvature of each input sample.
+            (default: :obj:`1.0`)
+        c_in (float): The hyperbolic curvature of each output sample.
+            (default: :obj:`1.0`)
         dropout (float, optional): Dropout probability of the hyperboloid
             linear layer. (default: :obj:`0`)
         use_bias (bool, optional): Whether to add bias with hyperboloid bias
@@ -40,11 +41,11 @@ class HGCNConv(MessagePassing):
             :class:`torch_geometric.nn.conv.MessagePassing`.
     """
     def __init__(self, in_channels: int, out_channels: int, c_in: float = 1.0,
-                 c_out: float = 1.0, act: Callable = None,
-                 dropout: float = 0.0, use_bias: bool = True,
-                 use_att: bool = True, local_agg: bool = True,
-                 add_self_loops: bool = True, manifold: str = 'euclidean',
-                 **kwargs):
+                c_out: float = 1.0, act: Callable = None,
+                dropout: float = 0.0, use_bias: bool = True,
+                use_att: bool = True, local_agg: bool = True,
+                add_self_loops: bool = True, manifold: str = 'euclidean',
+                **kwargs):
         kwargs.setdefault('aggr', 'mean')
         super().__init__(**kwargs)
 
@@ -58,7 +59,7 @@ class HGCNConv(MessagePassing):
             self.manifold = Euclidean()
         else:
             raise NotImplementedError(
-                f"Expected 'poincare' or 'hyperboloid' type, but got {manifold}"
+                f"Expected 'poincare' or 'hyperboloid', but got {manifold}"
             )
 
         self.hyp_linear = HypLinear(self.manifold, in_channels, out_channels,
@@ -80,7 +81,7 @@ class HGCNConv(MessagePassing):
                 edge_weight: OptTensor = None):
         assert len(
             x.shape
-        ) == 2, f"HGCNConv Expected 2D input, but got input of size: {list(x.shape)}"
+        ) == 2, f"Expected 2D input, but got input of size: {list(x.shape)}"
         if self.add_self_loops:
             edge_index, _ = add_self_loops(edge_index)
         h = self.hyp_linear.forward(x)
@@ -108,8 +109,7 @@ class HGCNConv(MessagePassing):
 
 
 class HypLinear(nn.Module):
-    """Hyperbolic linear layer.
-    """
+    """Hyperbolic linear layer."""
     def __init__(self, manifold, in_channels, out_channels, c, dropout,
                  use_bias):
         super(HypLinear, self).__init__()
@@ -145,8 +145,7 @@ class HypLinear(nn.Module):
 
 
 class HypAct(Module):
-    """Hyperbolic activation layer.
-    """
+    """Hyperbolic activation layer."""
     def __init__(self, manifold, c_in, c_out, act):
         super(HypAct, self).__init__()
         self.manifold = manifold
@@ -512,8 +511,7 @@ class Arcosh(torch.autograd.Function):
 
 
 class Euclidean():
-    """Euclidean Manifold class.
-    """
+    """Euclidean Manifold class."""
     def __init__(self):
         super(Euclidean, self).__init__()
         self.name = 'Euclidean'

--- a/torch_geometric/nn/conv/hgcn_conv.py
+++ b/torch_geometric/nn/conv/hgcn_conv.py
@@ -15,7 +15,7 @@ from torch_geometric.utils import add_self_loops
 class HGCNConv(MessagePassing):
     r"""The hyperbolic GCN operator from the
     `"Hyperbolic Graph Convolutional Neural Networks"
-    <https://arxiv.org/abs/1910.12933>`_ paper
+    <https://arxiv.org/abs/1910.12933>`_ paper.
 
     Args:
         in_channels (int): Size of each input sample.

--- a/torch_geometric/nn/conv/hgcn_conv.py
+++ b/torch_geometric/nn/conv/hgcn_conv.py
@@ -1,0 +1,573 @@
+import math
+from typing import Callable
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+import torch.nn.init as init
+from torch.nn.modules.module import Module
+
+from torch_geometric.nn.conv import MessagePassing
+from torch_geometric.typing import OptTensor
+from torch_geometric.utils import add_self_loops
+
+
+class HGCNConv(MessagePassing):
+    r"""The hyperbolic GCN operator from the
+    `"Hyperbolic Graph Convolutional Neural Networks"
+    <https://arxiv.org/abs/1910.12933>`_ paper
+    Args:
+        in_channels (int): Size of each input sample.
+        out_channels (int): Size of each output sample.
+        c_in (float): The hyperbolic curvature of each input sample. Equal to
+            :math:`1/K_{\ell - 1}` in the paper. (default: :obj:`1.0`)
+        c_in (float): The hyperbolic curvature of each output sample. Equal to
+            :math:`1/K_{\ell}` in the paper. (default: :obj:`1.0`)
+        dropout (float, optional): Dropout probability of the hyperboloid
+            linear layer. (default: :obj:`0`)
+        use_bias (bool, optional): Whether to add bias with hyperboloid bias
+            addition in the hyperboloid linear layer. (default: :obj:`True`)
+        use_att (bool, optional): Whether to use hyperboloid attention-based
+            neighbor aggregation. (default: :obj:`True`)
+        local_agg (bool, optional): Whether to use the tangent space of the
+            target node in hyperboloid attention. (default: :obj:`True`)
+        add_self_loops (bool, optional): If set to :obj:`False`, will not add
+            self-loops to the input graph. (default: :obj:`True`)
+        manifold (str, optional): If set to :obj:`hyperboloid`, use hyperboloid
+            projections. If set to :obj:`poincare`, use Poincare ball
+            projections. (default :obj:`hyperboloid`)
+        **kwargs (optional): Additional arguments of
+            :class:`torch_geometric.nn.conv.MessagePassing`.
+    """
+    def __init__(self, in_channels: int, out_channels: int, c_in: float = 1.0,
+                 c_out: float = 1.0, act: Callable = None,
+                 dropout: float = 0.0, use_bias: bool = True,
+                 use_att: bool = True, local_agg: bool = True,
+                 add_self_loops: bool = True, manifold: str = 'euclidean',
+                 **kwargs):
+        kwargs.setdefault('aggr', 'mean')
+        super().__init__(**kwargs)
+
+        self.manifold = None
+        self.act = act
+        if manifold == 'poincare':
+            self.manifold = PoincareBall()
+        elif manifold == 'hyperboloid':
+            self.manifold = Hyperboloid()
+        elif manifold == 'euclidean':
+            self.manifold = Euclidean()
+        else:
+            raise NotImplementedError(
+                f"Expected 'poincare' or 'hyperboloid' type, but got {manifold}"
+            )
+
+        self.hyp_linear = HypLinear(self.manifold, in_channels, out_channels,
+                                    c_in, dropout, use_bias)
+        self.hyp_act = HypAct(self.manifold, c_in, c_out, self.act)
+
+        self.c_in = torch.nn.Parameter(torch.FloatTensor([c_in]))
+
+        self.in_channels = in_channels
+        self.out_channels = out_channels
+        self.dropout = dropout
+
+        self.use_att = use_att
+        self.local_agg = local_agg
+        self.att_linear = nn.Linear(2 * out_channels, 1, bias=True)
+        self.add_self_loops = add_self_loops
+
+    def forward(self, x: torch.FloatTensor, edge_index,
+                edge_weight: OptTensor = None):
+        assert len(
+            x.shape
+        ) == 2, f"HGCNConv Expected 2D input, but got input of size: {list(x.shape)}"
+        if self.add_self_loops:
+            edge_index, _ = add_self_loops(edge_index)
+        h = self.hyp_linear.forward(x)
+        h_tangent = self.manifold.logmap0(h, c=self.c_in)
+        support_t = self.propagate(edge_index, x=(h, h),
+                                   x_tangent=(h_tangent, h_tangent),
+                                   edge_weight=edge_weight)
+        h = self.manifold.proj(self.manifold.expmap(h, support_t, c=self.c_in),
+                               c=self.c_in)
+        out = self.hyp_act.forward(h)
+        return out
+
+    def message(self, x_i, x_j, x_tangent_i, x_tangent_j):
+        if self.use_att:
+            x_cat = torch.cat((x_tangent_i, x_tangent_j), dim=1)
+            alpha = self.att_linear(x_cat)
+            alpha = torch.sigmoid(alpha)
+            if self.local_agg:
+                x_local_tangent_j = self.manifold.logmap(x_i, x_j, c=self.c_in)
+                return x_local_tangent_j * alpha
+            else:
+                return x_tangent_j * alpha
+        else:
+            return x_tangent_j
+
+
+class HypLinear(nn.Module):
+    """Hyperbolic linear layer.
+    """
+    def __init__(self, manifold, in_channels, out_channels, c, dropout,
+                 use_bias):
+        super(HypLinear, self).__init__()
+        self.manifold = manifold
+        self.in_channels = in_channels
+        self.out_channels = out_channels
+        self.c = torch.nn.Parameter(torch.FloatTensor([c]))
+        self.dropout = dropout
+        self.use_bias = use_bias
+        self.bias = nn.Parameter(torch.Tensor(out_channels))
+        self.weight = nn.Parameter(torch.Tensor(out_channels, in_channels))
+        self.reset_parameters()
+
+    def reset_parameters(self):
+        init.xavier_uniform_(self.weight, gain=math.sqrt(2))
+        init.constant_(self.bias, 0)
+
+    def forward(self, x):
+        drop_weight = F.dropout(self.weight, self.dropout,
+                                training=self.training)
+        mv = self.manifold.mobius_matvec(drop_weight, x, self.c)
+        res = self.manifold.proj(mv, self.c)
+        if self.use_bias:
+            bias = self.manifold.proj_tan0(self.bias.view(1, -1), self.c)
+            hyp_bias = self.manifold.expmap0(bias, self.c)
+            hyp_bias = self.manifold.proj(hyp_bias, self.c)
+            res = self.manifold.mobius_add(res, hyp_bias, c=self.c)
+            res = self.manifold.proj(res, self.c)
+        return res
+
+    def extra_repr(self):
+        return '{}, {}, {}'.format(self.in_channels, self.out_channels, self.c)
+
+
+class HypAct(Module):
+    """Hyperbolic activation layer.
+    """
+    def __init__(self, manifold, c_in, c_out, act):
+        super(HypAct, self).__init__()
+        self.manifold = manifold
+        self.c_in = torch.nn.Parameter(torch.FloatTensor([c_in]))
+        self.c_out = torch.nn.Parameter(torch.FloatTensor([c_out]))
+        self.act = torch.nn.ReLU() if act is None else act
+
+    def forward(self, x):
+        xt = self.act(self.manifold.logmap0(x, c=self.c_in))
+        xt = self.manifold.proj_tan0(xt, c=self.c_out)
+        return self.manifold.proj(self.manifold.expmap0(xt, c=self.c_out),
+                                  c=self.c_out)
+
+    def extra_repr(self):
+        return 'c_in={}, c_out={}'.format(self.c_in, self.c_out)
+
+
+class PoincareBall:
+    """PoicareBall Manifold class.
+    We use the following convention: x0^2 + x1^2 + ... + xd^2 < 1 / c
+    Note that 1/sqrt(c) is the Poincare ball radius.
+    """
+    def __init__(self):
+        super(PoincareBall, self).__init__()
+        self.name = 'PoincareBall'
+        self.min_norm = 1e-15
+        self.eps = {torch.float32: 4e-3, torch.float64: 1e-5}
+
+    def sqdist(self, p1, p2, c):
+        sqrt_c = c**0.5
+        dist_c = artanh(sqrt_c * self.mobius_add(-p1, p2, c, dim=-1).norm(
+            dim=-1, p=2, keepdim=False))
+        dist = dist_c * 2 / sqrt_c
+        return dist**2
+
+    def _lambda_x(self, x, c):
+        x_sqnorm = torch.sum(x.data.pow(2), dim=-1, keepdim=True)
+        return 2 / (1. - c * x_sqnorm).clamp_min(self.min_norm)
+
+    def egrad2rgrad(self, p, dp, c):
+        lambda_p = self._lambda_x(p, c)
+        dp /= lambda_p.pow(2)
+        return dp
+
+    def proj(self, x, c):
+        norm = torch.clamp_min(x.norm(dim=-1, keepdim=True, p=2),
+                               self.min_norm)
+        maxnorm = (1 - self.eps[x.dtype]) / (c**0.5)
+        cond = norm > maxnorm
+        projected = x / norm * maxnorm
+        return torch.where(cond, projected, x)
+
+    def proj_tan(self, u, p, c):
+        return u
+
+    def proj_tan0(self, u, c):
+        return u
+
+    def expmap(self, u, p, c):
+        sqrt_c = c**0.5
+        u_norm = u.norm(dim=-1, p=2, keepdim=True).clamp_min(self.min_norm)
+        second_term = (tanh(sqrt_c / 2 * self._lambda_x(p, c) * u_norm) * u /
+                       (sqrt_c * u_norm))
+        gamma_1 = self.mobius_add(p, second_term, c)
+        return gamma_1
+
+    def logmap(self, p1, p2, c):
+        sub = self.mobius_add(-p1, p2, c)
+        sub_norm = sub.norm(dim=-1, p=2, keepdim=True).clamp_min(self.min_norm)
+        lam = self._lambda_x(p1, c)
+        sqrt_c = c**0.5
+        return 2 / sqrt_c / lam * artanh(sqrt_c * sub_norm) * sub / sub_norm
+
+    def expmap0(self, u, c):
+        sqrt_c = c**0.5
+        u_norm = torch.clamp_min(u.norm(dim=-1, p=2, keepdim=True),
+                                 self.min_norm)
+        gamma_1 = tanh(sqrt_c * u_norm) * u / (sqrt_c * u_norm)
+        return gamma_1
+
+    def logmap0(self, p, c):
+        sqrt_c = c**0.5
+        p_norm = p.norm(dim=-1, p=2, keepdim=True).clamp_min(self.min_norm)
+        scale = 1. / sqrt_c * artanh(sqrt_c * p_norm) / p_norm
+        return scale * p
+
+    def mobius_add(self, x, y, c, dim=-1):
+        x2 = x.pow(2).sum(dim=dim, keepdim=True)
+        y2 = y.pow(2).sum(dim=dim, keepdim=True)
+        xy = (x * y).sum(dim=dim, keepdim=True)
+        num = (1 + 2 * c * xy + c * y2) * x + (1 - c * x2) * y
+        denom = 1 + 2 * c * xy + c**2 * x2 * y2
+        return num / denom.clamp_min(self.min_norm)
+
+    def mobius_matvec(self, m, x, c):
+        sqrt_c = c**0.5
+        x_norm = x.norm(dim=-1, keepdim=True, p=2).clamp_min(self.min_norm)
+        mx = x @ m.transpose(-1, -2)
+        mx_norm = mx.norm(dim=-1, keepdim=True, p=2).clamp_min(self.min_norm)
+        res_c = tanh(mx_norm / x_norm * artanh(sqrt_c * x_norm)) * mx \
+            / (mx_norm * sqrt_c)
+        cond = (mx == 0).prod(-1, keepdim=True, dtype=torch.uint8)
+        res_0 = torch.zeros(1, dtype=res_c.dtype, device=res_c.device)
+        res = torch.where(cond.bool(), res_0.bool(), res_c)
+        return res
+
+    def init_weights(self, w, c, irange=1e-5):
+        w.data.uniform_(-irange, irange)
+        return w
+
+    def _gyration(self, u, v, w, c, dim: int = -1):
+        u2 = u.pow(2).sum(dim=dim, keepdim=True)
+        v2 = v.pow(2).sum(dim=dim, keepdim=True)
+        uv = (u * v).sum(dim=dim, keepdim=True)
+        uw = (u * w).sum(dim=dim, keepdim=True)
+        vw = (v * w).sum(dim=dim, keepdim=True)
+        c2 = c**2
+        a = -c2 * uw * v2 + c * vw + 2 * c2 * uv * vw
+        b = -c2 * vw * u2 - c * uw
+        d = 1 + 2 * c * uv + c2 * u2 * v2
+        return w + 2 * (a * u + b * v) / d.clamp_min(self.min_norm)
+
+    def inner(self, x, c, u, v=None, keepdim=False):
+        if v is None:
+            v = u
+        lambda_x = self._lambda_x(x, c)
+        return lambda_x**2 * (u * v).sum(dim=-1, keepdim=keepdim)
+
+    def ptransp(self, x, y, u, c):
+        lambda_x = self._lambda_x(x, c)
+        lambda_y = self._lambda_x(y, c)
+        return self._gyration(y, -x, u, c) * lambda_x / lambda_y
+
+    def ptransp_(self, x, y, u, c):
+        lambda_x = self._lambda_x(x, c)
+        lambda_y = self._lambda_x(y, c)
+        return self._gyration(y, -x, u, c) * lambda_x / lambda_y
+
+    def ptransp0(self, x, u, c):
+        lambda_x = self._lambda_x(x, c)
+        return 2 * u / lambda_x.clamp_min(self.min_norm)
+
+    def to_hyperboloid(self, x, c):
+        K = 1. / c
+        sqrtK = K**0.5
+        sqnorm = torch.norm(x, p=2, dim=1, keepdim=True)**2
+        return sqrtK * torch.cat([K + sqnorm, 2 * sqrtK * x], dim=1) \
+            / (K - sqnorm)
+
+
+class Hyperboloid:
+    """Hyperboloid manifold class.
+    We use the following convention: -x0^2 + x1^2 + ... + xd^2 = -K
+    c = 1 / K is the hyperbolic curvature.
+    """
+    def __init__(self):
+        super(Hyperboloid, self).__init__()
+        self.name = 'Hyperboloid'
+        self.eps = {torch.float32: 1e-7, torch.float64: 1e-15}
+        self.min_norm = 1e-15
+        self.max_norm = 1e6
+
+    def minkowski_dot(self, x, y, keepdim=True):
+        res = torch.sum(x * y, dim=-1) - 2 * x[..., 0] * y[..., 0]
+        if keepdim:
+            res = res.view(res.shape + (1, ))
+        return res
+
+    def minkowski_norm(self, u, keepdim=True):
+        dot = self.minkowski_dot(u, u, keepdim=keepdim)
+        return torch.sqrt(torch.clamp(dot, min=self.eps[u.dtype]))
+
+    def sqdist(self, x, y, c):
+        K = 1. / c
+        prod = self.minkowski_dot(x, y)
+        theta = torch.clamp(-prod / K, min=1.0 + self.eps[x.dtype])
+        sqdist = K * arcosh(theta)**2
+        # clamp distance to avoid nans in Fermi-Dirac decoder
+        return torch.clamp(sqdist, max=50.0)
+
+    def proj(self, x, c):
+        K = 1. / c
+        d = x.size(-1) - 1
+        y = x.narrow(-1, 1, d)
+        y_sqnorm = torch.norm(y, p=2, dim=1, keepdim=True)**2
+        mask = torch.ones_like(x)
+        mask[:, 0] = 0
+        vals = torch.zeros_like(x)
+        vals[:,
+             0:1] = torch.sqrt(torch.clamp(K + y_sqnorm,
+                                           min=self.eps[x.dtype]))
+        return vals + mask * x
+
+    def proj_tan(self, u, x, c):
+        d = x.size(1) - 1
+        ux = torch.sum(
+            x.narrow(-1, 1, d) * u.narrow(-1, 1, d), dim=1, keepdim=True)
+        mask = torch.ones_like(u)
+        mask[:, 0] = 0
+        vals = torch.zeros_like(u)
+        vals[:, 0:1] = ux / torch.clamp(x[:, 0:1], min=self.eps[x.dtype])
+        return vals + mask * u
+
+    def proj_tan0(self, u, c):
+        narrowed = u.narrow(-1, 0, 1)
+        vals = torch.zeros_like(u)
+        vals[:, 0:1] = narrowed
+        return u - vals
+
+    def expmap(self, u, x, c):
+        K = 1. / c
+        sqrtK = K**0.5
+        normu = self.minkowski_norm(u)
+        normu = torch.clamp(normu, max=self.max_norm)
+        theta = normu / sqrtK
+        theta = torch.clamp(theta, min=self.min_norm)
+        result = cosh(theta) * x + sinh(theta) * u / theta
+        return self.proj(result, c)
+
+    def logmap(self, x, y, c):
+        K = 1. / c
+        xy = torch.clamp(self.minkowski_dot(x, y) + K, max=-self.eps[x.dtype])\
+            - K
+        u = y + xy * x * c
+        normu = self.minkowski_norm(u)
+        normu = torch.clamp(normu, min=self.min_norm)
+        dist = self.sqdist(x, y, c)**0.5
+        result = dist * u / normu
+        return self.proj_tan(result, x, c)
+
+    def expmap0(self, u, c):
+        K = 1. / c
+        sqrtK = K**0.5
+        d = u.size(-1) - 1
+        x = u.narrow(-1, 1, d).view(-1, d)
+        x_norm = torch.norm(x, p=2, dim=1, keepdim=True)
+        x_norm = torch.clamp(x_norm, min=self.min_norm)
+        theta = x_norm / sqrtK
+        res = torch.ones_like(u)
+        res[:, 0:1] = sqrtK * cosh(theta)
+        res[:, 1:] = sqrtK * sinh(theta) * x / x_norm
+        return self.proj(res, c)
+
+    def logmap0(self, x, c):
+        K = 1. / c
+        sqrtK = K**0.5
+        d = x.size(-1) - 1
+        y = x.narrow(-1, 1, d).view(-1, d)
+        y_norm = torch.norm(y, p=2, dim=1, keepdim=True)
+        y_norm = torch.clamp(y_norm, min=self.min_norm)
+        res = torch.zeros_like(x)
+        theta = torch.clamp(x[:, 0:1] / sqrtK, min=1.0 + self.eps[x.dtype])
+        res[:, 1:] = sqrtK * arcosh(theta) * y / y_norm
+        return res
+
+    def mobius_add(self, x, y, c):
+        u = self.logmap0(y, c)
+        v = self.ptransp0(x, u, c)
+        return self.expmap(v, x, c)
+
+    def mobius_matvec(self, m, x, c):
+        u = self.logmap0(x, c)
+        mu = u @ m.transpose(-1, -2)
+        return self.expmap0(mu, c)
+
+    def ptransp(self, x, y, u, c):
+        logxy = self.logmap(x, y, c)
+        logyx = self.logmap(y, x, c)
+        sqdist = torch.clamp(self.sqdist(x, y, c), min=self.min_norm)
+        alpha = self.minkowski_dot(logxy, u) / sqdist
+        res = u - alpha * (logxy + logyx)
+        return self.proj_tan(res, y, c)
+
+    def ptransp0(self, x, u, c):
+        K = 1. / c
+        sqrtK = K**0.5
+        x0 = x.narrow(-1, 0, 1)
+        d = x.size(-1) - 1
+        y = x.narrow(-1, 1, d)
+        y_norm = torch.clamp(torch.norm(y, p=2, dim=1, keepdim=True),
+                             min=self.min_norm)
+        y_normalized = y / y_norm
+        v = torch.ones_like(x)
+        v[:, 0:1] = -y_norm
+        v[:, 1:] = (sqrtK - x0) * y_normalized
+        alpha = torch.sum(y_normalized * u[:, 1:], dim=1, keepdim=True) / sqrtK
+        res = u - alpha * v
+        return self.proj_tan(res, x, c)
+
+    def to_poincare(self, x, c):
+        K = 1. / c
+        sqrtK = K**0.5
+        d = x.size(-1) - 1
+        return sqrtK * x.narrow(-1, 1, d) / (x[:, 0:1] + sqrtK)
+
+
+def cosh(x, clamp=15):
+    return x.clamp(-clamp, clamp).cosh()
+
+
+def sinh(x, clamp=15):
+    return x.clamp(-clamp, clamp).sinh()
+
+
+def tanh(x, clamp=15):
+    return x.clamp(-clamp, clamp).tanh()
+
+
+def arcosh(x):
+    return Arcosh.apply(x)
+
+
+def arsinh(x):
+    return Arsinh.apply(x)
+
+
+def artanh(x):
+    return Artanh.apply(x)
+
+
+class Artanh(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x):
+        x = x.clamp(-1 + 1e-15, 1 - 1e-15)
+        ctx.save_for_backward(x)
+        z = x.double()
+        return (torch.log_(1 + z).sub_(torch.log_(1 - z))).mul_(0.5) \
+            .to(x.dtype)
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        input, = ctx.saved_tensors
+        return grad_output / (1 - input**2)
+
+
+class Arsinh(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x):
+        ctx.save_for_backward(x)
+        z = x.double()
+        return (z + torch.sqrt_(1 + z.pow(2))).clamp_min_(1e-15).log_() \
+            .to(x.dtype)
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        input, = ctx.saved_tensors
+        return grad_output / (1 + input**2)**0.5
+
+
+class Arcosh(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x):
+        x = x.clamp(min=1.0 + 1e-15)
+        ctx.save_for_backward(x)
+        z = x.double()
+        return (z + torch.sqrt_(z.pow(2) - 1)).clamp_min_(1e-15).log_() \
+            .to(x.dtype)
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        input, = ctx.saved_tensors
+        return grad_output / (input**2 - 1)**0.5
+
+
+class Euclidean():
+    """Euclidean Manifold class.
+    """
+    def __init__(self):
+        super(Euclidean, self).__init__()
+        self.name = 'Euclidean'
+
+    def normalize(self, p):
+        dim = p.size(-1)
+        p.view(-1, dim).renorm_(2, 0, 1.)
+        return p
+
+    def sqdist(self, p1, p2, c):
+        return (p1 - p2).pow(2).sum(dim=-1)
+
+    def egrad2rgrad(self, p, dp, c):
+        return dp
+
+    def proj(self, p, c):
+        return p
+
+    def proj_tan(self, u, p, c):
+        return u
+
+    def proj_tan0(self, u, c):
+        return u
+
+    def expmap(self, u, p, c):
+        return p + u
+
+    def logmap(self, p1, p2, c):
+        return p2 - p1
+
+    def expmap0(self, u, c):
+        return u
+
+    def logmap0(self, p, c):
+        return p
+
+    def mobius_add(self, x, y, c, dim=-1):
+        return x + y
+
+    def mobius_matvec(self, m, x, c):
+        mx = x @ m.transpose(-1, -2)
+        return mx
+
+    def init_weights(self, w, c, irange=1e-5):
+        w.data.uniform_(-irange, irange)
+        return w
+
+    def inner(self, p, c, u, v=None, keepdim=False):
+        if v is None:
+            v = u
+        return (u * v).sum(dim=-1, keepdim=keepdim)
+
+    def ptransp(self, x, y, v, c):
+        return v
+
+    def ptransp0(self, x, v, c):
+        return x + v

--- a/torch_geometric/nn/conv/hgcn_conv.py
+++ b/torch_geometric/nn/conv/hgcn_conv.py
@@ -41,11 +41,11 @@ class HGCNConv(MessagePassing):
             :class:`torch_geometric.nn.conv.MessagePassing`.
     """
     def __init__(self, in_channels: int, out_channels: int, c_in: float = 1.0,
-                c_out: float = 1.0, act: Callable = None,
-                dropout: float = 0.0, use_bias: bool = True,
-                use_att: bool = True, local_agg: bool = True,
-                add_self_loops: bool = True, manifold: str = 'euclidean',
-                **kwargs):
+                 c_out: float = 1.0, act: Callable = None,
+                 dropout: float = 0.0, use_bias: bool = True,
+                 use_att: bool = True, local_agg: bool = True,
+                 add_self_loops: bool = True, manifold: str = 'euclidean',
+                 **kwargs):
         kwargs.setdefault('aggr', 'mean')
         super().__init__(**kwargs)
 
@@ -59,8 +59,7 @@ class HGCNConv(MessagePassing):
             self.manifold = Euclidean()
         else:
             raise NotImplementedError(
-                f"Expected 'poincare' or 'hyperboloid', but got {manifold}"
-            )
+                f"Expected 'poincare' or 'hyperboloid', but got {manifold}")
 
         self.hyp_linear = HypLinear(self.manifold, in_channels, out_channels,
                                     c_in, dropout, use_bias)


### PR DESCRIPTION
From [#1334](https://github.com/pyg-team/pytorch_geometric/issues/1334) and [#5453](https://github.com/pyg-team/pytorch_geometric/pull/5453).

When I try to add `HGCNConv` layer (paper [Hyperbolic Graph Convolutional Neural Networks](https://arxiv.org/abs/1910.12933)) I discover that somebody had done it two years ago. Then I find and fix some bugs in [#5453](https://github.com/pyg-team/pytorch_geometric/pull/5453).

 I also add test of `HGCNConv`, `HypAct` and `HypLinear` in `poincareBall` and `hyperboloid` two mod.

Moreover, I write an example of its use for giving people some idea of where it best applies.

[x] Add `HGCNConv` layer
[x] Add some test of `HGCNConv`, `HypAct` and `HypLinear`
[x] Add an example