### PR TITLE
fix a typo in explainability docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
+- Fixed a typo in explainability docs ([#9676](https://github.com/pyg-team/pytorch_geometric/pull/9676))
+
 ### Deprecated
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,6 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
-- Fixed a typo in explainability docs ([#9676](https://github.com/pyg-team/pytorch_geometric/pull/9676))
-
 ### Deprecated
 
 ### Fixed

--- a/docs/source/modules/explain.rst
+++ b/docs/source/modules/explain.rst
@@ -11,7 +11,7 @@ torch_geometric.explain
 .. contents:: Contents
     :local:
 
-Philoshopy
+Philosophy
 ----------
 
 This module provides a set of tools to explain the predictions of a PyG model or to explain the underlying phenomenon of a dataset (see the `"GraphFramEx: Towards Systematic Evaluation of Explainability Methods for Graph Neural Networks" <https://arxiv.org/abs/2206.09677>`_ paper for more details).


### PR DESCRIPTION
changed 'Philoshopy' to philosophy