### PR TITLE
Fixing `edge_mask` handling for directed graphs in `k_hop_subgraph`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- Fixed `k_hop_subgraph()` for directed graphs
 - Added the `WebQSPDataset` dataset ([#9481](https://github.com/pyg-team/pytorch_geometric/pull/9481))
 - Added the `GRetriever` model and an example ([#9480](https://github.com/pyg-team/pytorch_geometric/pull/9480), [#9167](https://github.com/pyg-team/pytorch_geometric/pull/9167))
 - Added the `ClusterPooling` layer ([#9627](https://github.com/pyg-team/pytorch_geometric/pull/9627))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- Fixed the `k_hop_subgraph()` method for directed graphs ([#9756](https://github.com/pyg-team/pytorch_geometric/pull/9756))
 - Fixed `WebQSDataset.process` raising exceptions ([#9665](https://github.com/pyg-team/pytorch_geometric/pull/9665))
 
 ### Removed
@@ -27,7 +28,6 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
-- Fixed `k_hop_subgraph()` for directed graphs
 - Added the `WebQSPDataset` dataset ([#9481](https://github.com/pyg-team/pytorch_geometric/pull/9481))
 - Added the `GRetriever` model and an example ([#9480](https://github.com/pyg-team/pytorch_geometric/pull/9480), [#9167](https://github.com/pyg-team/pytorch_geometric/pull/9167))
 - Added the `ClusterPooling` layer ([#9627](https://github.com/pyg-team/pytorch_geometric/pull/9627))

--- a/test/utils/test_subgraph.py
+++ b/test/utils/test_subgraph.py
@@ -101,9 +101,12 @@ def test_k_hop_subgraph():
         [0, 1, 2, 3, 4, 5],
         [2, 2, 4, 4, 6, 6],
     ])
-
     subset, edge_index, mapping, edge_mask = k_hop_subgraph(
-        6, 2, edge_index, relabel_nodes=True)
+        node_idx=6,
+        num_hops=2,
+        edge_index=edge_index,
+        relabel_nodes=True,
+    )
     assert subset.tolist() == [2, 3, 4, 5, 6]
     assert edge_index.tolist() == [[0, 1, 2, 3], [2, 2, 4, 4]]
     assert mapping.tolist() == [4]
@@ -113,12 +116,29 @@ def test_k_hop_subgraph():
         [1, 2, 4, 5],
         [0, 1, 5, 6],
     ])
-
-    subset, edge_index, mapping, edge_mask = k_hop_subgraph([0, 6], 2,
-                                                            edge_index,
-                                                            relabel_nodes=True)
-
+    subset, edge_index, mapping, edge_mask = k_hop_subgraph(
+        node_idx=[0, 6],
+        num_hops=2,
+        edge_index=edge_index,
+        relabel_nodes=True,
+    )
     assert subset.tolist() == [0, 1, 2, 4, 5, 6]
     assert edge_index.tolist() == [[1, 2, 3, 4], [0, 1, 4, 5]]
     assert mapping.tolist() == [0, 5]
     assert edge_mask.tolist() == [True, True, True, True]
+
+    edge_index = torch.tensor([
+        [0, 1, 2, 3, 4, 4, 5],
+        [2, 2, 4, 4, 2, 6, 6],
+    ])
+    subset, edge_index, mapping, edge_mask = k_hop_subgraph(
+        node_idx=6,
+        num_hops=2,
+        edge_index=edge_index,
+        relabel_nodes=False,
+        directed=True,
+    )
+    assert subset.tolist() == [2, 3, 4, 5, 6]
+    assert edge_index.tolist() == [[2, 3, 4, 5], [4, 4, 6, 6]]
+    assert mapping.tolist() == [4]
+    assert edge_mask.tolist() == [False, False, True, True, False, True, True]

--- a/torch_geometric/utils/_subgraph.py
+++ b/torch_geometric/utils/_subgraph.py
@@ -346,10 +346,12 @@ def k_hop_subgraph(
 
     subsets = [node_idx]
 
+    preserved_edge_mask = edge_mask.clone().fill_(False)
     for _ in range(num_hops):
         node_mask.fill_(False)
         node_mask[subsets[-1]] = True
         torch.index_select(node_mask, 0, row, out=edge_mask)
+        preserved_edge_mask = torch.logical_or(preserved_edge_mask, edge_mask)
         subsets.append(col[edge_mask])
 
     subset, inv = torch.cat(subsets).unique(return_inverse=True)
@@ -360,6 +362,8 @@ def k_hop_subgraph(
 
     if not directed:
         edge_mask = node_mask[row] & node_mask[col]
+    else:
+        edge_mask = preserved_edge_mask
 
     edge_index = edge_index[:, edge_mask]
 

--- a/torch_geometric/utils/_subgraph.py
+++ b/torch_geometric/utils/_subgraph.py
@@ -346,12 +346,12 @@ def k_hop_subgraph(
 
     subsets = [node_idx]
 
-    preserved_edge_mask = edge_mask.clone().fill_(False)
+    preserved_edge_mask = torch.zeros_like(edge_mask)
     for _ in range(num_hops):
         node_mask.fill_(False)
         node_mask[subsets[-1]] = True
         torch.index_select(node_mask, 0, row, out=edge_mask)
-        preserved_edge_mask = torch.logical_or(preserved_edge_mask, edge_mask)
+        preserved_edge_mask |= edge_mask
         subsets.append(col[edge_mask])
 
     subset, inv = torch.cat(subsets).unique(return_inverse=True)


### PR DESCRIPTION
Example use case:

```python
from torch_geometric.utils import k_hop_subgraph
import torch

edge_index = torch.tensor([[1, 2, 3],
                           [0, 1, 1]])
# get the 2-hop neighbors of node 0 in the directed graph.
_, edge_index, _, edge_mask = k_hop_subgraph(0, 2, edge_index, relabel_nodes=False, directed=True)
```

This gives the following result:

Expected Outcome:
```python
>>> edge_index
tensor([[1, 2, 3],
        [0, 1, 1]])

>>> edge_mask
tensor([True,  True,  True])
```

Actual Outcome:
```python
>>> edge_index
tensor([[2, 3],
        [1, 1]])
>>> edge_mask
tensor([False,  True,  True])
```

This stems from the fact that the line `torch.index_select(node_mask, 0, row, out=edge_mask)` overwrites `edge_mask`, effectively only marking the edges used in the final hop as `True`.

To fix this, I have added `preserved_edge_mask ` that will mark the edges used in each hop as `True`.


