### PR TITLE
Fixing `test_logger::test_logger_callback`.

### DIFF
--- a/test/graphgym/test_logger.py
+++ b/test/graphgym/test_logger.py
@@ -1,9 +1,15 @@
 from torch_geometric.graphgym.logger import Logger, LoggerCallback
+from torch_geometric.graphgym.loader import create_loader
+from torch_geometric.graphgym.config import set_run_dir
 from torch_geometric.testing import withPackage
 
 
 @withPackage('yacs', 'pytorch_lightning')
 def test_logger_callback():
+    loaders = create_loader()
+    assert len(loaders) == 3
+
+    set_run_dir('.')
     logger = LoggerCallback()
     assert isinstance(logger.train_logger, Logger)
     assert isinstance(logger.val_logger, Logger)

--- a/test/graphgym/test_logger.py
+++ b/test/graphgym/test_logger.py
@@ -1,6 +1,6 @@
-from torch_geometric.graphgym.logger import Logger, LoggerCallback
-from torch_geometric.graphgym.loader import create_loader
 from torch_geometric.graphgym.config import set_run_dir
+from torch_geometric.graphgym.loader import create_loader
+from torch_geometric.graphgym.logger import Logger, LoggerCallback
 from torch_geometric.testing import withPackage
 
 


### PR DESCRIPTION
The current PR provides a fix for `test_logger::test_logger_callback` test.

1. The call of `set_run_dir('.')` creates the `run_dir` attribute for default config. Without this call we get an AttributeError:
```
    def __getattr__(self, name):
        if name in self:
            return self[name]
        else:
>           raise AttributeError(name)
E           AttributeError: run_dir
```

2. The call of `create_loader()` modify the value `cfg.share.num_splits` to 3 which allows you to create train/val/test loggers and avoid the IndexError's like the following one:
```
    def val_logger(self) -> Any:
>       return self._logger[1]
E       IndexError: list index out of range
```