### PR TITLE
Support Mixup for Node and Graph Classification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Added `EdgeIndex.sparse_resize_` functionality ([#8983](https://github.com/pyg-team/pytorch_geometric/pull/8983))
 - Added approximate `faiss`-based KNN-search ([#8952](https://github.com/pyg-team/pytorch_geometric/pull/8952))
 - Added documentation on environment setup on XPU device ([#9407](https://github.com/pyg-team/pytorch_geometric/pull/9407))
+- Added the `MixupConv`, `node_mixup` and `graph_mixup` to support mixup for node and graph Classification (#9830)
 
 ### Changed
 

--- a/examples/contrib/README.md
+++ b/examples/contrib/README.md
@@ -10,3 +10,5 @@ Modules included here might be moved to the main library in the future.
 | [`rbcd_attack_poisoning.py`](./rbcd_attack_poisoning.py)                           | An example of the RBCD (Resource-Based Critical Data) attack with data poisoning strategies |
 | [`pgm_explainer_node_classification.py`](./pgm_explainer_node_classification.py)   | An example of the PGM (Probabilistic Graphical Model) explainer for node classification     |
 | [`pgm_explainer_graph_classification.py`](./pgm_explainer_graph_classification.py) | An example of the PGM (Probabilistic Graphical Model) explainer for graph classification    |
+| [`node_mixup.py`](./node_mixup.py) | An example of using Mixup for node classification    |
+| [`graph_mixup.py`](./graph_mixup.py) | An example of using Mixup for graph classification    |

--- a/examples/contrib/README.md
+++ b/examples/contrib/README.md
@@ -10,5 +10,5 @@ Modules included here might be moved to the main library in the future.
 | [`rbcd_attack_poisoning.py`](./rbcd_attack_poisoning.py)                           | An example of the RBCD (Resource-Based Critical Data) attack with data poisoning strategies |
 | [`pgm_explainer_node_classification.py`](./pgm_explainer_node_classification.py)   | An example of the PGM (Probabilistic Graphical Model) explainer for node classification     |
 | [`pgm_explainer_graph_classification.py`](./pgm_explainer_graph_classification.py) | An example of the PGM (Probabilistic Graphical Model) explainer for graph classification    |
-| [`node_mixup.py`](./node_mixup.py) | An example of using Mixup for node classification    |
-| [`graph_mixup.py`](./graph_mixup.py) | An example of using Mixup for graph classification    |
+| [`node_mixup.py`](./node_mixup.py)                                                 | An example of using Mixup for node classification                                           |
+| [`graph_mixup.py`](./graph_mixup.py)                                               | An example of using Mixup for graph classification                                          |

--- a/examples/contrib/graph_mixup.py
+++ b/examples/contrib/graph_mixup.py
@@ -1,0 +1,150 @@
+"""This is an example of using mixup for graph
+classification task.
+"""
+import os.path as osp
+import argparse
+import copy
+import numpy as np
+import torch
+import torch.nn.functional as F
+from torch_geometric.datasets import TUDataset
+from torch_geometric.data import DataLoader, Data, Batch
+from torch_geometric.nn import GCNConv
+
+from torch_geometric.contrib.nn import GraphMixup
+
+def parse_args():
+    parser = argparse.ArgumentParser(description='GraphMixup Training Example')
+    parser.add_argument('--dataset', type=str, default='PROTEINS',
+                        help='Dataset name (default: PROTEINS)')
+    parser.add_argument('--num_layers', type=int, default=3,
+                        help='Number of layers (default: 3)')
+    parser.add_argument('--hidden_channels', type=int, default=64,
+                        help='Hidden channels (default: 64)')
+    parser.add_argument('--dropout', type=float, default=0.5,
+                        help='Dropout rate (default: 0.5)')
+    parser.add_argument('--lr', type=float, default=0.001,
+                        help='Learning rate (default: 0.001)')
+    parser.add_argument('--epochs', type=int, default=50,
+                        help='Number of training epochs (default: 50)')
+    parser.add_argument('--alpha', type=float, default=2.0,
+                        help='Alpha parameter for Beta distribution in mixup (default: 2.0)')
+    parser.add_argument('--seed', type=int, default=42,
+                        help='Random seed (default: 42)')
+    parser.add_argument('--device', type=str, default='cuda' if torch.cuda.is_available() else 'cpu',
+                        choices=['cuda', 'cpu'], help='Device (default: cuda if available)')
+    args = parser.parse_args()
+    return args
+
+def shuffle_batch(data_list, seed=None):
+    if seed is not None:
+        np.random.seed(seed)
+    indices = np.arange(len(data_list))
+    np.random.shuffle(indices)
+    shuffled_list = [data_list[i] for i in indices]
+    return shuffled_list, indices
+
+def main():
+    args = parse_args()
+
+    # Set random seed
+    torch.manual_seed(args.seed)
+    np.random.seed(args.seed)
+
+    # Load dataset
+    path = osp.join(osp.dirname(osp.realpath(__file__)), '..', 'data', args.dataset)
+    dataset = TUDataset(path, name=args.dataset).shuffle()
+
+    # For simplicity, split dataset into train/val/test
+    train_size = int(len(dataset) * 0.6)
+    val_size = int(len(dataset) * 0.2)
+    test_size = len(dataset) - train_size - val_size
+
+    train_dataset = dataset[:train_size]
+    val_dataset = dataset[train_size:train_size+val_size]
+    test_dataset = dataset[train_size+val_size:]
+
+    train_loader = DataLoader(train_dataset, batch_size=32, shuffle=True)
+    val_loader = DataLoader(val_dataset, batch_size=32, shuffle=False)
+    test_loader = DataLoader(test_dataset, batch_size=32, shuffle=False)
+
+    device = torch.device(args.device)
+
+    model = GraphMixup(
+        num_layers=args.num_layers,
+        in_channels=dataset.num_node_features,
+        hidden_channels=args.hidden_channels,
+        out_channels=dataset.num_classes,
+        conv_layer=GCNConv,
+        dropout=args.dropout
+    ).to(device)
+
+    optimizer = torch.optim.Adam(model.parameters(), lr=args.lr)
+
+    def train():
+        model.train()
+        total_loss = 0
+        for batch in train_loader:
+            batch = batch.to(device)
+            # Shuffle batch to create second batch
+            data_list = batch.to_data_list()
+            data_b_list, _ = shuffle_batch(data_list, seed=args.seed)
+            batch_b = Batch.from_data_list(data_b_list).to(device)  # Corrected line
+
+            lam = np.random.beta(args.alpha, args.alpha)
+
+            out = model(
+                batch.x, batch.edge_index, batch.batch,
+                batch_b.x, batch_b.edge_index, batch_b.batch,
+                lam
+            )
+
+            # Mixup loss
+            y = batch.y
+            y_b = batch_b.y
+            loss = lam * F.nll_loss(out, y) + (1 - lam) * F.nll_loss(out, y_b)
+
+            optimizer.zero_grad()
+            loss.backward()
+            optimizer.step()
+
+            total_loss += loss.item() * batch.num_graphs
+
+        return total_loss / len(train_loader.dataset)
+
+    @torch.no_grad()
+    def eval(loader):
+        model.eval()
+        correct = 0
+        total = 0
+        for batch in loader:
+            batch = batch.to(device)
+            # For evaluation, no mixup (lam=1), or just feed same batch
+            out = model(
+                batch.x, batch.edge_index, batch.batch,
+                batch.x, batch.edge_index, batch.batch,
+                lam=1.0
+            )
+            pred = out.argmax(dim=-1)
+            correct += pred.eq(batch.y).sum().item()
+            total += batch.num_graphs
+        return correct / total
+
+    best_val_acc = 0
+    best_test_acc = 0
+    for epoch in range(1, args.epochs + 1):
+        loss = train()
+        val_acc = eval(val_loader)
+        test_acc = eval(test_loader)
+        if val_acc > best_val_acc:
+            best_val_acc = val_acc
+            best_test_acc = test_acc
+
+        if epoch % 10 == 0 or epoch == 1:
+            print(f"Epoch: {epoch:03d}, Loss: {loss:.4f}, "
+                  f"Val Acc: {val_acc:.4f}, Test Acc: {test_acc:.4f}")
+
+    print(f"Best Val Acc: {best_val_acc:.4f}, Corresponding Test Acc: {best_test_acc:.4f}")
+
+if __name__ == "__main__":
+    main()

--- a/examples/contrib/graph_mixup.py
+++ b/examples/contrib/graph_mixup.py
@@ -1,4 +1,5 @@
-"""This is an example of using mixup for graph classification task.
+"""This is an example of using mixup for
+graph classification task.
 """
 
 import argparse

--- a/examples/contrib/graph_mixup.py
+++ b/examples/contrib/graph_mixup.py
@@ -1,44 +1,89 @@
-"""This is an example of using mixup for graph
-classification task.
 """
+This is an example of using mixup for graph classification task.
+"""
+
 import os.path as osp
 import argparse
-import copy
 import numpy as np
 import torch
 import torch.nn.functional as F
 from torch_geometric.datasets import TUDataset
-from torch_geometric.data import DataLoader, Data, Batch
-from torch_geometric.nn import GCNConv, GATConv, GINConv, SAGEConv
-
+from torch_geometric.data import DataLoader, Batch
+from torch_geometric.nn import GCNConv, GATConv, SAGEConv
 from torch_geometric.contrib.nn import GraphMixup
 
+
 def parse_args():
-    parser = argparse.ArgumentParser(description='GraphMixup Training Example')
-    parser.add_argument('--dataset', type=str, default='PROTEINS',choices=['PROTEINS','DD'],
-                        help='Dataset name for graph classification (default: PROTEINS)')
-    parser.add_argument('--gnn', type=str, default='GCN',choices=['GCN', 'GAT', 'GraphSAGE'],
-                        help='GNN backbone to use (default: GCN)')
-    parser.add_argument('--num_layers', type=int, default=3,
-                        help='Number of layers (default: 3)')
-    parser.add_argument('--hidden_channels', type=int, default=64,
-                        help='Hidden channels (default: 64)')
-    parser.add_argument('--dropout', type=float, default=0.5,
-                        help='Dropout rate (default: 0.5)')
-    parser.add_argument('--lr', type=float, default=0.001,
-                        help='Learning rate (default: 0.001)')
-    parser.add_argument('--epochs', type=int, default=50,
-                        help='Number of training epochs (default: 50)')
-    parser.add_argument('--alpha', type=float, default=2.0,
-                        help='Alpha parameter for Beta distribution in mixup (default: 2.0)')
-    parser.add_argument('--seed', type=int, default=42,
-                        help='Random seed (default: 42)')
-    parser.add_argument('--device', type=str, default='cuda' if torch.cuda.is_available() else 'cpu',
-                        choices=['cuda', 'cpu'], help='Device (default: cuda if available)')
-    args = parser.parse_args()
-    return args
+    """Parse command-line arguments."""
+    parser = argparse.ArgumentParser(description="GraphMixup Training Example")
+    parser.add_argument(
+        '--dataset',
+        type=str,
+        default='PROTEINS',
+        choices=['PROTEINS', 'DD'],
+        help='Dataset name for graph classification (default: PROTEINS)',
+    )
+    parser.add_argument(
+        '--gnn',
+        type=str,
+        default='GCN',
+        choices=['GCN', 'GAT', 'GraphSAGE'],
+        help='GNN backbone to use (default: GCN)',
+    )
+    parser.add_argument(
+        '--num_layers',
+        type=int,
+        default=3,
+        help='Number of layers (default: 3)',
+    )
+    parser.add_argument(
+        '--hidden_channels',
+        type=int,
+        default=64,
+        help='Hidden channels (default: 64)',
+    )
+    parser.add_argument(
+        '--dropout',
+        type=float,
+        default=0.5,
+        help='Dropout rate (default: 0.5)',
+    )
+    parser.add_argument(
+        '--lr',
+        type=float,
+        default=0.001,
+        help='Learning rate (default: 0.001)',
+    )
+    parser.add_argument(
+        '--epochs',
+        type=int,
+        default=50,
+        help='Number of training epochs (default: 50)',
+    )
+    parser.add_argument(
+        '--alpha',
+        type=float,
+        default=2.0,
+        help='Alpha parameter for Beta distribution in mixup (default: 2.0)',
+    )
+    parser.add_argument(
+        '--seed',
+        type=int,
+        default=42,
+        help='Random seed (default: 42)'
+    )
+    parser.add_argument(
+        '--device',
+        type=str,
+        default='cuda' if torch.cuda.is_available() else 'cpu',
+        choices=['cuda', 'cpu'],
+        help='Device (default: cuda if available)',
+    )
+    return parser.parse_args()
+
 
 def get_gnn_layer(gnn_type: str):
+    """Retrieve the appropriate GNN layer based on the gnn_type."""
     if gnn_type == 'GCN':
         return GCNConv
     elif gnn_type == 'GAT':
@@ -48,13 +93,16 @@ def get_gnn_layer(gnn_type: str):
     else:
         raise ValueError(f"Unsupported GNN type: {gnn_type}")
 
+
 def shuffle_batch(data_list, seed=None):
+    """Shuffle the graph batches."""
     if seed is not None:
         np.random.seed(seed)
     indices = np.arange(len(data_list))
     np.random.shuffle(indices)
     shuffled_list = [data_list[i] for i in indices]
     return shuffled_list, indices
+
 
 def main():
     args = parse_args()
@@ -64,17 +112,18 @@ def main():
     np.random.seed(args.seed)
 
     # Load dataset
-    path = osp.join(osp.dirname(osp.realpath(__file__)), '..', 'data', args.dataset)
+    path = osp.join(
+        osp.dirname(osp.realpath(__file__)), '..', 'data', args.dataset
+    )
     dataset = TUDataset(path, name=args.dataset).shuffle()
 
-    # For simplicity, split dataset into train/val/test
+    # Split dataset into train/val/test
     train_size = int(len(dataset) * 0.6)
     val_size = int(len(dataset) * 0.2)
-    test_size = len(dataset) - train_size - val_size
 
     train_dataset = dataset[:train_size]
-    val_dataset = dataset[train_size:train_size+val_size]
-    test_dataset = dataset[train_size+val_size:]
+    val_dataset = dataset[train_size:train_size + val_size]
+    test_dataset = dataset[train_size + val_size:]
 
     train_loader = DataLoader(train_dataset, batch_size=32, shuffle=True)
     val_loader = DataLoader(val_dataset, batch_size=32, shuffle=False)
@@ -89,27 +138,32 @@ def main():
         hidden_channels=args.hidden_channels,
         out_channels=dataset.num_classes,
         conv_layer=gnn_layer,
-        dropout=args.dropout
+        dropout=args.dropout,
     ).to(device)
 
     optimizer = torch.optim.Adam(model.parameters(), lr=args.lr)
 
     def train():
+        """Train the model."""
         model.train()
         total_loss = 0
         for batch in train_loader:
             batch = batch.to(device)
-            # Shuffle batch to create second batch
+            # Shuffle batch to create a second batch
             data_list = batch.to_data_list()
             data_b_list, _ = shuffle_batch(data_list, seed=args.seed)
-            batch_b = Batch.from_data_list(data_b_list).to(device)  # Corrected line
+            batch_b = Batch.from_data_list(data_b_list).to(device)
 
             lam = np.random.beta(args.alpha, args.alpha)
 
             out = model(
-                batch.x, batch.edge_index, batch.batch,
-                batch_b.x, batch_b.edge_index, batch_b.batch,
-                lam
+                batch.x,
+                batch.edge_index,
+                batch.batch,
+                batch_b.x,
+                batch_b.edge_index,
+                batch_b.batch,
+                lam,
             )
 
             # Mixup loss
@@ -127,16 +181,20 @@ def main():
 
     @torch.no_grad()
     def eval(loader):
+        """Evaluate the model."""
         model.eval()
         correct = 0
         total = 0
         for batch in loader:
             batch = batch.to(device)
-            # For evaluation, no mixup (lam=1), or just feed same batch
             out = model(
-                batch.x, batch.edge_index, batch.batch,
-                batch.x, batch.edge_index, batch.batch,
-                lam=1.0
+                batch.x,
+                batch.edge_index,
+                batch.batch,
+                batch.x,
+                batch.edge_index,
+                batch.batch,
+                lam=1.0,
             )
             pred = out.argmax(dim=-1)
             correct += pred.eq(batch.y).sum().item()
@@ -154,10 +212,16 @@ def main():
             best_test_acc = test_acc
 
         if epoch % 10 == 0 or epoch == 1:
-            print(f"Epoch: {epoch:03d}, Loss: {loss:.4f}, "
-                  f"Val Acc: {val_acc:.4f}, Test Acc: {test_acc:.4f}")
+            print(
+                f"Epoch: {epoch:03d}, Loss: {loss:.4f}, "
+                f"Val Acc: {val_acc:.4f}, Test Acc: {test_acc:.4f}"
+            )
 
-    print(f"Best Val Acc: {best_val_acc:.4f}, Corresponding Test Acc: {best_test_acc:.4f}")
+    print(
+        f"Best Val Acc: {best_val_acc:.4f}, "
+        f"Corresponding Test Acc: {best_test_acc:.4f}"
+    )
+
 
 if __name__ == "__main__":
     main()

--- a/examples/contrib/graph_mixup.py
+++ b/examples/contrib/graph_mixup.py
@@ -1,16 +1,17 @@
-"""
-This is an example of using mixup for graph classification task.
+"""This is an example of using mixup for graph classification task.
 """
 
-import os.path as osp
 import argparse
+import os.path as osp
+
 import numpy as np
 import torch
 import torch.nn.functional as F
-from torch_geometric.datasets import TUDataset
-from torch_geometric.data import DataLoader, Batch
-from torch_geometric.nn import GCNConv, GATConv, SAGEConv
+
 from torch_geometric.contrib.nn import GraphMixup
+from torch_geometric.data import Batch, DataLoader
+from torch_geometric.datasets import TUDataset
+from torch_geometric.nn import GATConv, GCNConv, SAGEConv
 
 
 def parse_args():
@@ -66,12 +67,8 @@ def parse_args():
         default=2.0,
         help='Alpha parameter for Beta distribution in mixup (default: 2.0)',
     )
-    parser.add_argument(
-        '--seed',
-        type=int,
-        default=42,
-        help='Random seed (default: 42)'
-    )
+    parser.add_argument('--seed', type=int, default=42,
+                        help='Random seed (default: 42)')
     parser.add_argument(
         '--device',
         type=str,
@@ -112,9 +109,8 @@ def main():
     np.random.seed(args.seed)
 
     # Load dataset
-    path = osp.join(
-        osp.dirname(osp.realpath(__file__)), '..', 'data', args.dataset
-    )
+    path = osp.join(osp.dirname(osp.realpath(__file__)), '..', 'data',
+                    args.dataset)
     dataset = TUDataset(path, name=args.dataset).shuffle()
 
     # Split dataset into train/val/test
@@ -212,15 +208,11 @@ def main():
             best_test_acc = test_acc
 
         if epoch % 10 == 0 or epoch == 1:
-            print(
-                f"Epoch: {epoch:03d}, Loss: {loss:.4f}, "
-                f"Val Acc: {val_acc:.4f}, Test Acc: {test_acc:.4f}"
-            )
+            print(f"Epoch: {epoch:03d}, Loss: {loss:.4f}, "
+                  f"Val Acc: {val_acc:.4f}, Test Acc: {test_acc:.4f}")
 
-    print(
-        f"Best Val Acc: {best_val_acc:.4f}, "
-        f"Corresponding Test Acc: {best_test_acc:.4f}"
-    )
+    print(f"Best Val Acc: {best_val_acc:.4f}, "
+          f"Corresponding Test Acc: {best_test_acc:.4f}")
 
 
 if __name__ == "__main__":

--- a/examples/contrib/node_mixup.py
+++ b/examples/contrib/node_mixup.py
@@ -1,60 +1,95 @@
-"""This is an example of using mixup for node
-classification task.
 """
+This is an example of using mixup for node classification task.
+"""
+
 import os.path as osp
 import copy
 import numpy as np
 import torch
 import torch.nn.functional as F
-from torch import Tensor
 from torch_geometric.datasets import Planetoid
 from torch_geometric.transforms import NormalizeFeatures
 from torch_geometric.data import Data
 from torch_geometric.contrib.nn import NodeMixup
 import argparse
 
+
 def parse_args():
-    parser = argparse.ArgumentParser(description='NodeMixup Training')
+    """Parse command-line arguments."""
+    parser = argparse.ArgumentParser(description="NodeMixup Training")
 
     # Dataset parameters
-    parser.add_argument('--dataset', type=str, default='Pubmed',
-                        choices=['Cora', 'CiteSeer', 'Pubmed'],
-                        help='Name of the dataset to use (default: Pubmed)')
+    parser.add_argument(
+        '--dataset',
+        type=str,
+        default='Pubmed',
+        choices=['Cora', 'CiteSeer', 'Pubmed'],
+        help='Name of the dataset to use (default: Pubmed)',
+    )
 
     # Training hyperparameters
-    parser.add_argument('--num_layers', type=int, default=3,
-                        help='Number of layers in the model (default: 3)')
-    parser.add_argument('--hidden_channels', type=int, default=256,
-                        help='Number of hidden channels (default: 256)')
-    parser.add_argument('--dropout', type=float, default=0.4,
-                        help='Dropout rate (default: 0.4)')
+    parser.add_argument(
+        '--num_layers',
+        type=int,
+        default=3,
+        help='Number of layers (default: 3)')
+    parser.add_argument(
+        '--hidden_channels',
+        type=int,
+        default=256,
+        help='Number of hidden channels (default: 256)')
+    parser.add_argument(
+        '--dropout',
+        type=float,
+        default=0.4,
+        help='Dropout rate (default: 0.4)')
     parser.add_argument('--lr', type=float, default=0.001,
                         help='Learning rate (default: 0.001)')
-    parser.add_argument('--epochs', type=int, default=300,
-                        help='Number of training epochs (default: 300)')
+    parser.add_argument(
+        '--epochs',
+        type=int,
+        default=300,
+        help='Number of training epochs (default: 300)')
 
     # Mixup parameters
-    parser.add_argument('--alpha', type=float, default=4.0,
-                        help='Alpha parameter for Beta distribution in mixup (default: 4.0)')
+    parser.add_argument(
+        '--alpha',
+        type=float,
+        default=4.0,
+        help='Alpha parameter for Beta distribution in mixup (default: 4.0)',
+    )
 
     # Split ratios
-    parser.add_argument('--train_ratio', type=float, default=0.6,
-                        help='Ratio of training data (default: 0.6)')
-    parser.add_argument('--val_ratio', type=float, default=0.2,
-                        help='Ratio of validation data (default: 0.2)')
-    # Test ratio is implicitly 1 - train_ratio - val_ratio
+    parser.add_argument(
+        '--train_ratio',
+        type=float,
+        default=0.6,
+        help='Ratio of training data (default: 0.6)')
+    parser.add_argument(
+        '--val_ratio',
+        type=float,
+        default=0.2,
+        help='Ratio of validation data (default: 0.2)')
 
-    parser.add_argument('--seed', type=int, default=42,
-                        help='Random seed for reproducibility (default: 42)')
-    parser.add_argument('--device', type=str, default='cuda' if torch.cuda.is_available() else 'cpu',
-                        choices=['cuda', 'cpu'],
-                        help='Device to use for computation (default: cuda if available)')
+    # Miscellaneous
+    parser.add_argument(
+        '--seed',
+        type=int,
+        default=42,
+        help='Random seed for reproducibility (default: 42)')
+    parser.add_argument(
+        '--device',
+        type=str,
+        default='cuda' if torch.cuda.is_available() else 'cpu',
+        choices=['cuda', 'cpu'],
+        help='Device to use for computation (default: cuda if available)',
+    )
 
-    args = parser.parse_args()
-    return args
+    return parser.parse_args()
 
-# Function to get the shuffled version of the input graph
+
 def shuffle_data(data: Data, seed: int = None):
+    """Get the shuffled version of the input graph."""
     if seed is not None:
         np.random.seed(seed)
     data = copy.deepcopy(data)
@@ -65,11 +100,13 @@ def shuffle_data(data: Data, seed: int = None):
 
     row, col = data.edge_index[0].cpu(), data.edge_index[1].cpu()
     id_old_value_new = torch.zeros(id_new_value_old.shape[0], dtype=torch.long)
-    id_old_value_new[id_new_value_old] = torch.arange(id_new_value_old.shape[0], dtype=torch.long)
+    id_old_value_new[id_new_value_old] = torch.arange(
+        id_new_value_old.shape[0], dtype=torch.long)
     row, col = id_old_value_new[row], id_old_value_new[col]
     data.edge_index = torch.stack([row, col], dim=0)
 
     return data, id_new_value_old
+
 
 def main():
     args = parse_args()
@@ -82,7 +119,12 @@ def main():
 
     # Load dataset
     dataset_name = args.dataset
-    path = osp.join(osp.dirname(osp.realpath(__file__)), '..', 'data', dataset_name)
+    path = osp.join(
+        osp.dirname(
+            osp.realpath(__file__)),
+        '..',
+        'data',
+        dataset_name)
     dataset = Planetoid(path, dataset_name, transform=NormalizeFeatures())
     data = dataset[0]
 
@@ -101,7 +143,7 @@ def main():
         in_channels=dataset.num_node_features,
         hidden_channels=args.hidden_channels,
         out_channels=dataset.num_classes,
-        dropout=args.dropout
+        dropout=args.dropout,
     )
 
     # Define optimizer and device
@@ -109,8 +151,8 @@ def main():
     model = model.to(device)
     optimizer = torch.optim.Adam(model.parameters(), lr=args.lr)
 
-    # Training function
     def train(data):
+        """Training function."""
         model.train()
         lam = np.random.beta(args.alpha, args.alpha)
 
@@ -119,19 +161,35 @@ def main():
         data_b = data_b.to(device)
 
         optimizer.zero_grad()
-        out = model(data.x, data.edge_index, data_b.edge_index, lam, id_new_value_old)
-        loss = F.nll_loss(out[data.train_id], data.y[data.train_id]) * lam + \
-               F.nll_loss(out[data.train_id], data_b.y[data.train_id]) * (1 - lam)
+        out = model(
+            data.x,
+            data.edge_index,
+            data_b.edge_index,
+            lam,
+            id_new_value_old)
+        loss = (
+            F.nll_loss(out[data.train_id],
+                       data.y[data.train_id]) * lam
+            + F.nll_loss(out[data.train_id],
+                         data_b.y[data.train_id]) * (1 - lam)
+        )
+
         loss.backward()
         optimizer.step()
 
         return loss.item()
 
-    # Testing function
     @torch.no_grad()
     def test(data):
+        """Testing function."""
         model.eval()
-        out = model(data.x, data.edge_index, data.edge_index, 1, np.arange(data.num_nodes))
+        out = model(
+            data.x,
+            data.edge_index,
+            data.edge_index,
+            1,
+            np.arange(
+                data.num_nodes))
         pred = out.argmax(dim=-1)
         correct = pred.eq(data.y)
         accs = []
@@ -150,11 +208,16 @@ def main():
             best_val_acc = val_acc
             best_test_acc = test_acc
         if epoch % 10 == 0 or epoch == 1:
-            print(f'Epoch: {epoch:03d}, Loss: {loss:.4f}, '
-                  f'Train Acc: {train_acc:.4f}, Val Acc: {val_acc:.4f}, '
-                  f'Test Acc: {test_acc:.4f}')
+            print(
+                f"Epoch: {epoch:03d}, Loss: {loss:.4f}, \
+                Train Acc: {train_acc:.4f}"
+                f"Val Acc: {val_acc:.4f}, Test Acc: {test_acc:.4f}"
+            )
 
-    print(f'Best Val Acc: {best_val_acc:.4f}, Corresponding Test Acc: {best_test_acc:.4f}')
+    print(
+        f"Best Val Acc: {best_val_acc:.4f}, Corresponding Test Acc: \
+            {best_test_acc:.4f}")
+
 
 if __name__ == '__main__':
     main()

--- a/examples/contrib/node_mixup.py
+++ b/examples/contrib/node_mixup.py
@@ -1,0 +1,94 @@
+import os.path as osp
+import copy
+import numpy as np
+import torch
+import torch.nn.functional as F
+from torch import Tensor
+from torch_geometric.datasets import Planetoid
+from torch_geometric.transforms import NormalizeFeatures
+from torch_geometric.data import Data
+from torch_geometric.contrib.nn import NodeMixup
+
+# Function to get the shuffled version of the input graph
+def shuffle_data(data: Data):
+    data = copy.deepcopy(data)
+    id_new_value_old = np.arange(data.num_nodes)
+    train_id_shuffle = copy.deepcopy(data.train_id)
+    np.random.shuffle(train_id_shuffle)
+    id_new_value_old[data.train_id] = train_id_shuffle
+
+    row, col = data.edge_index[0], data.edge_index[1]
+    id_old_value_new = torch.zeros(id_new_value_old.shape[0], dtype=torch.long)
+    id_old_value_new[id_new_value_old] = torch.arange(id_new_value_old.shape[0], dtype=torch.long)
+    row, col = id_old_value_new[row], id_old_value_new[col]
+    data.edge_index = torch.stack([row, col], dim=0)
+    
+    return data, id_new_value_old
+
+# Load dataset
+dataset_name = 'Pubmed'
+path = osp.join(osp.dirname(osp.realpath(__file__)), '..', 'data', dataset_name)
+dataset = Planetoid(path, dataset_name, transform=NormalizeFeatures())
+data = dataset[0]
+
+# Split dataset
+node_id = np.arange(data.num_nodes)
+np.random.shuffle(node_id)
+data.train_id = node_id[:int(data.num_nodes * 0.6)]
+data.val_id = node_id[int(data.num_nodes * 0.6):int(data.num_nodes * 0.8)]
+data.test_id = node_id[int(data.num_nodes * 0.8):]
+
+# Initialize the model
+num_layers = 3
+in_channels = dataset.num_node_features
+hidden_channels = 256
+out_channels = dataset.num_classes
+model = NodeMixup(
+    num_layers=num_layers,
+    in_channels=in_channels,
+    hidden_channels=hidden_channels,
+    out_channels=out_channels,
+    dropout=0.4
+)
+
+# Define optimizer and device
+device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
+model = model.to(device)
+data = data.to(device)
+optimizer = torch.optim.Adam(model.parameters(), lr=0.001)
+
+# Training function
+def train(data):
+    model.train()
+    lam = np.random.beta(4.0, 4.0)
+
+    data_b, id_new_value_old = shuffle_data(data)
+    data_b = data_b.to(device)
+
+    optimizer.zero_grad()
+    out = model(data.x, data.edge_index, data_b.edge_index, lam, id_new_value_old)
+    loss = F.nll_loss(out[data.train_id], data.y[data.train_id]) * lam + \
+           F.nll_loss(out[data.train_id], data_b.y[data.train_id]) * (1 - lam)
+    loss.backward()
+    optimizer.step()
+    
+    return loss.item()
+
+# Testing function
+@torch.no_grad()
+def test(data):
+    model.eval()
+    out = model(data.x, data.edge_index, data.edge_index, 1, np.arange(data.num_nodes))
+    pred = out.argmax(dim=-1)
+    correct = pred.eq(data.y)
+    accs = []
+    for _, id_ in data('train_id', 'val_id', 'test_id'):
+        accs.append(correct[id_].sum().item() / id_.shape[0])
+    return accs
+
+# Training loop
+best_acc = 0
+for epoch in range(1, 301):
+    loss = train(data)
+    accs = test(data)
+    print(f'Epoch: {epoch:02d}, Loss: {loss:.4f}, Train Acc: {accs[0]:.4f}, Test Acc: {accs[2]:.4f}')

--- a/examples/contrib/node_mixup.py
+++ b/examples/contrib/node_mixup.py
@@ -1,4 +1,5 @@
-"""This is an example of using mixup for node classification task.
+"""This is an example of using mixup for
+node classification task.
 """
 
 import argparse

--- a/examples/contrib/node_mixup.py
+++ b/examples/contrib/node_mixup.py
@@ -8,9 +8,52 @@ from torch_geometric.datasets import Planetoid
 from torch_geometric.transforms import NormalizeFeatures
 from torch_geometric.data import Data
 from torch_geometric.contrib.nn import NodeMixup
+import argparse
+
+def parse_args():
+    parser = argparse.ArgumentParser(description='NodeMixup Training')
+
+    # Dataset parameters
+    parser.add_argument('--dataset', type=str, default='Pubmed',
+                        choices=['Cora', 'CiteSeer', 'Pubmed'],
+                        help='Name of the dataset to use (default: Pubmed)')
+
+    # Training hyperparameters
+    parser.add_argument('--num_layers', type=int, default=3,
+                        help='Number of layers in the model (default: 3)')
+    parser.add_argument('--hidden_channels', type=int, default=256,
+                        help='Number of hidden channels (default: 256)')
+    parser.add_argument('--dropout', type=float, default=0.4,
+                        help='Dropout rate (default: 0.4)')
+    parser.add_argument('--lr', type=float, default=0.001,
+                        help='Learning rate (default: 0.001)')
+    parser.add_argument('--epochs', type=int, default=300,
+                        help='Number of training epochs (default: 300)')
+
+    # Mixup parameters
+    parser.add_argument('--alpha', type=float, default=4.0,
+                        help='Alpha parameter for Beta distribution in mixup (default: 4.0)')
+
+    # Split ratios
+    parser.add_argument('--train_ratio', type=float, default=0.6,
+                        help='Ratio of training data (default: 0.6)')
+    parser.add_argument('--val_ratio', type=float, default=0.2,
+                        help='Ratio of validation data (default: 0.2)')
+    # Test ratio is implicitly 1 - train_ratio - val_ratio
+
+    parser.add_argument('--seed', type=int, default=42,
+                        help='Random seed for reproducibility (default: 42)')
+    parser.add_argument('--device', type=str, default='cuda' if torch.cuda.is_available() else 'cpu',
+                        choices=['cuda', 'cpu'],
+                        help='Device to use for computation (default: cuda if available)')
+
+    args = parser.parse_args()
+    return args
 
 # Function to get the shuffled version of the input graph
-def shuffle_data(data: Data):
+def shuffle_data(data: Data, seed: int = None):
+    if seed is not None:
+        np.random.seed(seed)
     data = copy.deepcopy(data)
     id_new_value_old = np.arange(data.num_nodes)
     train_id_shuffle = copy.deepcopy(data.train_id)
@@ -22,73 +65,93 @@ def shuffle_data(data: Data):
     id_old_value_new[id_new_value_old] = torch.arange(id_new_value_old.shape[0], dtype=torch.long)
     row, col = id_old_value_new[row], id_old_value_new[col]
     data.edge_index = torch.stack([row, col], dim=0)
-    
+
     return data, id_new_value_old
 
-# Load dataset
-dataset_name = 'Pubmed'
-path = osp.join(osp.dirname(osp.realpath(__file__)), '..', 'data', dataset_name)
-dataset = Planetoid(path, dataset_name, transform=NormalizeFeatures())
-data = dataset[0]
+def main():
+    args = parse_args()
 
-# Split dataset
-node_id = np.arange(data.num_nodes)
-np.random.shuffle(node_id)
-data.train_id = node_id[:int(data.num_nodes * 0.6)]
-data.val_id = node_id[int(data.num_nodes * 0.6):int(data.num_nodes * 0.8)]
-data.test_id = node_id[int(data.num_nodes * 0.8):]
+    # Set random seeds for reproducibility
+    np.random.seed(args.seed)
+    torch.manual_seed(args.seed)
+    if torch.cuda.is_available():
+        torch.cuda.manual_seed(args.seed)
 
-# Initialize the model
-num_layers = 3
-in_channels = dataset.num_node_features
-hidden_channels = 256
-out_channels = dataset.num_classes
-model = NodeMixup(
-    num_layers=num_layers,
-    in_channels=in_channels,
-    hidden_channels=hidden_channels,
-    out_channels=out_channels,
-    dropout=0.4
-)
+    # Load dataset
+    dataset_name = args.dataset
+    path = osp.join(osp.dirname(osp.realpath(__file__)), '..', 'data', dataset_name)
+    dataset = Planetoid(path, dataset_name, transform=NormalizeFeatures())
+    data = dataset[0]
 
-# Define optimizer and device
-device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
-model = model.to(device)
-optimizer = torch.optim.Adam(model.parameters(), lr=0.001)
+    # Split dataset
+    node_id = np.arange(data.num_nodes)
+    np.random.shuffle(node_id)
+    train_end = int(data.num_nodes * args.train_ratio)
+    val_end = train_end + int(data.num_nodes * args.val_ratio)
+    data.train_id = node_id[:train_end]
+    data.val_id = node_id[train_end:val_end]
+    data.test_id = node_id[val_end:]
 
-# Training function
-def train(data):
-    model.train()
-    lam = np.random.beta(4.0, 4.0)
+    # Initialize the model
+    model = NodeMixup(
+        num_layers=args.num_layers,
+        in_channels=dataset.num_node_features,
+        hidden_channels=args.hidden_channels,
+        out_channels=dataset.num_classes,
+        dropout=args.dropout
+    )
 
-    data_b, id_new_value_old = shuffle_data(data)
-    data = data.to(device)
-    data_b = data_b.to(device)
+    # Define optimizer and device
+    device = torch.device(args.device)
+    model = model.to(device)
+    optimizer = torch.optim.Adam(model.parameters(), lr=args.lr)
 
-    optimizer.zero_grad()
-    out = model(data.x, data.edge_index, data_b.edge_index, lam, id_new_value_old)
-    loss = F.nll_loss(out[data.train_id], data.y[data.train_id]) * lam + \
-           F.nll_loss(out[data.train_id], data_b.y[data.train_id]) * (1 - lam)
-    loss.backward()
-    optimizer.step()
-    
-    return loss.item()
+    # Training function
+    def train(data):
+        model.train()
+        lam = np.random.beta(args.alpha, args.alpha)
 
-# Testing function
-@torch.no_grad()
-def test(data):
-    model.eval()
-    out = model(data.x, data.edge_index, data.edge_index, 1, np.arange(data.num_nodes))
-    pred = out.argmax(dim=-1)
-    correct = pred.eq(data.y)
-    accs = []
-    for _, id_ in data('train_id', 'val_id', 'test_id'):
-        accs.append(correct[id_].sum().item() / id_.shape[0])
-    return accs
+        data_b, id_new_value_old = shuffle_data(data, seed=args.seed)
+        data = data.to(device)
+        data_b = data_b.to(device)
 
-# Training loop
-best_acc = 0
-for epoch in range(1, 301):
-    loss = train(data)
-    accs = test(data)
-    print(f'Epoch: {epoch:02d}, Loss: {loss:.4f}, Train Acc: {accs[0]:.4f}, Test Acc: {accs[2]:.4f}')
+        optimizer.zero_grad()
+        out = model(data.x, data.edge_index, data_b.edge_index, lam, id_new_value_old)
+        loss = F.nll_loss(out[data.train_id], data.y[data.train_id]) * lam + \
+               F.nll_loss(out[data.train_id], data_b.y[data.train_id]) * (1 - lam)
+        loss.backward()
+        optimizer.step()
+
+        return loss.item()
+
+    # Testing function
+    @torch.no_grad()
+    def test(data):
+        model.eval()
+        out = model(data.x, data.edge_index, data.edge_index, 1, np.arange(data.num_nodes))
+        pred = out.argmax(dim=-1)
+        correct = pred.eq(data.y)
+        accs = []
+        for id_ in [data.train_id, data.val_id, data.test_id]:
+            acc = correct[id_].sum().item() / id_.shape[0]
+            accs.append(acc)
+        return accs
+
+    # Training loop
+    best_val_acc = 0
+    best_test_acc = 0
+    for epoch in range(1, args.epochs + 1):
+        loss = train(data)
+        train_acc, val_acc, test_acc = test(data)
+        if val_acc > best_val_acc:
+            best_val_acc = val_acc
+            best_test_acc = test_acc
+        if epoch % 10 == 0 or epoch == 1:
+            print(f'Epoch: {epoch:03d}, Loss: {loss:.4f}, '
+                  f'Train Acc: {train_acc:.4f}, Val Acc: {val_acc:.4f}, '
+                  f'Test Acc: {test_acc:.4f}')
+
+    print(f'Best Val Acc: {best_val_acc:.4f}, Corresponding Test Acc: {best_test_acc:.4f}')
+
+if __name__ == '__main__':
+    main()

--- a/examples/contrib/node_mixup.py
+++ b/examples/contrib/node_mixup.py
@@ -1,3 +1,6 @@
+"""This is an example of using mixup for node
+classification task.
+"""
 import os.path as osp
 import copy
 import numpy as np

--- a/examples/contrib/node_mixup.py
+++ b/examples/contrib/node_mixup.py
@@ -209,14 +209,15 @@ def main():
             best_test_acc = test_acc
         if epoch % 10 == 0 or epoch == 1:
             print(
-                f"Epoch: {epoch:03d}, Loss: {loss:.4f}, \
-                Train Acc: {train_acc:.4f}"
+                f"Epoch: {epoch:03d}, Loss: {loss:.4f}, "
+                f"Train Acc: {train_acc:.4f}"
                 f"Val Acc: {val_acc:.4f}, Test Acc: {test_acc:.4f}"
             )
 
     print(
-        f"Best Val Acc: {best_val_acc:.4f}, Corresponding Test Acc: \
-            {best_test_acc:.4f}")
+        f"Best Val Acc: {best_val_acc:.4f}, Corresponding Test Acc: "
+        f"{best_test_acc:.4f}"
+    )
 
 
 if __name__ == '__main__':

--- a/examples/contrib/node_mixup.py
+++ b/examples/contrib/node_mixup.py
@@ -17,7 +17,7 @@ def shuffle_data(data: Data):
     np.random.shuffle(train_id_shuffle)
     id_new_value_old[data.train_id] = train_id_shuffle
 
-    row, col = data.edge_index[0], data.edge_index[1]
+    row, col = data.edge_index[0].cpu(), data.edge_index[1].cpu()
     id_old_value_new = torch.zeros(id_new_value_old.shape[0], dtype=torch.long)
     id_old_value_new[id_new_value_old] = torch.arange(id_new_value_old.shape[0], dtype=torch.long)
     row, col = id_old_value_new[row], id_old_value_new[col]
@@ -54,7 +54,6 @@ model = NodeMixup(
 # Define optimizer and device
 device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
 model = model.to(device)
-data = data.to(device)
 optimizer = torch.optim.Adam(model.parameters(), lr=0.001)
 
 # Training function
@@ -63,6 +62,7 @@ def train(data):
     lam = np.random.beta(4.0, 4.0)
 
     data_b, id_new_value_old = shuffle_data(data)
+    data = data.to(device)
     data_b = data_b.to(device)
 
     optimizer.zero_grad()

--- a/test/contrib/nn/conv/test_mixup_conv.py
+++ b/test/contrib/nn/conv/test_mixup_conv.py
@@ -1,0 +1,18 @@
+import pytest
+import torch
+
+from torch_geometric.contrib.nn.conv import MixupConv
+from torch_geometric.nn import GCNConv
+
+
+@pytest.mark.parametrize('conv_layer', [GCNConv])
+def test_mixup_conv(conv_layer):
+    in_channels, out_channels = 3, 16
+    x1 = torch.randn(8, in_channels)
+    x2 = torch.randn(8, in_channels)
+    edge_index = torch.tensor([[0, 1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6, 7]])
+
+    conv = MixupConv(in_channels, out_channels, conv_layer)
+    out = conv(x1, edge_index, x2)
+
+    assert out.size() == (8, out_channels)

--- a/torch_geometric/contrib/nn/conv/MixupConv.py
+++ b/torch_geometric/contrib/nn/conv/MixupConv.py
@@ -59,16 +59,15 @@ class MixupConv(MessagePassing):
 
         Args:
             x1 (Tensor): Node feature matrix of the first input graph with
-                shape :obj:`[num_nodes, in_channels]`.
+                shape [num_nodes, in_channels].
             edge_index (Tensor): Graph connectivity in COO format with shape
-                obj:`[2, num_edges]`.
+                [2, num_edges].
             x2 (Tensor): Node feature matrix of the second input graph with
-                shape :obj:`[num_nodes, in_channels]`.
+                shape [num_nodes, in_channels].
 
         Returns:
-            Tensor: Node feature matrix of shape :obj:`[num_nodes,
-                out_channels]`,where the messages from `x1` are used
-                to update `x2`.
+            Tensor: Node feature matrix of shape [num_nodes, out_channels],
+                where the messages from `x1` are used to update `x2`.
         """
         h1 = self.conv_layer(x1, edge_index)
         return h1 + self.lin(x2)

--- a/torch_geometric/contrib/nn/conv/MixupConv.py
+++ b/torch_geometric/contrib/nn/conv/MixupConv.py
@@ -25,17 +25,17 @@ class MixupConv(MessagePassing):
 
     Args:
         in_channels (int): Size of each input sample (number of input node
-        features).
+            features).
         out_channels (int): Size of each output sample (number of output node
-        features).
+            features).
         conv_layer (torch.nn.Module, optional): The PyG convolutional layer
-        to use (e.g., GCNConv, GATConv). Defaults to GCNConv.
+            to use (e.g., GCNConv, GATConv). Defaults to GCNConv.
         aggr (str, optional): The aggregation scheme to use ("add", "mean",
-        "max"). (default: :obj:`"mean"`)
+            "max"). (default: :obj:`"mean"`)
         bias (bool, optional): If set to `False`, the layer will not learn an
-        additive bias. (default: :obj:`True`)
+            additive bias. (default: :obj:`True`)
         **kwargs (optional): Additional arguments passed to the convolution
-        layer.
+            layer.
     """
     def __init__(self, in_channels: int, out_channels: int,
                  conv_layer: Optional[Module] = GCNConv, aggr='mean',
@@ -59,16 +59,16 @@ class MixupConv(MessagePassing):
 
         Args:
             x1 (Tensor): Node feature matrix of the first input graph with
-            shape :obj:`[num_nodes, in_channels]`.
+                shape :obj:`[num_nodes, in_channels]`.
             edge_index (Tensor): Graph connectivity in COO format with shape
-            :obj:`[2, num_edges]`.
+                obj:`[2, num_edges]`.
             x2 (Tensor): Node feature matrix of the second input graph with
-            shape :obj:`[num_nodes, in_channels]`.
+                shape :obj:`[num_nodes, in_channels]`.
 
         Returns:
             Tensor: Node feature matrix of shape :obj:`[num_nodes,
-            out_channels]`,
-            where the messages from `x1` are used to update `x2`.
+                out_channels]`,where the messages from `x1` are used
+                to update `x2`.
         """
         h1 = self.conv_layer(x1, edge_index)
         return h1 + self.lin(x2)

--- a/torch_geometric/contrib/nn/conv/MixupConv.py
+++ b/torch_geometric/contrib/nn/conv/MixupConv.py
@@ -14,49 +14,28 @@ class MixupConv(MessagePassing):
     update `x2`.
 
     **Mixup Logic**:
-    - The MixupConv layer computes messages from one set of node features
-      (`x1`) and applies them to update the second set of node features (`x2`),
-      thus maintaining the mixup between the two feature sets.
+    The MixupConv layer computes messages from one set of node features
+    (`x1`) and applies them to update the second set of node features (`x2`),
+    thus maintaining the mixup between the two feature sets.
 
     **Supported Convolution Types**:
-    - GCNConv
-    - GATConv
-    - Other PyG convolution types can be passed during initialization.
+    GCNConv
+    GATConv
+    Other PyG convolution types can be passed during initialization.
 
     Args:
         in_channels (int): Size of each input sample (number of input node
-            features).
+        features).
         out_channels (int): Size of each output sample (number of output node
-            features).
+        features).
         conv_layer (torch.nn.Module, optional): The PyG convolutional layer
