### PR TITLE
Support ONNX export for `scatter` with min/max reduction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- Added ONNX export for `scatter` with min/max reductions ([#9587](https://github.com/pyg-team/pytorch_geometric/pull/9587))
 - Added a `residual` option in `GATConv` and `GATv2Conv` ([#9515](https://github.com/pyg-team/pytorch_geometric/pull/9515))
 - Added the `PatchTransformerAggregation` layer ([#9487](https://github.com/pyg-team/pytorch_geometric/pull/9487))
 - Added the `nn.nlp.LLM` model ([#9462](https://github.com/pyg-team/pytorch_geometric/pull/9462))
@@ -61,7 +62,6 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
-- Fixed ONNX export for `scatter_reduce_` with min/max reductions ([#9587](https://github.com/pyg-team/pytorch_geometric/pull/9587))
 - Fixed an issue where import order in the multi-GPU `cugraph` example could cause an `rmm` error ([#9577](https://github.com/pyg-team/pytorch_geometric/pull/9577))
 - Made the output of the single-GPU `cugraph` example more readable ([#9577](https://github.com/pyg-team/pytorch_geometric/pull/9577))
 - Fixed `load_state_dict` behavior with lazy parameters in `HeteroDictLinear` ([#9493](https://github.com/pyg-team/pytorch_geometric/pull/9493))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- Fixed ONNX export for `torch.scatter_reduce` with min/max reductions ([#9587](https://github.com/pyg-team/pytorch_geometric/pull/9587))
 - Fixed an issue where import order in the multi-GPU `cugraph` example could cause an `rmm` error ([#9577](https://github.com/pyg-team/pytorch_geometric/pull/9577))
 - Made the output of the single-GPU `cugraph` example more readable ([#9577](https://github.com/pyg-team/pytorch_geometric/pull/9577))
 - Fixed `load_state_dict` behavior with lazy parameters in `HeteroDictLinear` ([#9493](https://github.com/pyg-team/pytorch_geometric/pull/9493))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,7 +61,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
-- Fixed ONNX export for `torch.scatter_reduce` with min/max reductions ([#9587](https://github.com/pyg-team/pytorch_geometric/pull/9587))
+- Fixed ONNX export for `scatter_reduce_` with min/max reductions ([#9587](https://github.com/pyg-team/pytorch_geometric/pull/9587))
 - Fixed an issue where import order in the multi-GPU `cugraph` example could cause an `rmm` error ([#9577](https://github.com/pyg-team/pytorch_geometric/pull/9577))
 - Made the output of the single-GPU `cugraph` example more readable ([#9577](https://github.com/pyg-team/pytorch_geometric/pull/9577))
 - Fixed `load_state_dict` behavior with lazy parameters in `HeteroDictLinear` ([#9493](https://github.com/pyg-team/pytorch_geometric/pull/9493))

--- a/torch_geometric/__init__.py
+++ b/torch_geometric/__init__.py
@@ -1,4 +1,5 @@
 from ._compile import compile, is_compiling
+from ._onnx import is_in_onnx_export
 from .index import Index
 from .edge_index import EdgeIndex
 from .seed import seed_everything
@@ -34,6 +35,7 @@ __all__ = [
     'set_home_dir',
     'compile',
     'is_compiling',
+    'is_in_onnx_export',
     'is_mps_available',
     'is_xpu_available',
     'device',

--- a/torch_geometric/_onnx.py
+++ b/torch_geometric/_onnx.py
@@ -1,0 +1,14 @@
+import torch
+
+from torch_geometric import is_compiling
+
+
+def is_in_onnx_export() -> bool:
+    r"""Returns :obj:`True` in case :pytorch:`PyTorch` is exporting to ONNX via
+    :meth:`torch.onnx.export`.
+    """
+    if is_compiling():
+        return False
+    if torch.jit.is_scripting():
+        return False
+    return torch.onnx.is_in_onnx_export()

--- a/torch_geometric/utils/_scatter.py
+++ b/torch_geometric/utils/_scatter.py
@@ -97,9 +97,9 @@ if torch_geometric.typing.WITH_PT112:  # pragma: no cover
                                   f" package, but it was not found")
 
                 res = src.new_zeros(size)
+                # `scatter_reduce_` with `include_self=False` is not currently
+                # supported by onnx
                 if src.numel() > 0:
-                    # `scatter_reduce_` with `include_self=False` is not
-                    # currently supported by onnx
                     fill_value = src.max() if "min" in reduce else src.min()
                     [res.select(dim, i).fill_(fill_value) for i in index]
                 index = broadcast(index, src, dim)

--- a/torch_geometric/utils/_scatter.py
+++ b/torch_geometric/utils/_scatter.py
@@ -97,8 +97,8 @@ if torch_geometric.typing.WITH_PT112:  # pragma: no cover
                                   f" package, but it was not found")
 
                 index = broadcast(index, src, dim)
-                fill_value = src.max().item() if "min" in reduce else src.min(
-                ).item()
+                fill_value = (0 if src.numel() == 0 else src.max().item()
+                              if "min" in reduce else src.min().item())
                 return src.new_full(size, fill_value).scatter_reduce_(
                     dim, index, src, reduce=f"a{reduce[-3:]}",
                     include_self=True)
@@ -202,7 +202,8 @@ def scatter_argmax(
         dim_size = int(index.max()) + 1 if index.numel() > 0 else 0
 
     if torch_geometric.typing.WITH_PT112:
-        res = src.new_full((dim_size, ), src.min().item())
+        fill_value = 0 if src.numel() == 0 else src.min().item()
+        res = src.new_full((dim_size, ), fill_value)
         res.scatter_reduce_(0, index, src.detach(), reduce="amax",
                             include_self=True)
     elif torch_geometric.typing.WITH_PT111:

--- a/torch_geometric/utils/_scatter.py
+++ b/torch_geometric/utils/_scatter.py
@@ -100,8 +100,7 @@ if torch_geometric.typing.WITH_PT112:  # pragma: no cover
                 if src.numel() > 0:
                     # `scatter_reduce_` with `include_self=False` is not
                     # currently supported by onnx
-                    fill_value = (src.max().item()
-                                  if "min" in reduce else src.min().item())
+                    fill_value = src.max() if "min" in reduce else src.min()
                     [res.select(dim, i).fill_(fill_value) for i in index]
                 index = broadcast(index, src, dim)
                 res.scatter_reduce_(dim, index, src, reduce=f"a{reduce[-3:]}",
@@ -211,8 +210,7 @@ def scatter_argmax(
         # `scatter_reduce_` with `include_self=False` is not currently
         # supported by onnx
         if src.numel() > 0:
-            fill_value = src.min().item()
-            [res.select(0, i).fill_(fill_value) for i in index]
+            [res.select(0, i).fill_(src.min()) for i in index]
         res.scatter_reduce_(0, index, src.detach(), reduce="amax",
                             include_self=True)
     elif torch_geometric.typing.WITH_PT111:

--- a/torch_geometric/utils/_scatter.py
+++ b/torch_geometric/utils/_scatter.py
@@ -103,8 +103,8 @@ if torch_geometric.typing.WITH_PT112:  # pragma: no cover
                         dim, index, src, reduce=f'a{reduce[-3:]}',
                         include_self=False)
 
-                fill = torch.full(
-                    (1, ),
+                fill = torch.full(  # type: ignore
+                    size=(1, ),
                     fill_value=src.min() if 'max' in reduce else src.max(),
                     dtype=src.dtype,
                     device=src.device,
@@ -222,7 +222,10 @@ def scatter_argmax(
                                 include_self=False)
         else:
             # `include_self=False` is currently not supported by ONNX:
-            res = src.new_full((dim_size, ), fill_value=src.min())
+            res = src.new_full(
+                size=(dim_size, ),
+                fill_value=src.min(),  # type: ignore
+            )
             res.scatter_reduce_(0, index, src.detach(), reduce="amax",
                                 include_self=True)
     elif torch_geometric.typing.WITH_PT111:


### PR DESCRIPTION
Attempt to address issue https://github.com/pyg-team/pytorch_geometric/issues/8415 and unblock ONNX export. 

As I understand it, the issue is that when we're applying min/max reductions with `scatter_reduce_` to populate a `self` tensor of zeroes or an empty tensor, we need to set `include_self=False` to prevent the initial fill value from influencing the min/max results. For that reason simply setting `include_self=True` in these cases is not the right solution since it would change the behaviour of the reduction.

A simple behaviour-preserving solution is to initialize the `self` tensor such that it doesn't influence the min/max result when `include_self=True`. This can be done using the dtype min/max values provided by `torch.finfo` or `torch.iinfo` to initialize the elements of `self` that will be populated by `scatter_reduce_`. Unfortunately they aren't currently scriptable (see https://github.com/pytorch/pytorch/issues/25661), but it's possible to get them in a roundabout way by casting `torch.inf` (which also works for int types).

There was a nuance where certain test cases expected zeros in the `self` tensor for entries that were not involved in the scatter-reduce index. We can preserve that behaviour by scattering the dtype min/max value into a zero tensor along the index so that only the relevant entries are initialized that way.

Another less efficient option would be to calculate the max/min value of the `src` tensor itself and use that as the fill value.