### PR TITLE
Add OPF solution objective function value as a graph level property

### DIFF
--- a/torch_geometric/datasets/opf.py
+++ b/torch_geometric/datasets/opf.py
@@ -139,10 +139,13 @@ class OPFDataset(InMemoryDataset):
 
                 grid = obj['grid']
                 solution = obj['solution']
+                metadata = obj['metadata']
 
                 # Graph-level properties:
                 data = HeteroData()
                 data.x = torch.tensor(grid['context']).view(-1)
+
+                data.objective = torch.tensor(metadata['objective'])
 
                 # Nodes (only some have a target):
                 data['bus'].x = torch.tensor(grid['nodes']['bus'])


### PR DESCRIPTION
As discussed with @mzgubic 

This PR has to do with the recently added OPFDataset. It reads the OPF solution objective function value from the json file, and adds it as a graph level property. This value is useful in creating optimality metrics that illustrate how far an ML predictions objective function is from the one achieved by a solver.