-            to use (e.g., GCNConv, GATConv). Defaults to GCNConv.
+        to use (e.g., GCNConv, GATConv). Defaults to GCNConv.
         aggr (str, optional): The aggregation scheme to use ("add", "mean",
-            "max"). (default: :obj:`"mean"`)
+        "max"). (default: :obj:`"mean"`)
         bias (bool, optional): If set to `False`, the layer will not learn an
-            additive bias. (default: :obj:`True`)
+        additive bias. (default: :obj:`True`)
         **kwargs (optional): Additional arguments passed to the convolution
-            layer.
-
-    Shapes:
-        - **Input:**
-            - `x1`: Node feature matrix of shape :obj:`[num_nodes,
-              in_channels]`
-            - `edge_index`: Graph connectivity in COO format with shape
-              :obj:`[2, num_edges]`
-            - `x2`: Node feature matrix of shape :obj:`[num_nodes,
-              in_channels]`
-        - **Output:**
-            - Node feature matrix of shape :obj:`[num_nodes, out_channels]`
-
-    Example:
-        >>> from torch_geometric.nn import GCNConv, MixupConv
-        >>> conv = MixupConv(GCNConv, in_channels=16, out_channels=32)
-        >>> x1 = torch.randn((100, 16))  # Input node features 1
-        >>> edge_index = torch.randint(0, 100, (2, 300))  # Edge index for the
-        >>> x2 = torch.randn((100, 16))  # Input node features 2
-        >>> out = conv(x1, edge_index, x2)
-        >>> print(out.shape)
-        torch.Size([100, 32])
+        layer.
     """
     def __init__(self, in_channels: int, out_channels: int,
                  conv_layer: Optional[Module] = GCNConv, aggr='mean',
@@ -80,11 +59,11 @@ class MixupConv(MessagePassing):
 
         Args:
             x1 (Tensor): Node feature matrix of the first input graph with
-                shape :obj:`[num_nodes, in_channels]`.
+            shape :obj:`[num_nodes, in_channels]`.
             edge_index (Tensor): Graph connectivity in COO format with shape
-                :obj:`[2, num_edges]`.
+            :obj:`[2, num_edges]`.
             x2 (Tensor): Node feature matrix of the second input graph with
-                shape :obj:`[num_nodes, in_channels]`.
+            shape :obj:`[num_nodes, in_channels]`.
 
         Returns:
             Tensor: Node feature matrix of shape :obj:`[num_nodes,

--- a/torch_geometric/contrib/nn/conv/MixupConv.py
+++ b/torch_geometric/contrib/nn/conv/MixupConv.py
@@ -1,8 +1,9 @@
+from typing import Optional
+
 import torch
 from torch.nn import Module
-from torch_geometric.nn import GCNConv
-from torch_geometric.nn import MessagePassing
-from typing import Optional
+
+from torch_geometric.nn import GCNConv, MessagePassing
 
 
 class MixupConv(MessagePassing):

--- a/torch_geometric/contrib/nn/conv/MixupConv.py
+++ b/torch_geometric/contrib/nn/conv/MixupConv.py
@@ -6,7 +6,7 @@ from typing import Optional
 
 
 class MixupConv(MessagePassing):
-    """MixupConv is a flexible graph convolution layer that supports mixup
+    r"""MixupConv is a flexible graph convolution layer that supports mixup
     logic between two sets of node features (`x1` and `x2`). It allows users
     to utilize different types of graph convolutions (e.g., GCNConv, GATConv)
     while maintaining the mixup logic, where messages from `x1` are passed to

--- a/torch_geometric/contrib/nn/conv/MixupConv.py
+++ b/torch_geometric/contrib/nn/conv/MixupConv.py
@@ -27,8 +27,8 @@ class MixupConv(MessagePassing):
             features).
         out_channels (int): Size of each output sample (number of output node
             features).
-        conv_layer (torch.nn.Module, optional): The PyG convolutional layer to use
-            (e.g., GCNConv, GATConv). Defaults to GCNConv.
+        conv_layer (torch.nn.Module, optional): The PyG convolutional layer
+            to use (e.g., GCNConv, GATConv). Defaults to GCNConv.
         aggr (str, optional): The aggregation scheme to use ("add", "mean",
             "max"). (default: :obj:`"mean"`)
         bias (bool, optional): If set to `False`, the layer will not learn an
@@ -57,7 +57,8 @@ class MixupConv(MessagePassing):
         >>> print(out.shape)
         torch.Size([100, 32])
     """
