### PR TITLE
[FutureWarning] Fixing multiple warnings generated by `is_compiling()`

### DIFF
--- a/torch_geometric/_compile.py
+++ b/torch_geometric/_compile.py
@@ -10,8 +10,10 @@ def is_compiling() -> bool:
     r"""Returns :obj:`True` in case :pytorch:`PyTorch` is compiling via
     :meth:`torch.compile`.
     """
-    if torch_geometric.typing.WITH_PT21:
+    if torch_geometric.typing.WITH_PT23:
         return torch.compiler.is_compiling()
+    if torch_geometric.typing.WITH_PT21:
+        return torch._dynamo.is_compiling()
     return False  # pragma: no cover
 
 

--- a/torch_geometric/_compile.py
+++ b/torch_geometric/_compile.py
@@ -11,7 +11,7 @@ def is_compiling() -> bool:
     :meth:`torch.compile`.
     """
     if torch_geometric.typing.WITH_PT21:
-        return torch._dynamo.is_compiling()
+        return torch.compiler.is_compiling()
     return False  # pragma: no cover
 
 


### PR DESCRIPTION
The following warning:
```
======================================================================================= warnings summary ========================================================================================
test/contrib/nn/models/test_rbcd_attack.py: 36 warnings
test/data/lightning/test_datamodule.py: 3 warnings
test/data/test_batch.py: 3 warnings
test/data/test_data.py: 2 warnings
test/data/test_datapipes.py: 1 warning
test/data/test_dataset_summary.py: 5 warnings
test/data/test_graph_store.py: 1 warning
test/data/test_hypergraph_data.py: 1 warning
test/datasets/graph_generator/test_ba_graph.py: 1 warning
test/datasets/graph_generator/test_er_graph.py: 1 warning
test/datasets/graph_generator/test_grid_graph.py: 1 warning
test/datasets/graph_generator/test_tree_graph.py: 1 warning
test/datasets/test_ba_shapes.py: 1 warning
test/datasets/test_bzr.py: 1 warning
test/datasets/test_enzymes.py: 2 warnings
test/datasets/test_explainer_dataset.py: 3 warnings
test/datasets/test_fake.py: 36 warnings
test/datasets/test_imdb_binary.py: 1 warning
test/datasets/test_infection_dataset.py: 2 warnings
test/datasets/test_mutag.py: 1 warning
test/datasets/test_planetoid.py: 1 warning
test/datasets/test_snap_dataset.py: 12 warnings
  /usr/local/lib/python3.10/dist-packages/torch_geometric/_compile.py:15: 
FutureWarning: `torch._dynamo.external_utils.is_compiling` is deprecated. 
Use `torch.compiler.is_compiling` instead.
    return torch._dynamo.is_compiling()
```
has recently started appearing in multiple PYG tests. This PR addresses the issue.