### PR TITLE
[UserWarning] Addressing the TorchScript warning in `RGCNConv`

### DIFF
--- a/torch_geometric/nn/conv/rgcn_conv.py
+++ b/torch_geometric/nn/conv/rgcn_conv.py
@@ -120,7 +120,8 @@ class RGCNConv(MessagePassing):
             in_channels = (in_channels, in_channels)
         self.in_channels_l = in_channels[0]
 
-        self._use_segment_matmul_heuristic_output: Attribute[bool] = None
+        self._use_segment_matmul_heuristic_output: torch.jit.Attribute(
+            None, Optional[float])
 
         if num_bases is not None:
             self.weight = Parameter(

--- a/torch_geometric/nn/conv/rgcn_conv.py
+++ b/torch_geometric/nn/conv/rgcn_conv.py
@@ -120,7 +120,7 @@ class RGCNConv(MessagePassing):
             in_channels = (in_channels, in_channels)
         self.in_channels_l = in_channels[0]
 
-        self._use_segment_matmul_heuristic_output: Optional[bool] = None
+        self._use_segment_matmul_heuristic_output: Attribute[bool] = None
 
         if num_bases is not None:
             self.weight = Parameter(


### PR DESCRIPTION
This PR resolves the following 12 warnings:
```
test/nn/conv/test_rgcn_conv.py: 12 warnings
  /usr/local/lib/python3.10/dist-packages/torch/jit/_check.py:178: UserWarning: The TorchScript type system doesn't 
support instance-level annotations on empty non-base types in `__init__`. Instead, either 1) use a type annotation in 
the class body, or 2) wrap the type in `torch.jit.Attribute`.
    warnings.warn(
```
that occur in `test/nn/conv/test_rgcn_conv.py::test_rgcn_conv_basic` tests.