### PR TITLE
CS224W: Add TransD KGE model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Added the `use_pcst` option to `WebQSPDataset` ([#9722](https://github.com/pyg-team/pytorch_geometric/pull/9722))
 - Allowed users to pass `edge_weight` to `GraphUNet` models ([#9737](https://github.com/pyg-team/pytorch_geometric/pull/9737))
 - Consolidated `examples/ogbn_{papers_100m,products_gat,products_sage}.py` into `examples/ogbn_train.py` ([#9467](https://github.com/pyg-team/pytorch_geometric/pull/9467))
+- Added the `TransD` KGE model ([#9858](https://github.com/pyg-team/pytorch_geometric/pull/9858))
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -279,6 +279,7 @@ Unlike simple stacking of GNN layers, these models could involve pre-processing,
 - **[ComplEx](https://pytorch-geometric.readthedocs.io/en/latest/generated/torch_geometric.nn.kge.ComplEx.html)** from Trouillon *et al.*: [Complex Embeddings for Simple Link Prediction](https://arxiv.org/abs/1606.06357) (ICML 2016) \[[**Example**](https://github.com/pyg-team/pytorch_geometric/blob/master/examples/kge_fb15k_237.py)\]
 - **[DistMult](https://pytorch-geometric.readthedocs.io/en/latest/generated/torch_geometric.nn.kge.DistMult.html)** from Yang *et al.*: [Embedding Entities and Relations for Learning and Inference in Knowledge Bases](https://arxiv.org/abs/1412.6575) (ICLR 2015) \[[**Example**](https://github.com/pyg-team/pytorch_geometric/blob/master/examples/kge_fb15k_237.py)\]
 - **[RotatE](https://pytorch-geometric.readthedocs.io/en/latest/generated/torch_geometric.nn.kge.RotatE.html)** from Sun *et al.*: [RotatE: Knowledge Graph Embedding by Relational Rotation in Complex Space](https://arxiv.org/abs/1902.10197) (ICLR 2019) \[[**Example**](https://github.com/pyg-team/pytorch_geometric/blob/master/examples/kge_fb15k_237.py)\]
+- **[TransD](https://pytorch-geometric.readthedocs.io/en/latest/generated/torch_geometric.nn.kge.TransD.html)** from Ji *et al.*: [Knowledge Graph Embedding via Dynamic Mapping Matrix](https://aclanthology.org/P15-1067.pdf) (ACL 2015) \[[**Example**](https://github.com/pyg-team/pytorch_geometric/blob/master/examples/kge_fb15k_237.py)\]
 
 </details>
 

--- a/examples/kge_fb15k_237.py
+++ b/examples/kge_fb15k_237.py
@@ -5,13 +5,14 @@ import torch
 import torch.optim as optim
 
 from torch_geometric.datasets import FB15k_237
-from torch_geometric.nn import ComplEx, DistMult, RotatE, TransE
+from torch_geometric.nn import ComplEx, DistMult, RotatE, TransD, TransE
 
 model_map = {
     'transe': TransE,
     'complex': ComplEx,
     'distmult': DistMult,
     'rotate': RotatE,
+    'transd': TransD,
 }
 
 parser = argparse.ArgumentParser()
@@ -47,6 +48,7 @@ optimizer_map = {
     'complex': optim.Adagrad(model.parameters(), lr=0.001, weight_decay=1e-6),
     'distmult': optim.Adam(model.parameters(), lr=0.0001, weight_decay=1e-6),
     'rotate': optim.Adam(model.parameters(), lr=1e-3),
+    'transd': optim.Adam(model.parameters(), lr=0.01),
 }
 optimizer = optimizer_map[args.model]
 

--- a/test/nn/kge/test_transd.py
+++ b/test/nn/kge/test_transd.py
@@ -1,0 +1,25 @@
+import torch
+
+from torch_geometric.nn import TransD
+
+
+def test_transe():
+    model = TransD(num_nodes=10, num_relations=5, hidden_channels=32)
+    assert str(model) == 'TransD(10, num_relations=5, hidden_channels=32)'
+
+    head_index = torch.tensor([0, 2, 4, 6, 8])
+    rel_type = torch.tensor([0, 1, 2, 3, 4])
+    tail_index = torch.tensor([1, 3, 5, 7, 9])
+
+    loader = model.loader(head_index, rel_type, tail_index, batch_size=5)
+    for h, r, t in loader:
+        out = model(h, r, t)
+        assert out.size() == (5, )
+
+        loss = model.loss(h, r, t)
+        assert loss >= 0.
+
+        mean_rank, mrr, hits = model.test(h, r, t, batch_size=5, log=False)
+        assert 0 <= mean_rank <= 10
+        assert 0 < mrr <= 1
+        assert hits == 1.0

--- a/torch_geometric/nn/kge/__init__.py
+++ b/torch_geometric/nn/kge/__init__.py
@@ -5,6 +5,7 @@ from .transe import TransE
 from .complex import ComplEx
 from .distmult import DistMult
 from .rotate import RotatE
+from .transd import TransD
 
 __all__ = classes = [
     'KGEModel',
@@ -12,4 +13,5 @@ __all__ = classes = [
     'ComplEx',
     'DistMult',
     'RotatE',
+    'TransD',
 ]

--- a/torch_geometric/nn/kge/transd.py
+++ b/torch_geometric/nn/kge/transd.py
@@ -1,0 +1,145 @@
+import torch
+import torch.nn.functional as F
+from torch import Tensor
+from torch.nn import Embedding
+
+from torch_geometric.nn.kge import KGEModel
+
+
+class TransD(KGEModel):
+    r"""The TransD model from the `"Knowledge Graph Embedding via Dynamic
+    Mapping Matrix" <https://aclanthology.org/P15-1067.pdf>`_ paper.
+
+    :class:`TransD` projects head and tail to relation embedding space with
+    dynamic mapping matrix constructed from node projection vector and relation
+    projection vector as:
+
+    .. math::
+        \mathbf{h}_\perp = \mathbf{h}_p^T\mathbf{h}\mathbf{r}_p +
+        \mathbf{I}\mathbf{h}
+
+        \mathbf{t}_\perp = \mathbf{t}_p^T\mathbf{t}\mathbf{r}_p +
+        \mathbf{I}\mathbf{t}
+
+    It then models the relations as a translation from projected heads
+    to projected tails in relation embedding space.
+
+    .. math::
+        \mathbf{h}_\perp + \mathbf{r} \approx \mathbf{t}_\perp,
+
+    resulting in the scoring function:
+
+    .. math::
+        d(h, r, t) = - {\| \mathbf{h}_\perp + \mathbf{r} - \mathbf{t}_\perp
+        \|}_p
+
+    .. note::
+
+        For an example of using the :class:`TransD` model, see
+        `examples/kge_fb15k_237.py
+        <https://github.com/pyg-team/pytorch_geometric/blob/master/examples/
+        kge_fb15k_237.py>`_.
+
+    Args:
+        num_nodes (int): The number of nodes/entities in the graph.
+        num_relations (int): The number of relations in the graph.
+        hidden_channels (int): The hidden embedding size.
+        margin (int, optional): The margin of the ranking loss.
+            (default: :obj:`1.0`)
+        p_norm (int, optional): The order embedding and distance normalization.
+            (default: :obj:`1.0`)
+        sparse (bool, optional): If set to :obj:`True`, gradients w.r.t. to the
+            embedding matrices will be sparse. (default: :obj:`False`)
+    """
+    def __init__(
+        self,
+        num_nodes: int,
+        num_relations: int,
+        hidden_channels: int,
+        margin: float = 1.0,
+        p_norm: float = 1.0,
+        sparse: bool = False,
+    ):
+        super().__init__(num_nodes, num_relations, hidden_channels, sparse)
+
+        self.p_norm = p_norm
+        self.margin = margin
+
+        self.node_proj_emb = Embedding(num_nodes, hidden_channels,
+                                       sparse=sparse)
+        self.rel_proj_emb = Embedding(num_relations, hidden_channels,
+                                      sparse=sparse)
+
+        self.reset_parameters()
+
+    def reset_parameters(self):
+        torch.nn.init.xavier_uniform_(self.node_emb.weight)
+        torch.nn.init.xavier_uniform_(self.node_proj_emb.weight)
+        torch.nn.init.xavier_uniform_(self.rel_emb.weight)
+        torch.nn.init.xavier_uniform_(self.rel_proj_emb.weight)
+
+    def forward(
+        self,
+        head_index: Tensor,
+        rel_type: Tensor,
+        tail_index: Tensor,
+    ) -> Tensor:
+        head = self.node_emb(head_index)
+        rel = self.rel_emb(rel_type)
+        tail = self.node_emb(tail_index)
+
+        head = F.normalize(head, p=self.p_norm, dim=-1)
+        rel = F.normalize(rel, p=self.p_norm, dim=-1)
+        tail = F.normalize(tail, p=self.p_norm, dim=-1)
+
+        # Project head and tail to relation embedding space.
+        head_proj = project_vector_ops(head, self.node_proj_emb(head_index),
+                                       self.rel_proj_emb(rel_type))
+        tail_proj = project_vector_ops(tail, self.node_proj_emb(tail_index),
+                                       self.rel_proj_emb(rel_type))
+
+        head_proj = F.normalize(head_proj, p=self.p_norm, dim=-1)
+        tail_proj = F.normalize(tail_proj, p=self.p_norm, dim=-1)
+
+        return -((head_proj + rel) - tail_proj).norm(p=self.p_norm, dim=-1)
+
+    def loss(
+        self,
+        head_index: Tensor,
+        rel_type: Tensor,
+        tail_index: Tensor,
+    ) -> Tensor:
+
+        pos_score = self(head_index, rel_type, tail_index)
+        neg_score = self(*self.random_sample(head_index, rel_type, tail_index))
+
+        return F.margin_ranking_loss(
+            pos_score,
+            neg_score,
+            target=torch.ones_like(pos_score),
+            margin=self.margin,
+        )
+
+
+def project_vector_ops(
+    node_emb: Tensor,
+    node_proj_emb: Tensor,
+    rel_proj_emb: Tensor,
+) -> Tensor:
+    r"""Compute the projected vector of the node.
+
+    .. math::
+        \mathbf{v}_\perp = \mathbf{v}_p^T\mathbf{v}\mathbf{r}_p +
+        \mathbf{I}\mathbf{v}
+
+    Args:
+        node_emb (Tensor): The node embedding.
+        node_proj_emb (Tensor): The node projection embedding.
+        rel_proj_emb (Tensor): The relation projection embedding.
+
+    Returns:
+        Tensor: The projected vector of node to relation embedding space.
+    """
+    out = (node_emb * node_proj_emb).sum(dim=-1).reshape(-1, 1)
+    out = out * rel_proj_emb + node_emb
+    return out


### PR DESCRIPTION
Add `TransD` KGE model as per paper [Knowledge Graph Embedding via Dynamic Mapping Matrix](https://aclanthology.org/P15-1067.pdf).

`TransD` model is improvement over other translation models, such as TransE, TransH and TransR.  It uses dynamic mapping matrix which takes account of both node and relation type instead of share same mapping Matrix which only focus on relation type.

Note: This is additional PR for the course not related to final project.