### PR TITLE
Add `group_batch` functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- Added `group_batch` functionality ([#9798](https://github.com/pyg-team/pytorch_geometric/pull/9798))
 - Added `nn.models.GLEM` ([#9662](https://github.com/pyg-team/pytorch_geometric/pull/9662))
 - Added `TAGDataset` ([#9662](https://github.com/pyg-team/pytorch_geometric/pull/9662))
 - Added support for fast `Delaunay()` triangulation via the `torch_delaunay` package ([#9748](https://github.com/pyg-team/pytorch_geometric/pull/9748))

--- a/test/utils/test_scatter.py
+++ b/test/utils/test_scatter.py
@@ -6,7 +6,7 @@ import torch
 import torch_geometric.typing
 from torch_geometric.profile import benchmark
 from torch_geometric.testing import withCUDA, withDevice, withPackage
-from torch_geometric.utils import group_argsort, group_cat, scatter
+from torch_geometric.utils import group_argsort, group_cat, group_batch, scatter
 from torch_geometric.utils._scatter import scatter_argmax
 
 
@@ -137,6 +137,21 @@ def test_group_cat(device):
     )
     assert torch.equal(out, expected)
     assert index.tolist() == [0, 0, 0, 1, 2, 2]
+
+
+@withDevice
+def test_group_batch(device):
+    src = torch.randn(6, 4, device=device)
+    index = torch.tensor([0, 0, 0, 1, 2, 2], device=device)
+
+    expected = torch.full((3,3,4), float("-inf"), device=device)
+    expected[0,:3,:] = src[:3]
+    expected[1,:1,:] = src[3]
+    expected[2,:2,:] = src[4:]
+
+    out, mask = group_batch(src, index, dim=0, padding_size=3, value=float("-inf"), return_mask=True)
+    assert torch.equal(out, expected)
+    assert torch.equal(out[mask].reshape(src.size()), src)
 
 
 if __name__ == '__main__':

--- a/test/utils/test_scatter.py
+++ b/test/utils/test_scatter.py
@@ -149,7 +149,7 @@ def test_group_batch(device):
     expected[1,:1,:] = src[3]
     expected[2,:2,:] = src[4:]
 
-    out, mask = group_batch(src, index, dim=0, padding_size=3, value=float("-inf"), return_mask=True)
+    out, mask = group_batch(src, index, dim=0, pad_size=3, pad_value=float("-inf"), return_mask=True)
     assert torch.equal(out, expected)
     assert torch.equal(out[mask].reshape(src.size()), src)
 

--- a/test/utils/test_scatter.py
+++ b/test/utils/test_scatter.py
@@ -6,7 +6,12 @@ import torch
 import torch_geometric.typing
 from torch_geometric.profile import benchmark
 from torch_geometric.testing import withCUDA, withDevice, withPackage
-from torch_geometric.utils import group_argsort, group_cat, group_batch, scatter
+from torch_geometric.utils import (
+    group_argsort,
+    group_batch,
+    group_cat,
+    scatter,
+)
 from torch_geometric.utils._scatter import scatter_argmax
 
 
@@ -144,12 +149,13 @@ def test_group_batch(device):
     src = torch.randn(6, 4, device=device)
     index = torch.tensor([0, 0, 0, 1, 2, 2], device=device)
 
-    expected = torch.full((3,3,4), float("-inf"), device=device)
-    expected[0,:3,:] = src[:3]
-    expected[1,:1,:] = src[3]
-    expected[2,:2,:] = src[4:]
+    expected = torch.full((3, 3, 4), float("-inf"), device=device)
+    expected[0, :3, :] = src[:3]
+    expected[1, :1, :] = src[3]
+    expected[2, :2, :] = src[4:]
 
-    out, mask = group_batch(src, index, dim=0, pad_size=3, pad_value=float("-inf"), return_mask=True)
+    out, mask = group_batch(src, index, dim=0, pad_size=3,
+                            pad_value=float("-inf"), return_mask=True)
     assert torch.equal(out, expected)
     assert torch.equal(out[mask].reshape(src.size()), src)
 

--- a/torch_geometric/utils/__init__.py
+++ b/torch_geometric/utils/__init__.py
@@ -2,7 +2,7 @@ r"""Utility package."""
 
 import copy
 
-from ._scatter import scatter, group_argsort, group_cat
+from ._scatter import scatter, group_argsort, group_cat, group_batch
 from ._segment import segment
 from ._index_sort import index_sort
 from .functions import cumsum
@@ -62,6 +62,7 @@ __all__ = [
     'scatter',
     'group_argsort',
     'group_cat',
+    'group_batch',
     'segment',
     'index_sort',
     'cumsum',

--- a/torch_geometric/utils/_scatter.py
+++ b/torch_geometric/utils/_scatter.py
@@ -363,7 +363,7 @@ def group_batch(
     value: Optional[float] = float("-inf"),
     padding_size: Optional[int] = None,
     return_mask: Optional[bool] = False
-) -> Tensor:
+) -> Tuple[Tensor, Tensor]:
     r"""Create a batched tensor for :obj:`src` using :obj:`index`.
     A batch dimension is created and :obj:`src` tensor is batched along the dimension :obj:`dim`.
 
@@ -393,24 +393,20 @@ def group_batch(
         tensor([[[0.1349, 0.8266],
                  [0.3651, 0.1737],
                  [  -inf,   -inf]],
-
-                 [[0.0211, 0.7000],
+                [[0.0211, 0.7000],
                  [  -inf,   -inf],
                  [  -inf,   -inf]],
-
-                 [[0.1971, 0.2903],
+                [[0.1971, 0.2903],
                  [0.4086, 0.7221],
                  [  -inf,   -inf]]])
         >>> mask
         tensor([[[ True,  True],
                  [ True,  True],
                  [False, False]],
-
-                 [[ True,  True],
+                [[ True,  True],
                  [False, False],
                  [False, False]],
-
-                 [[ True,  True],
+                [[ True,  True],
                  [ True,  True],
                  [False, False]]])
     """

--- a/torch_geometric/utils/_scatter.py
+++ b/torch_geometric/utils/_scatter.py
@@ -1,4 +1,4 @@
-from typing import List, Optional, Tuple, Union
+from typing import List, Optional, Tuple, Union, Any
 
 import torch
 from torch import Tensor
@@ -359,10 +359,10 @@ def group_cat(
 def group_batch(
     src: Tensor,
     index: Tensor,
-    dim: Optional[int] = 0,
-    value: Optional[float] = float("-inf"),
+    dim: int = 0,
+    value: float = float("-inf"),
     padding_size: Optional[int] = None,
-    return_mask: Optional[bool] = False
+    return_mask: bool = False
 ) -> Union[Tuple[Tensor, Tensor], Tensor]:
     r"""Create a batched tensor for :obj:`src` using :obj:`index`.
     A batch dimension is created and :obj:`src` tensor is batched along the dimension :obj:`dim`.
@@ -416,7 +416,10 @@ def group_batch(
     degree_missing_along_dim = (padding_size-d).to(torch.long)
     padding_index = torch.unique(index).repeat_interleave(degree_missing_along_dim)
 
-    def create_batched_tensor(input, fill) -> Tensor:
+    def create_batched_tensor( # type: ignore
+        input,
+        fill
+    ):
         padding_fill = torch.full(input.shape, fill, device=device).index_select(dim, padding_index)
         padded = group_cat([input, padding_fill], [index, padding_index], dim)
         return torch.stack(padded.split(padding_size, dim), dim)

--- a/torch_geometric/utils/_scatter.py
+++ b/torch_geometric/utils/_scatter.py
@@ -422,8 +422,4 @@ def group_batch(
         return torch.stack(padded.split(padding_size, dim), dim)
 
     out = create_batched_tensor(src, value)
-    ret = (out,)
-    if return_mask:
-        mask = create_batched_tensor(torch.full(src.shape, True, device=device), False)
-        ret += (mask,)
-    return ret
+    return(out, create_batched_tensor(torch.full(src.shape, True, device=device), False)) if return_mask else out

--- a/torch_geometric/utils/_scatter.py
+++ b/torch_geometric/utils/_scatter.py
@@ -1,4 +1,4 @@
-from typing import List, Optional, Tuple, Union, Any
+from typing import List, Optional, Tuple, Union
 
 import torch
 from torch import Tensor
@@ -6,8 +6,8 @@ from torch import Tensor
 import torch_geometric.typing
 from torch_geometric import is_compiling, is_in_onnx_export, warnings
 from torch_geometric.typing import torch_scatter
-from torch_geometric.utils.functions import cumsum
 from torch_geometric.utils._degree import degree
+from torch_geometric.utils.functions import cumsum
 
 if torch_geometric.typing.WITH_PT112:  # pragma: no cover
 
@@ -357,13 +357,9 @@ def group_cat(
 
 
 def group_batch(
-    src: Tensor,
-    index: Tensor,
-    dim: int = 0,
-    pad_size: Optional[int] = None,
-    pad_value: float = float("-inf"),
-    return_mask: bool = False
-) -> Union[Tuple[Tensor, Tensor], Tensor]:
+        src: Tensor, index: Tensor, dim: int = 0,
+        pad_size: Optional[int] = None, pad_value: float = float("-inf"),
+        return_mask: bool = False) -> Union[Tuple[Tensor, Tensor], Tensor]:
     r"""Tensor :obj:`src` is batched into groups according to :obj:`index` in the
     given dimension :obj:`dim`.
     Padding is applied to enforce consistent size of batched groups.
@@ -412,16 +408,19 @@ def group_batch(
     device = src.device
     d = degree(index)
     pad_size = max(d) if pad_size is None else pad_size
-    degree_missing_along_dim = (pad_size-d).to(torch.long)
-    padding_index = torch.unique(index).repeat_interleave(degree_missing_along_dim)
+    degree_missing_along_dim = (pad_size - d).to(torch.long)
+    padding_index = torch.unique(index).repeat_interleave(
+        degree_missing_along_dim)
 
-    def create_batched_tensor( # type: ignore
-        input,
-        fill
-    ):
-        padding_fill = torch.full(input.shape, fill, device=device).index_select(dim, padding_index)
+    def create_batched_tensor(  # type: ignore
+            input, fill):
+        padding_fill = torch.full(input.shape, fill,
+                                  device=device).index_select(
+                                      dim, padding_index)
         padded = group_cat([input, padding_fill], [index, padding_index], dim)
         return torch.stack(padded.split(pad_size, dim), dim)
 
     out = create_batched_tensor(src, pad_value)
-    return(out, create_batched_tensor(torch.full(src.shape, True, device=device), False)) if return_mask else out
+    return (out,
+            create_batched_tensor(torch.full(src.shape, True, device=device),
+                                  False)) if return_mask else out

--- a/torch_geometric/utils/_scatter.py
+++ b/torch_geometric/utils/_scatter.py
@@ -357,13 +357,9 @@ def group_cat(
 
 
 def group_batch(
-    src: Tensor,
-    index: Tensor,
-    dim: int = 0,
-    pad_size: Optional[int] = None,
-    pad_value: float = float("-inf"),
-    return_mask: bool = False
-) -> Union[Tuple[Tensor, Tensor], Tensor]:
+        src: Tensor, index: Tensor, dim: int = 0,
+        pad_size: Optional[int] = None, pad_value: float = float("-inf"),
+        return_mask: bool = False) -> Union[Tuple[Tensor, Tensor], Tensor]:
     r"""Tensor :obj:`src` is batched into groups according to :obj:`index`
     in the given dimension :obj:`dim`.
     Padding is applied to enforce consistent size of batched groups.
@@ -415,20 +411,13 @@ def group_batch(
     degree_missing_in_dim = (pad_size - d).to(torch.long)
     pad_index = torch.unique(index).repeat_interleave(degree_missing_in_dim)
 
-    def batching( # type: ignore
-        input,
-        fill
-    ):
-        padding_fill = torch.full(
-            input.shape,
-            fill,
-            device=device
-        ).index_select(dim, pad_index)
+    def batching(  # type: ignore
+            input, fill):
+        padding_fill = torch.full(input.shape, fill,
+                                  device=device).index_select(dim, pad_index)
         padded = group_cat([input, padding_fill], [index, pad_index], dim)
         return torch.stack(padded.split(pad_size, dim), dim)
 
     out = batching(src, pad_value)
-    return (
-        out,
-        batching(torch.full(src.shape, True, device=device), False)
-    ) if return_mask else out
+    return (out, batching(torch.full(src.shape, True, device=device),
+                          False)) if return_mask else out

--- a/torch_geometric/utils/_scatter.py
+++ b/torch_geometric/utils/_scatter.py
@@ -363,7 +363,7 @@ def group_batch(
     value: Optional[float] = float("-inf"),
     padding_size: Optional[int] = None,
     return_mask: Optional[bool] = False
-) -> Tuple[Tensor, Tensor]:
+) -> Union[Tuple[Tensor, Tensor], Tensor]:
     r"""Create a batched tensor for :obj:`src` using :obj:`index`.
     A batch dimension is created and :obj:`src` tensor is batched along the dimension :obj:`dim`.
 

--- a/torch_geometric/utils/_scatter.py
+++ b/torch_geometric/utils/_scatter.py
@@ -416,7 +416,7 @@ def group_batch(
     degree_missing_along_dim = (padding_size-d).to(torch.long)
     padding_index = torch.unique(index).repeat_interleave(degree_missing_along_dim)
 
-    def create_batched_tensor(input, fill):
+    def create_batched_tensor(input, fill) -> Tensor:
         padding_fill = torch.full(input.shape, fill, device=device).index_select(dim, padding_index)
         padded = group_cat([input, padding_fill], [index, padding_index], dim)
         return torch.stack(padded.split(padding_size, dim), dim)


### PR DESCRIPTION
Tensor `src` is batched into groups according to `index` tensor in the given dimension `dim`.
Padding is applied to enforce consistent size of batched groups.

Examples:
```
>>> src = tensor([[0.1349, 0.8266],
...               [0.3651, 0.1737],
...               [0.0211, 0.7000],
...               [0.1971, 0.2903],
...               [0.4086, 0.7221]])
>>> index = torch.LongTensor([0,0,1,2,2])
>>> group_batch(src, index, dim=0, pad_size=3, return_mask=True)
(tensor([[[0.1349, 0.8266],
          [0.3651, 0.1737],
          [  -inf,   -inf]],
         [[0.0211, 0.7000],
          [  -inf,   -inf],
          [  -inf,   -inf]],
         [[0.1971, 0.2903],
          [0.4086, 0.7221],
          [  -inf,   -inf]]])
tensor([[[ True,  True],
         [ True,  True],
         [False, False]],
        [[ True,  True],
         [False, False],
         [False, False]],
        [[ True,  True],
         [ True,  True],
         [False, False]]]))
```