### PR TITLE
Add an error message for batching when `num_nodes` is unknown

### DIFF
--- a/torch_geometric/data/data.py
+++ b/torch_geometric/data/data.py
@@ -659,6 +659,8 @@ class Data(BaseData, FeatureStore, GraphStore):
                 return value.get_dim_size()
             return int(value.max()) + 1
         elif 'index' in key or key == 'face':
+            if self.num_nodes is None:
+                raise ValueError(f'Can not infer inc number for {key}!')
             return self.num_nodes
         else:
             return 0


### PR DESCRIPTION
Provide a clear error message for error in 
https://github.com/pyg-team/pytorch_geometric/discussions/4554