### PR TITLE
Fix for empty `pd.DataFrame` in `WebQSPDataset`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- Fixed `WebQSDataset.process` raising exceptions ([#9665](https://github.com/pyg-team/pytorch_geometric/pull/9665))
+
 ### Removed
 
 ## \[2.6.0\] - 2024-09-13

--- a/torch_geometric/datasets/web_qsp_dataset.py
+++ b/torch_geometric/datasets/web_qsp_dataset.py
@@ -212,10 +212,10 @@ class WebQSPDataset(InMemoryDataset):
                     batch_size=256,
                     output_device='cpu',
                 )
-                edge_index = torch.LongTensor([
+                edge_index = torch.tensor([
                     edges.src.tolist(),
                     edges.dst.tolist(),
-                ])
+                ], dtype=torch.long)
 
                 question = f"Question: {example['question']}\nAnswer: "
                 label = ('|').join(example['answer']).lower()

--- a/torch_geometric/datasets/web_qsp_dataset.py
+++ b/torch_geometric/datasets/web_qsp_dataset.py
@@ -196,8 +196,8 @@ class WebQSPDataset(InMemoryDataset):
                 nodes = pd.DataFrame([{
                     "node_id": v,
                     "node_attr": k,
-                } for k, v in raw_nodes.items()])
-                edges = pd.DataFrame(raw_edges)
+                } for k, v in raw_nodes.items()], columns=["node_id", "node_attr"])
+                edges = pd.DataFrame(raw_edges, columns=["src", "edge_attr", "dst"])
 
                 nodes.node_attr = nodes.node_attr.fillna("")
                 x = model.encode(
@@ -210,7 +210,7 @@ class WebQSPDataset(InMemoryDataset):
                     batch_size=256,
                     output_device='cpu',
                 )
-                edge_index = torch.tensor([
+                edge_index = torch.LongTensor([
                     edges.src.tolist(),
                     edges.dst.tolist(),
                 ])

--- a/torch_geometric/datasets/web_qsp_dataset.py
+++ b/torch_geometric/datasets/web_qsp_dataset.py
@@ -196,8 +196,10 @@ class WebQSPDataset(InMemoryDataset):
                 nodes = pd.DataFrame([{
                     "node_id": v,
                     "node_attr": k,
-                } for k, v in raw_nodes.items()], columns=["node_id", "node_attr"])
-                edges = pd.DataFrame(raw_edges, columns=["src", "edge_attr", "dst"])
+                } for k, v in raw_nodes.items()],
+                                     columns=["node_id", "node_attr"])
+                edges = pd.DataFrame(raw_edges,
+                                     columns=["src", "edge_attr", "dst"])
 
                 nodes.node_attr = nodes.node_attr.fillna("")
                 x = model.encode(


### PR DESCRIPTION
this last minute commit broke things: https://github.com/pyg-team/pytorch_geometric/pull/9481/commits/e331dcd71d0d31948c002ecaa93b3443291afea9

the changes to `, columns=...` is for
```
Traceback (most recent call last):
  File "/opt/pyg/pytorch_geometric/examples/llm/g_retriever.py", line 262, in <module>
    train(
  File "/opt/pyg/pytorch_geometric/examples/llm/g_retriever.py", line 132, in train
    train_dataset = WebQSPDataset(path, split='train')
  File "/usr/local/lib/python3.10/dist-packages/torch_geometric/datasets/web_qsp_dataset.py", line 145, in __init__
    super().__init__(root, force_reload=force_reload)
  File "/usr/local/lib/python3.10/dist-packages/torch_geometric/data/in_memory_dataset.py", line 81, in __init__
    super().__init__(root, transform, pre_transform, pre_filter, log,
  File "/usr/local/lib/python3.10/dist-packages/torch_geometric/data/dataset.py", line 115, in __init__
    self._process()
  File "/usr/local/lib/python3.10/dist-packages/torch_geometric/data/dataset.py", line 262, in _process
    self.process()
  File "/usr/local/lib/python3.10/dist-packages/torch_geometric/datasets/web_qsp_dataset.py", line 202, in process
    nodes.node_attr = nodes.node_attr.fillna("")
  File "/usr/local/lib/python3.10/dist-packages/pandas/core/generic.py", line 6299, in __getattr__
    return object.__getattribute__(self, name)
AttributeError: 'DataFrame' object has no attribute 'node_attr'

```
then the LongTensor change is for


```
    return scatter(edge_attr, col, 0, num_nodes, fill_value)
  File "/usr/local/lib/python3.10/dist-packages/torch_geometric/utils/_scatter.py", line 79, in scatter
    count.scatter_add_(0, index, src.new_ones(src.size(dim)))
RuntimeError: scatter(): Expected dtype int64 for index
```

this is the handle the edgecase where the Question Answer pair has no knowledge graph associated