### PR TITLE
[FutureWarning] Addressing the warning related to use of a deprecated function.

### DIFF
--- a/torch_geometric/nn/nlp/llm.py
+++ b/torch_geometric/nn/nlp/llm.py
@@ -91,7 +91,7 @@ class LLM(torch.nn.Module):
             self.autocast_context = nullcontext()
         else:
             self.device = self.llm.device
-            self.autocast_context = torch.cuda.amp.autocast(dtype=dtype)
+            self.autocast_context = torch.amp.autocast('cuda', dtype=dtype)
 
     def _encode_inputs(
         self,


### PR DESCRIPTION
This PR resolves a FutureWarning that appears in several tests:
```
test/nn/models/test_g_retriever.py::test_g_retriever
test/nn/models/test_g_retriever.py::test_g_retriever_many_tokens
test/nn/nlp/test_llm.py::test_llm
  /usr/local/lib/python3.10/dist-packages/torch_geometric/nn/nlp/llm.py:97: FutureWarning: `torch.cuda.amp.autocast(args...)` is deprecated. Please use `torch.amp.autocast('cuda', args...)` instead.
    self.autocast_context = torch.cuda.amp.autocast(dtype=dtype)
``` 