-    def __init__(self, in_channels: int, out_channels: int, conv_layer: Optional[Module] = GCNConv, aggr='mean',
+    def __init__(self, in_channels: int, out_channels: int,
+                 conv_layer: Optional[Module] = GCNConv, aggr='mean',
                  bias=True, **kwargs):
         super().__init__(aggr=aggr, **kwargs)
 

--- a/torch_geometric/contrib/nn/conv/MixupConv.py
+++ b/torch_geometric/contrib/nn/conv/MixupConv.py
@@ -1,0 +1,30 @@
+import torch
+
+from torch_geometric.nn import MessagePassing
+
+
+class MixupConv(MessagePassing):
+    def __init__(self, conv_layer, in_channels, out_channels, aggr='mean',
+                 bias=True, **kwargs):
+        super().__init__(aggr=aggr, **kwargs)
+
+        self.in_channels = in_channels
+        self.out_channels = out_channels
+
+        self.conv_layer = conv_layer(in_channels, out_channels, bias=bias,
+                                     **kwargs)
+
+        self.lin = torch.nn.Linear(in_channels, out_channels, bias=bias)
+
+    def reset_parameters(self):
+        self.conv_layer.reset_parameters()
+        self.lin.reset_parameters()
+
+    def forward(self, x1, edge_index, x2):
+        h1 = self.conv_layer(x1, edge_index)
+        return h1 + self.lin(x2)
+
+    def __repr__(self):
+        return '{}(conv={}, in_channels={}, out_channels={})'.format(
+            self.__class__.__name__, self.conv_layer.__class__.__name__,
+            self.in_channels, self.out_channels)

--- a/torch_geometric/contrib/nn/conv/MixupConv.py
+++ b/torch_geometric/contrib/nn/conv/MixupConv.py
@@ -1,5 +1,6 @@
 import torch
-
+from torch.nn import Module
+from torch_geometric.nn import GCNConv
 from torch_geometric.nn import MessagePassing
 
 
@@ -21,12 +22,12 @@ class MixupConv(MessagePassing):
     - Other PyG convolution types can be passed during initialization.
 
     Args:
-        conv_layer (torch.nn.Module): The PyG convolutional layer to use
-            (e.g., GCNConv, GATConv).
         in_channels (int): Size of each input sample (number of input node
             features).
         out_channels (int): Size of each output sample (number of output node
             features).
+        conv_layer (torch.nn.Module, optional): The PyG convolutional layer to use
+            (e.g., GCNConv, GATConv). Defaults to GCNConv.
         aggr (str, optional): The aggregation scheme to use ("add", "mean",
             "max"). (default: :obj:`"mean"`)
         bias (bool, optional): If set to `False`, the layer will not learn an
@@ -55,7 +56,7 @@ class MixupConv(MessagePassing):
         >>> print(out.shape)
         torch.Size([100, 32])
     """
-    def __init__(self, conv_layer, in_channels, out_channels, aggr='mean',
+    def __init__(self, in_channels: int, out_channels: int, conv_layer: Optional[Module] = GCNConv, aggr='mean',
                  bias=True, **kwargs):
         super().__init__(aggr=aggr, **kwargs)
 

--- a/torch_geometric/contrib/nn/conv/MixupConv.py
+++ b/torch_geometric/contrib/nn/conv/MixupConv.py
@@ -2,6 +2,7 @@ import torch
 from torch.nn import Module
 from torch_geometric.nn import GCNConv
 from torch_geometric.nn import MessagePassing
+from typing import Optional
 
 
 class MixupConv(MessagePassing):

--- a/torch_geometric/contrib/nn/conv/__init__.py
+++ b/torch_geometric/contrib/nn/conv/__init__.py
@@ -1,1 +1,5 @@
-__all__ = classes = []
+from .MixupConv import MixupConv
+
+__all__ = classes = [
+    'MixupConv',
+]

--- a/torch_geometric/contrib/nn/models/GraphMixup.py
+++ b/torch_geometric/contrib/nn/models/GraphMixup.py
@@ -1,15 +1,15 @@
+from typing import Callable
+
 import torch
 import torch.nn.functional as F
 from torch import Tensor
-from torch.nn import Module, ModuleList, Linear
-from torch_geometric.nn import GCNConv, global_mean_pool
+from torch.nn import Linear, Module, ModuleList
 
-from typing import Callable
+from torch_geometric.nn import GCNConv, global_mean_pool
 
 
 class GraphMixup(torch.nn.Module):
-    r"""
-    The Mixup model for Graph Classification from the
+    r"""The Mixup model for Graph Classification from the
     `Mixup for Node and Graph Classification
     <https://dl.acm.org/doi/pdf/10.1145/3442381.3449796>`_ paper.
 
@@ -32,18 +32,10 @@ class GraphMixup(torch.nn.Module):
         readout (Callable): Readout function to aggregate node embeddings
             into a graph-level embedding. Defaults to global_mean_pool.
     """
-
-    def __init__(
-        self,
-        num_layers: int,
-        in_channels: int,
-        hidden_channels: int,
-        out_channels: int,
-        conv_layer: Module = GCNConv,
-        dropout: float = 0.5,
-        readout: Callable = global_mean_pool,
-        **kwargs
-    ):
+    def __init__(self, num_layers: int, in_channels: int, hidden_channels: int,
+                 out_channels: int, conv_layer: Module = GCNConv,
+                 dropout: float = 0.5, readout: Callable = global_mean_pool,
+                 **kwargs):
         super().__init__()
         self.num_layers = num_layers
         self.in_channels = in_channels
@@ -55,26 +47,15 @@ class GraphMixup(torch.nn.Module):
         self.convs = ModuleList()
         self.convs.append(conv_layer(in_channels, hidden_channels, **kwargs))
         for _ in range(num_layers - 1):
-            self.convs.append(conv_layer(
-                hidden_channels,
-                hidden_channels,
-                **kwargs)
-            )
+            self.convs.append(
+                conv_layer(hidden_channels, hidden_channels, **kwargs))
 
         self.lin = Linear(hidden_channels, out_channels)
 
-    def forward(
-        self,
-        x: Tensor,
-        edge_index: Tensor,
-        batch: Tensor,
-        x_b: Tensor,
-        edge_index_b: Tensor,
-        batch_b: Tensor,
-        lam: float
-    ) -> Tensor:
-        """
-        Forward pass for the GraphMixup model.
+    def forward(self, x: Tensor, edge_index: Tensor, batch: Tensor,
+                x_b: Tensor, edge_index_b: Tensor, batch_b: Tensor,
+                lam: float) -> Tensor:
+        """Forward pass for the GraphMixup model.
 
         This method takes two batches of graph data (x, edge_index, batch)
         and (x_b, edge_index_b, batch_b) along with a mixup coefficient `lam`.

--- a/torch_geometric/contrib/nn/models/GraphMixup.py
+++ b/torch_geometric/contrib/nn/models/GraphMixup.py
@@ -73,6 +73,37 @@ class GraphMixup(torch.nn.Module):
         batch_b: Tensor,
         lam: float
     ) -> Tensor:
