### PR TITLE
Add other pooling strategies to `SentenceTransformer`

### DIFF
--- a/test/nn/nlp/test_sentence_transformer.py
+++ b/test/nn/nlp/test_sentence_transformer.py
@@ -1,6 +1,6 @@
 import pytest
 
-from torch_geometric.nn.nlp import SentenceTransformer
+from torch_geometric.nn.nlp import PoolingStrategy, SentenceTransformer
 from torch_geometric.testing import onlyFullTest, withCUDA, withPackage
 
 
@@ -8,8 +8,14 @@ from torch_geometric.testing import onlyFullTest, withCUDA, withPackage
 @onlyFullTest
 @withPackage('transformers')
 @pytest.mark.parametrize('batch_size', [None, 1])
-def test_sentence_transformer(batch_size, device):
-    model = SentenceTransformer(model_name='prajjwal1/bert-tiny').to(device)
+@pytest.mark.parametrize('pooling_strategy', [
+    PoolingStrategy.MEAN,
+    PoolingStrategy.CLS,
+    PoolingStrategy.LAST,
+])
+def test_sentence_transformer(batch_size, pooling_strategy, device):
+    model = SentenceTransformer(model_name='prajjwal1/bert-tiny',
+                                pooling_strategy=pooling_strategy).to(device)
     assert model.device == device
     assert str(model) == 'SentenceTransformer(model_name=prajjwal1/bert-tiny)'
 

--- a/test/nn/nlp/test_sentence_transformer.py
+++ b/test/nn/nlp/test_sentence_transformer.py
@@ -1,6 +1,6 @@
 import pytest
 
-from torch_geometric.nn.nlp import PoolingStrategy, SentenceTransformer
+from torch_geometric.nn.nlp import SentenceTransformer
 from torch_geometric.testing import onlyFullTest, withCUDA, withPackage
 
 
@@ -8,14 +8,12 @@ from torch_geometric.testing import onlyFullTest, withCUDA, withPackage
 @onlyFullTest
 @withPackage('transformers')
 @pytest.mark.parametrize('batch_size', [None, 1])
-@pytest.mark.parametrize('pooling_strategy', [
-    PoolingStrategy.MEAN,
-    PoolingStrategy.CLS,
-    PoolingStrategy.LAST,
-])
+@pytest.mark.parametrize('pooling_strategy', ['mean', 'last', 'cls'])
 def test_sentence_transformer(batch_size, pooling_strategy, device):
-    model = SentenceTransformer(model_name='prajjwal1/bert-tiny',
-                                pooling_strategy=pooling_strategy).to(device)
+    model = SentenceTransformer(
+        model_name='prajjwal1/bert-tiny',
+        pooling_strategy=pooling_strategy,
+    ).to(device)
     assert model.device == device
     assert str(model) == 'SentenceTransformer(model_name=prajjwal1/bert-tiny)'
 

--- a/torch_geometric/nn/nlp/__init__.py
+++ b/torch_geometric/nn/nlp/__init__.py
@@ -1,5 +1,6 @@
-from .sentence_transformer import SentenceTransformer
+from .sentence_transformer import SentenceTransformer, PoolingStrategy
 
 __all__ = classes = [
     'SentenceTransformer',
+    'PoolingStrategy',
 ]

--- a/torch_geometric/nn/nlp/__init__.py
+++ b/torch_geometric/nn/nlp/__init__.py
@@ -1,6 +1,5 @@
-from .sentence_transformer import SentenceTransformer, PoolingStrategy
+from .sentence_transformer import SentenceTransformer
 
 __all__ = classes = [
     'SentenceTransformer',
-    'PoolingStrategy',
 ]

--- a/torch_geometric/nn/nlp/sentence_transformer.py
+++ b/torch_geometric/nn/nlp/sentence_transformer.py
@@ -1,30 +1,45 @@
-from typing import List, Optional
+from enum import Enum
+from typing import List, Optional, Union
 
 import torch
 import torch.nn.functional as F
 from torch import Tensor
 
 
+class PoolingStrategy(Enum):
+    MEAN = 'mean'
+    LAST = 'last'
+    CLS = 'cls'
+
+
 class SentenceTransformer(torch.nn.Module):
-    def __init__(self, model_name: str) -> None:
+    def __init__(
+        self, model_name: str,
+        pooling_strategy: Union[PoolingStrategy, str] = PoolingStrategy.MEAN
+    ) -> None:
         super().__init__()
 
         self.model_name = model_name
+        self.pooling_strategy = PoolingStrategy(pooling_strategy)
 
         from transformers import AutoModel, AutoTokenizer
 
         self.tokenizer = AutoTokenizer.from_pretrained(model_name)
         self.model = AutoModel.from_pretrained(model_name)
 
-    def mean_pooling(self, emb: Tensor, attention_mask: Tensor) -> Tensor:
-        mask = attention_mask.unsqueeze(-1).expand(emb.size()).to(emb.dtype)
-        return (emb * mask).sum(dim=1) / mask.sum(dim=1).clamp(min=1e-9)
-
     def forward(self, input_ids: Tensor, attention_mask: Tensor) -> Tensor:
         out = self.model(input_ids=input_ids, attention_mask=attention_mask)
 
         emb = out[0]  # First element contains all token embeddings.
-        emb = self.mean_pooling(emb, attention_mask)
+        if self.pooling_strategy == PoolingStrategy.MEAN:
+            emb = mean_pooling(emb, attention_mask)
+        elif self.pooling_strategy == PoolingStrategy.CLS:
+            emb = emb[:, 0, :]
+        elif self.pooling_strategy == PoolingStrategy.LAST:
+            emb = last_pooling(emb, attention_mask)
+        else:
+            raise ValueError(f"Unsupported pooling strategy "
+                             f"{self.pooling_strategy}")
         emb = F.normalize(emb, p=2, dim=1)
         return emb
 
@@ -61,3 +76,20 @@ class SentenceTransformer(torch.nn.Module):
 
     def __repr__(self) -> str:
         return f'{self.__class__.__name__}(model_name={self.model_name})'
+
+
+def mean_pooling(emb: Tensor, attention_mask: Tensor) -> Tensor:
+    mask = attention_mask.unsqueeze(-1).expand(emb.size()).to(emb.dtype)
+    return (emb * mask).sum(dim=1) / mask.sum(dim=1).clamp(min=1e-9)
+
+
+def last_pooling(emb: Tensor, attention_mask: Tensor) -> Tensor:
+    # Check whether language model uses left padding,
+    # which is always used for decoder LLMs
+    left_padding = (attention_mask[:, -1].sum() == attention_mask.shape[0])
+    if left_padding:
+        return emb[:, -1]
+    else:
+        seq_indices = attention_mask.sum(dim=1) - 1
+        batch_size = emb.shape[0]
+        return emb[torch.arange(batch_size, device=emb.device), seq_indices]


### PR DESCRIPTION
* Add `CLS` pooling, which is frequently used for BERT like model. It extracts the first token hidden states as the embeddings.
* Add last token pooling, which is frequently used for recent text embedding models with the decoder architecture, such as https://huggingface.co/intfloat/e5-mistral-7b-instruct. It basically uses the last token states as the embeddings.