### PR TITLE
CS224W - Bag of Tricks for Node Classification with GNN - GAT Normalization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- Added `normalize` parameter to `GATConv` and `GATv2Conv` ([#9840](https://github.com/pyg-team/pytorch_geometric/pull/9840))
 - Update Dockerfile to use latest from NVIDIA ([#9794](https://github.com/pyg-team/pytorch_geometric/pull/9794))
 - Added various GRetriever Architecture Benchmarking examples ([#9666](https://github.com/pyg-team/pytorch_geometric/pull/9666))
 - Added `profiler.nvtxit` with some examples ([#9666](https://github.com/pyg-team/pytorch_geometric/pull/9666))

--- a/benchmark/citation/gat.py
+++ b/benchmark/citation/gat.py
@@ -24,6 +24,7 @@ parser.add_argument('--inference', action='store_true')
 parser.add_argument('--profile', action='store_true')
 parser.add_argument('--bf16', action='store_true')
 parser.add_argument('--compile', action='store_true')
+parser.add_argument('--normalize', action='store_true')
 args = parser.parse_args()
 
 
@@ -31,10 +32,11 @@ class Net(torch.nn.Module):
     def __init__(self, dataset):
         super().__init__()
         self.conv1 = GATConv(dataset.num_features, args.hidden,
-                             heads=args.heads, dropout=args.dropout)
+                             heads=args.heads, dropout=args.dropout,
+                             normalize=args.normalize)
         self.conv2 = GATConv(args.hidden * args.heads, dataset.num_classes,
                              heads=args.output_heads, concat=False,
-                             dropout=args.dropout)
+                             dropout=args.dropout, normalize=args.normalize)
 
     def reset_parameters(self):
         self.conv1.reset_parameters()

--- a/examples/gat.py
+++ b/examples/gat.py
@@ -57,7 +57,7 @@ class GAT(torch.nn.Module):
 
 
 model = GAT(dataset.num_features, args.hidden_channels, dataset.num_classes,
-            args.heads, args.normalize).to(device)
+            args.heads, args.norm_adj).to(device)
 optimizer = torch.optim.Adam(model.parameters(), lr=0.005, weight_decay=5e-4)
 
 

--- a/examples/gat.py
+++ b/examples/gat.py
@@ -17,6 +17,8 @@ parser.add_argument('--hidden_channels', type=int, default=8)
 parser.add_argument('--heads', type=int, default=8)
 parser.add_argument('--lr', type=float, default=0.005)
 parser.add_argument('--epochs', type=int, default=200)
+parser.add_argument('--norm_adj', type=bool, default=False,
+                    help="GAT with symmetric normalized adjacency")
 parser.add_argument('--wandb', action='store_true', help='Track experiment')
 args = parser.parse_args()
 
@@ -28,7 +30,8 @@ else:
     device = torch.device('cpu')
 
 init_wandb(name=f'GAT-{args.dataset}', heads=args.heads, epochs=args.epochs,
-           hidden_channels=args.hidden_channels, lr=args.lr, device=device)
+           hidden_channels=args.hidden_channels, lr=args.lr, device=device,
+           norm_adj=args.norm_adj)
 
 path = osp.join(osp.dirname(osp.realpath(__file__)), '..', 'data', 'Planetoid')
 dataset = Planetoid(path, args.dataset, transform=T.NormalizeFeatures())
@@ -36,12 +39,14 @@ data = dataset[0].to(device)
 
 
 class GAT(torch.nn.Module):
-    def __init__(self, in_channels, hidden_channels, out_channels, heads):
+    def __init__(self, in_channels, hidden_channels, out_channels, heads,
+                 normalize):
         super().__init__()
-        self.conv1 = GATConv(in_channels, hidden_channels, heads, dropout=0.6)
+        self.conv1 = GATConv(in_channels, hidden_channels, heads, dropout=0.6,
+                             normalize=normalize)
         # On the Pubmed dataset, use `heads` output heads in `conv2`.
         self.conv2 = GATConv(hidden_channels * heads, out_channels, heads=1,
-                             concat=False, dropout=0.6)
+                             concat=False, dropout=0.6, normalize=normalize)
 
     def forward(self, x, edge_index):
         x = F.dropout(x, p=0.6, training=self.training)
@@ -52,7 +57,7 @@ class GAT(torch.nn.Module):
 
 
 model = GAT(dataset.num_features, args.hidden_channels, dataset.num_classes,
-            args.heads).to(device)
+            args.heads, args.normalize).to(device)
 optimizer = torch.optim.Adam(model.parameters(), lr=0.005, weight_decay=5e-4)
 
 

--- a/test/nn/conv/test_gat_conv.py
+++ b/test/nn/conv/test_gat_conv.py
@@ -267,10 +267,10 @@ def test_gat_norm_csc_error():
 
 def test_gat_conv_bipartite_error():
     x1 = torch.randn(4, 8)
+    x2 = torch.randn(2, 16)
     edge_index = torch.tensor([[0, 1, 2, 3], [0, 0, 1, 1]])
-    adj1 = to_torch_csc_tensor(edge_index, size=(4, 2))
 
     with pytest.raises(NotImplementedError,
                        match="not supported for bipartite message passing"):
-        conv = GATConv(8, 32, heads=2, normalize=True)
-        _ = conv(x1, adj1.t())
+        conv = GATConv((8, 16), 32, heads=2, normalize=True)
+        conv((x1, x2), edge_index)

--- a/test/nn/conv/test_gat_conv.py
+++ b/test/nn/conv/test_gat_conv.py
@@ -155,6 +155,23 @@ def test_gat_conv(residual):
             assert torch.allclose(jit((x1, x2), adj2.t()), out1, atol=1e-6)
             assert torch.allclose(jit((x1, None), adj2.t()), out2, atol=1e-6)
 
+    # Test GAT normalization:
+    x1 = torch.randn(4, 8)
+    x2 = torch.randn(2, 16)
+    edge_index = torch.tensor([[0, 1, 2, 3], [0, 0, 1, 1]])
+    adj1 = to_torch_csc_tensor(edge_index, size=(4, 4))
+
+    conv = GATConv(8, 32, heads=2, residual=residual, normalize=True)
+    assert str(conv) == 'GATConv(8, 32, heads=2)'
+    out = conv(x1, edge_index)
+    assert out.size() == (4, 64)
+    assert torch.allclose(conv(x1, edge_index, size=(4, 4)), out)
+    # assert torch.allclose(conv(x1, adj1.t()), out, atol=1e-6)
+
+    if torch_geometric.typing.WITH_TORCH_SPARSE:
+        adj2 = SparseTensor.from_edge_index(edge_index, sparse_sizes=(4, 4))
+        assert torch.allclose(conv(x1, adj2.t()), out, atol=1e-6)
+
 
 def test_gat_conv_with_edge_attr():
     x = torch.randn(4, 8)

--- a/test/nn/conv/test_gat_conv.py
+++ b/test/nn/conv/test_gat_conv.py
@@ -281,7 +281,8 @@ def test_remove_diag_sparse_tensor():
     edge_index = torch.tensor([[0, 1, 2, 3], [0, 0, 1, 1]])
     edge_index2 = torch.tensor([[1, 2, 3], [0, 1, 1]])
 
-    adj1 = SparseTensor.from_edge_index(edge_index, sparse_sizes=(4, 4))
-    adj2 = SparseTensor.from_edge_index(edge_index2, sparse_sizes=(4, 4))
+    if torch_geometric.typing.WITH_TORCH_SPARSE:
+        adj1 = SparseTensor.from_edge_index(edge_index, sparse_sizes=(4, 4))
+        adj2 = SparseTensor.from_edge_index(edge_index2, sparse_sizes=(4, 4))
 
-    assert torch_sparse.remove_diag(adj1.t()) == adj2.t()
+        assert torch_sparse.remove_diag(adj1.t()) == adj2.t()

--- a/test/nn/conv/test_gat_conv.py
+++ b/test/nn/conv/test_gat_conv.py
@@ -8,7 +8,7 @@ import torch_geometric.typing
 from torch_geometric.nn import GATConv
 from torch_geometric.nn.conv.gat_conv import gat_norm
 from torch_geometric.testing import is_full_test, withDevice
-from torch_geometric.typing import Adj, Size, SparseTensor
+from torch_geometric.typing import Adj, Size, SparseTensor, torch_sparse
 from torch_geometric.utils import to_torch_csc_tensor, to_torch_csr_tensor
 
 
@@ -274,3 +274,14 @@ def test_gat_conv_bipartite_error():
                        match="not supported for bipartite message passing"):
         conv = GATConv((8, 16), 32, heads=2, normalize=True)
         conv((x1, x2), edge_index)
+
+
+def test_remove_diag_sparse_tensor():
+    # Used in GAT Normalization
+    edge_index = torch.tensor([[0, 1, 2, 3], [0, 0, 1, 1]])
+    edge_index2 = torch.tensor([[1, 2, 3], [0, 1, 1]])
+
+    adj1 = SparseTensor.from_edge_index(edge_index, sparse_sizes=(4, 4))
+    adj2 = SparseTensor.from_edge_index(edge_index2, sparse_sizes=(4, 4))
+
+    assert torch_sparse.remove_diag(adj1.t()) == adj2.t()

--- a/test/nn/conv/test_gat_conv.py
+++ b/test/nn/conv/test_gat_conv.py
@@ -263,3 +263,14 @@ def test_gat_norm_csc_error():
     with pytest.raises(NotImplementedError,
                        match="Sparse CSC matrices are not yet supported"):
         gat_norm(adj1, edge_weight)
+
+
+def test_gat_conv_bipartite_error():
+    x1 = torch.randn(4, 8)
+    edge_index = torch.tensor([[0, 1, 2, 3], [0, 0, 1, 1]])
+    adj1 = to_torch_csc_tensor(edge_index, size=(4, 2))
+
+    with pytest.raises(NotImplementedError,
+                       match="not supported for bipartite message passing"):
+        conv = GATConv(8, 32, heads=2, normalize=True)
+        _ = conv(x1, adj1.t())

--- a/test/nn/conv/test_gat_conv.py
+++ b/test/nn/conv/test_gat_conv.py
@@ -6,9 +6,10 @@ from torch import Tensor
 
 import torch_geometric.typing
 from torch_geometric.nn import GATConv
+from torch_geometric.nn.conv.gat_conv import gat_norm
 from torch_geometric.testing import is_full_test, withDevice
 from torch_geometric.typing import Adj, Size, SparseTensor
-from torch_geometric.utils import to_torch_csc_tensor
+from torch_geometric.utils import to_torch_csc_tensor, to_torch_csr_tensor
 
 
 @pytest.mark.parametrize('residual', [False, True])
@@ -166,7 +167,7 @@ def test_gat_conv(residual):
     out = conv(x1, edge_index)
     assert out.size() == (4, 64)
     assert torch.allclose(conv(x1, edge_index, size=(4, 4)), out)
-    # assert torch.allclose(conv(x1, adj1.t()), out, atol=1e-6)
+    assert torch.allclose(conv(x1, adj1.t()), out)
 
     if torch_geometric.typing.WITH_TORCH_SPARSE:
         adj2 = SparseTensor.from_edge_index(edge_index, sparse_sizes=(4, 4))
@@ -218,3 +219,25 @@ def test_gat_conv_empty_edge_index(device):
     conv = GATConv(8, 32, heads=2).to(device)
     out = conv(x, edge_index)
     assert out.size() == (0, 64)
+
+
+def test_gat_conv_csc_error():
+    x1 = torch.randn(4, 8)
+    edge_index = torch.tensor([[0, 1, 2, 3], [0, 0, 1, 1]])
+    adj1 = to_torch_csr_tensor(edge_index, size=(4, 4))
+
+    with pytest.raises(ValueError, match="Unexpected sparse tensor layout"):
+        conv = GATConv(8, 32, heads=2, normalize=True)
+        assert str(conv) == 'GATConv(8, 32, heads=2)'
+        _ = conv(x1, adj1.t())
+
+
+def test_gat_norm_csc_error():
+    edge_index = torch.tensor([[1, 2, 3], [0, 1, 1]])
+    edge_weight = torch.tensor([[1.0000, 1.0000], [1.2341, 0.9614],
+                                [0.7659, 1.0386]])
+    adj1 = to_torch_csc_tensor(edge_index, size=(4, 4))
+
+    with pytest.raises(NotImplementedError,
+                       match="Sparse CSC matrices are not yet supported"):
+        gat_norm(adj1, edge_weight)

--- a/test/nn/conv/test_gat_conv.py
+++ b/test/nn/conv/test_gat_conv.py
@@ -173,6 +173,28 @@ def test_gat_conv(residual):
         adj2 = SparseTensor.from_edge_index(edge_index, sparse_sizes=(4, 4))
         assert torch.allclose(conv(x1, adj2.t()), out, atol=1e-6)
 
+    if is_full_test():
+
+        class MyModule(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.conv = conv
+
+            def forward(
+                self,
+                x: Tensor,
+                edge_index: Adj,
+                size: Size = None,
+            ) -> Tensor:
+                return self.conv(x, edge_index, size=size)
+
+        jit = torch.jit.script(MyModule())
+        assert torch.allclose(jit(x1, edge_index), out)
+        assert torch.allclose(jit(x1, edge_index, size=(4, 4)), out)
+
+        if torch_geometric.typing.WITH_TORCH_SPARSE:
+            assert torch.allclose(jit(x1, adj2.t()), out, atol=1e-6)
+
 
 def test_gat_conv_with_edge_attr():
     x = torch.randn(4, 8)

--- a/test/nn/conv/test_gatv2_conv.py
+++ b/test/nn/conv/test_gatv2_conv.py
@@ -201,3 +201,14 @@ def test_gatv2_conv_with_edge_attr():
     conv = GATv2Conv(8, 32, heads=2, edge_dim=4, fill_value='mean')
     out = conv(x, edge_index, edge_attr)
     assert out.size() == (4, 64)
+
+
+def test_gat_conv_bipartite_error():
+    x1 = torch.randn(4, 8)
+    edge_index = torch.tensor([[0, 1, 2, 3], [0, 0, 1, 1]])
+    adj1 = to_torch_csc_tensor(edge_index, size=(4, 2))
+
+    with pytest.raises(NotImplementedError,
+                       match="not supported for bipartite message passing"):
+        conv = GATv2Conv(8, 32, heads=2, normalize=True)
+        _ = conv(x1, adj1.t())

--- a/test/nn/conv/test_gatv2_conv.py
+++ b/test/nn/conv/test_gatv2_conv.py
@@ -205,10 +205,10 @@ def test_gatv2_conv_with_edge_attr():
 
 def test_gat_conv_bipartite_error():
     x1 = torch.randn(4, 8)
+    x2 = torch.randn(2, 16)
     edge_index = torch.tensor([[0, 1, 2, 3], [0, 0, 1, 1]])
-    adj1 = to_torch_csc_tensor(edge_index, size=(4, 2))
 
     with pytest.raises(NotImplementedError,
                        match="not supported for bipartite message passing"):
-        conv = GATv2Conv(8, 32, heads=2, normalize=True)
-        _ = conv(x1, adj1.t())
+        conv = GATv2Conv((8, 16), 32, heads=2, normalize=True)
+        conv((x1, x2), edge_index)

--- a/test/nn/conv/test_gatv2_conv.py
+++ b/test/nn/conv/test_gatv2_conv.py
@@ -141,6 +141,44 @@ def test_gatv2_conv(residual):
         if torch_geometric.typing.WITH_TORCH_SPARSE:
             assert torch.allclose(jit((x1, x2), adj2.t()), out, atol=1e-6)
 
+    # Test GAT normalization:
+    x1 = torch.randn(4, 8)
+    x2 = torch.randn(2, 16)
+    edge_index = torch.tensor([[0, 1, 2, 3], [0, 0, 1, 1]])
+    adj1 = to_torch_csc_tensor(edge_index, size=(4, 4))
+
+    conv = GATv2Conv(8, 32, heads=2, residual=residual, normalize=True)
+    assert str(conv) == 'GATv2Conv(8, 32, heads=2)'
+    out = conv(x1, edge_index)
+    assert out.size() == (4, 64)
+    assert torch.allclose(conv(x1, edge_index), out)
+    assert torch.allclose(conv(x1, adj1.t()), out, atol=1e-6)
+
+    if torch_geometric.typing.WITH_TORCH_SPARSE:
+        adj2 = SparseTensor.from_edge_index(edge_index, sparse_sizes=(4, 4))
+        assert torch.allclose(conv(x1, adj2.t()), out, atol=1e-6)
+
+    if is_full_test():
+
+        class MyModule(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.conv = conv
+
+            def forward(
+                self,
+                x: Tensor,
+                edge_index: Adj,
+            ) -> Tensor:
+                return self.conv(x, edge_index)
+
+        jit = torch.jit.script(MyModule())
+        assert torch.allclose(jit(x1, edge_index), out)
+        assert torch.allclose(jit(x1, edge_index, size=(4, 4)), out)
+
+        if torch_geometric.typing.WITH_TORCH_SPARSE:
+            assert torch.allclose(jit(x1, adj2.t()), out, atol=1e-6)
+
 
 def test_gatv2_conv_with_edge_attr():
     x = torch.randn(4, 8)

--- a/torch_geometric/nn/conv/gat_conv.py
+++ b/torch_geometric/nn/conv/gat_conv.py
@@ -102,7 +102,8 @@ def gat_norm(  # noqa: F811
                                    repeat_deg_tilde_inv.view(1, -1, num_heads))
         # should never be None, only for typing purpose
         alpha = att_mat.storage.value()
-        return adj_t, alpha if alpha is not None else edge_weight
+        return att_mat.set_value(
+            None), alpha if alpha is not None else edge_weight
 
     if is_torch_sparse_tensor(edge_index):
         assert edge_index.size(0) == edge_index.size(1)

--- a/torch_geometric/nn/conv/gat_conv.py
+++ b/torch_geometric/nn/conv/gat_conv.py
@@ -502,12 +502,10 @@ class GATConv(MessagePassing):
                         "'edge_index' in a 'SparseTensor' form")
 
         if self.normalize:
-            if isinstance(edge_index,
-                          SparseTensor) or is_torch_sparse_tensor(edge_index):
-                if edge_index.size(0) != edge_index.size(1):
-                    raise NotImplementedError(
-                        "The usage of 'normalize' is not supported "
-                        "for bipartite message passing.")
+            if not isinstance(self.in_channels, int):
+                raise NotImplementedError(
+                    "The usage of 'normalize' is not supported "
+                    "for bipartite message passing.")
 
             if isinstance(edge_index, Tensor):
                 edge_index, edge_attr = remove_self_loops(
@@ -520,7 +518,7 @@ class GATConv(MessagePassing):
                                   size=size)
 
         if self.normalize:
-            num_nodes = None
+            num_nodes: Optional[int] = None
             if isinstance(edge_index, Tensor):
                 num_nodes = x_src.size(0)
                 if x_dst is not None:

--- a/torch_geometric/nn/conv/gat_conv.py
+++ b/torch_geometric/nn/conv/gat_conv.py
@@ -100,8 +100,7 @@ def gat_norm(  # noqa: F811
                                       "supported in 'gat_norm'")
         num_nodes = maybe_num_nodes(edge_index, num_nodes)
 
-        adj_t = edge_index
-        edge_index, value = to_edge_index(adj_t)
+        edge_index, value = to_edge_index(edge_index)
 
         col, row = edge_index[0], edge_index[1]
         idx = col if flow == 'source_to_target' else row
@@ -513,7 +512,10 @@ class GATConv(MessagePassing):
                                   size=size)
 
         if self.normalize:
-            edge_index, alpha = gat_norm(edge_index, alpha)  # yapf: disable
+            edge_index, alpha = gat_norm(edge_index,
+                                         alpha,
+                                         flow=self.flow,
+                                         dtype=alpha.dtype)  # yapf: disable
 
         # propagate_type: (x: OptPairTensor, alpha: Tensor)
         out = self.propagate(edge_index, x=x, alpha=alpha, size=size)

--- a/torch_geometric/nn/conv/gat_conv.py
+++ b/torch_geometric/nn/conv/gat_conv.py
@@ -77,7 +77,10 @@ def gat_norm(  # noqa: F811
         if not adj_t.has_value():
             adj_t = adj_t.fill_value(1., dtype=dtype)
 
-        deg = torch_sparse.sum(adj_t, dim=1)
+        # idx = col if flow == 'source_to_target' else row
+        dim = 1 if flow == 'source_to_target' else 0
+        deg = torch_sparse.sum(adj_t, dim=dim)
+
         att_mat = adj_t.set_value(edge_weight)
         # repeat_interleave for any dtype tensor
         num_heads = edge_weight.shape[1] if edge_weight.dim() > 1 else 1
@@ -487,6 +490,8 @@ class GATConv(MessagePassing):
         alpha_dst = None if x_dst is None else (x_dst * self.att_dst).sum(-1)
         alpha = (alpha_src, alpha_dst)
 
+        # Skipping add_self_loops when normalize
+        # as we are performing it on gat_norm function
         if self.add_self_loops and not self.normalize:
             if isinstance(edge_index, Tensor):
                 # We only want to add self-loops for nodes that appear both as

--- a/torch_geometric/nn/conv/gat_conv.py
+++ b/torch_geometric/nn/conv/gat_conv.py
@@ -509,7 +509,6 @@ class GATConv(MessagePassing):
                         "The usage of 'normalize' is not supported "
                         "for bipartite message passing.")
 
-        if self.normalize:
             if isinstance(edge_index, Tensor):
                 edge_index, edge_attr = remove_self_loops(
                     edge_index, edge_attr)

--- a/torch_geometric/nn/conv/gatv2_conv.py
+++ b/torch_geometric/nn/conv/gatv2_conv.py
@@ -153,9 +153,6 @@ class GATv2Conv(MessagePassing):
     ):
         super().__init__(node_dim=0, **kwargs)
 
