### PR TITLE
Fix minor issues with `ogbn_papers_100m` example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 ### Changed
 
 - Support other than two-dimensional inputs in `AttentionalAggregation` ([#9433](https://github.com/pyg-team/pytorch_geometric/pull/9433))
-- Improved model performance of the `examples/ogbn_papers_100m.py` script ([#9386](https://github.com/pyg-team/pytorch_geometric/pull/9386))
+- Improved model performance of the `examples/ogbn_papers_100m.py` script ([#9386](https://github.com/pyg-team/pytorch_geometric/pull/9386), [#9445](https://github.com/pyg-team/pytorch_geometric/pull/9445))
 - Added the `fmt` arg to `Dataset.get_summary` ([#9408](https://github.com/pyg-team/pytorch_geometric/pull/9408))
 - Skipped zero atom molecules in `MoleculeNet` ([#9318](https://github.com/pyg-team/pytorch_geometric/pull/9318))
 - Ensure proper parallelism in `OnDiskDataset` for multi-threaded `get` calls ([#9140](https://github.com/pyg-team/pytorch_geometric/pull/9140))
@@ -47,7 +47,6 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Made `MessagePassing` interface thread-safe ([#9001](https://github.com/pyg-team/pytorch_geometric/pull/9001))
 - Breaking Change: Added support for `EdgeIndex` in `cugraph` GNN layers ([#8938](https://github.com/pyg-team/pytorch_geometric/pull/8937))
 - Added the `dim` arg to `torch.cross` calls ([#8918](https://github.com/pyg-team/pytorch_geometric/pull/8918))
-- Renamed `workers` to `num_workers` and removed `epoch` argument from the `train` function of the `examples/ogbn_papers_100m.py` script ([#9445](https://github.com/pyg-team/pytorch_geometric/pull/9445))
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Made `MessagePassing` interface thread-safe ([#9001](https://github.com/pyg-team/pytorch_geometric/pull/9001))
 - Breaking Change: Added support for `EdgeIndex` in `cugraph` GNN layers ([#8938](https://github.com/pyg-team/pytorch_geometric/pull/8937))
 - Added the `dim` arg to `torch.cross` calls ([#8918](https://github.com/pyg-team/pytorch_geometric/pull/8918))
+- Renamed `workers` to `num_workers` and removed `epoch` argument from the `train` function of the `examples/ogbn_papers_100m.py` script ([#9445](https://github.com/pyg-team/pytorch_geometric/pull/9445))
 
 ### Deprecated
 

--- a/examples/ogbn_papers_100m.py
+++ b/examples/ogbn_papers_100m.py
@@ -21,7 +21,7 @@ parser.add_argument('--num_neighbors', type=int, default=10)
 parser.add_argument('--channels', type=int, default=256)
 parser.add_argument('--lr', type=float, default=0.003)
 parser.add_argument('--dropout', type=float, default=0.5)
-parser.add_argument('--workers', type=int, default=12)
+parser.add_argument('--num_workers', type=int, default=12)
 args = parser.parse_args()
 
 root = osp.join(osp.dirname(osp.realpath(__file__)), '..', 'data', 'papers100')
@@ -118,7 +118,7 @@ def test(loader):
 
 
 for epoch in range(1, args.epochs + 1):
-    loss, train_acc = train(epoch)
+    loss, train_acc = train()
     print(f'Epoch {epoch:02d}, Loss: {loss:.4f}, Train Acc: {train_acc:.4f}')
     val_acc = test(val_loader)
     print(f'Epoch {epoch:02d}, Val Acc: {val_acc:.4f}')


### PR DESCRIPTION
### Issues
- Missing `num_workers`. 
- `epoch` passed to the `train` function that doesn't accept any arguments. 
### Fix
- Renamed `workers` to `num_workers`.
- Removed the `epoch` argument.