### PR TITLE
[ENH] Allow users to pass `edge_weight` to `GraphUNet` model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- Allowed users to pass `edge_weight` to `GraphUNet` models ([#9737](https://github.com/pyg-team/pytorch_geometric/pull/9737))
 - Consolidated `examples/ogbn_{papers_100m,products_gat,products_sage}.py` into `examples/ogbn_train.py` ([#9467](https://github.com/pyg-team/pytorch_geometric/pull/9467))
 
 ### Changed

--- a/torch_geometric/nn/models/graph_unet.py
+++ b/torch_geometric/nn/models/graph_unet.py
@@ -79,8 +79,8 @@ class GraphUNet(torch.nn.Module):
         for conv in self.up_convs:
             conv.reset_parameters()
 
-    def forward(self, x: Tensor, edge_index: Tensor, edge_weight: Tensor = None,
-                batch: OptTensor = None) -> Tensor:
+    def forward(self, x: Tensor, edge_index: Tensor,
+                edge_weight: Tensor = None, batch: OptTensor = None) -> Tensor:
         """"""  # noqa: D419
         if batch is None:
             batch = edge_index.new_zeros(x.size(0))

--- a/torch_geometric/nn/models/graph_unet.py
+++ b/torch_geometric/nn/models/graph_unet.py
@@ -79,16 +79,20 @@ class GraphUNet(torch.nn.Module):
         for conv in self.up_convs:
             conv.reset_parameters()
 
-    def forward(self, x: Tensor, edge_index: Tensor,
-                edge_weight: Tensor = None, batch: OptTensor = None) -> Tensor:
+    def forward(
+        self,
+        x: Tensor,
+        edge_index: Tensor,
+        batch: OptTensor = None,
+        edge_weight: Tensor = None,
+    ) -> Tensor:
         """"""  # noqa: D419
         if batch is None:
             batch = edge_index.new_zeros(x.size(0))
 
         if edge_weight is None:
             edge_weight = x.new_ones(edge_index.size(1))
-        else:
-            assert edge_weight.size(0) == edge_index.size(1)
+        assert edge_weight.size(0) == edge_index.size(1)
 
         x = self.down_convs[0](x, edge_index, edge_weight)
         x = self.act(x)

--- a/torch_geometric/nn/models/graph_unet.py
+++ b/torch_geometric/nn/models/graph_unet.py
@@ -79,12 +79,16 @@ class GraphUNet(torch.nn.Module):
         for conv in self.up_convs:
             conv.reset_parameters()
 
-    def forward(self, x: Tensor, edge_index: Tensor,
+    def forward(self, x: Tensor, edge_index: Tensor, edge_weight: Tensor = None,
                 batch: OptTensor = None) -> Tensor:
         """"""  # noqa: D419
         if batch is None:
             batch = edge_index.new_zeros(x.size(0))
-        edge_weight = x.new_ones(edge_index.size(1))
+
+        if edge_weight is None:
+            edge_weight = x.new_ones(edge_index.size(1))
+        else:
+            assert edge_weight.size(0) == edge_index.size(1)
 
         x = self.down_convs[0](x, edge_index, edge_weight)
         x = self.act(x)


### PR DESCRIPTION
Closes #9736.

This PR:

- Adds the `edge_weight` parameter to the `nn.models.GraphUNet` model's forward function, so that users can provide an initial weights vector.
- Makes `edge_weight` default to `None`.
- Initializes `edge_weight` to ones if it is `None`. This ensures functionality stays the same by default.
- If `edge_weight` is given by the user, its size is checked before running any of the code.