### PR TITLE
Drop support for Python 3.8

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -3,7 +3,7 @@ name: Setup
 inputs:
   python-version:
     required: false
-    default: '3.8'
+    default: '3.9'
   torch-version:
     required: false
     default: '2.4.0'
@@ -22,7 +22,7 @@ runs:
 
   steps:
     - name: Set up Python ${{ inputs.python-version }}
-      uses: actions/setup-python@v4.3.0
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ inputs.python-version }}
         check-latest: true

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -56,13 +56,13 @@ runs:
       shell: bash
 
     - name: Install faiss-cpu
-      if: ${{ inputs.full_install == 'true' && inputs.cuda-version == 'cpu' && runner.os != 'macOS' }}
+      if: ${{ inputs.full_install == 'true' && inputs.cuda-version == 'cpu' && runner.os == 'Linux' }}
       run: |
         pip install faiss-cpu==1.7.2
       shell: bash
 
     - name: Install faiss-gpu
-      if: ${{ inputs.full_install == 'true' && inputs.cuda-version != 'cpu' }}
+      if: ${{ inputs.full_install == 'true' && inputs.cuda-version != 'cpu' && runner.os == 'Linux' }}
       run: |
         pip install faiss-gpu==1.7.2
       shell: bash

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -30,6 +30,12 @@ runs:
         cache-dependency-path: |
           pyproject.toml
 
+    - name: Install numpy
+      if: ${{ runner.os == 'Windows' }}
+      run: |
+        pip install "numpy<2"
+      shell: bash
+
     - name: Install PyTorch ${{ inputs.torch-version }}+${{ inputs.cuda-version }}
       if: ${{ inputs.torch-version != 'nightly' }}
       run: |

--- a/.github/workflows/building_pyg_conda.yml
+++ b/.github/workflows/building_pyg_conda.yml
@@ -11,7 +11,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-14, windows-latest]
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.9', '3.10', '3.11', '3.12']
         torch-version: [1.12.0, 1.13.0, 2.0.0, 2.1.0, 2.2.0]
         cuda-version: ['cpu', 'cu113', 'cu116', 'cu117', 'cu118', 'cu121']
         exclude:
@@ -67,8 +67,6 @@ jobs:
             cuda-version: 'cu118'
           - os: macos-14
             cuda-version: 'cu121'
-          - os: macos-14
-            python-version: '3.8'
           - os: macos-14
             python-version: '3.9'
 

--- a/.github/workflows/building_rusty1s_conda.yml
+++ b/.github/workflows/building_rusty1s_conda.yml
@@ -11,7 +11,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-14, windows-latest]
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.9', '3.10', '3.11', '3.12']
         torch-version: [1.12.0, 1.13.0, 2.0.0, 2.1.0, 2.2.0]
         cuda-version: ['cpu', 'cu113', 'cu116', 'cu117', 'cu118', 'cu121']
         exclude:
@@ -67,8 +67,6 @@ jobs:
             cuda-version: 'cu118'
           - os: macos-14
             cuda-version: 'cu121'
-          - os: macos-14
-            python-version: '3.8'
           - os: macos-14
             python-version: '3.9'
 

--- a/.github/workflows/full_testing.yml
+++ b/.github/workflows/full_testing.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-14]
-        python-version: ['3.8', '3.10']
+        python-version: ['3.9', '3.10']
         torch-version: [1.13.0, 2.0.0, 2.1.0, 2.2.0, 2.3.0, 2.4.0, nightly]
         include:
           - torch-version: 1.13.0
@@ -33,8 +33,6 @@ jobs:
           - torch-version: nightly
             torchvision-version: nightly
         exclude:
-          - os: macos-14
-            python-version: '3.8'
           - os: macos-14
             torch-version: 1.13.0
           - os: macos-14

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -16,9 +16,9 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@v4.3.0
+        uses: actions/setup-python@v5
         with:
-          python-version: 3.8
+          python-version: 3.9
 
       - name: Set version
         run: echo "VERSION=$(sed -n "s/^__version__ = '\(.*\)'/\1/p" torch_geometric/__init__.py)" >> ${GITHUB_ENV}

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -17,9 +17,9 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-14]
         include:
           - os: ubuntu-latest
