### PR TITLE
Respect `torch.nn.Module.children` in `Sequential`

### DIFF
--- a/test/nn/test_sequential.py
+++ b/test/nn/test_sequential.py
@@ -28,7 +28,7 @@ def test_sequential_basic():
         (GCNConv(64, 64), 'x, edge_index -> x'),
         ReLU(inplace=True),
         Linear(64, 7),
-    ])
+    ]).cpu()
     model.reset_parameters()
 
     assert len(model) == 5


### PR DESCRIPTION
Fixes #9437.

This issue was introduced in #9369 since the name `children` is reserved in PyTorch. See https://github.com/pytorch/pytorch/blob/b57fa8d9c07b0e03afbe5dab279aa26697b828ea/torch/nn/modules/module.py#L2352-L2359.