### PR TITLE
Add extra condition to `GraphUNet` edge weights assert

### DIFF
--- a/torch_geometric/nn/models/graph_unet.py
+++ b/torch_geometric/nn/models/graph_unet.py
@@ -92,7 +92,8 @@ class GraphUNet(torch.nn.Module):
 
         if edge_weight is None:
             edge_weight = x.new_ones(edge_index.size(1))
-        assert edge_weight.dim() == 1 and edge_weight.size(0) == edge_index.size(1)
+        assert edge_weight.dim() == 1 and edge_weight.size(
+            0) == edge_index.size(1)
 
         x = self.down_convs[0](x, edge_index, edge_weight)
         x = self.act(x)

--- a/torch_geometric/nn/models/graph_unet.py
+++ b/torch_geometric/nn/models/graph_unet.py
@@ -92,8 +92,8 @@ class GraphUNet(torch.nn.Module):
 
         if edge_weight is None:
             edge_weight = x.new_ones(edge_index.size(1))
-        assert edge_weight.dim() == 1 and edge_weight.size(
-            0) == edge_index.size(1)
+        assert edge_weight.dim() == 1
+        assert edge_weight.size(0) == edge_index.size(1)
 
         x = self.down_convs[0](x, edge_index, edge_weight)
         x = self.act(x)

--- a/torch_geometric/nn/models/graph_unet.py
+++ b/torch_geometric/nn/models/graph_unet.py
@@ -92,7 +92,7 @@ class GraphUNet(torch.nn.Module):
 
         if edge_weight is None:
             edge_weight = x.new_ones(edge_index.size(1))
-        assert edge_weight.size(0) == edge_index.size(1)
+        assert edge_weight.dim() == 1 and edge_weight.size(0) == edge_index.size(1)
 
         x = self.down_convs[0](x, edge_index, edge_weight)
         x = self.act(x)


### PR DESCRIPTION
Closes #9741.

This PR adds an extra condition to the assert to ensure that the user-given edge weights are a 1D vector. 2D matrices make the adjacency matrix multiplication fail as described in the issue above.