### PR TITLE
Add `normalize_edge_index` function to utils

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- Added `utils.normalize_edge_index` for symmetric/asymmetric normalization of graph edges ([#9554](https://github.com/pyg-team/pytorch_geometric/pull/9554))
 - Added a `residual` option in `GATConv` and `GATv2Conv` ([#9515](https://github.com/pyg-team/pytorch_geometric/pull/9515))
 - Added the `PatchTransformerAggregation` layer ([#9487](https://github.com/pyg-team/pytorch_geometric/pull/9487))
 - Added the `nn.nlp.LLM` model ([#9462](https://github.com/pyg-team/pytorch_geometric/pull/9462))

--- a/test/utils/test_normalize_edge_index.py
+++ b/test/utils/test_normalize_edge_index.py
@@ -1,0 +1,27 @@
+import pytest
+import torch
+
+from torch_geometric.utils import normalize_edge_index
+
+
+@pytest.mark.parametrize('add_self_loops', [False, True])
+@pytest.mark.parametrize('symmetric', [False, True])
+def test_normalize_edge_index(add_self_loops: bool, symmetric: bool):
+    edge_index = torch.tensor([[0, 2, 2, 3], [2, 0, 3, 0]])
+
+    out = normalize_edge_index(
+        edge_index,
+        add_self_loops=add_self_loops,
+        symmetric=symmetric,
+    )
+    assert isinstance(out, tuple) and len(out) == 2
+    if not add_self_loops:
+        assert out[0].equal(edge_index)
+    else:
+        assert out[0].tolist() == [
+            [0, 2, 2, 3, 0, 1, 2, 3],
+            [2, 0, 3, 0, 0, 1, 2, 3],
+        ]
+
+    assert out[1].min() >= 0.0
+    assert out[1].min() <= 1.0

--- a/torch_geometric/utils/__init__.py
+++ b/torch_geometric/utils/__init__.py
@@ -21,6 +21,7 @@ from ._subgraph import (get_num_hops, subgraph, k_hop_subgraph,
 from .dropout import dropout_adj, dropout_node, dropout_edge, dropout_path
 from ._homophily import homophily
 from ._assortativity import assortativity
+from ._normalize_edge_index import normalize_edge_index
 from .laplacian import get_laplacian
 from .mesh_laplacian import get_mesh_laplacian
 from .mask import mask_select, index_to_mask, mask_to_index
@@ -89,6 +90,7 @@ __all__ = [
     'dropout_adj',
     'homophily',
     'assortativity',
+    'normalize_edge_index',
     'get_laplacian',
     'get_mesh_laplacian',
     'mask_select',

--- a/torch_geometric/utils/_normalize_edge_index.py
+++ b/torch_geometric/utils/_normalize_edge_index.py
@@ -1,0 +1,58 @@
+import torch
+from torch import Tensor
+from torch_geometric.utils import add_self_loops, degree
+from typing import Tuple
+
+
+def normalize_edge_index(
+        edge_index: Tensor,
+        num_nodes: int,
+        self_loop: bool = True,
+        symmetric_normalization: bool = True
+) -> Tuple[Tensor, Tensor]:
+    """
+    Normalizes the edge index of a graph for use in GNNs.
+
+    This function can add self-loops to the graph and apply either symmetric or
+    asymmetric normalization based on the node degrees.
+
+    Parameters:
+    -----------
+    edge_index : Tensor
+        The edge index tensor of shape [2, num_edges] representing the graph.
+        The first row contains the source nodes, and the second row contains the target nodes.
+    num_nodes : int
+        The number of nodes in the graph.
+    self_loop : bool, optional (default=True)
+        If True, self-loops are added to the graph.
+    symmetric_normalization : bool, optional (default=True)
+        If True, symmetric normalization (D^-1/2 A D^-1/2) is applied. Otherwise,
+        asymmetric normalization (D^-1 A) is used.
+
+    Returns:
+    --------
+    Tuple[Tensor, Tensor]
+        A tuple containing the edge index and edge weights:
+        - edge_index: The possibly modified edge index with self-loops.
+        - edge_weight: The normalized edge weights.
+    """
+
+    if self_loop:
+        edge_index, _ = add_self_loops(edge_index, num_nodes=num_nodes)
+
+    row, col = edge_index[0], edge_index[1]
+
+    deg = degree(row, num_nodes, dtype=torch.float)
+
+    if symmetric_normalization:
+        # Symmetric normalization: D^-1/2 * A * D^-1/2
+        deg_inv_sqrt = deg.pow(-0.5)
+        deg_inv_sqrt[torch.isinf(deg_inv_sqrt)] = 0
+        edge_weight = deg_inv_sqrt[row] * deg_inv_sqrt[col]
+    else:
+        # Asymmetric normalization: D^-1 * A
+        deg_inv = deg.pow(-1)
+        deg_inv[torch.isinf(deg_inv)] = 0
+        edge_weight = deg_inv[row]
+
+    return edge_index, edge_weight

--- a/torch_geometric/utils/_normalize_edge_index.py
+++ b/torch_geometric/utils/_normalize_edge_index.py
@@ -1,53 +1,44 @@
-from typing import Tuple
+from typing import Optional, Tuple
 
 import torch
 from torch import Tensor
 
-from torch_geometric.utils import add_self_loops, degree
+from torch_geometric.utils import add_self_loops as add_self_loops_fn
+from torch_geometric.utils import degree
 
 
 def normalize_edge_index(
-        edge_index: Tensor, num_nodes: int, self_loop: bool = True,
-        symmetric_normalization: bool = True) -> Tuple[Tensor, Tensor]:
-    """Normalizes the edge index of a graph for use in GNNs.
+    edge_index: Tensor,
+    num_nodes: Optional[int] = None,
+    add_self_loops: bool = True,
+    symmetric: bool = True,
+) -> Tuple[Tensor, Tensor]:
+    """Applies normalization to the edges of a graph.
 
     This function can add self-loops to the graph and apply either symmetric or
     asymmetric normalization based on the node degrees.
 
-    Parameters:
-    -----------
-    edge_index : Tensor
-        The edge index tensor of shape [2, num_edges] representing the graph.
-        The first row contains the source nodes, and the second row contains the target nodes.
-    num_nodes : int
-        The number of nodes in the graph.
-    self_loop : bool, optional (default=True)
-        If True, self-loops are added to the graph.
-    symmetric_normalization : bool, optional (default=True)
-        If True, symmetric normalization (D^-1/2 A D^-1/2) is applied. Otherwise,
-        asymmetric normalization (D^-1 A) is used.
-
-    Returns:
-    --------
-    Tuple[Tensor, Tensor]
-        A tuple containing the edge index and edge weights:
-        - edge_index: The possibly modified edge index with self-loops.
-        - edge_weight: The normalized edge weights.
+    Args:
+        edge_index (LongTensor): The edge indices.
+        num_nodes (int, int], optional): The number of nodes, *i.e.*
+            :obj:`max_val + 1` of :attr:`edge_index`. (default: :obj:`None`)
+        add_self_loops (bool, optional): If set to :obj:`False`, will not add
+            self-loops to the input graph. (default: :obj:`True`)
+        symmetric (bool, optional):  If set to :obj:`True`, symmetric
+            normalization (:math:`D^{-1/2} A D^{-1/2}`) is used, otherwise
+            asymmetric normalization (:math:`D^{-1} A`).
     """
-    if self_loop:
-        edge_index, _ = add_self_loops(edge_index, num_nodes=num_nodes)
+    if add_self_loops:
+        edge_index, _ = add_self_loops_fn(edge_index, num_nodes=num_nodes)
 
     row, col = edge_index[0], edge_index[1]
+    deg = degree(row, num_nodes, dtype=torch.get_default_dtype())
 
-    deg = degree(row, num_nodes, dtype=torch.float)
-
-    if symmetric_normalization:
-        # Symmetric normalization: D^-1/2 * A * D^-1/2
+    if symmetric:  # D^-1/2 * A * D^-1/2
         deg_inv_sqrt = deg.pow(-0.5)
         deg_inv_sqrt[torch.isinf(deg_inv_sqrt)] = 0
         edge_weight = deg_inv_sqrt[row] * deg_inv_sqrt[col]
-    else:
-        # Asymmetric normalization: D^-1 * A
+    else:  # D^-1 * A
         deg_inv = deg.pow(-1)
         deg_inv[torch.isinf(deg_inv)] = 0
         edge_weight = deg_inv[row]

--- a/torch_geometric/utils/_normalize_edge_index.py
+++ b/torch_geometric/utils/_normalize_edge_index.py
@@ -1,17 +1,15 @@
+from typing import Tuple
+
 import torch
 from torch import Tensor
+
 from torch_geometric.utils import add_self_loops, degree
-from typing import Tuple
 
 
 def normalize_edge_index(
-        edge_index: Tensor,
-        num_nodes: int,
-        self_loop: bool = True,
-        symmetric_normalization: bool = True
-) -> Tuple[Tensor, Tensor]:
-    """
-    Normalizes the edge index of a graph for use in GNNs.
+        edge_index: Tensor, num_nodes: int, self_loop: bool = True,
+        symmetric_normalization: bool = True) -> Tuple[Tensor, Tensor]:
+    """Normalizes the edge index of a graph for use in GNNs.
 
     This function can add self-loops to the graph and apply either symmetric or
     asymmetric normalization based on the node degrees.
@@ -36,7 +34,6 @@ def normalize_edge_index(
         - edge_index: The possibly modified edge index with self-loops.
         - edge_weight: The normalized edge weights.
     """
-
     if self_loop:
         edge_index, _ = add_self_loops(edge_index, num_nodes=num_nodes)
 


### PR DESCRIPTION
Normalizes the edge index of a graph for use in GNNs.

This function can add self-loops to the graph and apply symmetric or asymmetric normalization based on the node degrees. The function returns the new edge index and the edge weights.