### PR TITLE
[FutureWarning] Addressing warnings related to `cuda_memory_*` and `cuda_time_*` attributes

### DIFF
--- a/.github/workflows/full_testing.yml
+++ b/.github/workflows/full_testing.yml
@@ -36,13 +36,13 @@ jobs:
           - os: macos-14
             python-version: '3.8'
           - os: macos-14
-            torch-verion: 1.13.0
+            torch-version: 1.13.0
           - os: macos-14
-            torch-verion: 2.0.0
+            torch-version: 2.0.0
           - os: macos-14
-            torch-verion: 2.1.0
+            torch-version: 2.1.0
           - os: macos-14
-            torch-verion: 2.2.0
+            torch-version: 2.2.0
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/minimal_testing.yml
+++ b/.github/workflows/minimal_testing.yml
@@ -1,4 +1,4 @@
-name: Testing minimal PyTorch 2.3
+name: Testing minimal PyTorch 2.4
 
 on:  # yamllint disable-line rule:truthy
   push:

--- a/torch_geometric/profile/profiler.py
+++ b/torch_geometric/profile/profiler.py
@@ -5,6 +5,8 @@ from typing import Any, List, NamedTuple, Optional, Tuple
 import torch
 import torch.profiler as torch_profiler
 
+import torch_geometric.typing
+
 # predefined namedtuple for variable setting (global template)
 Trace = namedtuple('Trace', ['path', 'leaf', 'module'])
 
@@ -325,6 +327,8 @@ def _flatten_tree(t, depth=0):
 
 
 def _build_measure_tuple(events: List, occurrences: List) -> NamedTuple:
+    device_str = 'device' if torch_geometric.typing.WITH_PT24 else 'cuda'
+
     # memory profiling supported in torch >= 1.6
     self_cpu_memory = None
     has_self_cpu_memory = any(
@@ -339,29 +343,34 @@ def _build_measure_tuple(events: List, occurrences: List) -> NamedTuple:
             [getattr(e, "cpu_memory_usage", 0) or 0 for e in events])
     self_cuda_memory = None
     has_self_cuda_memory = any(
-        hasattr(e, "self_device_memory_usage") for e in events)
+        hasattr(e, f"self_{device_str}_memory_usage") for e in events)
     if has_self_cuda_memory:
-        self_cuda_memory = sum(
-            [getattr(e, "self_device_memory_usage", 0) or 0 for e in events])
+        self_cuda_memory = sum([
+            getattr(e, f"self_{device_str}_memory_usage", 0) or 0
+            for e in events
+        ])
     cuda_memory = None
-    has_cuda_memory = any(hasattr(e, "device_memory_usage") for e in events)
+    has_cuda_memory = any(
+        hasattr(e, f"{device_str}_memory_usage") for e in events)
     if has_cuda_memory:
         cuda_memory = sum(
-            [getattr(e, "device_memory_usage", 0) or 0 for e in events])
+            [getattr(e, f"{device_str}_memory_usage", 0) or 0 for e in events])
 
     # self CUDA time supported in torch >= 1.7
     self_cuda_total = None
     has_self_cuda_time = any(
-        hasattr(e, "self_device_time_total") for e in events)
+        hasattr(e, f"self_{device_str}_time_total") for e in events)
     if has_self_cuda_time:
-        self_cuda_total = sum(
-            [getattr(e, "self_device_time_total", 0) or 0 for e in events])
+        self_cuda_total = sum([
+            getattr(e, f"self_{device_str}_time_total", 0) or 0 for e in events
+        ])
 
     return Measure(
         self_cpu_total=sum([e.self_cpu_time_total or 0 for e in events]),
         cpu_total=sum([e.cpu_time_total or 0 for e in events]),
         self_cuda_total=self_cuda_total,
-        cuda_total=sum([e.device_time_total or 0 for e in events]),
+        cuda_total=sum(
+            [getattr(e, f"{device_str}_time_total") or 0 for e in events]),
         self_cpu_memory=self_cpu_memory,
         cpu_memory=cpu_memory,
         self_cuda_memory=self_cuda_memory,

--- a/torch_geometric/profile/profiler.py
+++ b/torch_geometric/profile/profiler.py
@@ -339,29 +339,29 @@ def _build_measure_tuple(events: List, occurrences: List) -> NamedTuple:
             [getattr(e, "cpu_memory_usage", 0) or 0 for e in events])
     self_cuda_memory = None
     has_self_cuda_memory = any(
-        hasattr(e, "self_cuda_memory_usage") for e in events)
+        hasattr(e, "self_device_memory_usage") for e in events)
     if has_self_cuda_memory:
         self_cuda_memory = sum(
-            [getattr(e, "self_cuda_memory_usage", 0) or 0 for e in events])
+            [getattr(e, "self_device_memory_usage", 0) or 0 for e in events])
     cuda_memory = None
