### PR TITLE
Destroy process group in `graphgym` test

### DIFF
--- a/test/data/lightning/test_datamodule.py
+++ b/test/data/lightning/test_datamodule.py
@@ -290,7 +290,8 @@ class LinearHeteroNodeModule(LightningModule):
 def preserve_context():
     num_threads = torch.get_num_threads()
     yield
-    torch.distributed.destroy_process_group()
+    if torch.distributed.is_initialized():
+        torch.distributed.destroy_process_group()
     torch.set_num_threads(num_threads)
 
 

--- a/test/graphgym/test_graphgym.py
+++ b/test/graphgym/test_graphgym.py
@@ -166,7 +166,8 @@ def test_graphgym_module(tmp_path):
 @pytest.fixture
 def destroy_process_group():
     yield
-    torch.distributed.destroy_process_group()
+    if torch.distributed.is_initialized():
+        torch.distributed.destroy_process_group()
 
 
 @onlyOnline

--- a/test/graphgym/test_graphgym.py
+++ b/test/graphgym/test_graphgym.py
@@ -164,7 +164,7 @@ def test_graphgym_module(tmp_path):
 
 
 @pytest.fixture
-def destroy_pg():
+def destroy_process_graph():
     yield
     torch.distributed.destroy_process_group()
 
@@ -172,7 +172,7 @@ def destroy_pg():
 @onlyOnline
 @onlyLinux
 @withPackage('yacs', 'pytorch_lightning')
-def test_train(destroy_pg, tmp_path, capfd):
+def test_train(destroy_process_group, tmp_path, capfd):
     warnings.filterwarnings('ignore', ".*does not have many workers.*")
 
     import pytorch_lightning as pl

--- a/test/graphgym/test_graphgym.py
+++ b/test/graphgym/test_graphgym.py
@@ -163,10 +163,16 @@ def test_graphgym_module(tmp_path):
     assert isinstance(outputs["loss"], torch.Tensor)
 
 
+@pytest.fixture
+def destroy_pg():
+     yield
+     torch.distributed.destroy_process_group()
+
+
 @onlyOnline
 @onlyLinux
 @withPackage('yacs', 'pytorch_lightning')
-def test_train(tmp_path, capfd):
+def test_train(destroy_pg, tmp_path, capfd):
     warnings.filterwarnings('ignore', ".*does not have many workers.*")
 
     import pytorch_lightning as pl

--- a/test/graphgym/test_graphgym.py
+++ b/test/graphgym/test_graphgym.py
@@ -165,8 +165,8 @@ def test_graphgym_module(tmp_path):
 
 @pytest.fixture
 def destroy_pg():
-     yield
-     torch.distributed.destroy_process_group()
+    yield
+    torch.distributed.destroy_process_group()
 
 
 @onlyOnline

--- a/test/graphgym/test_graphgym.py
+++ b/test/graphgym/test_graphgym.py
@@ -164,7 +164,7 @@ def test_graphgym_module(tmp_path):
 
 
 @pytest.fixture
-def destroy_process_graph():
+def destroy_process_group():
     yield
     torch.distributed.destroy_process_group()
 


### PR DESCRIPTION
When `test_graphgym.py::test_train` is executed, a process group is created.  If this group is not properly destroyed, it can interfere with subsequent tests, causing failures such as:
```
FAILED ../../pytorch_geometric/test/metrics/test_link_pred_metric.py::test_precision[1-32-3000-1000-100] - RuntimeError: No backend type associated with device type cpu
FAILED ../../pytorch_geometric/test/metrics/test_link_pred_metric.py::test_precision[10-32-3000-1000-100] - RuntimeError: No backend type associated with device type cpu
FAILED ../../pytorch_geometric/test/metrics/test_link_pred_metric.py::test_precision[100-32-3000-1000-100] - RuntimeError: No backend type associated with device type cpu
FAILED ../../pytorch_geometric/test/metrics/test_link_pred_metric.py::test_recall - RuntimeError: No backend type associated with device type cpu
FAILED ../../pytorch_geometric/test/metrics/test_link_pred_metric.py::test_f1 - RuntimeError: No backend type associated with device type cpu
FAILED ../../pytorch_geometric/test/metrics/test_link_pred_metric.py::test_map - RuntimeError: No backend type associated with device type cpu
FAILED ../../pytorch_geometric/test/metrics/test_link_pred_metric.py::test_ndcg - RuntimeError: No backend type associated with device type CPU
```
A similar bug was recently fixed by [PR#9534](https://github.com/pyg-team/pytorch_geometric/pull/9534). 