### PR TITLE
Fixing `test_lightning_dataset` with multiple GPUs

### DIFF
--- a/test/data/lightning/test_datamodule.py
+++ b/test/data/lightning/test_datamodule.py
@@ -128,8 +128,7 @@ def test_lightning_dataset(get_dataset, strategy_type):
                                    'pin_memory=True, '
                                    'persistent_workers=False)')
 
-        with pytest.warns(UserWarning, match="defined a `validation_step`"):
-            trainer.fit(model, datamodule)
+        trainer.fit(model, datamodule)
 
         assert not trainer.validate_loop._data_source.is_defined()
         assert not trainer.test_loop._data_source.is_defined()

--- a/test/data/lightning/test_datamodule.py
+++ b/test/data/lightning/test_datamodule.py
@@ -80,18 +80,19 @@ class LinearGraphModule(LightningModule):
 @withPackage('pytorch_lightning>=2.0.0', 'torchmetrics>=0.11.0')
 @pytest.mark.parametrize('strategy_type', [None, 'ddp'])
 def test_lightning_dataset(get_dataset, strategy_type):
-    import pytorch_lightning as pl
     from contextlib import contextmanager
+
+    import pytorch_lightning as pl
     from pytorch_lightning.utilities import rank_zero_only
 
     @contextmanager
     def expect_warning_on_rank_zero():
         if rank_zero_only.rank == 0:
-            with pytest.warns(UserWarning, match="defined a `validation_step`"):
+            with pytest.warns(UserWarning,
+                              match="defined a `validation_step`"):
                 yield
         else:
             yield
-
 
     dataset = get_dataset(name='MUTAG').shuffle()
     train_dataset = dataset[:50]


### PR DESCRIPTION
When run with `pytest` on a multi-GPU machine, the following two tests (`test_lightning_dataset` and `test_lightning_hetero_node_data`) recursively call `pytest` with the same set of parameters. For instance, when running
```
# pytest /opt/pyg/pytorch_geometric/test/data/lightning/test_datamodule.py::test_lightning_hetero_node_data
```
on machine with 4 GPU cards you will see
```
====================================================================================== test session starts =======================================================================================
platform linux -- Python 3.10.12, pytest-8.1.1, pluggy-1.5.0 -- /usr/bin/python
cachedir: .pytest_cache
hypothesis profile 'default' -> database=DirectoryBasedExampleDatabase('/opt/pyg/qa/L0_unittests/.hypothesis/examples')
rootdir: /opt/pyg/pytorch_geometric
configfile: pyproject.toml
plugins: cov-5.0.0, anyio-4.4.0, rerunfailures-14.0, hypothesis-5.35.1, xdist-3.6.1, flakefinder-1.1.0, xdoctest-1.0.2, shard-0.1.2
collected 1 item                                                                                                                                                                                 
Running 1 items in this shard: test/data/lightning/test_datamodule.py::test_lightning_hetero_node_data

../../pytorch_geometric/test/data/lightning/test_datamodule.py::test_lightning_hetero_node_data ====================================================================================== test session starts =======================================================================================
platform linux -- Python 3.10.12, pytest-8.1.1, pluggy-1.5.0 -- /usr/bin/python
cachedir: .pytest_cache
hypothesis profile 'default' -> database=DirectoryBasedExampleDatabase('/opt/pyg/qa/L0_unittests/.hypothesis/examples')
rootdir: /opt/pyg/pytorch_geometric
configfile: pyproject.toml
plugins: cov-5.0.0, anyio-4.4.0, rerunfailures-14.0, hypothesis-5.35.1, xdist-3.6.1, flakefinder-1.1.0, xdoctest-1.0.2, shard-0.1.2
collecting ... ====================================================================================== test session starts =======================================================================================
platform linux -- Python 3.10.12, pytest-8.1.1, pluggy-1.5.0 -- /usr/bin/python
cachedir: .pytest_cache
hypothesis profile 'default' -> database=DirectoryBasedExampleDatabase('/opt/pyg/qa/L0_unittests/.hypothesis/examples')
rootdir: /opt/pyg/pytorch_geometric
configfile: pyproject.toml
plugins: cov-5.0.0, anyio-4.4.0, rerunfailures-14.0, hypothesis-5.35.1, xdist-3.6.1, flakefinder-1.1.0, xdoctest-1.0.2, shard-0.1.2
collecting ... ====================================================================================== test session starts =======================================================================================
platform linux -- Python 3.10.12, pytest-8.1.1, pluggy-1.5.0 -- /usr/bin/python
cachedir: .pytest_cache
hypothesis profile 'default' -> database=DirectoryBasedExampleDatabase('/opt/pyg/qa/L0_unittests/.hypothesis/examples')
rootdir: /opt/pyg/pytorch_geometric
configfile: pyproject.toml
plugins: cov-5.0.0, anyio-4.4.0, rerunfailures-14.0, hypothesis-5.35.1, xdist-3.6.1, flakefinder-1.1.0, xdoctest-1.0.2, shard-0.1.2
collected 1 item                                                                                                                                                                                 
Running 1 items in this shard: test/data/lightning/test_datamodule.py::test_lightning_hetero_node_data

collected 1 item                                                                                                                                                                                 
Running 1 items in this shard: test/data/lightning/test_datamodule.py::test_lightning_hetero_node_data

collected 1 item                                                                                                                                                                                 
Running 1 items in this shard: test/data/lightning/test_datamodule.py::test_lightning_hetero_node_data

Epoch 4: 100%|#############################################################################################################################################| 1/1 [00:00<00:00, 35.88it/s, v_num=2]
Testing DataLoader 0: 100%|#########################################################################################################################################| 1/1 [00:00<00:00, 78.77it/s]

#########################################################
#        Test metric        #       DataLoader 0        #
#########################################################
|         test_acc          |    0.20000000298023224    |
+---------------------------+---------------------------+
PASSEDPASSEDPASSEDPASSED

======================================================================================= 1 passed in 3.23s ========================================================================================
```

As we can see, the line 
```
Running 1 items in this shard: test/data/lightning/test_datamodule.py::test_lightning_hetero_node_data
```
is repeated four times in the log file and `PASSED` appears as  `PASSEDPASSEDPASSEDPASSED`.


**First of all**, this means that we should NOT run any of these tests in a group with other tests. Because after 
```
# pytest /opt/pyg/pytorch_geometric/test/
```
All remaining tests from `/opt/pyg/pytorch_geometric/test/` and all its subdirectories will be launched 9 times (1 time by `pytest`, 4 times by `test_lightning_dataset` and 4 times by `test_lightning_hetero_node_data`).

**Secondly**, when these tests are launched separately, everything works fine for `test_lightning_hetero_node_data`. Unfortunately, for `test_lightning_dataset`, we encounter a problem:
```
>           with pytest.warns(UserWarning, match="defined a `validation_step`"):
E           Failed: DID NOT WARN. No warnings of type (<class 'UserWarning'>,) were emitted.
E            Emitted warnings: [].

../../pytorch_geometric/test/data/lightning/test_datamodule.py:131: Failed
```
The expected warning is either not generated or not handled correctly by the `pytest` instance launched internally in `test_lightning_hetero_node_data` when it's called with parameter `strategy_type` set to `"ddt"`.

The proposed PR addresses this issue.