-        if normalize:
-            add_self_loops = False
-
         self.in_channels = in_channels
         self.out_channels = out_channels
         self.heads = heads
@@ -311,7 +308,7 @@ class GATv2Conv(MessagePassing):
         assert x_l is not None
         assert x_r is not None
 
-        if self.add_self_loops:
+        if self.add_self_loops and not self.normalize:
             if isinstance(edge_index, Tensor):
                 num_nodes = x_l.size(0)
                 if x_r is not None:

--- a/torch_geometric/nn/conv/gatv2_conv.py
+++ b/torch_geometric/nn/conv/gatv2_conv.py
@@ -342,7 +342,10 @@ class GATv2Conv(MessagePassing):
                                   edge_attr=edge_attr)
 
         if self.normalize:
-            edge_index, alpha = gat_norm(edge_index, alpha)  # yapf: disable
+            edge_index, alpha = gat_norm(edge_index,
+                                         alpha,
+                                         flow=self.flow,
+                                         dtype=alpha.dtype)  # yapf: disable
 
         # propagate_type: (x: PairTensor, alpha: Tensor)
         out = self.propagate(edge_index, x=(x_l, x_r), alpha=alpha)

--- a/torch_geometric/nn/conv/gatv2_conv.py
+++ b/torch_geometric/nn/conv/gatv2_conv.py
@@ -331,12 +331,10 @@ class GATv2Conv(MessagePassing):
                         "'edge_index' in a 'SparseTensor' form")
 
         if self.normalize:
