### PR TITLE
[ISSUE 9455] Data preprocess fix in multi XPU training

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Fixed `OSError` on read-only file systems within `MessagePassing` ([#9032](https://github.com/pyg-team/pytorch_geometric/pull/9032))
 - Fixed metaclass conflict in `Dataset` ([#8999](https://github.com/pyg-team/pytorch_geometric/pull/8999))
 - Fixed import errors on `MessagePassing` modules with nested inheritance ([#8973](https://github.com/pyg-team/pytorch_geometric/pull/8973))
+- Fixed bug in multi XPU training ([#9456](https://github.com/pyg-team/pytorch_geometric/pull/9456))
 
 ### Removed
 

--- a/benchmark/multi_gpu/training/training_benchmark_xpu.py
+++ b/benchmark/multi_gpu/training/training_benchmark_xpu.py
@@ -50,7 +50,8 @@ if __name__ == '__main__':
         f"Dataset {args.dataset} isn't supported."
 
     # if the dataset is not present, it will be downloaded only by process rank=0
-    # other process will use the dataset cache from rank=0, and will not re-download and process it
+    # other process will use the dataset cache from rank=0, 
+    # and will not re-download and process it
     if rank == 0:
         data, num_classes = get_dataset(args.dataset, args.root)
     dist.barrier()

--- a/benchmark/multi_gpu/training/training_benchmark_xpu.py
+++ b/benchmark/multi_gpu/training/training_benchmark_xpu.py
@@ -49,6 +49,8 @@ if __name__ == '__main__':
     assert args.dataset in supported_sets.keys(), \
         f"Dataset {args.dataset} isn't supported."
 
+    # if the dataset is not present, it will be downloaded only by process rank=0
+    # other process will use the dataset cache from rank=0, and will not re-download and process it
     if rank == 0:
         data, num_classes = get_dataset(args.dataset, args.root)
     dist.barrier()

--- a/benchmark/multi_gpu/training/training_benchmark_xpu.py
+++ b/benchmark/multi_gpu/training/training_benchmark_xpu.py
@@ -49,9 +49,9 @@ if __name__ == '__main__':
     assert args.dataset in supported_sets.keys(), \
         f"Dataset {args.dataset} isn't supported."
 
-    # if the dataset is not present, it will be downloaded 
+    # if the dataset is not present, it will be downloaded
     # only by process with rank=0,
-    # other process will use the dataset cache from rank=0, 
+    # other process will use the dataset cache from rank=0,
     # and will not re-download and process it
     if rank == 0:
         data, num_classes = get_dataset(args.dataset, args.root)

--- a/benchmark/multi_gpu/training/training_benchmark_xpu.py
+++ b/benchmark/multi_gpu/training/training_benchmark_xpu.py
@@ -49,8 +49,9 @@ if __name__ == '__main__':
     assert args.dataset in supported_sets.keys(), \
         f"Dataset {args.dataset} isn't supported."
 
-    # if the dataset is not present, it will be downloaded only by process rank=0
-    # other process will use the dataset cache from rank=0,
+    # if the dataset is not present, it will be downloaded 
+    # only by process with rank=0,
+    # other process will use the dataset cache from rank=0, 
     # and will not re-download and process it
     if rank == 0:
         data, num_classes = get_dataset(args.dataset, args.root)

--- a/benchmark/multi_gpu/training/training_benchmark_xpu.py
+++ b/benchmark/multi_gpu/training/training_benchmark_xpu.py
@@ -48,6 +48,11 @@ if __name__ == '__main__':
 
     assert args.dataset in supported_sets.keys(), \
         f"Dataset {args.dataset} isn't supported."
-    data, num_classes = get_dataset(args.dataset, args.root)
+
+    if rank == 0:
+        data, num_classes = get_dataset(args.dataset, args.root)
+    dist.barrier()
+    if rank != 0:
+        data, num_classes = get_dataset(args.dataset, args.root)
 
     run(rank, world_size, args, num_classes, data, custom_optimizer)

--- a/benchmark/multi_gpu/training/training_benchmark_xpu.py
+++ b/benchmark/multi_gpu/training/training_benchmark_xpu.py
@@ -50,7 +50,7 @@ if __name__ == '__main__':
         f"Dataset {args.dataset} isn't supported."
 
     # if the dataset is not present, it will be downloaded only by process rank=0
-    # other process will use the dataset cache from rank=0, 
+    # other process will use the dataset cache from rank=0,
     # and will not re-download and process it
     if rank == 0:
         data, num_classes = get_dataset(args.dataset, args.root)


### PR DESCRIPTION
This is a follow-up PR for issue #9455 .

Say we want to lauch training on two XPUs:

- Before fixing
Data will be downloaded twice and process twice, and causing conflict, see below:
![image](https://github.com/pyg-team/pytorch_geometric/assets/12825276/6b2b7faa-239c-40f0-92b8-8f26926859a8)


- After fixing
Data will be downloaded and processed only once on main process, see below:
![image](https://github.com/pyg-team/pytorch_geometric/assets/12825276/3d2fa4fd-fd5c-4d1c-a6fc-8ad923c6ec9d)
