### PR TITLE
Extend manual sampling (__call__) and manual temporal sampling

### DIFF
--- a/test/loader/test_link_neighbor_loader.py
+++ b/test/loader/test_link_neighbor_loader.py
@@ -56,10 +56,14 @@ def test_homo_link_neighbor_loader_basic(device, subgraph_type,
     assert str(loader) == 'LinkNeighborLoader()'
     assert len(loader) == 1000 / 20
 
-    batch = loader([0])
+    # manually sample from the 0-th and 10-th edges
+    batch = loader([[input_edges[0, 0], input_edges[0, 10]],
+                    [input_edges[1, 0], input_edges[1, 10]]])
     assert isinstance(batch, Data)
     assert int(input_edges[0, 0]) in batch.n_id.tolist()
     assert int(input_edges[1, 0]) in batch.n_id.tolist()
+    assert int(input_edges[0, 10]) in batch.n_id.tolist()
+    assert int(input_edges[1, 10]) in batch.n_id.tolist()
 
     for batch in loader:
         assert isinstance(batch, Data)

--- a/test/loader/test_neighbor_loader.py
+++ b/test/loader/test_neighbor_loader.py
@@ -1001,33 +1001,51 @@ def test_temporal_neighbor_loader_manual_sampling():
     data = HeteroData()
     num_nodes = 5
 
-    data['user'].x = (torch.arange(1,num_nodes + 1)
-                      .repeat_interleave(3)
-                      .reshape(num_nodes,3))
-    data['user'].time =  torch.arange(0, num_nodes * 2, 2).long()
+    data['user'].x = (torch.arange(1,
+                                   num_nodes + 1).repeat_interleave(3).reshape(
+                                       num_nodes, 3))
+    data['user'].time = torch.arange(0, num_nodes * 2, 2).long()
 
-    data['item'].x = (torch.arange(1, num_nodes + 1)
-                      .repeat_interleave(3)
-                      .reshape(num_nodes,3) * 10)
-    data['item'].time =  torch.arange(1, num_nodes * 2 + 1, 2).long()
+    data['item'].x = (torch.arange(
+        1, num_nodes + 1).repeat_interleave(3).reshape(num_nodes, 3) * 10)
+    data['item'].time = torch.arange(1, num_nodes * 2 + 1, 2).long()
 
-    data['user', 'buys', 'item'].edge_index = torch.tensor([
-        [0, 0, 0, 1, 2, 2, 2, 3, 3, 3, 4,],
-        [0, 1, 2, 0, 1, 2, 3, 2, 3, 4, 4,]
-    ], dtype=torch.long)
+    data['user', 'buys', 'item'].edge_index = torch.tensor([[
+        0,
+        0,
+        0,
+        1,
+        2,
+        2,
+        2,
+        3,
+        3,
+        3,
+        4,
+    ], [
+        0,
+        1,
+        2,
+        0,
+        1,
+        2,
+        3,
+        2,
+        3,
+        4,
+        4,
+    ]], dtype=torch.long)
 
-    data['item', 'rev_buys', 'user'].edge_index = (
-        data['user', 'buys', 'item'].edge_index.flip(0))
+    data['item', 'rev_buys',
+         'user'].edge_index = (data['user', 'buys', 'item'].edge_index.flip(0))
 
     loader = NeighborLoader(
         data,
-        num_neighbors=[1,1],
+        num_neighbors=[1, 1],
         input_nodes='user',
-        input_time=torch.full(
-        size=(num_nodes,),
-        fill_value=data['item'].time.max().item(),
-        dtype=torch.long
-        ),
+        input_time=torch.full(size=(num_nodes, ),
+                              fill_value=data['item'].time.max().item(),
+                              dtype=torch.long),
         time_attr="time",
     )
 

--- a/test/loader/test_neighbor_loader.py
+++ b/test/loader/test_neighbor_loader.py
@@ -993,3 +993,57 @@ def test_temporal_neighbor_loader_single_link():
     assert batch['a'].num_nodes == 10
     assert batch['b'].num_nodes == 10
     assert batch['c'].num_nodes == 0
+
+
+@onlyNeighborSampler
+@withPackage('pyg_lib')
+def test_temporal_neighbor_loader_manual_sampling():
+    data = HeteroData()
+    num_nodes = 5
+
+    data['user'].x = (torch.arange(1,num_nodes + 1)
+                      .repeat_interleave(3)
+                      .reshape(num_nodes,3))
+    data['user'].time =  torch.arange(0, num_nodes * 2, 2).long()
+
+    data['item'].x = (torch.arange(1, num_nodes + 1)
+                      .repeat_interleave(3)
+                      .reshape(num_nodes,3) * 10)
+    data['item'].time =  torch.arange(1, num_nodes * 2 + 1, 2).long()
+
+    data['user', 'buys', 'item'].edge_index = torch.tensor([
+        [0, 0, 0, 1, 2, 2, 2, 3, 3, 3, 4,],
+        [0, 1, 2, 0, 1, 2, 3, 2, 3, 4, 4,]
+    ], dtype=torch.long)
+
+    data['item', 'rev_buys', 'user'].edge_index = (
+        data['user', 'buys', 'item'].edge_index.flip(0))
+
+    loader = NeighborLoader(
+        data,
+        num_neighbors=[1,1],
+        input_nodes='user',
+        input_time=torch.full(
+        size=(num_nodes,),
+        fill_value=data['item'].time.max().item(),
+        dtype=torch.long
+        ),
+        time_attr="time",
+    )
+
+    input_nodes = torch.tensor([0, 3], dtype=torch.long)
+    sampled_data_no_time = loader(input_nodes)
+
+    assert sampled_data_no_time['user'].x.size(0) >= 2
+
+    seed_time_max = 6
+
+    input_nodes = torch.tensor([0, 3], dtype=torch.long)
+    input_time = torch.tensor([seed_time_max, seed_time_max], dtype=torch.long)
+    sampled_data_with_time = loader(input_nodes, input_time)
+
+    sampled_user_times = sampled_data_with_time['user'].time
+    sampled_item_times = sampled_data_with_time['item'].time
+
+    assert torch.all(sampled_user_times <= seed_time_max)
+    assert torch.all(sampled_item_times <= seed_time_max)

--- a/torch_geometric/loader/node_loader.py
+++ b/torch_geometric/loader/node_loader.py
@@ -120,6 +120,7 @@ class NodeLoader(
         input_type, input_nodes, input_id = get_input_nodes(
             data, input_nodes, input_id)
 
+
         self.input_data = NodeSamplerInput(
             input_id=input_id,
             node=input_nodes,
@@ -132,12 +133,21 @@ class NodeLoader(
 
     def __call__(
         self,
-        index: Union[Tensor, List[int]],
+        input_nodes: Union[Tensor, List[int]],
+        input_time: OptTensor = None,
     ) -> Union[Data, HeteroData]:
-        r"""Samples a subgraph from a batch of input nodes."""
-        out = self.collate_fn(index)
-        if not self.filter_per_worker:
-            out = self.filter_fn(out)
+        r"""Samples a subgraph from a list of raw input nodes and
+        optionally, corresponding seed times."""
+        if not isinstance(input_nodes, Tensor):
+            input_nodes = torch.tensor(input_nodes, dtype=torch.long)
+        input_data = NodeSamplerInput(
+            input_id=torch.arange(input_nodes.shape[0]),
+            node=input_nodes,
+            time=input_time,
+            input_type=self.input_data.input_type,
+        )
+        out = self.node_sampler.sample_from_nodes(input_data)
+        out = self.filter_fn(out)
         return out
 
     def collate_fn(self, index: Union[Tensor, List[int]]) -> Any:

--- a/torch_geometric/loader/node_loader.py
+++ b/torch_geometric/loader/node_loader.py
@@ -120,7 +120,6 @@ class NodeLoader(
         input_type, input_nodes, input_id = get_input_nodes(
             data, input_nodes, input_id)
 
-
         self.input_data = NodeSamplerInput(
             input_id=input_id,
             node=input_nodes,
@@ -137,7 +136,8 @@ class NodeLoader(
         input_time: OptTensor = None,
     ) -> Union[Data, HeteroData]:
         r"""Samples a subgraph from a list of raw input nodes and
-        optionally, corresponding seed times."""
+        optionally, corresponding seed times.
+        """
         if not isinstance(input_nodes, Tensor):
             input_nodes = torch.tensor(input_nodes, dtype=torch.long)
         input_data = NodeSamplerInput(


### PR DESCRIPTION
This PR addresses #9785 

It changes the __call__ interface in `NodeLoader` and `LinkLoader`, that nows expect 'raw' seed nodes/seed edges instead of indices, and adding optional seed time argument.
