### PR TITLE
Fix argument count issue in `fs.mv` call within `TUDataset` download method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,7 +68,6 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Fixed `OSError` on read-only file systems within `MessagePassing` ([#9032](https://github.com/pyg-team/pytorch_geometric/pull/9032))
 - Fixed metaclass conflict in `Dataset` ([#8999](https://github.com/pyg-team/pytorch_geometric/pull/8999))
 - Fixed import errors on `MessagePassing` modules with nested inheritance ([#8973](https://github.com/pyg-team/pytorch_geometric/pull/8973))
-- Fix argument count issue in `fs.mv` call within `TUDataset (ENZYMES)` download method ([#9436](https://github.com/pyg-team/pytorch_geometric/pull/9436))
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Fixed `OSError` on read-only file systems within `MessagePassing` ([#9032](https://github.com/pyg-team/pytorch_geometric/pull/9032))
 - Fixed metaclass conflict in `Dataset` ([#8999](https://github.com/pyg-team/pytorch_geometric/pull/8999))
 - Fixed import errors on `MessagePassing` modules with nested inheritance ([#8973](https://github.com/pyg-team/pytorch_geometric/pull/8973))
+- Fix argument count issue in `fs.mv` call within `TUDataset (ENZYMES)` download method ([#9436](https://github.com/pyg-team/pytorch_geometric/pull/9436))
 
 ### Removed
 

--- a/torch_geometric/io/fs.py
+++ b/torch_geometric/io/fs.py
@@ -190,7 +190,7 @@ def mv(path1: str, path2: str, recursive: bool = True) -> None:
     fs1 = get_fs(path1)
     fs2 = get_fs(path2)
     assert fs1.protocol == fs2.protocol
-    fs1.mv(path1, path2, recursive=recursive)
+    fs1.mv(path1, path2)
 
 
 def glob(path: str) -> List[str]:

--- a/torch_geometric/io/fs.py
+++ b/torch_geometric/io/fs.py
@@ -186,7 +186,7 @@ def rm(path: str, recursive: bool = True) -> None:
     get_fs(path).rm(path, recursive)
 
 
-def mv(path1: str, path2: str, recursive: bool = True) -> None:
+def mv(path1: str, path2: str) -> None:
     fs1 = get_fs(path1)
     fs2 = get_fs(path2)
     assert fs1.protocol == fs2.protocol


### PR DESCRIPTION
## Cause Analysis
The `fs.mv` function was incorrectly called with an extra `recursive` argument that is not supported by the `LocalFileSystem.mv()` method in the underlying file system handling library. Please see:
```sh
Traceback (most recent call last):
  File "/home/ikao/test/GNNInference.py", line 83, in <module>
    main()
  File "/home/ikao/test/GNNInference.py", line 62, in main
    dataset = load_data("ENZYMES")
  File "/home/ikao/test/GNNInference.py", line 49, in load_data
    dataset = TUDataset(root="/tmp/TUDataset", name=dataset_name, use_node_attr=True, use_edge_attr=False, cleaned=False)
  File "/home/ikao/test/.venv/lib/python3.10/site-packages/torch_geometric/datasets/tu_dataset.py", line 129, in __init__
    super().__init__(root, transform, pre_transform, pre_filter,
  File "/home/ikao/test/.venv/lib/python3.10/site-packages/torch_geometric/data/in_memory_dataset.py", line 81, in __init__
    super().__init__(root, transform, pre_transform, pre_filter, log,
  File "/home/ikao/test/.venv/lib/python3.10/site-packages/torch_geometric/data/dataset.py", line 112, in __init__
    self._download()
  File "/home/ikao/test/.venv/lib/python3.10/site-packages/torch_geometric/data/dataset.py", line 229, in _download
    self.download()
  File "/home/ikao/test/.venv/lib/python3.10/site-packages/torch_geometric/datasets/tu_dataset.py", line 199, in download
    fs.mv(filename, osp.join(self.raw_dir, osp.basename(filename)))
  File "/home/ikao/test/.venv/lib/python3.10/site-packages/torch_geometric/io/fs.py", line 193, in mv
    fs1.mv(path1, path2, recursive)
TypeError: LocalFileSystem.mv() takes 3 positional arguments but 4 were given
```

## Changes Made
Removed the unsupported `recursive` argument from the `fs.mv` call in the `io.fs.py` file.

## Testing
Tested the download and processing of the `ENZYMES` dataset using the modified TUDataset class. The dataset downloads and processes without throwing the TypeError.