### PR TITLE
[FIX] Typo on `SetTransformerAggregation` docstring/docs

### DIFF
--- a/torch_geometric/nn/aggr/set_transformer.py
+++ b/torch_geometric/nn/aggr/set_transformer.py
@@ -38,7 +38,7 @@ class SetTransformerAggregation(Aggregation):
             (default: :obj:`1`)
         concat (bool, optional): If set to :obj:`False`, the seed embeddings
             are averaged instead of concatenated. (default: :obj:`True`)
-        norm (str, optional): If set to :obj:`True`, will apply layer
+        layer_norm (str, optional): If set to :obj:`True`, will apply layer
             normalization. (default: :obj:`False`)
         dropout (float, optional): Dropout probability of attention weights.
             (default: :obj:`0`)


### PR DESCRIPTION
This PR fixes a typo on the docstring for `nn.aggr.SetTransformerAggregation`.

I assume the docs will get updated automatically (being generated from the docstring). Please let me know if I should add any other change here.