### PR TITLE
Added functionality of `FaceToEdge` transform to work for 3D tetrahedral mesh elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- Support 3D tetrahedral mesh elements of shape `[4, num_faces]` in the `FaceToEdge` transformation ([#9776](https://github.com/pyg-team/pytorch_geometric/pull/9776))
 - Added the `use_pcst` option to `WebQSPDataset` ([#9722](https://github.com/pyg-team/pytorch_geometric/pull/9722))
 - Allowed users to pass `edge_weight` to `GraphUNet` models ([#9737](https://github.com/pyg-team/pytorch_geometric/pull/9737))
 - Consolidated `examples/ogbn_{papers_100m,products_gat,products_sage}.py` into `examples/ogbn_train.py` ([#9467](https://github.com/pyg-team/pytorch_geometric/pull/9467))

--- a/test/transforms/test_face_to_edge.py
+++ b/test/transforms/test_face_to_edge.py
@@ -21,6 +21,6 @@ def test_face_to_edge():
     data = Data(face=face.T, num_nodes=5)
 
     data = transform(data)
-    assert data.edge_index.tolist() == [[0, 0, 0, 1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3, 4, 4, 4],
-                                        [1, 2, 3, 0, 2, 3, 4, 0, 1, 3, 4, 0, 1, 2, 4, 1, 2, 3]]
-
+    assert data.edge_index.tolist() == [[
+        0, 0, 0, 1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3, 4, 4, 4
+    ], [1, 2, 3, 0, 2, 3, 4, 0, 1, 3, 4, 0, 1, 2, 4, 1, 2, 3]]

--- a/test/transforms/test_face_to_edge.py
+++ b/test/transforms/test_face_to_edge.py
@@ -4,7 +4,7 @@ from torch_geometric.data import Data
 from torch_geometric.transforms import FaceToEdge
 
 
-def test_face_to_edge():
+def test_2d_face_to_edge() -> None:
     transform = FaceToEdge()
     assert str(transform) == 'FaceToEdge()'
 
@@ -13,14 +13,23 @@ def test_face_to_edge():
 
     data = transform(data)
     assert len(data) == 2
-    assert data.edge_index.tolist() == [[0, 0, 0, 1, 1, 1, 2, 2, 3, 3],
-                                        [1, 2, 3, 0, 2, 3, 0, 1, 0, 1]]
+    assert data.edge_index.tolist() == [
+        [0, 0, 0, 1, 1, 1, 2, 2, 3, 3],
+        [1, 2, 3, 0, 2, 3, 0, 1, 0, 1],
+    ]
     assert data.num_nodes == 4
 
-    face = torch.tensor([[0, 1, 2, 3], [1, 2, 3, 4]], dtype=torch.long)
-    data = Data(face=face.T, num_nodes=5)
+
+def test_3d_face_to_edge() -> None:
+    transform = FaceToEdge()
+    assert str(transform) == 'FaceToEdge()'
+
+    face = torch.tensor([[0, 1, 2, 3], [1, 2, 3, 4]]).t()
+    data = Data(face=face, num_nodes=5)
 
     data = transform(data)
-    assert data.edge_index.tolist() == [[
-        0, 0, 0, 1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3, 4, 4, 4
-    ], [1, 2, 3, 0, 2, 3, 4, 0, 1, 3, 4, 0, 1, 2, 4, 1, 2, 3]]
+    assert data.edge_index.tolist() == [
+        [0, 0, 0, 1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3, 4, 4, 4],
+        [1, 2, 3, 0, 2, 3, 4, 0, 1, 3, 4, 0, 1, 2, 4, 1, 2, 3],
+    ]
+    assert data.num_nodes == 5

--- a/test/transforms/test_face_to_edge.py
+++ b/test/transforms/test_face_to_edge.py
@@ -16,3 +16,11 @@ def test_face_to_edge():
     assert data.edge_index.tolist() == [[0, 0, 0, 1, 1, 1, 2, 2, 3, 3],
                                         [1, 2, 3, 0, 2, 3, 0, 1, 0, 1]]
     assert data.num_nodes == 4
+
+    face = torch.tensor([[0, 1, 2, 3], [1, 2, 3, 4]], dtype=torch.long)
+    data = Data(face=face.T, num_nodes=5)
+
+    data = transform(data)
+    assert data.edge_index.tolist() == [[0, 0, 0, 1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3, 4, 4, 4],
+                                        [1, 2, 3, 0, 2, 3, 4, 0, 1, 3, 4, 0, 1, 2, 4, 1, 2, 3]]
+

--- a/torch_geometric/transforms/face_to_edge.py
+++ b/torch_geometric/transforms/face_to_edge.py
@@ -8,8 +8,9 @@ from torch_geometric.utils import to_undirected
 
 @functional_transform('face_to_edge')
 class FaceToEdge(BaseTransform):
-    r"""Converts mesh faces :obj:`[3, num_faces]` or :obj:`[4, num_faces]` to edge indices
-    :obj:`[2, num_edges]` (functional name: :obj:`face_to_edge`).
+    r"""Converts mesh faces of shape :obj:`[3, num_faces]` or shape
+    :obj:`[4, num_faces]` to edge indices :obj:`[2, num_edges]`
+    (functional name: :obj:`face_to_edge`).
 
     This transform supports both 2D triangular faces, represented by a
     tensor of shape :obj:`[3, num_faces]`, and 3D tetrahedral mesh faces,
@@ -29,18 +30,27 @@ class FaceToEdge(BaseTransform):
             assert data.face is not None
             face = data.face
 
-            assert face.size(0) in [
-                3, 4
-            ], ("Expected tensor with shape [3, num_faces] or [4, num_faces], "
-                f"but got shape {face.size()}.")
+            if face.size(0) not in [3, 4]:
+                raise RuntimeError(f"Expected 'face' tensor with shape "
+                                   f"[3, num_faces] or [4, num_faces] "
+                                   f"(got {list(face.size())})")
 
-            if face.size()[0] == 4:
+            if face.size()[0] == 3:
                 edge_index = torch.cat([
-                    face[:2], face[1:3], face[2:4], face[::2], face[1::2],
-                    face[::3]
+                    face[:2],
+                    face[1:],
+                    face[::2],
                 ], dim=1)
-            elif face.size()[0] == 3:
-                edge_index = torch.cat([face[:2], face[1:], face[::2]], dim=1)
+            else:
+                assert face.size()[0] == 4
+                edge_index = torch.cat([
+                    face[:2],
+                    face[1:3],
+                    face[2:4],
+                    face[::2],
+                    face[1::2],
+                    face[::3],
+                ], dim=1)
 
             edge_index = to_undirected(edge_index, num_nodes=data.num_nodes)
 

--- a/torch_geometric/transforms/face_to_edge.py
+++ b/torch_geometric/transforms/face_to_edge.py
@@ -8,8 +8,14 @@ from torch_geometric.utils import to_undirected
 
 @functional_transform('face_to_edge')
 class FaceToEdge(BaseTransform):
-    r"""Converts mesh faces :obj:`[3, num_faces]` to edge indices
+    r"""Converts mesh faces :obj:`[3, num_faces]` or :obj:`[4, num_faces]` to edge indices
     :obj:`[2, num_edges]` (functional name: :obj:`face_to_edge`).
+
+    This transform supports both 2D triangular faces, represented by a
+    tensor of shape :obj:`[3, num_faces]`, and 3D tetrahedral mesh faces,
+    represented by a tensor of shape :obj:`[4, num_faces]`. It will convert
+    these faces into edge indices, where each edge is defined by the indices
+    of its two endpoints.
 
     Args:
         remove_faces (bool, optional): If set to :obj:`False`, the face tensor
@@ -22,7 +28,17 @@ class FaceToEdge(BaseTransform):
         if hasattr(data, 'face'):
             assert data.face is not None
             face = data.face
-            edge_index = torch.cat([face[:2], face[1:], face[::2]], dim=1)
+
+            assert face.size(0) in [3, 4], (
+                "Expected tensor with shape [3, num_faces] or [4, num_faces], "
+                f"but got shape {face.size()}."
+            )
+
+            if face.size()[0] == 4:
+                edge_index = torch.cat([face[:2], face[1:3], face[2:4], face[::2], face[1::2], face[::3]], dim=1)
+            elif face.size()[0] == 3:
+                edge_index = torch.cat([face[:2], face[1:], face[::2]], dim=1)
+
             edge_index = to_undirected(edge_index, num_nodes=data.num_nodes)
 
             data.edge_index = edge_index

--- a/torch_geometric/transforms/face_to_edge.py
+++ b/torch_geometric/transforms/face_to_edge.py
@@ -29,13 +29,16 @@ class FaceToEdge(BaseTransform):
             assert data.face is not None
             face = data.face
 
-            assert face.size(0) in [3, 4], (
-                "Expected tensor with shape [3, num_faces] or [4, num_faces], "
-                f"but got shape {face.size()}."
-            )
+            assert face.size(0) in [
+                3, 4
+            ], ("Expected tensor with shape [3, num_faces] or [4, num_faces], "
+                f"but got shape {face.size()}.")
 
             if face.size()[0] == 4:
-                edge_index = torch.cat([face[:2], face[1:3], face[2:4], face[::2], face[1::2], face[::3]], dim=1)
+                edge_index = torch.cat([
+                    face[:2], face[1:3], face[2:4], face[::2], face[1::2],
+                    face[::3]
+                ], dim=1)
             elif face.size()[0] == 3:
                 edge_index = torch.cat([face[:2], face[1:], face[::2]], dim=1)
 

--- a/torch_geometric/transforms/face_to_edge.py
+++ b/torch_geometric/transforms/face_to_edge.py
@@ -8,8 +8,8 @@ from torch_geometric.utils import to_undirected
 
 @functional_transform('face_to_edge')
 class FaceToEdge(BaseTransform):
-    r"""Converts mesh faces of shape :obj:`[3, num_faces]` or shape
-    :obj:`[4, num_faces]` to edge indices :obj:`[2, num_edges]`
+    r"""Converts mesh faces of shape :obj:`[3, num_faces]` or
+    :obj:`[4, num_faces]` to edge indices of shape :obj:`[2, num_edges]`
     (functional name: :obj:`face_to_edge`).
 
     This transform supports both 2D triangular faces, represented by a


### PR DESCRIPTION
Now transforms 2D triangular elements/faces with shape [3,n] to  as well as 3D tetrahedral elements with shape [4,n] to edges of shape [2,n]. 

Including pytest case for face input with shape [4,n]