### PR TITLE
CS224W Project - GMixup data augmentation for graph classification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Added the `use_pcst` option to `WebQSPDataset` ([#9722](https://github.com/pyg-team/pytorch_geometric/pull/9722))
 - Allowed users to pass `edge_weight` to `GraphUNet` models ([#9737](https://github.com/pyg-team/pytorch_geometric/pull/9737))
 - Consolidated `examples/ogbn_{papers_100m,products_gat,products_sage}.py` into `examples/ogbn_train.py` ([#9467](https://github.com/pyg-team/pytorch_geometric/pull/9467))
+- Added `contrib.augmentation.GMixup`and `examples/contrib/gmixup_graph_augmentation.py` ([#9854](https://github.com/pyg-team/pytorch_geometric/pull/9854))
 
 ### Changed
 

--- a/examples/contrib/README.md
+++ b/examples/contrib/README.md
@@ -10,3 +10,4 @@ Modules included here might be moved to the main library in the future.
 | [`rbcd_attack_poisoning.py`](./rbcd_attack_poisoning.py)                           | An example of the RBCD (Resource-Based Critical Data) attack with data poisoning strategies |
 | [`pgm_explainer_node_classification.py`](./pgm_explainer_node_classification.py)   | An example of the PGM (Probabilistic Graphical Model) explainer for node classification     |
 | [`pgm_explainer_graph_classification.py`](./pgm_explainer_graph_classification.py) | An example of the PGM (Probabilistic Graphical Model) explainer for graph classification    |
+| [`gmixup_graph_augmentation.py`](./gmixup_graph_augmentation.py)                   | An example of the G-Mixup graph generator for graph classification data augmentation        |

--- a/examples/contrib/gmixup_graph_augmentation.py
+++ b/examples/contrib/gmixup_graph_augmentation.py
@@ -1,5 +1,5 @@
 """This is an example of using the G-Mixup graph generator for graph
-classification data augmentation
+classification data augmentation.
 """
 import argparse
 
@@ -10,15 +10,15 @@ import torch.nn.functional as F
 import torch_geometric
 import torch_geometric.nn as pyg_nn
 import torch_geometric.utils
-from torch_geometric.data import Dataset, InMemoryDataset
-from torch_geometric.loader import DataLoader
-from torch_geometric.datasets import TUDataset
 from torch_geometric.contrib.augmentation import GMixup
+from torch_geometric.data import Dataset
+from torch_geometric.datasets import TUDataset
+from torch_geometric.loader import DataLoader
 
 
 class GCN(nn.Module):
     def __init__(self, input_dim, output_dim, hidden_dim=64):
-        super(GCN, self).__init__()
+        super().__init__()
         self.gcn = pyg_nn.GCN(
             in_channels=input_dim,
             hidden_channels=hidden_dim,
@@ -30,7 +30,7 @@ class GCN(nn.Module):
     def forward(self, x, edge_index, batch):
         x = self.gcn(x, edge_index)
         return pyg_nn.global_mean_pool(x, batch)
-    
+
     def predict(self, x, edge_index, batch):
         x = self.forward(x, edge_index, batch)
         return torch.argmax(x, dim=1)
@@ -39,21 +39,21 @@ class GCN(nn.Module):
 def create_node_features(dataset: Dataset):
     num_classes = dataset.num_classes
     dataset = list(dataset)
-    # Get node degrees: list of tensors of shape (num_nodes,)
+    # Get node degrees: list of tensors of shape (num_nodes,).
     all_degrees = []
     for graph in dataset:
         all_degrees.append(
-            torch_geometric.utils.degree(graph.edge_index[0], dtype=torch.long)
-        )
+            torch_geometric.utils.degree(graph.edge_index[0],
+                                         dtype=torch.long))
         graph.num_nodes = int(torch.max(graph.edge_index)) + 1
-        # Make labels one-hot
+        # Make labels one-hot.
         graph.y = F.one_hot(graph.y.long(), num_classes=num_classes).float()
     max_degree = max(d.max().item() for d in all_degrees)
-    # If sparse enough, use one-hot
+    # If sparse enough, use one-hot.
     if max_degree < 2000:
         for graph, degrees in zip(dataset, all_degrees):
-            graph.x = F.one_hot(degrees, num_classes=max_degree+1).float()
-    # Else use degree z-score
+            graph.x = F.one_hot(degrees, num_classes=max_degree + 1).float()
+    # Else use degree z-score.
     else:
         std, mean = torch.std_mean(torch.cat(all_degrees).float())
         std, mean = std.item(), mean.item()
@@ -74,9 +74,11 @@ if __name__ == '__main__':
     parser.add_argument('--lr', type=float, default=0.01)
     # GMixup
     parser.add_argument('--vanilla', dest='use_mixup', action='store_false')
+    parser.add_argument('--method', type=str, default='sorted_smooth',
+                        choices=['sorted_smooth', 'usvt'])
     parser.add_argument('--aug-ratio', type=float, default=0.5)
-    parser.add_argument('--interpolation-range',
-                        nargs=2, type=float, default=(0.1,0.2))
+    parser.add_argument('--interpolation-range', nargs=2, type=float,
+                        default=(0.1, 0.2))
     args = parser.parse_args()
 
     torch.manual_seed(args.seed)
@@ -89,65 +91,58 @@ if __name__ == '__main__':
     train = [ds[i] for i in shuffled_indices[:ntrain]]
     test = [ds[i] for i in shuffled_indices[ntrain:]]
     print(f'Train: {len(train)} graphs | Test: {len(test)} graphs')
-
+    num_features = train[0].x.shape[-1]
+    num_classes = train[0].y.shape[-1]
 
     if args.use_mixup:
-        
-        gmixup = GMixup(train)
+
+        gmixup = GMixup(train, method=args.method)
         synthetic = gmixup.generate(
             num_samples=int(len(train) * args.aug_ratio),
             interpolation_range=args.interpolation_range,
         )
         print(f'Generated {len(synthetic)} synthetic graphs')
-        dataloader = DataLoader(
-            train + synthetic,
-            batch_size=args.batch_size,
-            shuffle=True
-        )
+        dataloader = DataLoader(train + synthetic, batch_size=args.batch_size,
+                                shuffle=True)
 
     else:
-        dataloader = DataLoader(
-            train,
-            batch_size=args.batch_size,
-            shuffle=True
-        )
+        dataloader = DataLoader(train, batch_size=args.batch_size,
+                                shuffle=True)
 
     device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
-    model = GCN(ds.num_features, ds.num_classes).to(device).train()
+    model = GCN(num_features, num_classes).to(device).train()
     optimizer = torch.optim.Adam(model.parameters(), lr=args.lr)
-    scheduler = torch.optim.lr_scheduler.StepLR(
-        optimizer, step_size=100, gamma=0.5)
+    scheduler = torch.optim.lr_scheduler.StepLR(optimizer, step_size=100,
+                                                gamma=0.5)
 
-    # Training loop
+    # Training loop.
     for epoch in range(args.epochs):
         total_loss, total_samples = 0, 0
         for batch in dataloader:
             batch = batch.to(device)
             out = model.forward(batch.x, batch.edge_index, batch.batch)
-            # Compute loss
+            # Compute loss.
             loss = F.cross_entropy(out, batch.y)
             total_loss += len(batch) * loss.item()
             total_samples += len(batch)
-            # Backward pass and optimization step
+            # Backward pass and optimization step.
             optimizer.zero_grad()
             loss.backward()
             optimizer.step()
         scheduler.step()
-        
+
         avg_loss = total_loss / total_samples
         print(f'Epoch {epoch+1}/{args.epochs}, Loss: {avg_loss:.4f}')
-    
-    # Evaluate
+
+    # Evaluate.
     model.eval()
     total_correct, total_samples = 0, 0
     for batch in DataLoader(test, args.batch_size):
         batch = batch.to(device)
         out = model.predict(batch.x, batch.edge_index, batch.batch)
-        # Convert one-hot to class indices
+        # Convert one-hot to class indices.
         labels = torch.argmax(batch.y, dim=1)
         total_correct += (out == labels).sum()
         total_samples += len(batch)
     acc = total_correct / total_samples
     print(f'Test Accuracy: {100*acc:.3f}%')
-
-

--- a/examples/contrib/gmixup_graph_augmentation.py
+++ b/examples/contrib/gmixup_graph_augmentation.py
@@ -1,0 +1,173 @@
+"""This is an example of using the G-Mixup graph generator for graph
+classification data augmentation
+"""
+import argparse
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+import torch_geometric
+import torch_geometric.nn as pyg_nn
+import torch_geometric.utils
+from torch_geometric.data import Dataset, InMemoryDataset
+from torch_geometric.loader import DataLoader
+from torch_geometric.datasets import TUDataset
+from torch_geometric.contrib.augmentation import GMixup
+
+
+class GCN(nn.Module):
+    def __init__(self, input_dim, output_dim, hidden_dim=64):
+        super(GCN, self).__init__()
+        self.gcn = pyg_nn.GCN(
+            in_channels=input_dim,
+            hidden_channels=hidden_dim,
+            num_layers=4,
+            out_channels=output_dim,
+            act='relu',
+        )
+
+    def forward(self, x, edge_index, batch):
+        x = self.gcn(x, edge_index)
+        return pyg_nn.global_mean_pool(x, batch)
+    
+    def predict(self, x, edge_index, batch):
+        x = self.forward(x, edge_index, batch)
+        return torch.argmax(x, dim=1)
+
+
+class DatasetFromList(InMemoryDataset):
+    def __init__(self, listOfDataObjects):
+        super().__init__()
+        self.data, self.slices = self.collate(listOfDataObjects)
+    
+    def __getitem__(self, idx):
+        return self.get(idx)
+        
+
+def create_node_features(dataset: Dataset):
+    num_classes = dataset.num_classes
+    dataset = list(dataset)
+    # Get node degrees: list of tensors of shape (num_nodes,)
+    all_degrees = []
+    for graph in dataset:
+        all_degrees.append(
+            torch_geometric.utils.degree(graph.edge_index[0], dtype=torch.long)
+        )
+        graph.num_nodes = int(torch.max(graph.edge_index)) + 1
+        # Make labels one-hot
+        graph.y = F.one_hot(graph.y.long(), num_classes=num_classes).float()
+    max_degree = max(d.max().item() for d in all_degrees)
+    # If sparse enough, use one-hot
+    if max_degree < 2000:
+        for graph, graph_degrees in zip(dataset, all_degrees):
+            graph.x = F.one_hot(graph_degrees, num_classes=max_degree+1).float()
+    # Else use degree z-score
+    else:
+        std, mean = torch.std_mean(torch.cat(all_degrees).float())
+        std, mean = std.item(), mean.item()
+        for graph, graph_degrees in zip(dataset, all_degrees):
+            graph.x = ((graph_degrees - mean) / std).view(-1, 1)
+    dataset = DatasetFromList(dataset)
+    return dataset
+
+
+# TODO: Move?
+def mixup_cross_entropy_loss(input, target, size_average=True):   
+    loss = -torch.sum(input * target)
+    return loss / input.size(0) if size_average else loss
+
+
+if __name__ == '__main__':
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--dataset', type=str, default='IMDB-BINARY')
+    parser.add_argument('--dataset-path', type=str, default='./datasets/')
+    parser.add_argument('--seed', type=int, default=42)
+    # Training
+    parser.add_argument('--batch-size', type=int, default=128)
+    parser.add_argument('--epochs', type=int, default=100)
+    parser.add_argument('--lr', type=float, default=0.01)
+    # GMixup
+    parser.add_argument('--vanilla', dest='use_mixup', action='store_false')
+    parser.add_argument('--aug-ratio', type=float, default=0.5)
+    parser.add_argument('--interpolation-lambda', type=float, default=0.1)
+    args = parser.parse_args()
+
+    torch.manual_seed(args.seed)
+
+    ds = TUDataset(args.dataset_path, args.dataset)
+    ds = create_node_features(ds)
+    ds.print_summary()
+    ntrain = int(0.8 * len(ds))
+    train = ds.index_select(slice(0, ntrain))
+    test = ds.index_select(slice(ntrain, len(ds)))
+    print(f'Train: {len(train)} graphs | Test: {len(test)} graphs')
+
+
+    if args.use_mixup:
+        
+        gmixup = GMixup(train)
+        synthetic = gmixup.generate(
+            aug_ratio=0.5,
+            num_samples=5,
+            interpolation_lambda=args.interpolation_lambda,
+        )
+        print(f'Generated {len(synthetic)} synthetic graphs')
+        dataloader = DataLoader(
+            train + synthetic,
+            batch_size=args.batch_size,
+            shuffle=True
+        )
+        def loss_fn(preds, target):
+            preds = F.log_softmax(preds, dim=1)
+            return mixup_cross_entropy_loss(preds, target)
+
+    else:
+        dataloader = DataLoader(
+            train,
+            batch_size=args.batch_size,
+            shuffle=True
+        )
+        loss_fn = F.cross_entropy
+
+    model = GCN(ds.num_features, ds.num_classes)
+    device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
+    model = model.to(device).train()
+    optimizer = torch.optim.Adam(model.parameters(), lr=args.lr)
+    scheduler = torch.optim.lr_scheduler.StepLR(
+        optimizer, step_size=100, gamma=0.5)
+
+    # Training loop
+    for epoch in range(args.epochs):
+        total_loss, total_samples = 0, 0
+        for batch in dataloader:
+            batch = batch.to(device)
+            out = model.forward(batch.x, batch.edge_index, batch.batch)
+            # Compute loss
+            loss = loss_fn(out, batch.y)
+            total_loss += len(batch) * loss.item()
+            total_samples += len(batch)
+            # Backward pass and optimization step
+            optimizer.zero_grad()
+            loss.backward()
+            optimizer.step()
+        scheduler.step()
+        
+        avg_loss = total_loss / total_samples
+        print(f'Epoch {epoch+1}/{args.epochs}, Loss: {avg_loss:.4f}')
+    
+    # Evaluate
+    model.eval()
+    total_correct, total_samples = 0, 0
+    for batch in DataLoader(test, args.batch_size):
+        batch = batch.to(device)
+        out = model.predict(batch.x, batch.edge_index, batch.batch)
+        # Convert one-hot to class indices
+        labels = torch.argmax(batch.y, dim=1)
+        total_correct += (out == labels).sum()
+        total_samples += len(batch)
+    acc = total_correct / total_samples
+    print(f'Test Accuracy: {100*acc:.3f}%')
+
+

--- a/torch_geometric/contrib/__init__.py
+++ b/torch_geometric/contrib/__init__.py
@@ -4,6 +4,7 @@ import torch_geometric.contrib.transforms  # noqa
 import torch_geometric.contrib.datasets  # noqa
 import torch_geometric.contrib.nn  # noqa
 import torch_geometric.contrib.explain  # noqa
+import torch_geometric.contrib.augmentation  # noqa
 
 warnings.warn(
     "'torch_geometric.contrib' contains experimental code and is subject to "

--- a/torch_geometric/contrib/augmentation/__init__.py
+++ b/torch_geometric/contrib/augmentation/__init__.py
@@ -1,5 +1,3 @@
 from .gmixup import GMixup
 
-__all__ = classes = [
-    'GMixup'
-]
+__all__ = classes = ['GMixup']

--- a/torch_geometric/contrib/augmentation/__init__.py
+++ b/torch_geometric/contrib/augmentation/__init__.py
@@ -1,0 +1,5 @@
+from .gmixup import GMixup
+
+__all__ = classes = [
+    'GMixup'
+]

--- a/torch_geometric/contrib/augmentation/gmixup.py
+++ b/torch_geometric/contrib/augmentation/gmixup.py
@@ -1,0 +1,14 @@
+
+import numpy as np
+import torch
+import torch.nn.functional as F
+# TODO: is this allowed?
+from skimage.restoration import denoise_tv_chambolle
+
+import torch_geometric
+from torch_geometric.data import Data
+from torch_geometric.datasets.graph_generator import GraphGenerator
+
+
+class GMixup(GraphGenerator):
+    pass

--- a/torch_geometric/contrib/augmentation/gmixup.py
+++ b/torch_geometric/contrib/augmentation/gmixup.py
@@ -1,14 +1,268 @@
+from typing import List, Literal, Tuple
 
 import numpy as np
 import torch
 import torch.nn.functional as F
-# TODO: is this allowed?
-from skimage.restoration import denoise_tv_chambolle
+from torch import Tensor
 
-import torch_geometric
-from torch_geometric.data import Data
+from torch_geometric.data import Data, Dataset
 from torch_geometric.datasets.graph_generator import GraphGenerator
 
 
 class GMixup(GraphGenerator):
-    pass
+    r"""The synthetic graph generator from the `"G-Mixup: Graph Data
+    Augmentation for Graph Classification"
+    <https://arxiv.org/abs/2202.07179>_` paper to generate mixup samples for
+    graph classification.
+
+    Args:
+        dataset (torch_geometric.data.Dataset): A graph classification dataset
+            for computing class graphons.
+        method (str): The method to use for graphon estimation, either
+            :obj:`"sorted_smooth"` (sorted smoothing method) or :obj:`"usvt"`
+            (SVD-based thresholding method). Defaults to
+            :obj:`"sorted_smooth"`.
+    """
+    def __init__(self, dataset: Dataset,
+                 method: Literal['sorted_smooth', 'usvt'] = 'sorted_smooth', *,
+                 sorted_smooth_h: int = 5, usvt_threshold: float = 2.02):
+        super().__init__()
+        self.sorted_smooth_h = sorted_smooth_h
+        self.usvt_threshold = usvt_threshold
+
+        # Partition into classes.
+        class_graphs = {}
+        for graph in dataset:
+            if graph.y.numel() == 1:
+                raise RuntimeError('graph labels must be one-hot vectors')
+            label = tuple(graph.y.squeeze().tolist())
+            if label not in class_graphs:
+                class_graphs[label] = []
+            class_graphs[label].append(graph)
+
+        # Estimate graphons from classes.
+        self.class_graphons = {}
+        self.class_features = {}
+        for label, graphs in class_graphs.items():
+            features_list = [graph.x for graph in graphs]
+            graphon, features = self.estimate_graphon(graphs, features_list,
+                                                      method)
+            self.class_graphons[label] = graphon
+            self.class_features[label] = features
+
+        # Pad graphons to the same size.
+        num_nodes = max(f.shape[0] for f in self.class_features.values())
+        for label, graphon in self.class_graphons.items():
+            self.class_graphons[label] = self.pad_adjacency(graphon, num_nodes)
+        for label, features in self.class_features.items():
+            self.class_features[label] = self.pad_features(features, num_nodes)
+
+        # Create mapping of idx -> label for fast class sampling.
+        self.label_lookup = {
+            i: l
+            for i, l in enumerate(self.class_graphons.keys())
+        }
+
+    def __call__(self, interpolation_lambda: float) -> Data:
+        r"""Equivalent to :obj:`self.sample`."""
+        return self.sample(interpolation_lambda)
+
+    def align_nodes(self, graph: Data, original_features: Tensor):
+        r"""Aligns nodes and node features by sorting by degree."""
+        edge_index = graph.edge_index
+        num_nodes = graph.num_nodes
+
+        node_degrees = torch.bincount(edge_index[0], minlength=num_nodes)
+        sorted_indices = torch.argsort(node_degrees, descending=True)
+
+        adjacency_matrix = torch.zeros((num_nodes, num_nodes))
+        adjacency_matrix[edge_index[0], edge_index[1]] = 1
+
+        aligned_matrix = adjacency_matrix[sorted_indices][:, sorted_indices]
+        aligned_features = original_features[sorted_indices]
+        return aligned_matrix, aligned_features
+
+    def estimate_graphon(
+            self, graphs: List[Data], features_list: List[Tensor],
+            method: str = "sorted_smooth") -> Tuple[Tensor, Tensor]:
+        r"""Takes a set of graphs, returns an approximation of the graphon for
+        that set of graphs. Uses one of two methods:
+            "usvt": SVD-based thresholding method
+            "sorted_smooth": Sorted smooth method.
+        """
+        aligned_adjacency = []
+        aligned_features = []
+        for graph, features in zip(graphs, features_list):
+            aligned_mat, aligned_feat = self.align_nodes(graph, features)
+            aligned_adjacency.append(aligned_mat)
+            aligned_features.append(aligned_feat)
+
+        # Pad adjacency and features to the maximum size.
+        max_nodes = max(features.shape[0] for features in aligned_features)
+        aligned_features = [
+            self.pad_features(features, max_nodes)
+            for features in aligned_features
+        ]
+        aligned_adjacency = [
+            self.pad_adjacency(m, max_nodes) for m in aligned_adjacency
+        ]
+        # Use sum instead of stack+mean to reduce memory usage from copying.
+        graphon_features = sum(aligned_features) / len(aligned_features)
+        mean_adjacency = sum(aligned_adjacency) / len(aligned_adjacency)
+
+        if method == "usvt":
+            graphon = self.universal_svd(mean_adjacency,
+                                         threshold=self.usvt_threshold)
+            return graphon, graphon_features
+        elif method == "sorted_smooth":
+            graphon = self.sorted_smooth(mean_adjacency,
+                                         h=self.sorted_smooth_h)
+            return graphon, graphon_features
+        else:
+            raise ValueError(f"Unknown graphon estimation method: {method}")
+
+    def generate(self, num_samples: int,
+                 interpolation_range: Tuple[float, float]) -> List[Data]:
+        r"""Generates synthetic graphs with aligned node features for data
+        augmentation.
+
+        Args:
+            num_samples (int): Number of synthetic graphs to generate.
+            interpolation_range (Tuple[float, float]): a low and high value
+                for interpolation
+        """
+        synthetic_graphs = []
+        low = interpolation_range[0]
+        high = interpolation_range[1]
+        for _ in range(num_samples):
+            interp_lambda = low + (high - low) * torch.rand(1)
+            graph = self.sample(interp_lambda)
+            synthetic_graphs.append(graph)
+        return synthetic_graphs
+
+    def sample(self, interpolation_lambda: float) -> Data:
+        r"""Generates one synthetic graph with aligned node features for data
+        augmentation.
+
+        Args:
+            interpolation_lambda (float): Interpolation factor between
+                graphons, features, and labels.
+        """
+        class1, class2 = np.random.choice(len(self.class_graphons), size=2,
+                                          replace=False)
+        label1 = self.label_lookup[class1]
+        label2 = self.label_lookup[class2]
+        graphon1 = self.class_graphons[label1]
+        graphon2 = self.class_graphons[label2]
+        features1 = self.class_features[label1]
+        features2 = self.class_features[label2]
+
+        mixed_graphon = self.mixup(graphon1, graphon2, interpolation_lambda)
+        mixed_features = self.mixup(features1, features2, interpolation_lambda)
+        label1 = torch.tensor(label1).to(mixed_graphon.device)
+        label2 = torch.tensor(label2).to(mixed_graphon.device)
+        mixed_label = self.mixup(label1, label2, interpolation_lambda)
+
+        graph = self.generate_from_graphon(mixed_graphon, mixed_features)
+        graph.y = mixed_label.unsqueeze(0)
+        return graph
+
+    def pad_features(self, features: Tensor, target_size: int) -> Tensor:
+        r"""Pads the node features to the target size."""
+        if not isinstance(features, torch.Tensor):
+            features = torch.tensor(features, dtype=torch.float)
+        num_nodes, num_features = features.shape
+        if num_nodes >= target_size:
+            return features
+        padded_features = torch.zeros((target_size, num_features),
+                                      dtype=features.dtype)
+        padded_features[:num_nodes, :] = features
+        return padded_features
+
+    def pad_adjacency(self, adj: torch.Tensor, target_size: int) -> Tensor:
+        r"""Pads the adjacency matrix to the target size."""
+        if not isinstance(adj, torch.Tensor):
+            adj = torch.tensor(adj, dtype=torch.float)
+        num_nodes = adj.shape[-1]
+        padded_adj = torch.zeros((target_size, target_size), dtype=adj.dtype)
+        padded_adj[:num_nodes, :num_nodes] = adj
+        return padded_adj
+
+    def mixup(self, tensor1: Tensor, tensor2: Tensor,
+              interpolation_lambda: float) -> Tensor:
+        r"""Interpolates between two tensors (ex. graphon, feature, label)
+        based on an interpolation factor.
+        """
+        assert 0 <= interpolation_lambda <= 1, \
+            "lambda should be in the range [0, 1]"
+        return interpolation_lambda * tensor1 + \
+            (1 - interpolation_lambda) * tensor2
+
+    def generate_from_graphon(self, graphon: Tensor,
+                              graphon_features: Tensor) -> Data:
+        r"""Generates a synthetic graph from a graphon matrix and assigns
+        node features.
+        """
+        num_nodes = graphon.shape[0]
+
+        # generate adjacency matrix from graphon
+        adjacency_matrix = (torch.rand(num_nodes, num_nodes) < graphon)
+        adjacency_matrix = torch.triu(adjacency_matrix).to(torch.float32)
+
+        # make the matrix symmetric
+        adjacency_matrix += (adjacency_matrix.T -
+                             torch.diag(torch.diag(adjacency_matrix)))
+
+        edge_index = adjacency_matrix.nonzero(as_tuple=False).t()
+        if not isinstance(graphon_features, torch.Tensor):
+            graphon_features = torch.tensor(graphon_features,
+                                            dtype=torch.float)
+
+        synthetic_graph = Data(edge_index=edge_index)
+        synthetic_graph.num_nodes = num_nodes
+        synthetic_graph.x = graphon_features.clone().detach()
+
+        return synthetic_graph
+
+    def universal_svd(self, adj_matrix: Tensor,
+                      threshold: float = 2.02) -> Tensor:
+        r"""Estimate a graphon by universal singular value thresholding.
+        Reference:
+        Chatterjee, Sourav.
+        "Matrix estimation by universal singular value thresholding."
+        The Annals of Statistics 43.1 (2015): 177-214.
+        """
+        num_nodes = adj_matrix.size(0)
+        u, s, v = torch.svd(adj_matrix)
+        singular_threshold = threshold * (num_nodes**0.5)
+        # Zero out singular values below threshold.
+        s[s < singular_threshold] = 0
+        graphon = u @ torch.diag(s) @ v.t()
+        graphon = torch.clamp(graphon, min=0, max=1)
+        return graphon
+
+    def sorted_smooth(self, mean_adjacency: Tensor, h: int = 5) -> Tensor:
+        r"""Implement the sorted_smooth method. This first averages the
+        aligned graphs and then applies a block-averaging via a convolutional
+        operation. Finally, it applies total variation denoising to produce a
+        smooth graphon estimate.
+        """
+        try:
+            from skimage.restoration import denoise_tv_chambolle
+        except ImportError:
+            raise RuntimeError('sorted_smooth method requires scikit-image')
+        num_nodes = mean_adjacency.shape[-1]
+        mean_adjacency = mean_adjacency.reshape(1, 1, num_nodes, num_nodes)
+
+        # Uniform kernel for block-averaging.
+        kernel = torch.ones(1, 1, h, h) / (h**2)
+        graphon = F.conv2d(mean_adjacency, kernel, padding=0, stride=h,
+                           bias=None)
+        graphon = graphon[0, 0, :, :].numpy()
+
+        # Apply TV denoising (https://www.ipol.im/pub/art/2013/61/article.pdf).
+        graphon = denoise_tv_chambolle(graphon, weight=h)
+
+        graphon = torch.tensor(graphon, dtype=torch.float32)
+        graphon = torch.clamp(graphon, min=0, max=1)
+        return graphon


### PR DESCRIPTION
An implementation of [G-Mixup](https://arxiv.org/abs/2202.07179) data augmentation for graph classification in the `torch_geometric.contrib` module. This PR does the following:

- Adds new `torch_geometric.contrib.augmentation.GMixup` class derived from `GraphGenerator`. Supports `'sorted_smooth'` and `'usvt'` graphon estimation methods.
- Adds example file `examples/contrib/gmixup_graph_augmentation.py`
- Updates `README`s accordingly

This implementation estimates graphons using a graph classification dataset as input:
```py
dataset = Dataset(...)
gmixup = GMixup(dataset, method='sorted_smooth')
```

Graphs can then be sampled just like any other `GraphGenerator` with a mixup parameter `interpolation_lambda`:
```py
sampled_graph = gmixup(interpolation_lambda=0.1)
```

Alternatively, a batch of graphs can be sampled using the `generate` method with randomized mixup factors:
```py
sampled_graphs = gmixup.generate(num_samples=100, interpolation_range=(0.1, 0.2))
```