### PR TITLE
Fix arrow direction in `_visualize_graph_via_networkx`

### DIFF
--- a/torch_geometric/visualization/graph.py
+++ b/torch_geometric/visualization/graph.py
@@ -132,7 +132,7 @@ def _visualize_graph_via_networkx(
             xy=pos[src],
             xytext=pos[dst],
             arrowprops=dict(
-                arrowstyle="->",
+                arrowstyle="<-",
                 alpha=data['alpha'],
                 shrinkA=sqrt(node_size) / 2.0,
                 shrinkB=sqrt(node_size) / 2.0,


### PR DESCRIPTION
Matplotlib arrows don't have a source and a destination. They have a text and a dot. As the [example](https://matplotlib.org/stable/gallery/text_labels_and_annotations/fancyarrow_demo.html) shows, a `<-` arrow points from the dot to the text and `->` points from the text to the dot.
<img width="153" alt="Screenshot 2024-11-11 at 15 47 24" src="https://github.com/user-attachments/assets/7a8333d3-6c58-46b2-a47b-ae6c6afff87d">
`_visualize_graph_via_networkx()` sets `xy=pos[src]` and `xytext=pos[dst]`, so we want arrows from the dot (`xy`) to the text (`xytext`). That's the `<-` arrow.

This can also be confirmed by comparing the visualization to the GraphViz version. The arrows go the other way. Or just looking at the data and the picture, haha! It took me a while to figure out that it's not my graph that's messed up! 😅 