+        """
+        Forward pass for the GraphMixup model.
+
+        This method takes two batches of graph data (x, edge_index, batch)
+        and (x_b, edge_index_b, batch_b) along with a mixup coefficient `lam`.
+        It computes the graph-level embeddings for both batches using
+        multiple GNN layers, mixes the embeddings using `lam`,
+        and finally predicts the class probabilities using a linear
+        layer followed by log-softmax.
+
+        Args:
+            x (Tensor): Node feature matrix for the first batch of graphs
+                with shape [num_nodes, in_channels].
+            edge_index (Tensor): Edge index for the first batch of graphs
+                with shape [2, num_edges], defining the graph connectivity.
+            batch (Tensor): Batch vector that assigns each node to a graph
+                in the first batch. Shape: [num_nodes].
+            x_b (Tensor): Node feature matrix for the second (shuffled)
+                batch of graphs with shape [num_nodes, in_channels].
+            edge_index_b (Tensor): Edge index for the second batch of graphs
+                with shape [2, num_edges], defining the graph connectivity.
+            batch_b (Tensor): Batch vector that assigns each node to a graph
+                in the second batch. Shape: [num_nodes].
+            lam (float): Mixup coefficient (lambda) from the Beta distribution,
+                used to interpolate between the two graph embeddings.
+
+        Returns:
+            Tensor: The prediction logits for each graph in the batch.
+                Shape: [num_graphs, out_channels], where out_channels
+                is the number of classes.
+        """
         # Compute embeddings for the first batch
         h = x
         for conv in self.convs:

