### PR TITLE
Add TokenGT model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- Added the `TokenGT` model along with `AddOrthonormalNodeIdentifiers` transform and example usage ([](<>))
 - Update Dockerfile to use latest from NVIDIA ([#9794](https://github.com/pyg-team/pytorch_geometric/pull/9794))
 - Added various GRetriever Architecture Benchmarking examples ([#9666](https://github.com/pyg-team/pytorch_geometric/pull/9666))
 - Added `profiler.nvtxit` with some examples ([#9666](https://github.com/pyg-team/pytorch_geometric/pull/9666))

--- a/README.md
+++ b/README.md
@@ -279,6 +279,7 @@ Unlike simple stacking of GNN layers, these models could involve pre-processing,
 - **[ComplEx](https://pytorch-geometric.readthedocs.io/en/latest/generated/torch_geometric.nn.kge.ComplEx.html)** from Trouillon *et al.*: [Complex Embeddings for Simple Link Prediction](https://arxiv.org/abs/1606.06357) (ICML 2016) \[[**Example**](https://github.com/pyg-team/pytorch_geometric/blob/master/examples/kge_fb15k_237.py)\]
 - **[DistMult](https://pytorch-geometric.readthedocs.io/en/latest/generated/torch_geometric.nn.kge.DistMult.html)** from Yang *et al.*: [Embedding Entities and Relations for Learning and Inference in Knowledge Bases](https://arxiv.org/abs/1412.6575) (ICLR 2015) \[[**Example**](https://github.com/pyg-team/pytorch_geometric/blob/master/examples/kge_fb15k_237.py)\]
 - **[RotatE](https://pytorch-geometric.readthedocs.io/en/latest/generated/torch_geometric.nn.kge.RotatE.html)** from Sun *et al.*: [RotatE: Knowledge Graph Embedding by Relational Rotation in Complex Space](https://arxiv.org/abs/1902.10197) (ICLR 2019) \[[**Example**](https://github.com/pyg-team/pytorch_geometric/blob/master/examples/kge_fb15k_237.py)\]
+- **[TokenGT](https://pytorch-geometric.readthedocs.io/en/latest/generated/torch_geometric.nn.models.TokenGT.html)** from Kim *et al.*: [Pure Transformers are Powerful Graph Learners](https://arxiv.org/abs/2207.02505) (NeurIPS 2022) \[[**Example**](https://github.com/pyg-team/pytorch_geometric/blob/master/examples/token_gt_regression.py)\]
 
 </details>
 

--- a/examples/token_gt_regression.py
+++ b/examples/token_gt_regression.py
@@ -1,0 +1,135 @@
+import os.path as osp
+from typing import Optional
+
+import torch
+import torch.nn as nn
+from torch import Tensor
+
+from torch_geometric.datasets import ZINC
+from torch_geometric.loader import DataLoader
+from torch_geometric.nn import TokenGT
+from torch_geometric.transforms import AddOrthonormalNodeIdentifiers
+
+
+class TokenGTGraphRegression(nn.Module):
+    def __init__(
+        self,
+        dim_node,
+        d_p,
+        d,
+        num_heads,
+        num_encoder_layers,
+        dim_feedforward,
+        is_laplacian_node_ids,
+        dim_edge,
+        dropout,
+        device,
+    ):
+        super().__init__()
+        self._token_gt = TokenGT(
+            dim_node=dim_node,
+            d_p=d_p,
+            d=d,
+            num_heads=num_heads,
+            num_encoder_layers=num_encoder_layers,
+            dim_feedforward=dim_feedforward,
+            dim_edge=dim_edge,
+            is_laplacian_node_ids=is_laplacian_node_ids,
+            include_graph_token=True,
+            dropout=dropout,
+            device=device,
+        )
+        self.lm = nn.Linear(d, 1, device=device)
+
+    def forward(
+        self,
+        x: Tensor,
+        edge_index: Tensor,
+        edge_attr: Optional[Tensor],
+        ptr: Tensor,
+        batch: Tensor,
+        node_ids: Tensor,
+    ):
+        _, graph_emb = self._token_gt(x, edge_index, edge_attr, ptr, batch,
+                                      node_ids)
+        return self.lm(graph_emb)
+
+
+def train(model, loader, criterion, optimizer):
+    model.train()
+    for batch in loader:
+        optimizer.zero_grad()
+        out = model(
+            batch.x.float(),
+            batch.edge_index,
+            batch.edge_attr.unsqueeze(1).float(),
+            batch.ptr,
+            batch.batch,
+            batch.node_ids,
+        )
+        loss = criterion(out, batch.y.unsqueeze(1))
+        loss.backward()
+        optimizer.step()
+
+
+def get_test_loss(model, loader) -> float:
+    criterion = nn.L1Loss(reduction="sum")
+    model.eval()
+    total_loss = 0.0
+    with torch.no_grad():
+        for batch in loader:
+            out = model(
+                batch.x.float(),
+                batch.edge_index,
+                batch.edge_attr.unsqueeze(1).float(),
+                batch.ptr,
+                batch.batch,
+                batch.node_ids,
+            )
+            loss = criterion(out, batch.y.unsqueeze(1)).item()
+            total_loss += loss
+    return total_loss / len(loader.dataset)
+
+
+D_P = 37
+
+transform = AddOrthonormalNodeIdentifiers(D_P, True)
+path = osp.join(osp.dirname(osp.realpath(__file__)), "..", "data", "ZINC-lap")
+# note: use pre_transform (avoid unnecessary duplicate eigenvector calculation)
+train_dataset = ZINC(path, subset=True, split="train", pre_transform=transform)
+test_dataset = ZINC(path, subset=True, split="test", pre_transform=transform)
+
+if torch.cuda.is_available():
+    train_dataset.cuda()
+    test_dataset.cuda()
+
+train_loader = DataLoader(train_dataset, batch_size=32, shuffle=True)
+test_loader = DataLoader(test_dataset, batch_size=128)
+
+device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+
+model = TokenGTGraphRegression(
+    dim_node=train_dataset.num_node_features,
+    d_p=D_P,
+    d=32,
+    num_heads=4,
+    num_encoder_layers=2,
+    dim_feedforward=64,
+    is_laplacian_node_ids=True,
+    dim_edge=train_dataset.num_edge_features,
+    dropout=0.1,
+    device=device,
+)
+
+criterion = nn.L1Loss(reduction="mean")
+optimizer = torch.optim.AdamW(model.parameters(), lr=0.00001)
+
+train_loss = round(get_test_loss(model, train_loader), 5)
+test_loss = round(get_test_loss(model, test_loader), 5)
+print(f"Epoch 0: train_loss={train_loss} test_loss={test_loss}")
+
+for i in range(100):
+    train(model, train_loader, criterion, optimizer)
+    train_loss = round(get_test_loss(model, train_loader), 5)
+    test_loss = round(get_test_loss(model, test_loader), 5)
+    print(f"Epoch {i+1}: train_loss={train_loss} test_loss={test_loss}")

--- a/test/nn/models/test_token_gt.py
+++ b/test/nn/models/test_token_gt.py
@@ -7,16 +7,23 @@ from torch_geometric.nn import TokenGT
 @pytest.mark.parametrize("dim_edge", [None, 16])
 @pytest.mark.parametrize("include_graph_token", [True, False])
 @pytest.mark.parametrize("is_laplacian_node_ids", [True, False])
-def test_token_gt(dim_edge, include_graph_token, is_laplacian_node_ids):
+@pytest.mark.parametrize("is_multiple_graph_input", [True, False])
+def test_token_gt(
+    dim_edge,
+    include_graph_token,
+    is_laplacian_node_ids,
+    is_multiple_graph_input,
+):
     dim_node, d_p = 10, 5
     x = torch.rand(5, dim_node)
     edge_index = torch.tensor([[0, 1, 2, 3, 3], [1, 0, 3, 2, 4]])
-    if dim_edge is not None:
-        edge_attr = torch.rand(5, dim_edge)
+    edge_attr = torch.rand(5, dim_edge) if dim_edge is not None else None
+    if is_multiple_graph_input:
+        ptr = torch.tensor([0, 2, 5])
+        batch = torch.tensor([0, 0, 1, 1, 1])
     else:
-        edge_attr = None
-    ptr = torch.tensor([0, 2, 5])
-    batch = torch.tensor([0, 0, 1, 1, 1])
+        ptr = torch.tensor([0, 5])
+        batch = torch.tensor([0, 0, 0, 0, 0])
     node_ids = torch.rand(5, d_p)
 
     model = TokenGT(
@@ -35,7 +42,9 @@ def test_token_gt(dim_edge, include_graph_token, is_laplacian_node_ids):
 
     node_emb, graph_emb = model(x, edge_index, edge_attr, ptr, batch, node_ids)
     assert node_emb.shape == (5, 16)
-    if include_graph_token is True:
+    if include_graph_token and is_multiple_graph_input:
         assert graph_emb.shape == (2, 16)
+    elif include_graph_token and not is_multiple_graph_input:
+        assert graph_emb.shape == (1, 16)
     else:
         assert graph_emb is None

--- a/test/nn/models/test_token_gt.py
+++ b/test/nn/models/test_token_gt.py
@@ -1,0 +1,41 @@
+import pytest
+import torch
+
+from torch_geometric.nn import TokenGT
+
+
+@pytest.mark.parametrize("dim_edge", [None, 16])
+@pytest.mark.parametrize("include_graph_token", [True, False])
+@pytest.mark.parametrize("is_laplacian_node_ids", [True, False])
+def test_token_gt(dim_edge, include_graph_token, is_laplacian_node_ids):
+    dim_node, d_p = 10, 5
+    x = torch.rand(5, dim_node)
+    edge_index = torch.tensor([[0, 1, 2, 3, 3], [1, 0, 3, 2, 4]])
+    if dim_edge is not None:
+        edge_attr = torch.rand(5, dim_edge)
+    else:
+        edge_attr = None
+    ptr = torch.tensor([0, 2, 5])
+    batch = torch.tensor([0, 0, 1, 1, 1])
+    node_ids = torch.rand(5, d_p)
+
+    model = TokenGT(
+        dim_node=10,
+        dim_edge=dim_edge,
+        d_p=d_p,
+        d=16,
+        num_heads=1,
+        num_encoder_layers=1,
+        dim_feedforward=16,
+        include_graph_token=include_graph_token,
+        is_laplacian_node_ids=is_laplacian_node_ids,
+    )
+    model.reset_params()
+    assert str(model) == "TokenGT(16)"
+
+    node_emb, graph_emb = model(x, edge_index, edge_attr, ptr, batch, node_ids)
+    assert node_emb.shape == (5, 16)
+    if include_graph_token is True:
+        assert graph_emb.shape == (2, 16)
+    else:
+        assert graph_emb is None

--- a/test/transforms/test_add_orthonormal_node_identifiers.py
+++ b/test/transforms/test_add_orthonormal_node_identifiers.py
@@ -1,0 +1,44 @@
+import pytest
+import torch
+import torch.nn.functional as F
+from torch.testing import assert_close
+
+from torch_geometric.data import Data
+from torch_geometric.transforms import AddOrthonormalNodeIdentifiers
+
+
+@pytest.mark.parametrize("use_laplacian", [True, False])
+def test_add_orthonormal_node_identifiers(use_laplacian):
+    n = 4  # num_nodes
+    x = torch.rand(n, 10)
+    edge_index = torch.tensor([[0, 1, 2, 2], [1, 0, 1, 3]])
+
+    # d_p == num_nodes
+    data = Data(x=x, edge_index=edge_index)
+    transform = AddOrthonormalNodeIdentifiers(n, use_laplacian)
+    data = transform(data)
+
+    assert data.node_ids.shape == (n, n)
+    actual = data.node_ids.t() @ data.node_ids
+    expected = torch.eye(n, n)
+    assert_close(actual, expected)
+
+    # d_p > num_nodes
+    data = Data(x=x, edge_index=edge_index)
+    transform = AddOrthonormalNodeIdentifiers(n + 1, use_laplacian)
+    data = transform(data)
+
+    assert data.node_ids.shape == (n, n + 1)
+    actual = data.node_ids.t() @ data.node_ids
+    expected = F.pad(torch.eye(n, n), (0, 1, 0, 1), value=0.0)
+    assert_close(actual, expected)
+
+    # d_p < num_nodes
+    data = Data(x=x, edge_index=edge_index)
+    transform = AddOrthonormalNodeIdentifiers(n - 1, use_laplacian)
+    data = transform(data)
+
+    assert data.node_ids.shape == (n, n - 1)
+    actual = (data.node_ids * data.node_ids).sum(dim=1)
+    expected = torch.ones(n)
+    assert_close(actual, expected)

--- a/torch_geometric/nn/models/__init__.py
+++ b/torch_geometric/nn/models/__init__.py
@@ -32,6 +32,7 @@ from .g_retriever import GRetriever
 from .git_mol import GITMol
 from .molecule_gpt import MoleculeGPT
 from .glem import GLEM
+from .token_gt import TokenGT
 # Deprecated:
 from torch_geometric.explain.algorithm.captum import (to_captum_input,
                                                       captum_output_to_dicts)
@@ -82,4 +83,5 @@ __all__ = classes = [
     'GITMol',
     'MoleculeGPT',
     'GLEM',
+    'TokenGT',
 ]

--- a/torch_geometric/nn/models/token_gt.py
+++ b/torch_geometric/nn/models/token_gt.py
@@ -1,0 +1,287 @@
+import math
+from typing import Optional, Tuple
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from torch import Tensor
+
+from torch_geometric.utils import unbatch
+
+
+class TokenGT(nn.Module):
+    r"""The Tokenized Graph Transformer (TokenGT) model from the
+    `"Pure Transformers are Powerful Graph Learners"
+    <https://arxiv.org/pdf/2207.02505>` paper.
+
+    TokenGT models graph data by 1. treating all nodes and edges as independent
+    tokens, 2. augmenting said tokens with structural information (node and
+    type identifiers), and 3. feeding tokens into a standard multi-head
+    self-attention Transformer model.
+
+    Args:
+        dim_node (int): The node feature dimension.
+        dim_edge (int, optional): The edge feature dimension.
+        d_p (int): The dimension of node identifiers.
+        d (int): The dimension of output embeddings.
+        num_heads (int): The number of heads in the multi-head self-attention
+            of the Transformer.
+        num_encoder_layers (int): The number of sub-encoder layers in the
+            Transformer.
+        dim_feedforward (int): The dimension of the feedforward neural network
+            in the sub-encoder layers of the Transformer.
+        include_graph_token (bool): Whether to include a special [graph_token]
+            embedding to use for graph-level tasks.
+        is_laplacian_node_ids (bool): Whether the provided node identifiers are
+            Laplacian eigenvectors. If :obj:`True`, then, during training, 1.
+            the sign of eigenvectors are randomly flipped, and 2. dropout gets
+            applied to node identifiers.
+        dropout (float): Dropout probability used for both the Transformer
+            sub-encoder layers and the Laplacian node identifiers.
+        device (torch.device): Accelerator device to use.
+        norm_first (bool): Whether to perform layer normalisation prior to
+            self-attention in the sub-encoder layers.
+        activation (str): The activation function used in the sub-encoder
+            layers.
+        **transformer_kwargs: (optional): Additional arguments passed to
+            :class:`TransformerEncoderLayer` object.
+    """
+    def __init__(
+        self,
+        dim_node: int,
+        dim_edge: Optional[int],
+        d_p: int,
+        d: int,
+        num_heads: int,
+        num_encoder_layers: int,
+        dim_feedforward: int,
+        include_graph_token: bool = False,
+        is_laplacian_node_ids: bool = True,
+        dropout: float = 0.1,
+        device: torch.device = torch.device("cpu"),
+        norm_first: bool = True,
+        activation: str = "gelu",
+        **transformer_kwargs,
+    ):
+        super().__init__()
+        self._d_p = d_p
+        self._d = d
+        self._num_encoder_layers = num_encoder_layers
+        self._is_laplacian_node_ids = is_laplacian_node_ids
+        self._device = device
+
+        self._node_features_enc = nn.Linear(dim_node, d, False, device)
+        if dim_edge is not None:
+            self._edge_features_enc = nn.Linear(dim_edge, d, False, device)
+        else:
+            self._edge_features_enc = None
+        self._node_id_enc = nn.Linear(d_p * 2, d, False, device)
+        self._type_id_enc = nn.Embedding(2, d, device=device)
+        if include_graph_token is True:
+            self._graph_emb = nn.Embedding(1, d, device=device)
+        else:
+            self._graph_emb = None
+
+        if is_laplacian_node_ids is True:
+            self._node_id_dropout = nn.Dropout(dropout)
+        else:
+            self._node_id_dropout = None
+
+        # standard encoder-only transformer
+        enc_layer = nn.TransformerEncoderLayer(
+            d,
+            num_heads,
+            dim_feedforward,
+            dropout,
+            batch_first=True,
+            device=device,
+            norm_first=norm_first,
+            activation=activation,
+            **transformer_kwargs,
+        )
+        self._encoder = nn.TransformerEncoder(enc_layer, num_encoder_layers)
+
+        # initialise parameters
+        self.apply(lambda m: self._init_params(m, num_encoder_layers))
+
+    def forward(
+        self,
+        x: Tensor,
+        edge_index: Tensor,
+        edge_attr: Optional[Tensor],
+        ptr: Tensor,
+        batch: Tensor,
+        node_ids: Tensor,
+    ) -> Tuple[Tensor, Optional[Tensor]]:
+        batched_emb, src_key_padding_mask, node_mask = (
+            self._get_tokenwise_batched_emb(x, edge_index, edge_attr, ptr,
+                                            batch, node_ids))
+        if self._graph_emb is not None:
+            # append special graph token
+            b_s = batched_emb.shape[0]
+            graph_emb = self._graph_emb.weight.expand(b_s, 1, -1)
+            batched_emb = torch.concat((graph_emb, batched_emb), 1)
+            b_t = torch.tensor([False], device=self._device).expand(b_s, -1)
+            src_key_padding_mask = torch.concat((b_t, src_key_padding_mask), 1)
+
+        batched_emb = self._encoder(batched_emb, None, src_key_padding_mask)
+        if self._graph_emb is not None:
+            # grab graph token embedding from each batch
+            graph_emb = batched_emb[:, 0, :]
+            batched_emb = batched_emb[:, 1:, :]
+        else:
+            graph_emb = None
+
+        # each batch has node + edge + padded entries;
+        # select node emb and collapse into 2d tensor that matches x
+        node_emb = batched_emb[node_mask]
+        return node_emb, graph_emb
+
+    def _get_tokenwise_batched_emb(
+        self,
+        x: Tensor,
+        edge_index: Tensor,
+        edge_attr: Optional[Tensor],
+        ptr: Tensor,
+        batch: Tensor,
+        node_ids: Tensor,
+    ) -> Tuple[Tensor, Tensor, Tensor]:
+        if self._is_laplacian_node_ids is True and self.training is True:
+            # flip eigenvector signs and apply dropout
+            unbatched_node_ids = list(unbatch(node_ids, batch))
+            for i in range(len(unbatched_node_ids)):
+                sign = -1 + 2 * torch.randint(0, 2, (self._d_p, ),
+                                              device=self._device)
+                unbatched_node_ids[i] = sign * unbatched_node_ids[i]
+                unbatched_node_ids[i] = self._node_id_dropout(
+                    unbatched_node_ids[i])
+            node_ids = torch.concat(unbatched_node_ids, 0)
+
+        node_emb = self._get_node_token_emb(x, node_ids)
+        edge_emb = self._get_edge_token_emb(edge_attr, edge_index, node_ids)
+
+        # combine node + edge tokens,
+        # and split graphs into padded batches -> [batch_size, max_tokens, d]
+        n_nodes = ptr[1:] - ptr[:-1]
+        n_edges = self._get_n_edges(edge_index, ptr)
+        n_tokens = n_nodes + n_edges
+        batched_emb = self._get_batched_emb(
+            node_emb,
+            edge_emb,
+            ptr,
+            edge_index,
+            n_tokens,
+        )
+
+        # construct self-attention and node masks
+        src_key_padding_mask = self._get_src_key_padding_mask(n_tokens)
+        node_mask = self._get_node_mask(n_tokens, n_nodes)
+
+        return batched_emb, src_key_padding_mask, node_mask
+
+    def _get_node_token_emb(self, x: Tensor, node_ids: Tensor) -> Tensor:
+        # node token embedding: x_prj + node_ids_prj + type_ids
+        x_prj = self._node_features_enc(x)
+        node_ids_prj = self._node_id_enc(torch.concat((node_ids, node_ids), 1))
+        total_nodes = x.shape[0]
+        type_ids = self._type_id_enc.weight[0].expand(total_nodes, -1)
+
+        node_emb = x_prj + node_ids_prj + type_ids
+        return node_emb  # [total_nodes, d]
+
+    def _get_edge_token_emb(
+        self,
+        edge_attr: Optional[Tensor],
+        edge_index: Tensor,
+        node_ids: Tensor,
+    ) -> Tensor:
+        # edge token embedding: edge_attr_prj + node_ids_prj + type_ids
+        if edge_attr is not None:
+            edge_attr_prj = self._edge_features_enc(edge_attr)
+        else:
+            edge_attr_prj = None
+        node_ids_concat = torch.concat(
+            (node_ids[edge_index[0]], node_ids[edge_index[1]]), 1)
+        node_ids_prj = self._node_id_enc(node_ids_concat)
+        total_edges = edge_index.shape[1]
+        type_ids = self._type_id_enc.weight[1].expand(total_edges, -1)
+
+        edge_emb = node_ids_prj + type_ids
+        if edge_attr_prj is not None:
+            edge_emb = edge_emb + edge_attr_prj
+        return edge_emb  # [total_edges, d]
+
+    @staticmethod
+    @torch.no_grad()
+    def _get_batched_emb(
+        node_emb: Tensor,
+        edge_emb: Tensor,
+        ptr: Tensor,
+        edge_index: Tensor,
+        n_tokens: Tensor,
+    ):
+        max_tokens = n_tokens.max().item()
+        batch_size = n_tokens.shape[0]
+        batched_emb = []
+        for i in range(batch_size):
+            graph_node_emb = node_emb[ptr[i]:ptr[i + 1]]
+            graph_edge_emb = edge_emb[(edge_index[0] >= ptr[i])
+                                      & (edge_index[0] < ptr[i + 1])]
+            unpadded_emb = torch.concat((graph_node_emb, graph_edge_emb), 0)
+            pad = (0, 0, 0, max_tokens - n_tokens[i])
+            padded_emb = F.pad(unpadded_emb, pad, value=0.0).unsqueeze(0)
+            batched_emb.append(padded_emb)
+        return torch.concat(batched_emb, 0)
+
+    @torch.no_grad()
+    def _get_src_key_padding_mask(self, n_tokens: Tensor) -> Tensor:
+        n_batches = len(n_tokens)
+        token_index = torch.arange(
+            n_tokens.max().item(),
+            dtype=torch.long,
+            device=self._device,
+        ).unsqueeze(0).expand(n_batches, -1)
+        src_key_padding_mask = ~torch.less(token_index, n_tokens.unsqueeze(1))
+        return src_key_padding_mask
+
+    @torch.no_grad()
+    def _get_node_mask(self, n_tokens: Tensor, n_nodes: Tensor) -> Tensor:
+        n_batches = len(n_tokens)
+        token_index = torch.arange(
+            n_tokens.max().item(),
+            dtype=torch.long,
+            device=self._device,
+        ).unsqueeze(0).expand(n_batches, -1)
+        node_mask = torch.less(token_index, n_nodes.unsqueeze(1))
+        return node_mask
+
+    @torch.no_grad()
+    def _get_n_edges(self, edge_index: Tensor, ptr: Tensor) -> Tensor:
+        n_edges = torch.tensor(
+            [((edge_index[0] >= ptr[i]) & (edge_index[0] < ptr[i + 1])).sum()
+             for i in range(ptr.shape[0] - 1)], device=self._device)
+        return n_edges
+
+    def reset_params(self) -> None:
+        for layer in self._encoder.layers:
+            for module in layer.modules():
+                if isinstance(module, nn.Linear):
+                    module.reset_parameters()
+                elif isinstance(module, nn.LayerNorm):
+                    module.reset_parameters()
+        # reinitialise parameters
+        self.apply(lambda m: self._init_params(m, self._num_encoder_layers))
+
+    @staticmethod
+    def _init_params(module, layers) -> None:
+        # modified from https://github.com/jw9730/tokengt/blob/main/
+        # large-scale-regression/tokengt/modules/tokenizer.py
+        if isinstance(module, nn.Linear):
+            module.weight.data.normal_(mean=0.0, std=0.02 / math.sqrt(layers))
+            if module.bias is not None:
+                module.bias.data.zero_()
+        if isinstance(module, nn.Embedding):
+            module.weight.data.normal_(mean=0.0, std=0.02)
+
+    def __repr__(self) -> str:
+        return f"{self.__class__.__name__}({self._d})"

--- a/torch_geometric/nn/models/token_gt.py
+++ b/torch_geometric/nn/models/token_gt.py
@@ -113,6 +113,25 @@ class TokenGT(nn.Module):
         batch: Tensor,
         node_ids: Tensor,
     ) -> Tuple[Tensor, Optional[Tensor]]:
+        r"""Forward pass that returns embeddings for each input node and
+        (optionally) a graph-level embedding for each graph in the input.
+
+        Args:
+            x (torch.Tensor): The input node features. Needs to have number of
+                channels equal to dim_node.
+            edge_index (torch.Tensor): The edge indices.
+            edge_attr (torch.Tensor, optional): The edge features. If provided,
+                needs to have number of channels equal to dim_edge.
+            ptr (torch.Tensor): The pointed vector that provides a cumulative
+                sum of each graph's node count. Note: when providing a single
+                graph with (say) 5 nodes as input, set equal to
+                torch.tensor([0, 5]).
+            batch (torch.Tensor): The batch vector that relates each node to a
+                specific graph. Note: when providing a single graph with (say)
+                5 nodes as input, set equal to torch.tensor([0, 0, 0, 0, 0]).
+            node_ids (torch.Tensor): Orthonormal node identifiers (needs to
+                have number of channels equal to d_p).
+        """
         batched_emb, src_key_padding_mask, node_mask = (
             self._get_tokenwise_batched_emb(x, edge_index, edge_attr, ptr,
                                             batch, node_ids))
@@ -263,6 +282,7 @@ class TokenGT(nn.Module):
         return n_edges
 
     def reset_params(self) -> None:
+        r"""Resets all learnable parameters of the module."""
         for layer in self._encoder.layers:
             for module in layer.modules():
                 if isinstance(module, nn.Linear):

--- a/torch_geometric/transforms/__init__.py
+++ b/torch_geometric/transforms/__init__.py
@@ -39,6 +39,7 @@ from .virtual_node import VirtualNode
 from .add_positional_encoding import AddLaplacianEigenvectorPE, AddRandomWalkPE
 from .feature_propagation import FeaturePropagation
 from .half_hop import HalfHop
+from .add_orthornormal_node_identifiers import AddOrthonormalNodeIdentifiers
 
 from .distance import Distance
 from .cartesian import Cartesian
@@ -110,6 +111,7 @@ graph_transforms = [
     'AddRandomWalkPE',
     'FeaturePropagation',
     'HalfHop',
+    'AddOrthonormalNodeIdentifiers',
 ]
 
 vision_transforms = [

--- a/torch_geometric/transforms/add_orthornormal_node_identifiers.py
+++ b/torch_geometric/transforms/add_orthornormal_node_identifiers.py
@@ -1,0 +1,59 @@
+import torch
+import torch.nn.functional as F
+from torch import Tensor
+
+from torch_geometric.data import Data
+from torch_geometric.data.datapipes import functional_transform
+from torch_geometric.nn.attention.performer import orthogonal_matrix
+from torch_geometric.transforms import BaseTransform
+from torch_geometric.utils import get_laplacian, to_dense_adj
+
+
+@functional_transform("add_orthonormal_node_identifiers")
+class AddOrthonormalNodeIdentifiers(BaseTransform):
+    r"""Adds orthonormal node identifiers to a given input graph as described
+    in the `"Pure Transformers are Powerful Graph Learners"
+    <https://arxiv.org/pdf/2207.02505>` paper.
+    (functional name: :obj:`add_orthonormal_node_identifiers`).
+
+    Args:
+        d_p (int): Dimension of node identifiers. If using Laplacian
+            identifiers and d_p is smaller than the number of nodes in the
+            graph, the eigenvectors corresponding to the d_p smallest
+            eigenvalues are used. If using orthogonal random features (ORFs)
+            and d_p is smaller than the number of nodes in the graph, we
+            randomly pick d_p channels. If d_p is larger than the number of
+            nodes in the graph, we zero pad channels.
+        use_laplacian (bool): If :obj:`True`, use eigenvectors of Laplacian
+            matrix as node identifiers. Otherwise, use ORFs.
+    """
+    def __init__(self, d_p: int, use_laplacian: bool = True):
+        self._d_p = d_p
+        self._use_laplacian = use_laplacian
+
+    def forward(self, data: Data) -> Data:
+        n = data.num_nodes
+        if self._use_laplacian is True:
+            node_ids = self._get_lap_eigenvectors(data.edge_index, n)
+        else:
+            node_ids = orthogonal_matrix(n, n)
+
+        if n < self._d_p:
+            node_ids = F.pad(node_ids, (0, self._d_p - n), value=0.0)
+        else:
+            node_ids = node_ids[:, :self._d_p]
+        node_ids = F.normalize(node_ids, p=2, dim=1)
+
+        data["node_ids"] = node_ids
+        return data
+
+    @staticmethod
+    def _get_lap_eigenvectors(edge_index: Tensor, n: int) -> Tensor:
+        lap_edge_index, lap_edge_attr = get_laplacian(
+            edge_index,
+            normalization="sym",
+            num_nodes=n,
+        )
+        lap_mat = to_dense_adj(lap_edge_index, edge_attr=lap_edge_attr)[0]
+        _, eigenvectors = torch.linalg.eigh(lap_mat)
+        return eigenvectors

--- a/torch_geometric/transforms/add_orthornormal_node_identifiers.py
+++ b/torch_geometric/transforms/add_orthornormal_node_identifiers.py
@@ -14,10 +14,9 @@ class AddOrthonormalNodeIdentifiers(BaseTransform):
     r"""Adds orthonormal node identifiers to a given input graph as described
     in the `"Pure Transformers are Powerful Graph Learners"
     <https://arxiv.org/pdf/2207.02505>` paper.
-    (functional name: :obj:`add_orthonormal_node_identifiers`).
-
-    Note: when use_laplacian is :object:`True`, use as `pre_transform` to
-        avoid re-calculating eigenvectors.
+    (functional name: :obj:`add_orthonormal_node_identifiers`). When
+    use_laplacian is true, use as `pre_transform` to avoid unnecessary
+    re-calculating of eigenvectors. Otherwise, use as `transform`.
 
     Args:
         d_p (int): Dimension of node identifiers. If using Laplacian

--- a/torch_geometric/transforms/add_orthornormal_node_identifiers.py
+++ b/torch_geometric/transforms/add_orthornormal_node_identifiers.py
@@ -16,6 +16,9 @@ class AddOrthonormalNodeIdentifiers(BaseTransform):
     <https://arxiv.org/pdf/2207.02505>` paper.
     (functional name: :obj:`add_orthonormal_node_identifiers`).
 
+    Note: when use_laplacian is :object:`True`, use as `pre_transform` to
+        avoid re-calculating eigenvectors.
+
     Args:
         d_p (int): Dimension of node identifiers. If using Laplacian
             identifiers and d_p is smaller than the number of nodes in the

--- a/torch_geometric/transforms/add_orthornormal_node_identifiers.py
+++ b/torch_geometric/transforms/add_orthornormal_node_identifiers.py
@@ -13,7 +13,7 @@ from torch_geometric.utils import get_laplacian, to_dense_adj
 class AddOrthonormalNodeIdentifiers(BaseTransform):
     r"""Adds orthonormal node identifiers to a given input graph as described
     in the `"Pure Transformers are Powerful Graph Learners"
-    <https://arxiv.org/pdf/2207.02505>` paper.
+    <https://arxiv.org/pdf/2207.02505>`_ paper.
     (functional name: :obj:`add_orthonormal_node_identifiers`). When
     use_laplacian is true, use as `pre_transform` to avoid unnecessary
     re-calculating of eigenvectors. Otherwise, use as `transform`.

--- a/torch_geometric/transforms/add_orthornormal_node_identifiers.py
+++ b/torch_geometric/transforms/add_orthornormal_node_identifiers.py
@@ -13,7 +13,7 @@ from torch_geometric.utils import get_laplacian, to_dense_adj
 class AddOrthonormalNodeIdentifiers(BaseTransform):
     r"""Adds orthonormal node identifiers to a given input graph as described
     in the `"Pure Transformers are Powerful Graph Learners"
-    <https://arxiv.org/pdf/2207.02505>`_ paper.
+    <https://arxiv.org/pdf/2207.02505>`_ paper
     (functional name: :obj:`add_orthonormal_node_identifiers`). When
     use_laplacian is true, use as `pre_transform` to avoid unnecessary
     re-calculating of eigenvectors. Otherwise, use as `transform`.


### PR DESCRIPTION
PyG implementation of the Tokenized Graph Transformer following "Pure Transformers are Powerful Graph Learners" (https://arxiv.org/pdf/2207.02505). Includes support for both Laplacian eigenvectors and ORF node identifiers (implemented via a simple data Transform object). A graph regression example is included. 