### PR TITLE
Add conversion to and from RDKit Molecule 

### DIFF
--- a/test/utils/test_smiles.py
+++ b/test/utils/test_smiles.py
@@ -1,11 +1,10 @@
 import pytest
 
 from torch_geometric.testing import withPackage
-from torch_geometric.utils import from_smiles, to_smiles
+from torch_geometric.utils import from_smiles, to_smiles, from_rdmol, to_rdmol
 
 
-@withPackage('rdkit')
-@pytest.mark.parametrize('smiles', [
+smiles = [
     r'F/C=C/F',
     r'F/C=C\F',
     r'F/C=C\F',
@@ -16,7 +15,19 @@ from torch_geometric.utils import from_smiles, to_smiles
     r'COC(=O)[C@@]1(Cc2ccccc2)[C@H]2C(=O)N(C)C(=O)[C@H]2[C@H]2CN=C(SC)N21',
     (r'O=C(O)c1ccc(NS(=O)(=O)c2ccc3c(c2)C(=O)c2cc(S(=O)(=O)Nc4ccc(C(=O)O)'
      r'cc4)ccc2-3)cc1'),
-])
+]
+
+@withPackage('rdkit')
+@pytest.mark.parametrize('smiles', smiles)
 def test_from_to_smiles(smiles):
     data = from_smiles(smiles)
     assert to_smiles(data) == smiles
+
+@withPackage('rdkit')
+@pytest.mark.parametrize('smiles', smiles)
+def test_from_to_rdmol(smiles):
+    from rdkit import Chem
+    mol1 = Chem.MolFromSmiles(smiles)
+    data = from_rdmol(mol1)
+    mol2 = to_rdmol(data)
+    assert Chem.MolToSmiles(mol1) == Chem.MolToSmiles(mol2)

--- a/torch_geometric/utils/__init__.py
+++ b/torch_geometric/utils/__init__.py
@@ -44,7 +44,7 @@ from .convert import to_networkit, from_networkit
 from .convert import to_trimesh, from_trimesh
 from .convert import to_cugraph, from_cugraph
 from .convert import to_dgl, from_dgl
-from .smiles import from_smiles, to_smiles
+from .smiles import from_smiles, to_smiles, to_rdmol, from_rdmol
 from .random import (erdos_renyi_graph, stochastic_blockmodel_graph,
                      barabasi_albert_graph)
 from ._negative_sampling import (negative_sampling, batched_negative_sampling,
@@ -129,6 +129,8 @@ __all__ = [
     'from_dgl',
     'from_smiles',
     'to_smiles',
+    'from_rdmol',
+    'to_rdmol',
     'erdos_renyi_graph',
     'stochastic_blockmodel_graph',
     'barabasi_albert_graph',


### PR DESCRIPTION
Currently the `utils` submodule includes [functions](https://github.com/pyg-team/pytorch_geometric/blob/9b7874b2cae24dfccfa59d76cfd545fdf6b97118/torch_geometric/utils/smiles.py#L80) that support conversion of `SMILES strings <-> Data` and back. 

However, there is value in adding that functionality on the level of `rdkit.Chem.Mol <-> Data`.
The motivation for this is that users might be interested in pre-processing the chemical structure prior to conversion. This might for example include operations such as the removal of salt ions, chiral centers, or standardization tautomer on the level of the Molecule object.

This PR adds two new functions, [`from_rdmol`](https://github.com/pyg-team/pytorch_geometric/blob/7293e22b75c31b14588fa22f3096022e82a19afa/torch_geometric/utils/smiles.py#L110)/[`to_rdmol`](https://github.com/pyg-team/pytorch_geometric/blob/7293e22b75c31b14588fa22f3096022e82a19afa/torch_geometric/utils/smiles.py#L163), leaving most of the original functionality in place, and re-defining the conversion from/to SMILES as an extension of the conversion to the Molecule objects.