--- a/torch_geometric/contrib/nn/models/GraphMixup.py
+++ b/torch_geometric/contrib/nn/models/GraphMixup.py
@@ -2,22 +2,23 @@ import torch
 import torch.nn.functional as F
 from torch import Tensor
 from torch.nn import Module, ModuleList, Linear
-from torch_geometric.nn import GCNConv, global_mean_pool, MessagePassing
+from torch_geometric.nn import GCNConv, global_mean_pool
 
-from typing import Optional, Union, Callable
+from typing import Callable
+
 
 class GraphMixup(torch.nn.Module):
-    r"""The Mixup model for Graph Classification from the 
+    r"""
+    The Mixup model for Graph Classification from the
     `Mixup for Node and Graph Classification
-    <https://dl.acm.org/doi/pdf/10.1145/3442381.3449796>`_ paper
+    <https://dl.acm.org/doi/pdf/10.1145/3442381.3449796>`_ paper.
 
-    .. note::
-        For examples of using the Mixup for Graph Classification, see
-        `examples/contrib/graph_mixup.py
+    For examples of using Mixup for Graph Classification, see
+    `examples/contrib/graph_mixup.py`.
 
     This model applies mixup at the graph-level embedding space. Given two
-    batches of graphs, the embeddings of both batches are combined based on 
-    a mixup coefficient lambda. The final mixed embedding is then passed 
+    batches of graphs, the embeddings of both batches are combined based on
+    a mixup coefficient lambda. The final mixed embedding is then passed
     through a linear layer (or MLP) followed by a softmax output layer.
 
     Args:
@@ -30,6 +31,7 @@ class GraphMixup(torch.nn.Module):
         readout (Callable): Readout function to aggregate node embeddings
             into a graph-level embedding. Defaults to global_mean_pool.
     """
+
     def __init__(
         self,
         num_layers: int,
@@ -52,7 +54,11 @@ class GraphMixup(torch.nn.Module):
         self.convs = ModuleList()
         self.convs.append(conv_layer(in_channels, hidden_channels, **kwargs))
         for _ in range(num_layers - 1):
-            self.convs.append(conv_layer(hidden_channels, hidden_channels, **kwargs))
+            self.convs.append(conv_layer(
+                hidden_channels,
+                hidden_channels,
+                **kwargs)
+            )
 
         self.lin = Linear(hidden_channels, out_channels)
 

--- a/torch_geometric/contrib/nn/models/GraphMixup.py
+++ b/torch_geometric/contrib/nn/models/GraphMixup.py
@@ -30,7 +30,7 @@ class GraphMixup(torch.nn.Module):
         conv_layer (Module): A PyG convolution layer class (e.g. GCNConv).
         dropout (float): Dropout probability.
         readout (Callable): Readout function to aggregate node embeddings
-            into a graph-level embedding. Defaults to global_mean_pool.
+        into a graph-level embedding. Defaults to global_mean_pool.
     """
     def __init__(self, num_layers: int, in_channels: int, hidden_channels: int,
                  out_channels: int, conv_layer: Module = GCNConv,

--- a/torch_geometric/contrib/nn/models/GraphMixup.py
+++ b/torch_geometric/contrib/nn/models/GraphMixup.py
@@ -13,8 +13,9 @@ class GraphMixup(torch.nn.Module):
     `Mixup for Node and Graph Classification
     <https://dl.acm.org/doi/pdf/10.1145/3442381.3449796>`_ paper.
 