-            if isinstance(edge_index,
-                          SparseTensor) or is_torch_sparse_tensor(edge_index):
-                if edge_index.size(0) != edge_index.size(1):
-                    raise NotImplementedError(
-                        "The usage of 'normalize' is not supported "
-                        "for bipartite message passing.")
+            if not isinstance(self.in_channels, int):
+                raise NotImplementedError(
+                    "The usage of 'normalize' is not supported "
+                    "for bipartite message passing.")
 
             if isinstance(edge_index, Tensor):
                 edge_index, edge_attr = remove_self_loops(

--- a/torch_geometric/nn/conv/gatv2_conv.py
+++ b/torch_geometric/nn/conv/gatv2_conv.py
@@ -337,7 +337,7 @@ class GATv2Conv(MessagePassing):
                 edge_index, edge_attr = remove_self_loops(
                     edge_index, edge_attr)
             elif isinstance(edge_index, SparseTensor):
-                edge_index = torch_sparse.fill_diag(edge_index, 0.0)
+                edge_index = torch_sparse.remove_diag(edge_index)
 
         # edge_updater_type: (x: PairTensor, edge_attr: OptTensor)
         alpha = self.edge_updater(edge_index, x=(x_l, x_r),

--- a/torch_geometric/nn/conv/gatv2_conv.py
+++ b/torch_geometric/nn/conv/gatv2_conv.py
@@ -338,7 +338,6 @@ class GATv2Conv(MessagePassing):
                         "The usage of 'normalize' is not supported "
                         "for bipartite message passing.")
 
-        if self.normalize:
             if isinstance(edge_index, Tensor):
                 edge_index, edge_attr = remove_self_loops(
                     edge_index, edge_attr)

--- a/torch_geometric/typing.py
+++ b/torch_geometric/typing.py
@@ -183,9 +183,6 @@ except Exception as e:
                        has_value: bool = True) -> 'SparseTensor':
             raise ImportError("'SparseTensor' requires 'torch-sparse'")
 
