### PR TITLE
Resolve `type_repr` function bug for objects missing `_name` attribute.

### DIFF
--- a/torch_geometric/inspector.py
+++ b/torch_geometric/inspector.py
@@ -451,7 +451,7 @@ def type_repr(obj: Any, _globals: Dict[str, Any]) -> str:
 
         if not hasattr(obj, '_name'):
             return repr(obj)
-        
+
         name = obj._name
         if name is None:  # In some cases, `_name` is not populated.
             name = str(obj.__origin__).split('.')[-1]

--- a/torch_geometric/inspector.py
+++ b/torch_geometric/inspector.py
@@ -448,6 +448,10 @@ def type_repr(obj: Any, _globals: Dict[str, Any]) -> str:
         return '...'
 
     if obj.__module__ == 'typing':  # Special logic for `typing.*` types:
+
+        if not hasattr(obj, '_name'):
+            return repr(obj)
+        
         name = obj._name
         if name is None:  # In some cases, `_name` is not populated.
             name = str(obj.__origin__).split('.')[-1]


### PR DESCRIPTION
This PR addresses the issue caused by the absence of the `_name` attribute in the `typing.Any` object. 

It's what we had in the previous Python 3.10.12 release:
```
(Pdb) dir(Any)
['__call__', '__class__', '__delattr__', '__dir__', '__doc__', '__eq__', '__format__', '__ge__', '__getattr__', 
'__getattribute__', '__getitem__', '__gt__', '__hash__', '__init__', '__init_subclass__', '__instancecheck__', 
'__le__', '__lt__', '__module__', '__mro_entries__', '__ne__', '__new__', '__or__', '__reduce__', '__reduce_ex__', 
'__repr__', '__ror__', '__setattr__', '__sizeof__', '__slots__', '__str__', '__subclasscheck__', '__subclasshook__', 
'__weakref__', '_getitem', '_name']
```
And it's what we have in Python 3.12.3:
```
(Pdb) dir(Any)
['__class__', '__delattr__', '__dict__', '__dir__', '__doc__', '__eq__', '__format__', '__ge__', '__getattribute__', 
'__getstate__', '__gt__', '__hash__', '__init__', '__init_subclass__', '__le__', '__lt__', '__module__', '__ne__', '__new__', 
'__reduce__', '__reduce_ex__', '__repr__', '__setattr__', '__sizeof__', '__str__', '__subclasshook__', '__weakref__']
``` 

This fix resolvs the following failure in `pytorch_geometric/test/test_inspector.py::test_type_repr`:
```
        if obj.__module__ == 'typing':  # Special logic for `typing.*` types:
>           name = obj._name
E           AttributeError: type object 'Any' has no attribute '_name'

/usr/local/lib/python3.12/dist-packages/torch_geometric/inspector.py:451: AttributeError
```