### PR TITLE
Add support for `torch_delaunay` package in `Delaunay` transformation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- Added support of fast delaunay triangulation via the `torch_delaunay` package ([#9748](https://github.com/pyg-team/pytorch_geometric/pull/9748))
 - Added the `use_pcst` option to `WebQSPDataset` ([#9722](https://github.com/pyg-team/pytorch_geometric/pull/9722))
 - Allowed users to pass `edge_weight` to `GraphUNet` models ([#9737](https://github.com/pyg-team/pytorch_geometric/pull/9737))
 - Consolidated `examples/ogbn_{papers_100m,products_gat,products_sage}.py` into `examples/ogbn_train.py` ([#9467](https://github.com/pyg-team/pytorch_geometric/pull/9467))
-- Added support of fast Delaunay triangulation computation through `torch_delaunay` package ([#9748](https://github.com/pyg-team/pytorch_geometric/pull/9748))
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
-- Added support of fast delaunay triangulation via the `torch_delaunay` package ([#9748](https://github.com/pyg-team/pytorch_geometric/pull/9748))
+- Added support for fast `Delaunay()` triangulation via the `torch_delaunay` package ([#9748](https://github.com/pyg-team/pytorch_geometric/pull/9748))
 - Added the `use_pcst` option to `WebQSPDataset` ([#9722](https://github.com/pyg-team/pytorch_geometric/pull/9722))
 - Allowed users to pass `edge_weight` to `GraphUNet` models ([#9737](https://github.com/pyg-team/pytorch_geometric/pull/9737))
 - Consolidated `examples/ogbn_{papers_100m,products_gat,products_sage}.py` into `examples/ogbn_train.py` ([#9467](https://github.com/pyg-team/pytorch_geometric/pull/9467))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Added the `use_pcst` option to `WebQSPDataset` ([#9722](https://github.com/pyg-team/pytorch_geometric/pull/9722))
 - Allowed users to pass `edge_weight` to `GraphUNet` models ([#9737](https://github.com/pyg-team/pytorch_geometric/pull/9737))
 - Consolidated `examples/ogbn_{papers_100m,products_gat,products_sage}.py` into `examples/ogbn_train.py` ([#9467](https://github.com/pyg-team/pytorch_geometric/pull/9467))
+- Added support of fast Delaunay triangulation computation through `torch_delaunay` package ([#9748](https://github.com/pyg-team/pytorch_geometric/pull/9748))
 
 ### Changed
 

--- a/test/transforms/test_delaunay.py
+++ b/test/transforms/test_delaunay.py
@@ -2,34 +2,39 @@ import torch
 
 from torch_geometric.data import Data
 from torch_geometric.testing import withPackage
-from torch_geometric.transforms import BaseTransform, Delaunay
+from torch_geometric.transforms import Delaunay
 
 
-def assert_one_point(delaunay: BaseTransform) -> None:
-    pos = torch.rand((1, 2), dtype=torch.float)
-    data = delaunay(Data(pos=pos))
+def assert_one_point(transform: Delaunay) -> None:
+    data = Data(pos=torch.rand(1, 2))
+    data = transform(data)
     assert len(data) == 2
     assert data.edge_index.tolist() == [[], []]
 
 
-def assert_two_points(delaunay: BaseTransform) -> None:
-    pos = torch.rand((2, 2), dtype=torch.float)
-    data = delaunay(Data(pos=pos))
+def assert_two_points(transform: Delaunay) -> None:
+    data = Data(pos=torch.rand(2, 2))
+    data = transform(data)
     assert len(data) == 2
     assert data.edge_index.tolist() == [[0, 1], [1, 0]]
 
 
-def assert_three_points(delaunay: BaseTransform) -> None:
-    pos = torch.rand((3, 2), dtype=torch.float)
-    data = delaunay(Data(pos=pos))
+def assert_three_points(transform: Delaunay) -> None:
+    data = Data(pos=torch.rand(3, 2))
+    data = transform(data)
     assert len(data) == 2
     assert data.face.tolist() == [[0], [1], [2]]
 
 
-def assert_four_points(delaunay: BaseTransform) -> None:
-    pos = torch.tensor([[-1, -1], [-1, 1], [1, 1], [0.5, -0.5]],
-                       dtype=torch.float)
-    data = delaunay(Data(pos=pos))
+def assert_four_points(transform: Delaunay) -> None:
+    pos = torch.tensor([
+        [-1.0, -1.0],
+        [-1.0, 1.0],
+        [1.0, 1.0],
+        [0.5, -0.5],
+    ])
+    data = Data(pos=pos)
+    data = transform(data)
     assert len(data) == 2
 
     # The order of the simplices does not matter, therefore assert sets.
@@ -38,7 +43,7 @@ def assert_four_points(delaunay: BaseTransform) -> None:
 
 
 @withPackage('scipy')
-def test_delaunay() -> None:
+def test_qhull_delaunay() -> None:
     transform = Delaunay()
 
     assert str(transform) == 'Delaunay()'
@@ -49,7 +54,7 @@ def test_delaunay() -> None:
 
 
 @withPackage('torch_delaunay')
-def test_shull_delaunay():
+def test_shull_delaunay() -> None:
     transform = Delaunay()
 
     assert str(transform) == 'Delaunay()'

--- a/test/transforms/test_delaunay.py
+++ b/test/transforms/test_delaunay.py
@@ -2,33 +2,58 @@ import torch
 
 from torch_geometric.data import Data
 from torch_geometric.testing import withPackage
-from torch_geometric.transforms import Delaunay
+from torch_geometric.transforms import BaseTransform, Delaunay
 
 
-@withPackage('scipy')
-def test_delaunay():
-    assert str(Delaunay()) == 'Delaunay()'
-
-    pos = torch.tensor([[-1, -1], [-1, 1], [1, 1], [1, -1]], dtype=torch.float)
-    data = Data(pos=pos)
-    data = Delaunay()(data)
+def assert_one_point(delaunay: BaseTransform) -> None:
+    pos = torch.rand((1, 2), dtype=torch.float)
+    data = delaunay(Data(pos=pos))
     assert len(data) == 2
-    assert data.face.tolist() == [[3, 1], [1, 3], [0, 2]]
+    assert data.edge_index.tolist() == [[], []]
 
-    pos = torch.tensor([[-1, -1], [-1, 1], [1, 1]], dtype=torch.float)
-    data = Data(pos=pos)
-    data = Delaunay()(data)
-    assert len(data) == 2
-    assert data.face.tolist() == [[0], [1], [2]]
 
-    pos = torch.tensor([[-1, -1], [1, 1]], dtype=torch.float)
-    data = Data(pos=pos)
-    data = Delaunay()(data)
+def assert_two_points(delaunay: BaseTransform) -> None:
+    pos = torch.rand((2, 2), dtype=torch.float)
+    data = delaunay(Data(pos=pos))
     assert len(data) == 2
     assert data.edge_index.tolist() == [[0, 1], [1, 0]]
 
-    pos = torch.tensor([[-1, -1]], dtype=torch.float)
-    data = Data(pos=pos)
-    data = Delaunay()(data)
+
+def assert_three_points(delaunay: BaseTransform) -> None:
+    pos = torch.rand((3, 2), dtype=torch.float)
+    data = delaunay(Data(pos=pos))
     assert len(data) == 2
-    assert data.edge_index.tolist() == [[], []]
+    assert data.face.tolist() == [[0], [1], [2]]
+
+
+def assert_four_points(delaunay: BaseTransform) -> None:
+    pos = torch.tensor([[-1, -1], [-1, 1], [1, 1], [0.5, -0.5]],
+                       dtype=torch.float)
+    data = delaunay(Data(pos=pos))
+    assert len(data) == 2
+
+    # The order of the simplices does not matter, therefore assert sets.
+    faces = set(map(tuple, data.face.tolist()))
+    assert faces == {(3, 1), (1, 3), (0, 2)}
+
+
+@withPackage('scipy')
+def test_delaunay() -> None:
+    transform = Delaunay()
+
+    assert str(transform) == 'Delaunay()'
+    assert_one_point(transform)
+    assert_two_points(transform)
+    assert_three_points(transform)
+    assert_four_points(transform)
+
+
+@withPackage('torch_delaunay')
+def test_shull_delaunay():
+    transform = Delaunay()
+
+    assert str(transform) == 'Delaunay()'
+    assert_one_point(transform)
+    assert_two_points(transform)
+    assert_three_points(transform)
+    assert_four_points(transform)

--- a/torch_geometric/transforms/delaunay.py
+++ b/torch_geometric/transforms/delaunay.py
@@ -57,7 +57,7 @@ class Delaunay(BaseTransform):
     (functional name: :obj:`delaunay`).
 
     .. hint::
-        Consider installing
+        Consider installing the
         `torch_delaunay <https://github.com/ybubnov/torch_delaunay>`_ package
         to speed up computation.
     """

--- a/torch_geometric/transforms/delaunay.py
+++ b/torch_geometric/transforms/delaunay.py
@@ -10,6 +10,7 @@ from torch_geometric.transforms import BaseTransform
 class _QhullTransform(BaseTransform):
     r"""Q-hull implementation of Delaunay triangulation, uses NumPy arrays."""
     def forward(self, data: Data) -> Data:
+        assert data.pos is not None
         import scipy.spatial
 
         pos = data.pos.cpu().numpy()
@@ -25,6 +26,7 @@ class _ShullTransform(BaseTransform):
     tensors.
     """
     def forward(self, data: Data) -> Data:
+        assert data.pos is not None
         from torch_delaunay.functional import shull2d
 
         face = shull2d(data.pos.cpu())

--- a/torch_geometric/transforms/delaunay.py
+++ b/torch_geometric/transforms/delaunay.py
@@ -53,6 +53,7 @@ class _SequentialTransform(BaseTransform):
             except ModuleNotFoundError as e:
                 if i == len(self.transforms) - 1:
                     raise e
+        return data
 
 
 @functional_transform('delaunay')

--- a/torch_geometric/transforms/delaunay.py
+++ b/torch_geometric/transforms/delaunay.py
@@ -1,3 +1,5 @@
+from typing import List
+
 import torch
 
 from torch_geometric.data import Data
@@ -5,14 +7,62 @@ from torch_geometric.data.datapipes import functional_transform
 from torch_geometric.transforms import BaseTransform
 
 
+class _QhullTransform(BaseTransform):
+    r"""Q-hull implementation of Delaunay triangulation, uses NumPy arrays."""
+    def forward(self, data: Data) -> Data:
+        import scipy.spatial
+
+        pos = data.pos.cpu().numpy()
+        tri = scipy.spatial.Delaunay(pos, qhull_options='QJ')
+        face = torch.from_numpy(tri.simplices)
+
+        data.face = face.t().contiguous().to(data.pos.device, torch.long)
+        return data
+
+
+class _ShullTransform(BaseTransform):
+    r"""Sweep-hull implementation of Delaunay triangulation, uses Torch
+    tensors.
+    """
+    def forward(self, data: Data) -> Data:
+        from torch_delaunay.functional import shull2d
+
+        face = shull2d(data.pos.cpu())
+        data.face = face.t().contiguous().to(data.pos.device)
+        return data
+
+
+class _SequentialTransform(BaseTransform):
+    r"""Runs the specifies transforms one after another sequentially.
+
+    Returns the first successful result, and raises exception otherwise. All
+    intermediate exceptions are suppressed except the last.
+    """
+    def __init__(self, transforms: List[BaseTransform]) -> None:
+        if (num_transforms := len(transforms)) == 0:
+            raise ValueError(
+                f"at least one transform is expected, got {num_transforms}")
+        self.transforms = transforms
+
+    def forward(self, data: Data) -> Data:
+        for i, transform in enumerate(self.transforms):
+            try:
+                return transform.forward(data)
+            except ModuleNotFoundError as e:
+                if i == len(self.transforms) - 1:
+                    raise e
+
+
 @functional_transform('delaunay')
 class Delaunay(BaseTransform):
     r"""Computes the delaunay triangulation of a set of points
     (functional name: :obj:`delaunay`).
+
+    .. hint::
+        Consider installing `torch_delaunay` python package to speed up
+        computations of Delaunay tessellations.
     """
     def forward(self, data: Data) -> Data:
-        import scipy.spatial
-
         assert data.pos is not None
 
         if data.pos.size(0) < 2:
@@ -25,10 +75,10 @@ class Delaunay(BaseTransform):
             data.face = torch.tensor([[0], [1], [2]], dtype=torch.long,
                                      device=data.pos.device)
         if data.pos.size(0) > 3:
-            pos = data.pos.cpu().numpy()
-            tri = scipy.spatial.Delaunay(pos, qhull_options='QJ')
-            face = torch.from_numpy(tri.simplices)
-
-            data.face = face.t().contiguous().to(data.pos.device, torch.long)
+            transform = _SequentialTransform([
+                _QhullTransform(),
+                _ShullTransform(),
+            ])
+            data = transform.forward(data)
 
         return data

--- a/torch_geometric/transforms/delaunay.py
+++ b/torch_geometric/transforms/delaunay.py
@@ -45,7 +45,7 @@ class _SequentialTransform(BaseTransform):
         for i, transform in enumerate(self.transforms):
             try:
                 return transform.forward(data)
-            except Exception as e:
+            except ImportError as e:
                 if i == len(self.transforms) - 1:
                     raise e
         return data


### PR DESCRIPTION
This patch adds support of torch_delaunay package, which works with Torch tensors. The new implementation uses `torch_delaunay` package if it is installed (by default), and then falls back to the `scipy` implementation otherwise.