### PR TITLE
Add no PCST option in `WebQSPDataset`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- Added the `use_pcst` option to `WebQSPDataset` ([#9722](https://github.com/pyg-team/pytorch_geometric/pull/9722))
 - Consolidated `examples/ogbn_{papers_100m,products_gat,products_sage}.py` into `examples/ogbn_train.py` ([#9467](https://github.com/pyg-team/pytorch_geometric/pull/9467))
 
 ### Changed

--- a/torch_geometric/datasets/web_qsp_dataset.py
+++ b/torch_geometric/datasets/web_qsp_dataset.py
@@ -130,7 +130,7 @@ class WebQSPDataset(InMemoryDataset):
         force_reload (bool, optional): Whether to re-process the dataset.
             (default: :obj:`False`)
         use_pcst (bool, optional): Whether to preprocess the dataset's graph
-                    with PCST or return the full graphs. (default: :obj:`True`)
+            with PCST or return the full graphs. (default: :obj:`True`)
     """
     def __init__(
         self,


### PR DESCRIPTION
This PR adds an option to disable PCST in WebQSPDataset, it allows the user to use some custom retrieval method (such as GNN-RAG).