### PR TITLE
On single-CPU systems, skip tests which are known not to work

### DIFF
--- a/test/loader/test_mixin.py
+++ b/test/loader/test_mixin.py
@@ -1,6 +1,7 @@
 import subprocess
 from time import sleep
 
+import psutil
 import pytest
 import torch
 
@@ -12,6 +13,8 @@ from torch_geometric.testing import onlyLinux, onlyNeighborSampler
 @pytest.mark.xfail(reason="TODO: Fix test")
 @onlyLinux
 @onlyNeighborSampler
+@pytest.mark.skipif(
+    psutil.cpu_count(logical=False) == 1, reason="Requires multiple CPU cores")
 @pytest.mark.parametrize('loader_cores', [None, [1, 2]])
 def test_cpu_affinity_neighbor_loader(loader_cores, spawn_context):
     data = Data(x=torch.randn(1, 1))
@@ -41,6 +44,8 @@ def init_fn(worker_id):
 
 @onlyLinux
 @onlyNeighborSampler
+@pytest.mark.skipif(
+    psutil.cpu_count(logical=False) == 1, reason="Requires multiple CPU cores")
 def test_multithreading_neighbor_loader(spawn_context):
     loader = NeighborLoader(
         data=Data(x=torch.randn(1, 1)),


### PR DESCRIPTION
Hello. While building this package on a single-CPU system I noticed that two tests fail.

`test_cpu_affinity_neighbor_loader()` fails in this way:

`E    ValueError: More workers (got 2) than available cores (got 1)`

and `test_multithreading_neighbor_loader()` fails in this way:

`E    ValueError: 'worker_threads' should be smaller than the total available number of threads 1 (got 2)`

I guess those tests are simply not suitable to be executed on single-CPU systems, so the proposed MR uses `os.cpu_count()` to test before executing them.

The failures may be reproduced easily by booting with `GRUB_CMDLINE_LINUX="nr_cpus=1"`.

Thanks.