### PR TITLE
Drop `TensorAttr.fully_specify`

### DIFF
--- a/test/data/test_feature_store.py
+++ b/test/data/test_feature_store.py
@@ -78,7 +78,7 @@ def test_feature_store():
 
     # Partially-specified forms, when called, produce a Tensor output
     # from the `TensorAttr` that has been partially specified.
-    store[group_name] = tensor
+    store[group_name, None, None] = tensor
     assert isinstance(store[group_name], AttrView)
     assert torch.equal(store[group_name](), tensor)
 

--- a/torch_geometric/data/feature_store.py
+++ b/torch_geometric/data/feature_store.py
@@ -223,9 +223,8 @@ class AttrView(CastMixin):
 
             store[group_name, attr_name]()
         """
-        # Set all UNSET values to None:
-        out = copy.copy(self)
-        return out._store.get_tensor(out._attr)
+        assert self._attr.is_fully_specified()
+        return self._store.get_tensor(self._attr)
 
     def __copy__(self) -> 'AttrView':
         out = self.__class__.__new__(self.__class__)
@@ -471,8 +470,7 @@ class FeatureStore(ABC):
         # CastMixin will handle the case of key being a tuple or TensorAttr
         # object:
         key = self._tensor_attr_cls.cast(key)
-        # We need to fully-specify the key for __setitem__ as it does not make
-        # sense to work with a view here:
+        assert key.is_fully_specified()
         self.put_tensor(value, key)
 
     def __getitem__(self, key: TensorAttr) -> Any:
@@ -499,6 +497,7 @@ class FeatureStore(ABC):
         # CastMixin will handle the case of key being a tuple or TensorAttr
         # object:
         key = self._tensor_attr_cls.cast(key)
+        assert key.is_fully_specified()
         self.remove_tensor(key)
 
     def __iter__(self):

--- a/torch_geometric/data/feature_store.py
+++ b/torch_geometric/data/feature_store.py
@@ -74,13 +74,6 @@ class TensorAttr(CastMixin):
         r"""Whether the :obj:`TensorAttr` has no unset fields."""
         return all([self.is_set(key) for key in self.__dataclass_fields__])
 
-    def fully_specify(self) -> 'TensorAttr':
-        r"""Sets all :obj:`UNSET` fields to :obj:`None`."""
-        for key in self.__dataclass_fields__:
-            if not self.is_set(key):
-                setattr(self, key, None)
-        return self
-
     def update(self, attr: 'TensorAttr') -> 'TensorAttr':
         r"""Updates an :class:`TensorAttr` with set attributes from another
         :class:`TensorAttr`.
@@ -232,7 +225,6 @@ class AttrView(CastMixin):
         """
         # Set all UNSET values to None:
         out = copy.copy(self)
-        out._attr.fully_specify()
         return out._store.get_tensor(out._attr)
 
     def __copy__(self) -> 'AttrView':
@@ -481,7 +473,6 @@ class FeatureStore(ABC):
         key = self._tensor_attr_cls.cast(key)
         # We need to fully-specify the key for __setitem__ as it does not make
         # sense to work with a view here:
-        key.fully_specify()
         self.put_tensor(value, key)
 
     def __getitem__(self, key: TensorAttr) -> Any:
@@ -508,7 +499,6 @@ class FeatureStore(ABC):
         # CastMixin will handle the case of key being a tuple or TensorAttr
         # object:
         key = self._tensor_attr_cls.cast(key)
-        key.fully_specify()
         self.remove_tensor(key)
 
     def __iter__(self):

--- a/torch_geometric/data/feature_store.py
+++ b/torch_geometric/data/feature_store.py
@@ -500,6 +500,7 @@ class FeatureStore(ABC):
         # CastMixin will handle the case of key being a tuple or TensorAttr
         # object:
         attr = self._tensor_attr_cls.cast(attr)
+        attr = copy.copy(attr)
         for key in attr.__dataclass_fields__:  # Set all UNSET values to None.
             if not attr.is_set(key):
                 setattr(attr, key, None)

--- a/torch_geometric/data/feature_store.py
+++ b/torch_geometric/data/feature_store.py
@@ -224,7 +224,7 @@ class AttrView(CastMixin):
             store[group_name, attr_name]()
         """
         attr = copy.copy(self._attr)
-        for key in attr.__dataclass_fields__:
+        for key in attr.__dataclass_fields__:  # Set all UNSET values to None.
             if not attr.is_set(key):
                 setattr(attr, key, None)
         return self._store.get_tensor(attr)
@@ -500,7 +500,7 @@ class FeatureStore(ABC):
         # CastMixin will handle the case of key being a tuple or TensorAttr
         # object:
         attr = self._tensor_attr_cls.cast(attr)
-        for key in attr.__dataclass_fields__:
+        for key in attr.__dataclass_fields__:  # Set all UNSET values to None.
             if not attr.is_set(key):
                 setattr(attr, key, None)
         self.remove_tensor(attr)


### PR DESCRIPTION
Removes `TensorAttr.fully_specify` which was originally added in #4534.