### PR TITLE
Add `AttentionExplainer` example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Added `EdgeIndex.sparse_resize_` functionality ([#8983](https://github.com/pyg-team/pytorch_geometric/pull/8983))
 - Added approximate `faiss`-based KNN-search ([#8952](https://github.com/pyg-team/pytorch_geometric/pull/8952))
 - Added documentation on environment setup on XPU device ([#9407](https://github.com/pyg-team/pytorch_geometric/pull/9407))
+- Added a `attention explainer` example ([#9482](https://github.com/pyg-team/pytorch_geometric/pull/9482))
 
 ### Changed
 

--- a/examples/explain/attention_exaplainer.py
+++ b/examples/explain/attention_exaplainer.py
@@ -5,8 +5,8 @@ import torch.nn.functional as F
 
 import torch_geometric
 from torch_geometric.datasets import Planetoid
-from torch_geometric.explain import Explainer, GraphMaskExplainer
-from torch_geometric.nn import GCNConv
+from torch_geometric.explain import Explainer, AttentionExplainer
+from torch_geometric.nn import GATConv
 
 if torch.cuda.is_available():
     device = torch.device('cuda')
@@ -20,23 +20,23 @@ dataset = Planetoid(path, name='Cora')
 data = dataset[0].to(device)
 
 
-# GCN Node Classification =====================================================
+# GAT Node Classification =====================================================
 
-
-class GCN(torch.nn.Module):
+class GAT(torch.nn.Module):
     def __init__(self):
         super().__init__()
-        self.conv1 = GCNConv(dataset.num_features, 16)
-        self.conv2 = GCNConv(16, dataset.num_classes)
+        self.conv1 = GATConv(dataset.num_features, 8, heads=8, dropout=0.6)
+        self.conv2 = GATConv(64, dataset.num_classes, heads=1, concat=False, dropout=0.6)
 
     def forward(self, x, edge_index):
-        x = self.conv1(x, edge_index).relu()
-        x = F.dropout(x, training=self.training)
+        x = F.dropout(x, p=0.6, training=self.training)
+        x = F.elu(self.conv1(x, edge_index))
+        x = F.dropout(x, p=0.6, training=self.training)
         x = self.conv2(x, edge_index)
-        return F.log_softmax(x, dim=1)
+        return x
 
 
-model = GCN().to(device)
+model = GAT().to(device)
 optimizer = torch.optim.Adam(model.parameters(), lr=0.01, weight_decay=5e-4)
 
 for epoch in range(1, 201):
@@ -49,7 +49,7 @@ for epoch in range(1, 201):
 
 explainer = Explainer(
     model=model,
-    algorithm=GraphMaskExplainer(2, epochs=5),
+    algorithm=AttentionExplainer(),
     explanation_type='model',
     node_mask_type='attributes',
     edge_mask_type='object',
@@ -60,6 +60,6 @@ explainer = Explainer(
     ),
 )
 
-node_index = 10
+node_index = torch.tensor([10, 20])
 explanation = explainer(data.x, data.edge_index, index=node_index)
 print(f'Generated explanations in {explanation.available_explanations}')

--- a/examples/explain/attention_exaplainer.py
+++ b/examples/explain/attention_exaplainer.py
@@ -5,7 +5,7 @@ import torch.nn.functional as F
 
 import torch_geometric
 from torch_geometric.datasets import Planetoid
-from torch_geometric.explain import Explainer, AttentionExplainer
+from torch_geometric.explain import AttentionExplainer, Explainer
 from torch_geometric.nn import GATConv
 
 if torch.cuda.is_available():
@@ -19,14 +19,15 @@ path = osp.join(osp.dirname(osp.realpath(__file__)), 'data', 'Planetoid')
 dataset = Planetoid(path, name='Cora')
 data = dataset[0].to(device)
 
-
 # GAT Node Classification =====================================================
+
 
 class GAT(torch.nn.Module):
     def __init__(self):
         super().__init__()
         self.conv1 = GATConv(dataset.num_features, 8, heads=8, dropout=0.6)
-        self.conv2 = GATConv(64, dataset.num_classes, heads=1, concat=False, dropout=0.6)
+        self.conv2 = GATConv(64, dataset.num_classes, heads=1, concat=False,
+                             dropout=0.6)
 
     def forward(self, x, edge_index):
         x = F.dropout(x, p=0.6, training=self.training)

--- a/examples/explain/graphmask_explainer.py
+++ b/examples/explain/graphmask_explainer.py
@@ -19,7 +19,6 @@ path = osp.join(osp.dirname(osp.realpath(__file__)), 'data', 'Planetoid')
 dataset = Planetoid(path, name='Cora')
 data = dataset[0].to(device)
 
-
 # GCN Node Classification =====================================================
 
 


### PR DESCRIPTION
This PR mainly removes GAT from the [graphmask_explainer.py](https://github.com/pyg-team/pytorch_geometric/blob/master/examples/explain/graphmask_explainer.py#L63) example and adds examples for the attention explainer.

When I was running [graphmask_explainer.py](https://github.com/pyg-team/pytorch_geometric/blob/master/examples/explain/graphmask_explainer.py#L63) , I encountered the following error:

![image](https://github.com/pyg-team/pytorch_geometric/assets/1573221/4c420846-37e1-456b-a819-397d79075cdc)

Referring to [test_attention_explainer](https://github.com/pyg-team/pytorch_geometric/blob/master/test/explain/algorithm/test_attention_explainer.py), I found that the  attention explainer should be used for the GAT model.


