### PR TITLE
Fix Profiler String Parsing Bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- Fixed an issue with string parsing on `profile.Profiler` with determining stack frame depth ([#9599](https://github.com/pyg-team/pytorch_geometric/pull/9599))
 - Fixed an issue where import order in the multi-GPU `cugraph` example could cause an `rmm` error ([#9577](https://github.com/pyg-team/pytorch_geometric/pull/9577))
 - Made the output of the single-GPU `cugraph` example more readable ([#9577](https://github.com/pyg-team/pytorch_geometric/pull/9577))
 - Fixed `load_state_dict` behavior with lazy parameters in `HeteroDictLinear` ([#9493](https://github.com/pyg-team/pytorch_geometric/pull/9493))

--- a/torch_geometric/profile/profiler.py
+++ b/torch_geometric/profile/profiler.py
@@ -1,6 +1,7 @@
 import functools
 from collections import OrderedDict, defaultdict, namedtuple
 from typing import Any, List, NamedTuple, Optional, Tuple
+import re
 
 import torch
 import torch.profiler as torch_profiler
@@ -300,13 +301,14 @@ def _layer_trace(
     layer_names = []
     layer_stats = []
     for format_line in format_lines:  # body
+        # get current line's level based on number of '-' in prefix
+        current_line_level = len(re.match(r'^(-+).*', format_line[0]).group(1))
         if format_line[1] == '':  # key line
-            key_dict[format_line[0].count("-")] = format_line[0]
+            key_dict[current_line_level] = format_line[0]
         else:  # must print
             # get current line's level
-            curr_level = format_line[0].count("-")
             par_str = ""
-            for i in range(1, curr_level):
+            for i in range(1, current_line_level):
                 par_str += key_dict[i]
             curr_key = par_str + format_line[0]
             layer_names.append(curr_key)

--- a/torch_geometric/profile/profiler.py
+++ b/torch_geometric/profile/profiler.py
@@ -1,7 +1,7 @@
 import functools
+import re
 from collections import OrderedDict, defaultdict, namedtuple
 from typing import Any, List, NamedTuple, Optional, Tuple
-import re
 
 import torch
 import torch.profiler as torch_profiler


### PR DESCRIPTION
Fix a bug in the profiler where the stack trace isn't parsed correctly due to string parsing issues. It looks like this case was already checked for in the unittests but was previously failing.