### PR TITLE
Fix for "Multiple top level packages" issue.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -208,3 +208,6 @@ exclude_lines = [
     "register_parameter",
     "torch.cuda.is_available",
 ]
+
+[tool.setuptools]
+py-modules = []


### PR DESCRIPTION
With the merged [PR#9410](https://github.com/pyg-team/pytorch_geometric/pull/9410) **[BUG] Fixing Bug in Version Handling**, we started running some tests that hadn't been executed for a long time. Unfortunately, 7 of them:
```
FAILED test/nn/conv/test_hetero_conv.py::test_compile_hetero_conv_graph_breaks[cuda:0]
FAILED test/nn/conv/test_sage_conv.py::test_compile_multi_aggr_sage_conv[cuda:0]
FAILED test/nn/models/test_basic_gnn.py::test_compile_basic[cuda:0]
FAILED test/nn/test_compile_basic.py::test_torch_compile[cuda:0]
FAILED test/nn/test_compile_conv.py::test_compile_conv[GCNConv-cuda:0
FAILED test/nn/test_compile_conv.py::test_compile_conv[SAGEConv-cuda:0]
FAILED test/nn/test_compile_dynamic.py::test_dynamic_torch_compile[cuda:0]
```
are failing with the same error message:
```
SystemExit: error: Multiple top-level packages discovered in a flat-layout: ['conda', 'docker', 'graphgym', 'torch_geometric'].
 ```
The changes proposed [here](https://stackoverflow.com/questions/72294299/multiple-top-level-packages-discovered-in-a-flat-layout) address this issue.