### PR TITLE
Fix `visualize_feature_importance` in heterogenous graphs with single features

### DIFF
--- a/torch_geometric/explain/explanation.py
+++ b/torch_geometric/explain/explanation.py
@@ -340,7 +340,7 @@ class HeteroExplanation(HeteroData, ExplanationMixin):
         """
         node_mask_dict = self.node_mask_dict
         for node_mask in node_mask_dict.values():
-            if node_mask.dim() != 2 or node_mask.size(1) < 1:
+            if node_mask.dim() != 2:
                 raise ValueError(f"Cannot compute feature importance for "
                                  f"object-level 'node_mask' "
                                  f"(got shape {node_mask.size()})")

--- a/torch_geometric/explain/explanation.py
+++ b/torch_geometric/explain/explanation.py
@@ -340,10 +340,10 @@ class HeteroExplanation(HeteroData, ExplanationMixin):
         """
         node_mask_dict = self.node_mask_dict
         for node_mask in node_mask_dict.values():
-            if node_mask.dim() != 2 or node_mask.size(1) <= 1:
+            if node_mask.dim() != 2 or node_mask.size(1) < 1:
                 raise ValueError(f"Cannot compute feature importance for "
                                  f"object-level 'node_mask' "
-                                 f"(got shape {node_mask_dict.size()})")
+                                 f"(got shape {node_mask.size()})")
 
         if feat_labels is None:
             feat_labels = {}


### PR DESCRIPTION
When calling visualize_feature_importance for a HeteroExplanation object, an error occurs if one of the Heterogenous graph's node types has one single feature. The error message also had a bug, as "node_mask_dict" has no attribute "size()". 

<img width="591" alt="image" src="https://github.com/pyg-team/pytorch_geometric/assets/160508240/f078882a-79cf-40e0-8162-4afb20df1b13">


This is a simple fix for both bugs.