-        def copy(self) -> 'SparseTensor':
-            raise ImportError("'SparseTensor' requires 'torch-sparse'")
-
         def size(self, dim: int) -> int:
             raise ImportError("'SparseTensor' requires 'torch-sparse'")
 
@@ -219,9 +216,6 @@ except Exception as e:
             self,
             dtype: Optional[torch.dtype] = None,
         ) -> Tensor:
-            raise ImportError("'SparseTensor' requires 'torch-sparse'")
-
-        def to_dense(self) -> torch.Tensor:
             raise ImportError("'SparseTensor' requires 'torch-sparse'")
 
     class torch_sparse:  # type: ignore

--- a/torch_geometric/typing.py
+++ b/torch_geometric/typing.py
@@ -183,6 +183,9 @@ except Exception as e:
                        has_value: bool = True) -> 'SparseTensor':
             raise ImportError("'SparseTensor' requires 'torch-sparse'")
 
+        def copy(self) -> 'SparseTensor':
+            raise ImportError("'SparseTensor' requires 'torch-sparse'")
+
         def size(self, dim: int) -> int:
             raise ImportError("'SparseTensor' requires 'torch-sparse'")
 
@@ -216,6 +219,9 @@ except Exception as e:
             self,
             dtype: Optional[torch.dtype] = None,
         ) -> Tensor:
