### PR TITLE
Control factor to limit data download in `OPFDataset`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- Added control factor `num_groups=20` for controlling the size of OPFDataset download ([#9621](https://github.com/pyg-team/pytorch_geometric/pull/9621))
 - Added PyTorch 2.4 support ([#9594](https://github.com/pyg-team/pytorch_geometric/pull/9594))
 - Added `utils.normalize_edge_index` for symmetric/asymmetric normalization of graph edges ([#9554](https://github.com/pyg-team/pytorch_geometric/pull/9554))
 - Added the `RemoveSelfLoops` transformation ([#9562](https://github.com/pyg-team/pytorch_geometric/pull/9562))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,6 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
-- Added control factor `num_groups=20` for controlling the size of OPFDataset download ([#9621](https://github.com/pyg-team/pytorch_geometric/pull/9621))
 - Added PyTorch 2.4 support ([#9594](https://github.com/pyg-team/pytorch_geometric/pull/9594))
 - Added `utils.normalize_edge_index` for symmetric/asymmetric normalization of graph edges ([#9554](https://github.com/pyg-team/pytorch_geometric/pull/9554))
 - Added the `RemoveSelfLoops` transformation ([#9562](https://github.com/pyg-team/pytorch_geometric/pull/9562))

--- a/torch_geometric/datasets/opf.py
+++ b/torch_geometric/datasets/opf.py
@@ -41,10 +41,10 @@ class OPFDataset(InMemoryDataset):
             If :obj:`"test"`, loads the test dataset. (default: :obj:`"train"`)
         case_name (str, optional): The name of the original pglib-opf case.
             (default: :obj:`"pglib_opf_case14_ieee"`)
-        num_groups (int, optional): The dataset is divided into 20 groups with 
+        num_groups (int, optional): The dataset is divided into 20 groups with
             each group containing 15000 samples. For large systems, this amount
             of data can be overwhelming. The num_groups parameters controls the
-            amount of data being downloaded. Allowable values are [1, 20]. 
+            amount of data being downloaded. Allowable values are [1, 20].
             (default: :obj:`20`)
         topological_perturbations (bool, optional): Whether to use the dataset
             with added topological perturbations. (default: :obj:`False`)

--- a/torch_geometric/datasets/opf.py
+++ b/torch_geometric/datasets/opf.py
@@ -43,7 +43,7 @@ class OPFDataset(InMemoryDataset):
             (default: :obj:`"pglib_opf_case14_ieee"`)
         num_groups (int, optional): The dataset is divided into 20 groups with
             each group containing 15,000 samples.
-            On smaller systems, this amount of data can be overwhelming.
+            For large networks, this amount of data can be overwhelming.
             The :obj:`num_groups` parameters controls the amount of data being
             downloaded. Allowed values are :obj:`[1, 20]`.
             (default: :obj:`20`)

--- a/torch_geometric/datasets/opf.py
+++ b/torch_geometric/datasets/opf.py
@@ -42,9 +42,10 @@ class OPFDataset(InMemoryDataset):
         case_name (str, optional): The name of the original pglib-opf case.
             (default: :obj:`"pglib_opf_case14_ieee"`)
         num_groups (int, optional): The dataset is divided into 20 groups with
-            each group containing 15000 samples. For large systems, this amount
-            of data can be overwhelming. The num_groups parameters controls the
-            amount of data being downloaded. Allowable values are [1, 20].
+            each group containing 15,000 samples.
+            On smaller systems, this amount of data can be overwhelming.
+            The :obj:`num_groups` parameters controls the amount of data being
+            downloaded. Allowed values are :obj:`[1, 20]`.
             (default: :obj:`20`)
         topological_perturbations (bool, optional): Whether to use the dataset
             with added topological perturbations. (default: :obj:`False`)

--- a/torch_geometric/datasets/opf.py
+++ b/torch_geometric/datasets/opf.py
@@ -111,7 +111,8 @@ class OPFDataset(InMemoryDataset):
 
     @property
     def processed_dir(self) -> str:
-        return osp.join(self.root, self._release, self.case_name, 'processed')
+        return osp.join(self.root, self._release, self.case_name,
+                        f'processed_{self.num_groups}')
 
     @property
     def raw_file_names(self) -> List[str]:

--- a/torch_geometric/datasets/opf.py
+++ b/torch_geometric/datasets/opf.py
@@ -41,6 +41,11 @@ class OPFDataset(InMemoryDataset):
             If :obj:`"test"`, loads the test dataset. (default: :obj:`"train"`)
         case_name (str, optional): The name of the original pglib-opf case.
             (default: :obj:`"pglib_opf_case14_ieee"`)
+        num_groups (int, optional): The dataset is divided into 20 groups with 
+            each group containing 15000 samples. For large systems, this amount
+            of data can be overwhelming. The num_groups parameters controls the
+            amount of data being downloaded. Allowable values are [1, 20]. 
+            (default: :obj:`20`)
         topological_perturbations (bool, optional): Whether to use the dataset
             with added topological perturbations. (default: :obj:`False`)
         transform (callable, optional): A function/transform that takes in
@@ -76,6 +81,7 @@ class OPFDataset(InMemoryDataset):
             'pglib_opf_case10000_goc',
             'pglib_opf_case13659_pegase',
         ] = 'pglib_opf_case14_ieee',
+        num_groups: int = 20,
         topological_perturbations: bool = False,
         transform: Optional[Callable] = None,
         pre_transform: Optional[Callable] = None,
@@ -85,6 +91,7 @@ class OPFDataset(InMemoryDataset):
 
         self.split = split
         self.case_name = case_name
+        self.num_groups = num_groups
         self.topological_perturbations = topological_perturbations
 
         self._release = 'dataset_release_1'
@@ -107,7 +114,7 @@ class OPFDataset(InMemoryDataset):
 
     @property
     def raw_file_names(self) -> List[str]:
-        return [f'{self.case_name}_{i}.tar.gz' for i in range(20)]
+        return [f'{self.case_name}_{i}.tar.gz' for i in range(self.num_groups)]
 
     @property
     def processed_file_names(self) -> List[str]:
@@ -124,7 +131,7 @@ class OPFDataset(InMemoryDataset):
         val_data_list = []
         test_data_list = []
 
-        for group in tqdm.tqdm(range(20)):
+        for group in tqdm.tqdm(range(self.num_groups)):
             tmp_dir = osp.join(
                 self.raw_dir,
                 'gridopt-dataset-tmp',


### PR DESCRIPTION
Adds additional parameter ``num_groups``, with default value of 20 to control the amount of data being downloaded. This factor is necessary because the larger test cases's size can be > 3 TB.