### PR TITLE
[FutureWarning] Fixing warning generated by the use of `torch.cuda.amp.autocast(...)`

### DIFF
--- a/benchmark/citation/train_eval.py
+++ b/benchmark/citation/train_eval.py
@@ -130,7 +130,7 @@ def run_inference(dataset, model, epochs, profiling, bf16, use_compile,
         model = torch.compile(model)
 
     if torch.cuda.is_available():
-        amp = torch.cuda.amp.autocast(enabled=False)
+        amp = torch.amp.autocast('cuda', enabled=False)
     else:
         amp = torch.cpu.amp.autocast(enabled=bf16)
     if bf16:

--- a/benchmark/inference/inference_benchmark.py
+++ b/benchmark/inference/inference_benchmark.py
@@ -87,7 +87,7 @@ def run(args: argparse.ArgumentParser):
             raise ValueError("Layer-wise inference requires `steps=-1`")
 
         if args.device == 'cuda':
-            amp = torch.cuda.amp.autocast(enabled=False)
+            amp = torch.amp.autocast('cuda', enabled=False)
         elif args.device == 'xpu':
             amp = torch.xpu.amp.autocast(enabled=False)
         else:

--- a/benchmark/kernel/main_performance.py
+++ b/benchmark/kernel/main_performance.py
@@ -43,7 +43,7 @@ else:
     device = torch.device('cpu')
 
 if torch.cuda.is_available():
-    amp = torch.cuda.amp.autocast(enabled=False)
+    amp = torch.amp.autocast('cuda', enabled=False)
 else:
     amp = torch.cpu.amp.autocast(enabled=args.bf16)
 

--- a/benchmark/points/train_eval.py
+++ b/benchmark/points/train_eval.py
@@ -63,7 +63,7 @@ def run_inference(test_dataset, model, epochs, batch_size, profiling, bf16,
     test_loader = DataLoader(test_dataset, batch_size, shuffle=False)
 
     if torch.cuda.is_available():
-        amp = torch.cuda.amp.autocast(enabled=False)
+        amp = torch.amp.autocast('cuda', enabled=False)
     else:
         amp = torch.cpu.amp.autocast(enabled=bf16)
 

--- a/benchmark/training/training_benchmark.py
+++ b/benchmark/training/training_benchmark.py
@@ -132,7 +132,7 @@ def run(args: argparse.ArgumentParser):
         if args.device == 'cpu':
             amp = torch.cpu.amp.autocast(enabled=args.bf16)
         elif args.device == 'cuda':
-            amp = torch.cuda.amp.autocast(enabled=False)
+            amp = torch.amp.autocast('cuda', enabled=False)
         elif args.device == 'xpu':
             amp = torch.xpu.amp.autocast(enabled=False)
         else:

--- a/test/nn/dense/test_linear.py
+++ b/test/nn/dense/test_linear.py
@@ -174,7 +174,7 @@ def test_hetero_linear_amp(device, use_segment_matmul):
 
     lin = HeteroLinear(16, 32, num_types=3).to(device)
 
-    with torch.cuda.amp.autocast():
+    with torch.amp.autocast('cuda'):
         assert lin(x, type_vec).size() == (3, 32)
 
     torch_geometric.backend.use_segment_matmul = old_state


### PR DESCRIPTION
This PR provides a fix for the warning
```
 /opt/pyg/pytorch_geometric/test/nn/dense/test_linear.py:177: FutureWarning: `torch.cuda.amp.autocast(args...)` 
is deprecated. Please use `torch.amp.autocast('cuda', args...)` instead.
```
that appears in the following tests:
```
test/nn/dense/test_linear.py::test_hetero_linear_amp[None-cpu]
test/nn/dense/test_linear.py::test_hetero_linear_amp[None-cuda:0]
test/nn/dense/test_linear.py::test_hetero_linear_amp[True-cpu]
test/nn/dense/test_linear.py::test_hetero_linear_amp[True-cuda:0]
test/nn/dense/test_linear.py::test_hetero_linear_amp[False-cpu]
test/nn/dense/test_linear.py::test_hetero_linear_amp[False-cuda:0]
```
and several other places.