-    For examples of using Mixup for Graph Classification, see
-    `examples/contrib/graph_mixup.py`.
+    .. note::
+        For examples of using Mixup for Graph Classification, see
+        `examples/contrib/graph_mixup.py`.
 
     This model applies mixup at the graph-level embedding space. Given two
     batches of graphs, the embeddings of both batches are combined based on

--- a/torch_geometric/contrib/nn/models/GraphMixup.py
+++ b/torch_geometric/contrib/nn/models/GraphMixup.py
@@ -1,0 +1,90 @@
+import torch
+import torch.nn.functional as F
+from torch import Tensor
+from torch.nn import Module, ModuleList, Linear
+from torch_geometric.nn import GCNConv, global_mean_pool, MessagePassing
+
+from typing import Optional, Union, Callable
+
+class GraphMixup(torch.nn.Module):
+    r"""The Mixup model for Graph Classification from the 
+    `Mixup for Node and Graph Classification
+    <https://dl.acm.org/doi/pdf/10.1145/3442381.3449796>`_ paper
+
+    .. note::
+        For examples of using the Mixup for Graph Classification, see
+        `examples/contrib/graph_mixup.py
+
+    This model applies mixup at the graph-level embedding space. Given two
+    batches of graphs, the embeddings of both batches are combined based on 
+    a mixup coefficient lambda. The final mixed embedding is then passed 
+    through a linear layer (or MLP) followed by a softmax output layer.
+
+    Args:
+        num_layers (int): Number of GNN layers.
+        in_channels (int): Input feature dimension.
+        hidden_channels (int): Hidden dimension.
+        out_channels (int): Number of classes.
+        conv_layer (Module): A PyG convolution layer class (e.g. GCNConv).
+        dropout (float): Dropout probability.
+        readout (Callable): Readout function to aggregate node embeddings
+            into a graph-level embedding. Defaults to global_mean_pool.
+    """
+    def __init__(
+        self,
+        num_layers: int,
+        in_channels: int,
+        hidden_channels: int,
+        out_channels: int,
+        conv_layer: Module = GCNConv,
+        dropout: float = 0.5,
+        readout: Callable = global_mean_pool,
+        **kwargs
+    ):
+        super().__init__()
+        self.num_layers = num_layers
+        self.in_channels = in_channels
+        self.hidden_channels = hidden_channels
+        self.out_channels = out_channels
+        self.dropout = dropout
+        self.readout = readout
+
+        self.convs = ModuleList()
+        self.convs.append(conv_layer(in_channels, hidden_channels, **kwargs))
+        for _ in range(num_layers - 1):
+            self.convs.append(conv_layer(hidden_channels, hidden_channels, **kwargs))
+
+        self.lin = Linear(hidden_channels, out_channels)
+
+    def forward(
+        self,
+        x: Tensor,
+        edge_index: Tensor,
+        batch: Tensor,
+        x_b: Tensor,
+        edge_index_b: Tensor,
+        batch_b: Tensor,
+        lam: float
+    ) -> Tensor:
+        # Compute embeddings for the first batch
+        h = x
+        for conv in self.convs:
+            h = conv(h, edge_index)
+            h = F.relu(h)
+            h = F.dropout(h, p=self.dropout, training=self.training)
+        h = self.readout(h, batch)
+
+        # Compute embeddings for the second (shuffled) batch
+        h_b = x_b
+        for conv in self.convs:
+            h_b = conv(h_b, edge_index_b)
+            h_b = F.relu(h_b)
+            h_b = F.dropout(h_b, p=self.dropout, training=self.training)
+        h_b = self.readout(h_b, batch_b)
+
+        # Mixup the graph embeddings
+        h_mix = lam * h + (1 - lam) * h_b
+
+        # Predict
+        out = self.lin(h_mix)
+        return out.log_softmax(dim=-1)

