### PR TITLE
Fix Docstring Typos for LargeGraphIndexer

### DIFF
--- a/torch_geometric/data/large_graph_indexer.py
+++ b/torch_geometric/data/large_graph_indexer.py
@@ -85,7 +85,7 @@ class LargeGraphIndexer:
         by id. Not meant to be used directly.
 
         Args:
-            nodes (Iterable[str]): Node ids in the graph. Can be used with any 
+            nodes (Iterable[str]): Node ids in the graph. Can be used with any
                 hashable datatype.
             edges (KnowledgeGraphLike): Edge ids in the graph.
             node_attr (Optional[Dict[str, List[Any]]], optional): Mapping node
@@ -349,7 +349,7 @@ class LargeGraphIndexer:
                 Defaults to EDGE_PID.
 
         Returns:
-            List[str]: List of unique values for the specified feature. Can be 
+            List[str]: List of unique values for the specified feature. Can be
                 used with any hashable datatype.
         """
         try:
@@ -409,7 +409,7 @@ class LargeGraphIndexer:
             feature_name (str, optional): Name of feature to fetch.
                 Defaults to EDGE_PID.
             pids (Optional[Iterable[str]], optional): Edge ids to fetch
-                for. Can be used with any hashable datatype. Defaults to 
+                for. Can be used with any hashable datatype. Defaults to
                 None, which fetches all edges.
 
         Returns:

--- a/torch_geometric/data/large_graph_indexer.py
+++ b/torch_geometric/data/large_graph_indexer.py
@@ -7,7 +7,6 @@ from typing import (
     Any,
     Callable,
     Dict,
-    Hashable,
     Iterable,
     Iterator,
     List,
@@ -25,12 +24,13 @@ from tqdm import tqdm
 from torch_geometric.data import Data
 from torch_geometric.typing import WITH_PT24
 
-TripletLike = Tuple[Hashable, Hashable, Hashable]
+# Could be any hashable type
+TripletLike = Tuple[str, str, str]
 
 KnowledgeGraphLike = Iterable[TripletLike]
 
 
-def ordered_set(values: Iterable[Hashable]) -> List[Hashable]:
+def ordered_set(values: Iterable[str]) -> List[str]:
     return list(dict.fromkeys(values))
 
 
@@ -76,7 +76,7 @@ class LargeGraphIndexer:
     """
     def __init__(
         self,
-        nodes: Iterable[Hashable],
+        nodes: Iterable[str],
         edges: KnowledgeGraphLike,
         node_attr: Optional[Dict[str, List[Any]]] = None,
         edge_attr: Optional[Dict[str, List[Any]]] = None,
@@ -85,8 +85,7 @@ class LargeGraphIndexer:
         by id. Not meant to be used directly.
 
         Args:
-            nodes (Iterable[str]): Node ids in the graph. Can be used with any
-                hashable datatype.
+            nodes (Iterable[str]): Node ids in the graph.
             edges (KnowledgeGraphLike): Edge ids in the graph.
             node_attr (Optional[Dict[str, List[Any]]], optional): Mapping node
                 attribute name and list of their values in order of unique node
@@ -95,7 +94,7 @@ class LargeGraphIndexer:
                 attribute name and list of their values in order of unique edge
                 ids. Defaults to None.
         """
-        self._nodes: Dict[Hashable, int] = dict()
+        self._nodes: Dict[str, int] = dict()
         self._edges: Dict[TripletLike, int] = dict()
 
         self._mapped_node_features: Set[str] = set()
@@ -213,8 +212,8 @@ class LargeGraphIndexer:
         trips = chain.from_iterable([graph.to_triplets() for graph in graphs])
         return cls.from_triplets(trips)
 
-    def get_unique_node_features(
-            self, feature_name: str = NODE_PID) -> List[Hashable]:
+    def get_unique_node_features(self,
+                                 feature_name: str = NODE_PID) -> List[str]:
         r"""Get all the unique values for a specific node attribute.
 
         Args:
@@ -222,8 +221,7 @@ class LargeGraphIndexer:
                 Defaults to NODE_PID.
 
         Returns:
-            List[str]: List of unique values for the specified feature. Can be
-                used with any hashable datatype.
+            List[str]: List of unique values for the specified feature.
         """
         try:
             if feature_name in self._mapped_node_features:
@@ -274,7 +272,7 @@ class LargeGraphIndexer:
     def get_node_features(
         self,
         feature_name: str = NODE_PID,
-        pids: Optional[Iterable[Hashable]] = None,
+        pids: Optional[Iterable[str]] = None,
     ) -> List[Any]:
         r"""Get node feature values for a given set of unique node ids.
             Returned values are not necessarily unique.
@@ -283,8 +281,7 @@ class LargeGraphIndexer:
             feature_name (str, optional): Name of feature to fetch. Defaults
                 to NODE_PID.
             pids (Optional[Iterable[str]], optional): Node ids to fetch
-                for. Can be used with any hashable datatype. Defaults to None,
-                which fetches all nodes.
+                for. Defaults to None, which fetches all nodes.
 
         Returns:
             List[Any]: Node features corresponding to the specified ids.
@@ -305,7 +302,7 @@ class LargeGraphIndexer:
     def get_node_features_iter(
         self,
         feature_name: str = NODE_PID,
-        pids: Optional[Iterable[Hashable]] = None,
+        pids: Optional[Iterable[str]] = None,
         index_only: bool = False,
     ) -> Iterator[Any]:
         """Iterator version of get_node_features. If index_only is True,
@@ -340,8 +337,8 @@ class LargeGraphIndexer:
                 else:
                     yield self.node_attr[feature_name][idx]
 
-    def get_unique_edge_features(
-            self, feature_name: str = EDGE_PID) -> List[Hashable]:
+    def get_unique_edge_features(self,
+                                 feature_name: str = EDGE_PID) -> List[str]:
         r"""Get all the unique values for a specific edge attribute.
 
         Args:
@@ -349,8 +346,7 @@ class LargeGraphIndexer:
                 Defaults to EDGE_PID.
 
         Returns:
-            List[str]: List of unique values for the specified feature. Can be
-                used with any hashable datatype.
+            List[str]: List of unique values for the specified feature.
         """
         try:
             if feature_name in self._mapped_edge_features:
@@ -400,7 +396,7 @@ class LargeGraphIndexer:
     def get_edge_features(
         self,
         feature_name: str = EDGE_PID,
-        pids: Optional[Iterable[Hashable]] = None,
+        pids: Optional[Iterable[str]] = None,
     ) -> List[Any]:
         r"""Get edge feature values for a given set of unique edge ids.
             Returned values are not necessarily unique.
@@ -409,8 +405,7 @@ class LargeGraphIndexer:
             feature_name (str, optional): Name of feature to fetch.
                 Defaults to EDGE_PID.
             pids (Optional[Iterable[str]], optional): Edge ids to fetch
-                for. Can be used with any hashable datatype. Defaults to
-                None, which fetches all edges.
+                for. Defaults to None, which fetches all edges.
 
         Returns:
             List[Any]: Node features corresponding to the specified ids.

--- a/torch_geometric/data/large_graph_indexer.py
+++ b/torch_geometric/data/large_graph_indexer.py
@@ -70,7 +70,7 @@ if WITH_PT24:
 
 
 class LargeGraphIndexer:
-    """For a dataset that consists of mulitiple subgraphs that are assumed to
+    """For a dataset that consists of multiple subgraphs that are assumed to
     be part of a much larger graph, collate the values into a large graph store
     to save resources.
     """

--- a/torch_geometric/data/large_graph_indexer.py
+++ b/torch_geometric/data/large_graph_indexer.py
@@ -85,7 +85,8 @@ class LargeGraphIndexer:
         by id. Not meant to be used directly.
 
         Args:
-            nodes (Iterable[Hashable]): Node ids in the graph.
+            nodes (Iterable[str]): Node ids in the graph. Can be used with any 
+                hashable datatype.
             edges (KnowledgeGraphLike): Edge ids in the graph.
             node_attr (Optional[Dict[str, List[Any]]], optional): Mapping node
                 attribute name and list of their values in order of unique node
@@ -201,7 +202,7 @@ class LargeGraphIndexer:
         index.
 
         Args:
-            graphs (Iterable[&quot;LargeGraphIndexer&quot;]): Indices to be
+            graphs (Iterable[LargeGraphIndexer]): Indices to be
                 combined.
 
         Returns:
@@ -221,7 +222,8 @@ class LargeGraphIndexer:
                 Defaults to NODE_PID.
 
         Returns:
-            List[Hashable]: List of unique values for the specified feature.
+            List[str]: List of unique values for the specified feature. Can be
+                used with any hashable datatype.
         """
         try:
             if feature_name in self._mapped_node_features:
@@ -280,8 +282,9 @@ class LargeGraphIndexer:
         Args:
             feature_name (str, optional): Name of feature to fetch. Defaults
                 to NODE_PID.
-            pids (Optional[Iterable[Hashable]], optional): Node ids to fetch
-                for. Defaults to None, which fetches all nodes.
+            pids (Optional[Iterable[str]], optional): Node ids to fetch
+                for. Can be used with any hashable datatype. Defaults to None,
+                which fetches all nodes.
 
         Returns:
             List[Any]: Node features corresponding to the specified ids.
@@ -346,7 +349,8 @@ class LargeGraphIndexer:
                 Defaults to EDGE_PID.
 
         Returns:
-            List[Hashable]: List of unique values for the specified feature.
+            List[str]: List of unique values for the specified feature. Can be 
+                used with any hashable datatype.
         """
         try:
             if feature_name in self._mapped_edge_features:
@@ -404,8 +408,9 @@ class LargeGraphIndexer:
         Args:
             feature_name (str, optional): Name of feature to fetch.
                 Defaults to EDGE_PID.
-            pids (Optional[Iterable[Hashable]], optional): Edge ids to fetch
-                for. Defaults to None, which fetches all edges.
+            pids (Optional[Iterable[str]], optional): Edge ids to fetch
+                for. Can be used with any hashable datatype. Defaults to 
+                None, which fetches all edges.
 
         Returns:
             List[Any]: Node features corresponding to the specified ids.

--- a/torch_geometric/loader/__init__.py
+++ b/torch_geometric/loader/__init__.py
@@ -22,7 +22,7 @@ from .dynamic_batch_sampler import DynamicBatchSampler
 from .prefetch import PrefetchLoader
 from .cache import CachedLoader
 from .mixin import AffinityMixin
-from .rag_loader import RAGQueryLoader
+from .rag_loader import RAGQueryLoader, RAGFeatureStore, RAGGraphStore
 
 __all__ = classes = [
     'DataLoader',
@@ -52,6 +52,8 @@ __all__ = classes = [
     'CachedLoader',
     'AffinityMixin',
     'RAGQueryLoader',
+    'RAGFeatureStore',
+    'RAGGraphStore'
 ]
 
 RandomNodeSampler = deprecated(

--- a/torch_geometric/loader/rag_loader.py
+++ b/torch_geometric/loader/rag_loader.py
@@ -7,7 +7,7 @@ from torch_geometric.typing import InputEdges, InputNodes
 
 
 class RAGFeatureStore(Protocol):
-    """Feature store for remote GNN RAG backend."""
+    """Feature store template for remote GNN RAG backend."""
     @abstractmethod
     def retrieve_seed_nodes(self, query: Any, **kwargs) -> InputNodes:
         """Makes a comparison between the query and all the nodes to get all
@@ -33,7 +33,7 @@ class RAGFeatureStore(Protocol):
 
 
 class RAGGraphStore(Protocol):
-    """Graph store for remote GNN RAG backend."""
+    """Graph store template for remote GNN RAG backend."""
     @abstractmethod
     def sample_subgraph(self, seed_nodes: InputNodes, seed_edges: InputEdges,
                         **kwargs) -> Union[SamplerOutput, HeteroSamplerOutput]:

--- a/torch_geometric/loader/rag_loader.py
+++ b/torch_geometric/loader/rag_loader.py
@@ -52,6 +52,7 @@ class RAGGraphStore(Protocol):
 
 
 class RAGQueryLoader:
+    """Loader meant for making RAG queries from a remote backend."""
     def __init__(self, data: Tuple[RAGFeatureStore, RAGGraphStore],
                  local_filter: Optional[Callable[[Data, Any], Data]] = None,
                  seed_nodes_kwargs: Optional[Dict[str, Any]] = None,


### PR DESCRIPTION
Fix some issues with the docstrings of LargeGraphIndexer.