### PR TITLE
`[PGExplainer]` Change default bias to `0.01`

### DIFF
--- a/torch_geometric/explain/algorithm/pg_explainer.py
+++ b/torch_geometric/explain/algorithm/pg_explainer.py
@@ -59,7 +59,7 @@ class PGExplainer(ExplainerAlgorithm):
         'edge_size': 0.05,
         'edge_ent': 1.0,
         'temp': [5.0, 2.0],
-        'bias': 0.0,
+        'bias': 0.01,
     }
 
     def __init__(self, epochs: int, lr: float = 0.003, **kwargs):


### PR DESCRIPTION
Fixes https://github.com/pyg-team/pytorch_geometric/issues/9469