--- a/torch_geometric/contrib/nn/models/NodeMixup.py
+++ b/torch_geometric/contrib/nn/models/NodeMixup.py
@@ -1,0 +1,138 @@
+from collections import defaultdict
+from functools import partial
+from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple, Union
+
+import numpy as np
+import torch
+import torch.nn.functional as F
+from torch import Tensor
+from torch.nn import Module, ModuleList
+from tqdm import tqdm
+
+from torch_geometric.nn import GCNConv
+from torch_geometric.contrib.nn.conv import MixupConv
+
+class NodeMixup(torch.nn.Module):
+    r"""The Mixup model for Node Classification from the 
+    `Mixup for Node and Graph Classification
+    <https://dl.acm.org/doi/pdf/10.1145/3442381.3449796>`_ paper
+
+    .. note::
+        For examples of using the Mixup for Node Classification, see
+        `examples/contrib/node_mixup.py
+
+    Args:
+        num_layers (int): Number of message passing layers.
+        in_channels (int): Size of each input sample, or :obj:`-1` to derive
+            the size from the first input(s) to the forward method.
+        hidden_channels (int): Size of each hidden sample.
+        out_channels (int, optional): If not set to :obj:`None`, will apply a
+            final linear transformation to convert hidden node embeddings to
+            output size :obj:`out_channels`. (default: :obj:`None`)
+        conv_layer (torch.nn.Module, optional): The PyG convolutional layer to use
+            (e.g., GCNConv, GATConv). Defaults to GCNConv.
+        dropout (float, optional): Dropout probability. (default: :obj:`0.`)
+    """
+    def __init__(
+        self, 
+        num_layers: int,
+        in_channel: int, 
+        hidden_channels: int, 
+        out_channels: Optional[int] = None,
+        conv_layer: Optional[Module] = GCNConv,
+        dropout: float = 0.0,
+        **kwargs,
+    ):
+        super().__init__()
+
+        self.in_channels = in_channels
+        self.hidden_channels = hidden_channels
+        self.num_layers = num_layers
+
+        self.dropout = dropout
+
+        if out_channels is not None:
+            self.out_channels = out_channels
+        else:
+            self.out_channels = hidden_channels
+        
+        self.convs = ModuleList()
+        self.convs.append(
+            self.init_conv(in_channels, hidden_channels, conv_layer, **kwargs))
+        
+        for _ in range(num_layers - 2):
+            self.convs.append(
+                self.init_conv(hidden_channels, hidden_channels, conv_layer, **kwargs))
+        
+        self.convs.append(
+            self.init_conv(hidden_channels, self.out_channels, conv_layer, **kwargs))
+        
+        self.lin = torch.nn.Linear(hidden_channels, self.out_channels)
+        
+        
+    def init_conv(self, in_channels: int, out_channels: int, conv_layer: Optional[Module] = GCNConv,
+                  **kwargs) -> MessagePassing:
+        return MixupConv(in_channels, out_channels, conv_layer, **kwargs)
+
+    def reset_parameters(self):
+        r"""Resets all learnable parameters of the module."""
+        for conv in self.convs:
+            conv.reset_parameters()
+        for norm in self.norms:
+            if hasattr(norm, 'reset_parameters'):
+                norm.reset_parameters()
+        self.lin.reset_parameters()
+
+    def forward(
+        self, 
+        x: Tensor, 
+        edge_index: Tensor,
+        edge_index_b: Tensor,
+        lam: float,
+        id_new_value_old: Tensor):
+
+        """
+        Forward pass for NodeMixup.
+
+        Args:
+            x1 (Tensor): Node feature matrix of the first input graph with shape :obj:`[num_nodes, in_channels]`.
+            edge_index (Tensor): Graph connectivity in COO format with shape :obj:`[2, num_edges]`.
+            edge_index_b (Tensor): Graph connectivity in COO format for shuffled graph.
+            lam (float): Lambda for the mixup.
+            id_new_value_old (Tensor): Mapping of node IDs after shuffle.
+
+        Returns:
+            Tensor: Node feature matrix of shape :obj:`[num_nodes, out_channels]`.
+        """
+        
+        x0 = x
+        x0_b = x0[id_new_value_old]
+        x_mix = x0 * lam + x0_b * (1 - lam)
+        for conv in self.convs[:-1]:
+            x = conv(x0, edge_index, x_mix)
+            x_b = conv(x0_b, edge_index_b, x_mix)
+            x = F.relu(x)
+            x_b = F.relu(x_b)
+            x = F.dropout(x, p=self.dropout, training=self.training)
+            x_b = F.dropout(x_b, p=self.dropout, training=self.training)
+
+            x_mix = x * lam + x_b * (1 - lam)
+            x_mix = F.dropout(x_mix, p=self.dropout, training=self.training)
+
+            x0 = conv(x0, edge_index, x0)
+            x0 = F.relu(x0)
+            x0 = F.dropout(x0, p=self.dropout, training=self.training)
+            x0_b = x0[id_new_value_old]
+
+        # Final layer without ReLU
+        x = self.convs[-1](x0, edge_index, x_mix)
+        x_b = self.convs[-1](x0_b, edge_index_b, x_mix)
+        x = F.relu(x)
+        x_b = F.relu(x_b)
+
+        # Mixup for final output
+        x_out = x * lam + x_b * (1 - lam)
+        x_out = F.dropout(x_out, p=self.dropout, training=self.training)
+
+        # Linear layer for classification/logits
+        return self.lin(x_out).log_softmax(dim=-1)

