### PR TITLE
Ignore a typing error caught by the new `mypy==1.11.0`

### DIFF
--- a/torch_geometric/config_mixin.py
+++ b/torch_geometric/config_mixin.py
@@ -82,7 +82,7 @@ def _recursive_from_config(value: Any) -> Any:
     cls: Any = None
     if is_dataclass(value):
         if getattr(value, '_target_', None):
-            cls = _locate_cls(value._target_)
+            cls = _locate_cls(value._target_)  # type: ignore[attr-defined]
         else:
             cls = class_from_dataclass(value.__class__)
     elif isinstance(value, dict) and '_target_' in value:


### PR DESCRIPTION
- `mypy==1.10.1`: https://github.com/pyg-team/pytorch_geometric/actions/runs/10011975801/job/27676479993
- `mypy==1.11.0`: https://github.com/pyg-team/pytorch_geometric/actions/runs/10026612987/job/27711130309