-            python-version: '3.8'
+            python-version: '3.9'
           - os: windows-latest
-            python-version: '3.8'
+            python-version: '3.9'
           - os: macos-14
             python-version: '3.10'
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,7 +38,7 @@ repos:
     hooks:
       - id: pyupgrade
         name: Upgrade Python syntax
-        args: [--py38-plus]
+        args: [--py39-plus]
 
   - repo: https://github.com/PyCQA/autoflake
     rev: v2.3.1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,7 +38,7 @@ repos:
     hooks:
       - id: pyupgrade
         name: Upgrade Python syntax
-        args: [--py39-plus]
+        args: [--py39-plus, --keep-runtime-typing]
 
   - repo: https://github.com/PyCQA/autoflake
     rev: v2.3.1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,7 +38,7 @@ repos:
     hooks:
       - id: pyupgrade
         name: Upgrade Python syntax
-        args: [--py39-plus, --keep-runtime-typing]
+        args: [--py38-plus]
 
   - repo: https://github.com/PyCQA/autoflake
     rev: v2.3.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
+- Dropped Python 3.8 support ([#9696](https://github.com/pyg-team/pytorch_geometric/pull/9606))
+
 ### Deprecated
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -334,7 +334,7 @@ These approaches have been implemented in PyG, and can benefit from the above GN
 
 ## Installation
 
-PyG is available for Python 3.8 to Python 3.12.
+PyG is available for Python 3.9 to Python 3.12.
 
 ### Anaconda
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,3 @@
-https://download.pytorch.org/whl/cpu/torch-1.13.0%2Bcpu-cp38-cp38-linux_x86_64.whl
+https://download.pytorch.org/whl/cpu/torch-1.13.0%2Bcpu-cp39-cp39-linux_x86_64.whl
 numpy>=1.19.5
 git+https://github.com/pyg-team/pyg_sphinx_theme.git

--- a/docs/source/install/installation.rst
+++ b/docs/source/install/installation.rst
@@ -1,7 +1,7 @@
 Installation
 ============
 
-:pyg:`PyG` is available for :python:`Python 3.8` to :python:`Python 3.12`.
+:pyg:`PyG` is available for :python:`Python 3.9` to :python:`Python 3.12`.
 
 .. note::
    We do not recommend installation as a root user on your system :python:`Python`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ authors=[
 ]
 description="Graph Neural Network Library for PyTorch"
 readme="README.md"
-requires-python=">=3.8"
+requires-python=">=3.9"
 keywords=[
     "deep-learning",
     "pytorch",
@@ -22,7 +22,6 @@ classifiers=[
     "Development Status :: 5 - Production/Stable",
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
@@ -143,7 +142,7 @@ skip = [".gitignore", "__init__.py"]
 src = ["torch_geometric"]
 line-length = 80
 indent-width = 4
-target-version = "py38"
+target-version = "py39"
 
 [tool.ruff.lint]
 select = [

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -3,7 +3,7 @@ version: 2
 build:
    os: ubuntu-22.04
    tools:
-      python: "3.8"
+      python: "3.9"
 
 python:
    install:

--- a/torch_geometric/distributed/partition.py
+++ b/torch_geometric/distributed/partition.py
@@ -3,7 +3,7 @@ import logging
 import os
 import os.path as osp
 from collections import defaultdict
-from typing import List, Optional, Union
+from typing import Dict, List, Optional, Tuple, Union
 
 import torch
 
@@ -12,7 +12,7 @@ from torch_geometric.data import Data, HeteroData
 from torch_geometric.io import fs
 from torch_geometric.loader.cluster import ClusterData
 from torch_geometric.sampler.utils import sort_csc
-from torch_geometric.typing import Dict, EdgeType, EdgeTypeStr, NodeType, Tuple
+from torch_geometric.typing import EdgeType, EdgeTypeStr, NodeType
 
 
 class Partitioner:


### PR DESCRIPTION
It makes sense to drop Python 3.8 support as its EOL is scheduled for October 2024, and the next PyTorch release (2.5) drops Python 3.8 support as well.

References:

* https://download.pytorch.org/whl/test/torch/
* https://devguide.python.org/versions/