+            raise ImportError("'SparseTensor' requires 'torch-sparse'")
+
+        def to_dense(self) -> torch.Tensor:
             raise ImportError("'SparseTensor' requires 'torch-sparse'")
 
     class torch_sparse:  # type: ignore

--- a/torch_geometric/typing.py
+++ b/torch_geometric/typing.py
@@ -249,6 +249,10 @@ except Exception as e:
             raise ImportError("'fill_diag' requires 'torch-sparse'")
 
         @staticmethod
+        def remove_diag(src: SparseTensor, k: int = 0) -> SparseTensor:
+            raise ImportError("'remove_diag' requires 'torch-sparse'")
+
+        @staticmethod
         def masked_select_nnz(src: SparseTensor, mask: Tensor,
                               layout: Optional[str] = None) -> SparseTensor:
             raise ImportError("'masked_select_nnz' requires 'torch-sparse'")


### PR DESCRIPTION
Add `normalize` parameter to `GATConv` and `GATv2Conv`.

Part of https://github.com/pyg-team/pytorch_geometric/issues/9831 for our final project for the Stanford CS224W course, this allows "GAT with Symmetric Normalized Adjacency Matrix" as described in [“Bag of Tricks for Node Classification with Graph Neural Networks”](https://arxiv.org/abs/2103.13355).