-    has_cuda_memory = any(hasattr(e, "cuda_memory_usage") for e in events)
+    has_cuda_memory = any(hasattr(e, "device_memory_usage") for e in events)
     if has_cuda_memory:
         cuda_memory = sum(
-            [getattr(e, "cuda_memory_usage", 0) or 0 for e in events])
+            [getattr(e, "device_memory_usage", 0) or 0 for e in events])
 
     # self CUDA time supported in torch >= 1.7
     self_cuda_total = None
     has_self_cuda_time = any(
-        hasattr(e, "self_cuda_time_total") for e in events)
+        hasattr(e, "self_device_time_total") for e in events)
     if has_self_cuda_time:
         self_cuda_total = sum(
-            [getattr(e, "self_cuda_time_total", 0) or 0 for e in events])
+            [getattr(e, "self_device_time_total", 0) or 0 for e in events])
 
     return Measure(
         self_cpu_total=sum([e.self_cpu_time_total or 0 for e in events]),
         cpu_total=sum([e.cpu_time_total or 0 for e in events]),
         self_cuda_total=self_cuda_total,
-        cuda_total=sum([e.cuda_time_total or 0 for e in events]),
+        cuda_total=sum([e.device_time_total or 0 for e in events]),
         self_cpu_memory=self_cpu_memory,
         cpu_memory=cpu_memory,
         self_cuda_memory=self_cuda_memory,


### PR DESCRIPTION
This PR resolves the following set of warnings:
```
test/profile/test_profiler.py::test_profiler[cpu]
test/profile/test_profiler.py::test_profiler[cuda:0]
  /usr/local/lib/python3.10/dist-packages/torch_geometric/profile/profiler.py:342: FutureWarning: `self_cuda_memory_usage` is deprecated. Use `self_device_memory_usage` instead.
    hasattr(e, "self_cuda_memory_usage") for e in events)

test/profile/test_profiler.py::test_profiler[cpu]
test/profile/test_profiler.py::test_profiler[cuda:0]
  /usr/local/lib/python3.10/dist-packages/torch_geometric/profile/profiler.py:345: FutureWarning: `self_cuda_memory_usage` is deprecated. Use `self_device_memory_usage` instead.
    [getattr(e, "self_cuda_memory_usage", 0) or 0 for e in events])

test/profile/test_profiler.py::test_profiler[cpu]
test/profile/test_profiler.py::test_profiler[cuda:0]
  /usr/local/lib/python3.10/dist-packages/torch_geometric/profile/profiler.py:355: FutureWarning: `self_cuda_time_total` is deprecated. Use `self_device_time_total` instead.
    hasattr(e, "self_cuda_time_total") for e in events)

test/profile/test_profiler.py::test_profiler[cpu]
test/profile/test_profiler.py::test_profiler[cuda:0]
  /usr/local/lib/python3.10/dist-packages/torch_geometric/profile/profiler.py:358: FutureWarning: `self_cuda_time_total` is deprecated. Use `self_device_time_total` instead.
    [getattr(e, "self_cuda_time_total", 0) or 0 for e in events])

test/profile/test_profiler.py::test_profiler[cpu]
test/profile/test_profiler.py::test_profiler[cuda:0]
  /usr/local/lib/python3.10/dist-packages/torch_geometric/profile/profiler.py:364: FutureWarning: `cuda_time_total` is deprecated. Use `device_time_total` instead.
    cuda_total=sum([e.cuda_time_total or 0 for e in events]),
```