### PR TITLE
Support bipartite graph for utils isolated nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Added the `use_pcst` option to `WebQSPDataset` ([#9722](https://github.com/pyg-team/pytorch_geometric/pull/9722))
 - Allowed users to pass `edge_weight` to `GraphUNet` models ([#9737](https://github.com/pyg-team/pytorch_geometric/pull/9737))
 - Consolidated `examples/ogbn_{papers_100m,products_gat,products_sage}.py` into `examples/ogbn_train.py` ([#9467](https://github.com/pyg-team/pytorch_geometric/pull/9467))
+- Allowed `num_isolated_nodes`, `contains_isolated_nodes`, and `remove_isolated_nodes` in `utils` to handle bipartite graphs ([#9825](https://github.com/pyg-team/pytorch_geometric/pull/9825))
 
 ### Changed
 

--- a/test/utils/test_isolated.py
+++ b/test/utils/test_isolated.py
@@ -3,8 +3,36 @@ import torch
 from torch_geometric.testing import is_full_test
 from torch_geometric.utils import (
     contains_isolated_nodes,
+    num_isolated_nodes,
     remove_isolated_nodes,
 )
+
+
+def test_num_isolated_nodes():
+    edge_index = torch.tensor([[0, 1, 0], [1, 0, 0]])
+    assert num_isolated_nodes(edge_index) == 0
+    assert num_isolated_nodes(edge_index, num_nodes=3) == 1
+
+    if is_full_test():
+        jit = torch.jit.script(num_isolated_nodes)
+        assert jit(edge_index) == 0
+        assert jit(edge_index, num_nodes=3) == 1
+
+    edge_index = torch.tensor([[0, 1, 2, 0], [1, 0, 2, 0]])
+    assert num_isolated_nodes(edge_index, num_nodes=3) == 1
+
+
+def test_bipartite_num_isolated_nodes():
+    edge_index = torch.tensor([[0, 1], [0, 1]])
+    assert num_isolated_nodes(edge_index, num_nodes=(2, 2)) == 0
+    assert num_isolated_nodes(edge_index, num_nodes=(2, 3)) == 1
+    assert num_isolated_nodes(edge_index, num_nodes=(3, 3)) == 2
+
+    if is_full_test():
+        jit = torch.jit.script(num_isolated_nodes)
+        assert jit(edge_index, num_nodes=(2, 2)) == 0
+        assert jit(edge_index, num_nodes=(2, 3)) == 1
+        assert jit(edge_index, num_nodes=(3, 3)) == 2
 
 
 def test_contains_isolated_nodes():
@@ -19,6 +47,19 @@ def test_contains_isolated_nodes():
 
     edge_index = torch.tensor([[0, 1, 2, 0], [1, 0, 2, 0]])
     assert contains_isolated_nodes(edge_index)
+
+
+def test_bipartite_contains_isolated_nodes():
+    edge_index = torch.tensor([[0, 1], [0, 1]])
+    assert not contains_isolated_nodes(edge_index, num_nodes=(2, 2))
+    assert contains_isolated_nodes(edge_index, num_nodes=(2, 3))
+    assert contains_isolated_nodes(edge_index, num_nodes=(3, 3))
+
+    if is_full_test():
+        jit = torch.jit.script(contains_isolated_nodes)
+        assert not jit(edge_index, num_nodes=(2, 2))
+        assert jit(edge_index, num_nodes=(2, 3))
+        assert jit(edge_index, num_nodes=(3, 3))
 
 
 def test_remove_isolated_nodes():
@@ -44,3 +85,26 @@ def test_remove_isolated_nodes():
     assert out1.tolist() == [[0, 1, 0, 1], [1, 0, 0, 1]]
     assert out2.tolist() == [1, 2, 4, 5]
     assert mask.tolist() == [1, 0, 1]
+
+
+def test_remove_bipartite_isolated_nodes():
+    edge_index = torch.tensor([[0, 1], [1, 2]])
+
+    out, _, (src_mask,
+             dst_mask) = remove_isolated_nodes(edge_index, num_nodes=(2, 3))
+    assert out.tolist() == [[0, 1], [0, 1]]
+    assert src_mask.tolist() == [1, 1]
+    assert dst_mask.tolist() == [0, 1, 1]
+
+    if is_full_test():
+        jit = torch.jit.script(remove_isolated_nodes)
+        out, _, (src_mask, dst_mask) = jit(edge_index, num_nodes=(2, 3))
+        assert out.tolist() == [[0, 1], [0, 1]]
+        assert src_mask.tolist() == [1, 1]
+        assert dst_mask.tolist() == [0, 1, 1]
+
+    edge_index = torch.tensor([[0, 1, 0], [1, 0, 0]])
+    out, _, mask = remove_isolated_nodes(edge_index, num_nodes=(3, 3))
+    assert out.tolist() == [[0, 1, 0], [1, 0, 0]]
+    assert mask[0].tolist() == [1, 1, 0]
+    assert mask[1].tolist() == [1, 1, 0]

--- a/test/utils/test_isolated.py
+++ b/test/utils/test_isolated.py
@@ -98,8 +98,8 @@ def test_remove_bipartite_isolated_nodes():
                     dst_mask) = remove_isolated_nodes(edge_index, edge_attr,
                                                       num_nodes=(2, 4))
     assert out.tolist() == [[0, 1, 1], [0, 1, 2]]
-    assert src_mask.tolist() == [1, 1]
-    assert dst_mask.tolist() == [0, 1, 1, 1]
+    assert src_mask.tolist() == [True, True]
+    assert dst_mask.tolist() == [False, True, True, True]
     assert out_attr.tolist() == [[1.0, 1.0], [1.0, 1.0], [1.0, 1.0]]
 
     if is_full_test():
@@ -107,14 +107,14 @@ def test_remove_bipartite_isolated_nodes():
         out, out_attr, (src_mask, dst_mask) = jit(edge_index, edge_attr,
                                                   num_nodes=(2, 4))
         assert out.tolist() == [[0, 1, 1], [0, 1, 2]]
-        assert src_mask.tolist() == [1, 1]
-        assert dst_mask.tolist() == [0, 1, 1, 1]
+        assert src_mask.tolist() == [True, True]
+        assert dst_mask.tolist() == [False, True, True, True]
         assert out_attr.tolist() == [[1.0, 1.0], [1.0, 1.0], [1.0, 1.0]]
 
     edge_index = torch.tensor([[0, 1, 0], [1, 0, 0]])
     out, out_attr, mask = remove_isolated_nodes(edge_index, edge_attr,
                                                 num_nodes=(3, 3))
     assert out.tolist() == [[0, 1, 0], [1, 0, 0]]
-    assert mask[0].tolist() == [1, 1, 0]
-    assert mask[1].tolist() == [1, 1, 0]
+    assert mask[0].tolist() == [True, True, False]
+    assert mask[1].tolist() == [True, True, False]
     assert out_attr.tolist() == [[1.0, 1.0], [1.0, 1.0], [1.0, 1.0]]

--- a/test/utils/test_isolated.py
+++ b/test/utils/test_isolated.py
@@ -51,15 +51,18 @@ def test_contains_isolated_nodes():
 
 def test_bipartite_contains_isolated_nodes():
     edge_index = torch.tensor([[0, 1], [0, 1]])
-    assert not contains_isolated_nodes(edge_index, num_nodes=(2, 2))
-    assert contains_isolated_nodes(edge_index, num_nodes=(2, 3))
-    assert contains_isolated_nodes(edge_index, num_nodes=(3, 3))
+    assert contains_isolated_nodes(edge_index,
+                                   num_nodes=(2, 2)) == (False, False)
+    assert contains_isolated_nodes(edge_index,
+                                   num_nodes=(2, 3)) == (False, True)
+    assert contains_isolated_nodes(edge_index,
+                                   num_nodes=(3, 3)) == (True, True)
 
     if is_full_test():
         jit = torch.jit.script(contains_isolated_nodes)
-        assert not jit(edge_index, num_nodes=(2, 2))
-        assert jit(edge_index, num_nodes=(2, 3))
-        assert jit(edge_index, num_nodes=(3, 3))
+        assert jit(edge_index, num_nodes=(2, 2)) == (False, False)
+        assert jit(edge_index, num_nodes=(2, 3)) == (False, True)
+        assert jit(edge_index, num_nodes=(3, 3)) == (True, True)
 
 
 def test_remove_isolated_nodes():

--- a/test/utils/test_isolated.py
+++ b/test/utils/test_isolated.py
@@ -24,15 +24,15 @@ def test_num_isolated_nodes():
 
 def test_bipartite_num_isolated_nodes():
     edge_index = torch.tensor([[0, 1], [0, 1]])
-    assert num_isolated_nodes(edge_index, num_nodes=(2, 2)) == 0
-    assert num_isolated_nodes(edge_index, num_nodes=(2, 3)) == 1
-    assert num_isolated_nodes(edge_index, num_nodes=(3, 3)) == 2
+    assert num_isolated_nodes(edge_index, num_nodes=(2, 2)) == (0, 0)
+    assert num_isolated_nodes(edge_index, num_nodes=(2, 3)) == (0, 1)
+    assert num_isolated_nodes(edge_index, num_nodes=(3, 3)) == (1, 1)
 
     if is_full_test():
         jit = torch.jit.script(num_isolated_nodes)
-        assert jit(edge_index, num_nodes=(2, 2)) == 0
-        assert jit(edge_index, num_nodes=(2, 3)) == 1
-        assert jit(edge_index, num_nodes=(3, 3)) == 2
+        assert jit(edge_index, num_nodes=(2, 2)) == (0, 0)
+        assert jit(edge_index, num_nodes=(2, 3)) == (0, 1)
+        assert jit(edge_index, num_nodes=(3, 3)) == (1, 1)
 
 
 def test_contains_isolated_nodes():

--- a/torch_geometric/utils/__init__.py
+++ b/torch_geometric/utils/__init__.py
@@ -15,7 +15,8 @@ from .undirected import is_undirected, to_undirected
 from .loop import (contains_self_loops, remove_self_loops,
                    segregate_self_loops, add_self_loops,
                    add_remaining_self_loops, get_self_loop_attr)
-from .isolated import contains_isolated_nodes, remove_isolated_nodes
+from .isolated import (contains_isolated_nodes, remove_isolated_nodes,
+                       num_isolated_nodes)
 from ._subgraph import (get_num_hops, subgraph, k_hop_subgraph,
                         bipartite_subgraph)
 from .dropout import dropout_adj, dropout_node, dropout_edge, dropout_path
@@ -80,6 +81,7 @@ __all__ = [
     'get_self_loop_attr',
     'contains_isolated_nodes',
     'remove_isolated_nodes',
+    'num_isolated_nodes',
     'get_num_hops',
     'subgraph',
     'bipartite_subgraph',

--- a/torch_geometric/utils/isolated.py
+++ b/torch_geometric/utils/isolated.py
@@ -17,7 +17,7 @@ def num_isolated_nodes(
     automatically removed before checking for isolated nodes.
 
     Args:
-        edge_index (Tensor): The edge indices.
+        edge_index (torch.Tensor): The edge indices.
         num_nodes (int or tuple, optional): The number of nodes, *i.e.*
             :obj:`max_val + 1` of :attr:`edge_index`. For bipartite graph,
             provide a tuple of two integers `(num_src_nodes, num_dst_nodes)`.
@@ -73,7 +73,7 @@ def contains_isolated_nodes(
     contain isolated nodes.
 
     Args:
-        edge_index (Tensor): The edge indices.
+        edge_index (torch.Tensor): The edge indices.
         num_nodes (int or tuple, optional): The number of nodes, *i.e.*
             :obj:`max_val + 1` of :attr:`edge_index`. For bipartite graph,
             provide a tuple of two integers `(num_src_nodes, num_dst_nodes)`.
@@ -128,8 +128,8 @@ def remove_isolated_nodes(
     if the graph is bipartite.
 
     Args:
-        edge_index (Tensor): The edge indices.
-        edge_attr (Tensor, optional): Edge weights or multi-dimensional
+        edge_index (torch.Tensor): The edge indices.
+        edge_attr (torch.Tensor, optional): Edge weights or multi-dimensional
             edge features. (default: :obj:`None`)
         num_nodes (int or tuple, optional): The number of nodes, *i.e.*
             :obj:`max_val + 1` of :attr:`edge_index`.For bipartite graph,

--- a/torch_geometric/utils/isolated.py
+++ b/torch_geometric/utils/isolated.py
@@ -30,8 +30,8 @@ def num_isolated_nodes(
         ...                            [1, 0, 0]])
         >>> num_isolated_nodes(edge_index)
         0
-        >>> bi_edge_index = torch.tensor([[0, 0],
-        ...                               [1, 1]])
+        >>> bi_edge_index = torch.tensor([[0, 1],
+        ...                               [1, 0]])
         >>> num_isolated_nodes(bi_edge_index, num_nodes=(2, 2))
         (0, 0)
         >>> num_isolated_nodes(bi_edge_index, num_nodes=(2, 3))

--- a/torch_geometric/utils/isolated.py
+++ b/torch_geometric/utils/isolated.py
@@ -1,4 +1,4 @@
-from typing import Optional, Tuple
+from typing import Optional, Tuple, Union
 
 import torch
 from torch import Tensor
@@ -7,17 +7,62 @@ from torch_geometric.utils import remove_self_loops, segregate_self_loops
 from torch_geometric.utils.num_nodes import maybe_num_nodes
 
 
-def contains_isolated_nodes(
-    edge_index: Tensor,
-    num_nodes: Optional[int] = None,
-) -> bool:
-    r"""Returns :obj:`True` if the graph given by :attr:`edge_index` contains
-    isolated nodes.
+def num_isolated_nodes(
+        edge_index: Tensor,
+        num_nodes: Optional[Union[int, Tuple[int, int]]] = None) -> int:
+    r"""Returns the number of isolated nodes in the graph given by
+    :attr:`edge_index`. Please specify :obj:`num_nodes` as a tuple of two
+    integers if the graph is bipartite. For normal graph, self loops are
+    automatically removed before checking for isolated nodes.
 
     Args:
         edge_index (LongTensor): The edge indices.
-        num_nodes (int, optional): The number of nodes, *i.e.*
-            :obj:`max_val + 1` of :attr:`edge_index`. (default: :obj:`None`)
+        num_nodes (int or tuple, optional): The number of nodes, *i.e.*
+            :obj:`max_val + 1` of :attr:`edge_index`. For bipartite graph,
+            provide a tuple of two integers `(num_src_nodes, num_dst_nodes)`.
+            (default: :obj:`None`)
+
+    :rtype: int
+
+    Examples:
+        >>> edge_index = torch.tensor([[0, 1, 0],
+        ...                            [1, 0, 0]])
+        >>> num_isolated_nodes(edge_index)
+        0
+        >>> bi_edge_index = torch.tensor([[0, 0],
+        ...                               [1, 1]])
+        >>> num_isolated_nodes(bi_edge_index, num_nodes=(2, 2))
+        0
+        >>> num_isolated_nodes(bi_edge_index, num_nodes=(3, 3))
+        2
+    """
+    if not isinstance(num_nodes, tuple):
+        num_nodes = maybe_num_nodes(edge_index, num_nodes)
+        edge_index, _ = remove_self_loops(edge_index)
+        return num_nodes - torch.unique(edge_index.view(-1)).numel()
+    else:
+        num_src_nodes, num_dst_nodes = num_nodes
+        edge_index = edge_index.clone()
+        edge_index[1, :] += num_src_nodes
+    return (num_src_nodes + num_dst_nodes) - torch.unique(
+        edge_index.view(-1)).numel()
+
+
+def contains_isolated_nodes(
+    edge_index: Tensor,
+    num_nodes: Optional[Union[int, Tuple[int, int]]] = None,
+) -> bool:
+    r"""Returns :obj:`True` if the graph given by :attr:`edge_index` contains
+    isolated nodes. Please specify :obj:`num_nodes` as a tuple of two integers
+    if the graph is bipartite. For normal graph, self loops are automatically
+    removed before checking for isolated nodes.
+
+    Args:
+        edge_index (LongTensor): The edge indices.
+        num_nodes (int or tuple, optional): The number of nodes, *i.e.*
+            :obj:`max_val + 1` of :attr:`edge_index`. For bipartite graph,
+            provide a tuple of two integers `(num_src_nodes, num_dst_nodes)`.
+            (default: :obj:`None`)
 
     :rtype: bool
 
@@ -29,31 +74,49 @@ def contains_isolated_nodes(
 
         >>> contains_isolated_nodes(edge_index, num_nodes=3)
         True
+
+        >>> bi_edge_index = torch.tensor([[0, 0],
+        ...                               [1, 1]])
+        >>> contains_isolated_nodes(bi_edge_index, num_nodes=(2, 2))
+        False
+        >>> contains_isolated_nodes(bi_edge_index, num_nodes=(3, 3))
+        True
     """
-    num_nodes = maybe_num_nodes(edge_index, num_nodes)
-    edge_index, _ = remove_self_loops(edge_index)
+    if not isinstance(num_nodes, tuple):
+        num_nodes = maybe_num_nodes(edge_index, num_nodes)
+        edge_index, _ = remove_self_loops(edge_index)
+    else:
+        num_src_nodes, num_dst_nodes = num_nodes
+        num_nodes = num_src_nodes + num_dst_nodes
+        # Clone the edge_index to avoid in-place modification
+        edge_index = edge_index.clone()
+        edge_index[1, :] += num_src_nodes
     return torch.unique(edge_index.view(-1)).numel() < num_nodes
 
 
 def remove_isolated_nodes(
     edge_index: Tensor,
     edge_attr: Optional[Tensor] = None,
-    num_nodes: Optional[int] = None,
-) -> Tuple[Tensor, Optional[Tensor], Tensor]:
+    num_nodes: Optional[Union[int, Tuple[int, int]]] = None,
+) -> Tuple[Tensor, Optional[Tensor], Union[Tensor, Tuple[Tensor, Tensor]]]:
     r"""Removes the isolated nodes from the graph given by :attr:`edge_index`
     with optional edge attributes :attr:`edge_attr`.
     In addition, returns a mask of shape :obj:`[num_nodes]` to manually filter
     out isolated node features later on.
     Self-loops are preserved for non-isolated nodes.
+    Please specify :obj:`num_nodes` as a tuple of two integers
+    if the graph is bipartite.
 
     Args:
         edge_index (LongTensor): The edge indices.
         edge_attr (Tensor, optional): Edge weights or multi-dimensional
             edge features. (default: :obj:`None`)
-        num_nodes (int, optional): The number of nodes, *i.e.*
-            :obj:`max_val + 1` of :attr:`edge_index`. (default: :obj:`None`)
+        num_nodes (int or tuple, optional): The number of nodes, *i.e.*
+            :obj:`max_val + 1` of :attr:`edge_index`.For bipartite graph,
+            provide a tuple of two integers `(num_src_nodes, num_dst_nodes)`.
+            (default: :obj:`None`)
 
-    :rtype: (LongTensor, Tensor, BoolTensor)
+    :rtype: (LongTensor, Tensor, BoolTensor or Tuple[BoolTensor, BoolTensor])
 
     Examples:
         >>> edge_index = torch.tensor([[0, 1, 0],
@@ -66,33 +129,62 @@ def remove_isolated_nodes(
         ...                                                     num_nodes=3)
         >>> mask # node mask (3 nodes)
         tensor([True, True, False])
+
+        >>> bi_edge_index = torch.tensor([[0, 1],
+        ...                               [1, 2]])
+        >>> edge_index, _, (src_mask, dst_mask) = \
+        ... remove_isolated_nodes(bi_edge_index, num_nodes=(2, 3))
+        >>> src_mask # source node mask (2 nodes)
+        tensor([True, True])
+        >>> dst_mask # destination node mask (3 nodes)
+        tensor([False, True, True])
     """
-    num_nodes = maybe_num_nodes(edge_index, num_nodes)
+    if not isinstance(num_nodes, tuple):
+        num_nodes = maybe_num_nodes(edge_index, num_nodes)
+        out = segregate_self_loops(edge_index, edge_attr)
+        edge_index, edge_attr, loop_edge_index, loop_edge_attr = out
+        mask = torch.zeros(num_nodes, dtype=torch.bool,
+                           device=edge_index.device)
+        mask[edge_index.view(-1)] = 1
+        assoc = torch.full((num_nodes, ), -1, dtype=torch.long,
+                           device=mask.device)
+        assoc[mask] = torch.arange(mask.sum(),
+                                   device=assoc.device)  # type: ignore
+        edge_index = assoc[edge_index]
 
-    out = segregate_self_loops(edge_index, edge_attr)
-    edge_index, edge_attr, loop_edge_index, loop_edge_attr = out
+        loop_mask = torch.zeros_like(mask)
+        loop_mask[loop_edge_index[0]] = 1
+        loop_mask = loop_mask & mask
+        loop_assoc = torch.full_like(assoc, -1)
+        loop_assoc[loop_edge_index[0]] = torch.arange(loop_edge_index.size(1),
+                                                      device=loop_assoc.device)
+        loop_idx = loop_assoc[loop_mask]
+        loop_edge_index = assoc[loop_edge_index[:, loop_idx]]
+        edge_index = torch.cat([edge_index, loop_edge_index], dim=1)
 
-    mask = torch.zeros(num_nodes, dtype=torch.bool, device=edge_index.device)
-    mask[edge_index.view(-1)] = 1
+        if edge_attr is not None:
+            assert loop_edge_attr is not None
+            loop_edge_attr = loop_edge_attr[loop_idx]
+            edge_attr = torch.cat([edge_attr, loop_edge_attr], dim=0)
+        return edge_index, edge_attr, mask
+    else:
+        num_src_nodes, num_dst_nodes = num_nodes
+        src_mask = torch.zeros(num_src_nodes, dtype=torch.bool,
+                               device=edge_index.device)
+        src_mask[edge_index[0, :]] = 1
+        src_assoc = torch.full((num_src_nodes, ), -1, dtype=torch.long,
+                               device=src_mask.device)
+        src_assoc[src_mask] = torch.arange(
+            src_mask.sum(), device=src_assoc.device)  # type: ignore
+        src_edge_index = src_assoc[edge_index[0, :]]
 
-    assoc = torch.full((num_nodes, ), -1, dtype=torch.long, device=mask.device)
-    assoc[mask] = torch.arange(mask.sum(), device=assoc.device)  # type: ignore
-    edge_index = assoc[edge_index]
-
-    loop_mask = torch.zeros_like(mask)
-    loop_mask[loop_edge_index[0]] = 1
-    loop_mask = loop_mask & mask
-    loop_assoc = torch.full_like(assoc, -1)
-    loop_assoc[loop_edge_index[0]] = torch.arange(loop_edge_index.size(1),
-                                                  device=loop_assoc.device)
-    loop_idx = loop_assoc[loop_mask]
-    loop_edge_index = assoc[loop_edge_index[:, loop_idx]]
-
-    edge_index = torch.cat([edge_index, loop_edge_index], dim=1)
-
-    if edge_attr is not None:
-        assert loop_edge_attr is not None
-        loop_edge_attr = loop_edge_attr[loop_idx]
-        edge_attr = torch.cat([edge_attr, loop_edge_attr], dim=0)
-
-    return edge_index, edge_attr, mask
+        dst_mask = torch.zeros(num_dst_nodes, dtype=torch.bool,
+                               device=edge_index.device)
+        dst_mask[edge_index[1, :]] = 1
+        dst_assoc = torch.full((num_dst_nodes, ), -1, dtype=torch.long,
+                               device=dst_mask.device)
+        dst_assoc[dst_mask] = torch.arange(
+            dst_mask.sum(), device=dst_assoc.device)  # type: ignore
+        dst_edge_index = dst_assoc[edge_index[1, :]]
+        edge_index = torch.stack([src_edge_index, dst_edge_index], dim=0)
+        return edge_index, edge_attr, (src_mask, dst_mask)


### PR DESCRIPTION
- Add bipartite graph support for `contains_isolated_nodes` and `remove_isolated_nodes`
- For `contains_isolated_nodes` returns a tuple of boolean if it's a bipartite graph
- Add `num_isolated_nodes` for both bipartite and normal graph
  - For bipartite graph, return `(src_num_isolated_nodes, dst_num_isolated_nodes)`