## Details

- Implementation of `gat_norm` inspired from `gcn_norm`, when `edge_index` is a `SparseTensor`, `is_torch_sparse_tensor` or dense torch `Tensor`.
- `gat_norm` is called after computing the `alpha` coefficients and return the updated values of `edge_index` and `alpha`. The outputs of `gat_norm` are passed as inputs of `self.propagate`.
- Update the docstring of `GATConv` and `GATv2Conv`.
- Add unit test cases.
- Override the `add_self_loops` parameter. We remove self loops from the initial graph before calling to `gat_norm` and add self loops with normalization in `gat_norm` as described in the paper. We tried to use the tools already provided in the library such as `torch_sparse.fill_diag`, `to_edge_index`, `add_remaining_self_loops`, `add_self_loops` and `to_torch_csr_tensor`. 
- One concern is that there is no learned weight regardless of add_self_loops, because we explicitly remove self loops before edge update. This is consistent with the paper's description and gcn_norm, but different from the paper's [implementation](https://github.com/AiRyunn/BoT/blob/d2ff78e41ced91a944b84760b5d81af3bf589627/src/no-sampling/models.py#L500). Also, it seems that they use both out-degree and in-degree. We would appreciate your feedback on the preferred approach.
- When `is_torch_sparse_tensor(edge_index) == True`, we have an issue formatting back the index `edge_index` and the corresponding values in `att_mat` to the appropriate format. Our workaround consists of sorting lexicographically the values of `att_mat`, so it matches the index of `edge_index` for the `propagate` and  `update` subsequent steps.
- When `isinstance(edge_index, SparseTensor)` and in the case we have multiple heads, e.g. `num_heads > 1`, we need to perform the operation $D \alpha$, which is a multiplication of SparseTensor (with values dimension greater than 1) and degree matrix. Our solution is based on repeating the degree matrix `num_heads` times. We don't use `repeat_interleave` directly as we encounter the following error: `"repeat_interleave_cpu" not implemented for 'Float'`, but the current implementation should follow the same behavior.
- Only support non-bipartite graph mesasge passing.

## Benchmarks

I have the following metrics with one T4 GPU, so it performs better for CiteSeer and PubMed dataset with a computation time cost.

|  dataset | Test Accuracy  | Test Accuracy (with GAT Norm) | Duration  |  Duration (with GAT Norm) |
|---|---|---|---|---|
|  Cora | **0.831 ± 0.004**  | 0.825 ± 0.005 | 4.296s  | 5.172s  |
|  CiteSeer | 0.707 ± 0.005  | **0.715 ± 0.005**  |  4.767s | 5.592s |
|  PubMed |  0.789 ± 0.003 | **0.796 ± 0.004**  | 6.603s  |  7.204s |

with the following run commands:
````
python gat.py --dataset=Cora
python gat.py --dataset=Cora --normalize

python gat.py --dataset=CiteSeer
python gat.py --dataset=CiteSeer --normalize  

python gat.py --dataset=PubMed --lr=0.01 --output_heads=8 --weight_decay=0.001
python gat.py --dataset=PubMed --lr=0.01 --output_heads=8 --weight_decay=0.001 --normalize 