--- a/torch_geometric/contrib/nn/models/NodeMixup.py
+++ b/torch_geometric/contrib/nn/models/NodeMixup.py
@@ -13,8 +13,9 @@ class NodeMixup(torch.nn.Module):
     `Mixup for Node and Graph Classification
     <https://dl.acm.org/doi/pdf/10.1145/3442381.3449796>`_ paper.
 
-    For examples of using the Mixup for Node Classification, see
-    `examples/contrib/node_mixup.py`.
+    .. note::
+        For examples of using the Mixup for Node Classification, see
+        `examples/contrib/node_mixup.py`.
 
     Args:
         num_layers (int): Number of message passing layers.

--- a/torch_geometric/contrib/nn/models/NodeMixup.py
+++ b/torch_geometric/contrib/nn/models/NodeMixup.py
@@ -1,15 +1,16 @@
 from typing import Optional
+
 import torch
 import torch.nn.functional as F
 from torch import Tensor
 from torch.nn import Module, ModuleList
-from torch_geometric.nn import GCNConv, MessagePassing
+
 from torch_geometric.contrib.nn.conv import MixupConv
+from torch_geometric.nn import GCNConv, MessagePassing
 
 
 class NodeMixup(torch.nn.Module):
-    """
-    The Mixup model for Node Classification from the
+    """The Mixup model for Node Classification from the
     `Mixup for Node and Graph Classification
     <https://dl.acm.org/doi/pdf/10.1145/3442381.3449796>`_ paper.
 
@@ -29,7 +30,6 @@ class NodeMixup(torch.nn.Module):
             to use (e.g., GCNConv, GATConv). Defaults to GCNConv.
         dropout (float, optional): Dropout probability. (default: :obj:`0.`)
     """
-
     def __init__(
         self,
         num_layers: int,
@@ -54,15 +54,12 @@ class NodeMixup(torch.nn.Module):
 
         self.convs = ModuleList()
         self.convs.append(
-            self.init_conv(in_channels, hidden_channels, conv_layer, **kwargs)
-        )
+            self.init_conv(in_channels, hidden_channels, conv_layer, **kwargs))
 
         for _ in range(num_layers - 1):
             self.convs.append(
-                self.init_conv(
-                    hidden_channels, hidden_channels,
-                    conv_layer, **kwargs)
-            )
+                self.init_conv(hidden_channels, hidden_channels, conv_layer,
+                               **kwargs))
 
         self.lin = torch.nn.Linear(hidden_channels, self.out_channels)
 
@@ -89,8 +86,7 @@ class NodeMixup(torch.nn.Module):
         lam: float,
         id_new_value_old: Tensor,
     ) -> Tensor:
-        """
-        Forward pass for NodeMixup.
+        """Forward pass for NodeMixup.
 
         Args:
             x (Tensor): Node feature matrix of the first input graph with

--- a/torch_geometric/contrib/nn/models/NodeMixup.py
+++ b/torch_geometric/contrib/nn/models/NodeMixup.py
@@ -24,8 +24,8 @@ class NodeMixup(torch.nn.Module):
         out_channels (int, optional): If not set to :obj:`None`, will apply a
             final linear transformation to convert hidden node embeddings to
             output size :obj:`out_channels`. (default: :obj:`None`)
-        conv_layer (torch.nn.Module, optional): The PyG convolutional layer to use
-            (e.g., GCNConv, GATConv). Defaults to GCNConv.
+        conv_layer (torch.nn.Module, optional): The PyG convolutional layer
+            to use (e.g., GCNConv, GATConv). Defaults to GCNConv.
         dropout (float, optional): Dropout probability. (default: :obj:`0.`)
     """
 
@@ -58,7 +58,9 @@ class NodeMixup(torch.nn.Module):
 
         for _ in range(num_layers - 1):
             self.convs.append(
-                self.init_conv(hidden_channels, hidden_channels, conv_layer, **kwargs)
+                self.init_conv(
+                    hidden_channels, hidden_channels,
+                    conv_layer, **kwargs)
             )
 
         self.lin = torch.nn.Linear(hidden_channels, self.out_channels)
@@ -94,12 +96,14 @@ class NodeMixup(torch.nn.Module):
                 shape :obj:`[num_nodes, in_channels]`.
             edge_index (Tensor): Graph connectivity in COO format with shape
                 :obj:`[2, num_edges]`.
-            edge_index_b (Tensor): Graph connectivity in COO format for shuffled graph.
+            edge_index_b (Tensor): Graph connectivity in COO format for
+                shuffled graph.
             lam (float): Lambda for the mixup.
             id_new_value_old (Tensor): Mapping of node IDs after shuffle.
 
         Returns:
-            Tensor: Node feature matrix of shape :obj:`[num_nodes, out_channels]`.
+            Tensor: Node feature matrix of shape: obj:`[num_nodes,
+                out_channels]`.
         """
         x0 = x
         x0_b = x0[id_new_value_old]

--- a/torch_geometric/contrib/nn/models/NodeMixup.py
+++ b/torch_geometric/contrib/nn/models/NodeMixup.py
@@ -9,7 +9,7 @@ from torch import Tensor
 from torch.nn import Module, ModuleList
 from tqdm import tqdm
 
-from torch_geometric.nn import GCNConv
+from torch_geometric.nn import GCNConv, MessagePassing
 from torch_geometric.contrib.nn.conv import MixupConv
 
 class NodeMixup(torch.nn.Module):
@@ -36,7 +36,7 @@ class NodeMixup(torch.nn.Module):
     def __init__(
         self, 
         num_layers: int,
-        in_channel: int, 
+        in_channels: int, 
         hidden_channels: int, 
         out_channels: Optional[int] = None,
         conv_layer: Optional[Module] = GCNConv,
@@ -60,12 +60,9 @@ class NodeMixup(torch.nn.Module):
         self.convs.append(
             self.init_conv(in_channels, hidden_channels, conv_layer, **kwargs))
         
-        for _ in range(num_layers - 2):
+        for _ in range(num_layers - 1):
             self.convs.append(
                 self.init_conv(hidden_channels, hidden_channels, conv_layer, **kwargs))
-        
-        self.convs.append(
-            self.init_conv(hidden_channels, self.out_channels, conv_layer, **kwargs))
         
         self.lin = torch.nn.Linear(hidden_channels, self.out_channels)
         

--- a/torch_geometric/contrib/nn/models/NodeMixup.py
+++ b/torch_geometric/contrib/nn/models/NodeMixup.py
@@ -99,8 +99,8 @@ class NodeMixup(torch.nn.Module):
             id_new_value_old (Tensor): Mapping of node IDs after shuffle.
 
         Returns:
-            Tensor: Node feature matrix of shape: obj:`[num_nodes,
-                out_channels]`.
+            Tensor: Node feature matrix of shape:
+                obj:`[num_nodes,out_channels]`.
         """
         x0 = x
         x0_b = x0[id_new_value_old]

--- a/torch_geometric/contrib/nn/models/__init__.py
+++ b/torch_geometric/contrib/nn/models/__init__.py
@@ -1,6 +1,8 @@
 from .rbcd_attack import PRBCDAttack, GRBCDAttack
+from .NodeMixup import NodeMixup
 
 __all__ = classes = [
     'PRBCDAttack',
     'GRBCDAttack',
+    'NodeMixup'
 ]

--- a/torch_geometric/contrib/nn/models/__init__.py
+++ b/torch_geometric/contrib/nn/models/__init__.py
@@ -1,8 +1,10 @@
 from .rbcd_attack import PRBCDAttack, GRBCDAttack
 from .NodeMixup import NodeMixup
+from .GraphMixup import GraphMixup
 
 __all__ = classes = [
     'PRBCDAttack',
     'GRBCDAttack',
-    'NodeMixup'
+    'NodeMixup',
+    'GraphMixup'
 ]

--- a/torch_geometric/contrib/nn/models/__init__.py
+++ b/torch_geometric/contrib/nn/models/__init__.py
@@ -2,9 +2,4 @@ from .rbcd_attack import PRBCDAttack, GRBCDAttack
 from .NodeMixup import NodeMixup
 from .GraphMixup import GraphMixup
 
-__all__ = classes = [
-    'PRBCDAttack',
-    'GRBCDAttack',
-    'NodeMixup',
-    'GraphMixup'
-]
+__all__ = classes = ['PRBCDAttack', 'GRBCDAttack', 'NodeMixup', 'GraphMixup']


### PR DESCRIPTION
- Add `MixupConv` that can be integrated into node mixup models.
- Add `NodeMixup` and `GraphMixup` models for using Mixup for node and graph classifications
- Add `node_mixup` and `graph_mixup` examples demonstrating how to use the Mixup models for node and graph classification