### PR TITLE
Fixing `test_lightning_hetero_node_data`.

### DIFF
--- a/test/data/lightning/test_datamodule.py
+++ b/test/data/lightning/test_datamodule.py
@@ -302,6 +302,7 @@ def test_lightning_hetero_node_data(get_dataset):
     assert torch.all(data['paper'].x > original_x)  # Ensure shared data.
     assert trainer.validate_loop._data_source.is_defined()
     assert trainer.test_loop._data_source.is_defined()
+    torch.distributed.destroy_process_group()
 
 
 @withPackage('pytorch_lightning')


### PR DESCRIPTION
When `test_lightning_hetero_node_data` is executed, a process group is created and if it is not destroyed, it may affect other tests. For example, in our test suite the following tests fail:
```
FAILED test/metrics/test_link_pred_metric.py::test_precision[1-32-3000-1000-100] - RuntimeError: No backend type associated with device type cpu
FAILED test/metrics/test_link_pred_metric.py::test_precision[10-32-3000-1000-100] - RuntimeError: No backend type associated with device type cpu
FAILED test/metrics/test_link_pred_metric.py::test_precision[100-32-3000-1000-100] - RuntimeError: No backend type associated with device type cpu
FAILED test/metrics/test_link_pred_metric.py::test_recall - RuntimeError: No backend type associated with device type cpu
FAILED test/metrics/test_link_pred_metric.py::test_f1 - RuntimeError: No backend type associated with device type cpu
FAILED test/metrics/test_link_pred_metric.py::test_map - RuntimeError: No backend type associated with device type cpu
FAILED test/metrics/test_link_pred_metric.py::test_ndcg - RuntimeError: No backend type associated with device type cpu