### PR TITLE
Add target threshold to explainer's config params.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Added the `use_pcst` option to `WebQSPDataset` ([#9722](https://github.com/pyg-team/pytorch_geometric/pull/9722))
 - Allowed users to pass `edge_weight` to `GraphUNet` models ([#9737](https://github.com/pyg-team/pytorch_geometric/pull/9737))
 - Consolidated `examples/ogbn_{papers_100m,products_gat,products_sage}.py` into `examples/ogbn_train.py` ([#9467](https://github.com/pyg-team/pytorch_geometric/pull/9467))
+- Added optional threshold parameter to the config for explainer's `get_target` method ([#9865](https://github.com/pyg-team/pytorch_geometric/pull/9865))
 
 ### Changed
 

--- a/test/explain/algorithm/test_gnn_explainer.py
+++ b/test/explain/algorithm/test_gnn_explainer.py
@@ -75,6 +75,7 @@ edge_index = torch.tensor([
 edge_attr = torch.randn(edge_index.size(1), 5)
 batch = torch.tensor([0, 0, 0, 1, 1, 2, 2, 2])
 edge_label_index = torch.tensor([[0, 1, 2], [3, 4, 5]])
+prediction_threshold=[None, -1, 0.2, 0.5, 1.0, 5]
 
 
 @pytest.mark.parametrize('Conv', [GCNConv, TransformerConv])
@@ -87,6 +88,7 @@ edge_label_index = torch.tensor([[0, 1, 2], [3, 4, 5]])
     ModelReturnType.raw,
 ])
 @pytest.mark.parametrize('index', indices)
+@pytest.mark.parametrize('prediction_threshold', prediction_threshold)
 def test_gnn_explainer_binary_classification(
     Conv,
     edge_mask_type,
@@ -95,12 +97,14 @@ def test_gnn_explainer_binary_classification(
     task_level,
     return_type,
     index,
+    prediction_threshold,
     check_explanation,
 ):
     model_config = ModelConfig(
         mode='binary_classification',
         task_level=task_level,
         return_type=return_type,
+        prediction_threshold=prediction_threshold,
     )
 
     model = GNN(Conv, model_config)
@@ -149,6 +153,7 @@ def test_gnn_explainer_binary_classification(
     ModelReturnType.raw,
 ])
 @pytest.mark.parametrize('index', indices)
+@pytest.mark.parametrize('prediction_threshold', prediction_threshold)
 def test_gnn_explainer_multiclass_classification(
     Conv,
     edge_mask_type,
@@ -157,12 +162,14 @@ def test_gnn_explainer_multiclass_classification(
     task_level,
     return_type,
     index,
+    prediction_threshold,
     check_explanation,
 ):
     model_config = ModelConfig(
         mode='multiclass_classification',
         task_level=task_level,
         return_type=return_type,
+        prediction_threshold=prediction_threshold,
     )
 
     model = GNN(Conv, model_config)
@@ -202,6 +209,7 @@ def test_gnn_explainer_multiclass_classification(
 @pytest.mark.parametrize('explanation_type', explanation_types)
 @pytest.mark.parametrize('task_level', task_levels)
 @pytest.mark.parametrize('index', indices)
+@pytest.mark.parametrize('prediction_threshold', prediction_threshold)
 def test_gnn_explainer_regression(
     Conv,
     edge_mask_type,
@@ -209,11 +217,13 @@ def test_gnn_explainer_regression(
     explanation_type,
     task_level,
     index,
+    prediction_threshold,
     check_explanation,
 ):
     model_config = ModelConfig(
         mode='regression',
         task_level=task_level,
+        prediction_threshold=prediction_threshold,
     )
 
     model = GNN(Conv, model_config)

--- a/test/explain/algorithm/test_gnn_explainer.py
+++ b/test/explain/algorithm/test_gnn_explainer.py
@@ -75,7 +75,7 @@ edge_index = torch.tensor([
 edge_attr = torch.randn(edge_index.size(1), 5)
 batch = torch.tensor([0, 0, 0, 1, 1, 2, 2, 2])
 edge_label_index = torch.tensor([[0, 1, 2], [3, 4, 5]])
-prediction_threshold=[None, -1, 0.2, 0.5, 1.0, 5]
+prediction_threshold = [None, -1, 0.2, 0.5, 1.0, 5]
 
 
 @pytest.mark.parametrize('Conv', [GCNConv, TransformerConv])

--- a/torch_geometric/explain/config.py
+++ b/torch_geometric/explain/config.py
@@ -132,6 +132,11 @@ class ModelConfig(CastMixin):
                 - :obj:`"edge"`: An edge-level prediction model.
 
                 - :obj:`"graph"`: A graph-level prediction model.
+                
+        prediction_threshold (float): The number used as a threshold 
+            to obtain the target from the explained model.
+            Defaults to 0.5 for :obj:`"binary_classification"` and 
+            0.0 for :obj:`"multiclass_classification"`.
 
         return_type (ModelReturnType or str, optional): The return type of the
             model. The possible values are (default: :obj:`None`):
@@ -145,21 +150,33 @@ class ModelConfig(CastMixin):
     mode: ModelMode
     task_level: ModelTaskLevel
     return_type: ModelReturnType
+    prediction_threshold: float
 
     def __init__(
         self,
         mode: Union[ModelMode, str],
         task_level: Union[ModelTaskLevel, str],
         return_type: Optional[Union[ModelReturnType, str]] = None,
+        prediction_threshold: Optional[float] = None
     ):
         self.mode = ModelMode(mode)
         self.task_level = ModelTaskLevel(task_level)
 
         if return_type is None and self.mode == ModelMode.regression:
             return_type = ModelReturnType.raw
-
+        
         self.return_type = ModelReturnType(return_type)
-
+        
+        if prediction_threshold is None and return_type == ModelReturnType.probs:
+            prediction_threshold = 0.5
+        elif prediction_threshold is None and return_type == ModelReturnType.raw:
+            prediction_threshold = 0.0
+        elif prediction_threshold is None and return_type == ModelReturnType.log_probs:
+            prediction_threshold = -1.0
+        else:
+            prediction_threshold = 0.5
+        
+        self.prediction_threshold = prediction_threshold
         if (self.mode == ModelMode.regression
                 and self.return_type != ModelReturnType.raw):
             raise ValueError(f"A model for regression needs to return raw "

--- a/torch_geometric/explain/config.py
+++ b/torch_geometric/explain/config.py
@@ -165,11 +165,14 @@ class ModelConfig(CastMixin):
 
         self.return_type = ModelReturnType(return_type)
 
-        if prediction_threshold is None and return_type == ModelReturnType.probs:
+        if (prediction_threshold is None 
+            and return_type == ModelReturnType.probs):
             prediction_threshold = 0.5
-        elif prediction_threshold is None and return_type == ModelReturnType.raw:
+        elif (prediction_threshold is None 
+              and return_type == ModelReturnType.raw):
             prediction_threshold = 0.0
-        elif prediction_threshold is None and return_type == ModelReturnType.log_probs:
+        elif (prediction_threshold is None 
+              and return_type == ModelReturnType.log_probs):
             prediction_threshold = -1.0
         else:
             prediction_threshold = 0.5

--- a/torch_geometric/explain/config.py
+++ b/torch_geometric/explain/config.py
@@ -165,13 +165,13 @@ class ModelConfig(CastMixin):
 
         self.return_type = ModelReturnType(return_type)
 
-        if (prediction_threshold is None 
-            and return_type == ModelReturnType.probs):
+        if (prediction_threshold is None
+                and return_type == ModelReturnType.probs):
             prediction_threshold = 0.5
-        elif (prediction_threshold is None 
+        elif (prediction_threshold is None
               and return_type == ModelReturnType.raw):
             prediction_threshold = 0.0
-        elif (prediction_threshold is None 
+        elif (prediction_threshold is None
               and return_type == ModelReturnType.log_probs):
             prediction_threshold = -1.0
         else:

--- a/torch_geometric/explain/config.py
+++ b/torch_geometric/explain/config.py
@@ -132,10 +132,10 @@ class ModelConfig(CastMixin):
                 - :obj:`"edge"`: An edge-level prediction model.
 
                 - :obj:`"graph"`: A graph-level prediction model.
-                
-        prediction_threshold (float): The number used as a threshold 
+
+        prediction_threshold (float): The number used as a threshold
             to obtain the target from the explained model.
-            Defaults to 0.5 for :obj:`"binary_classification"` and 
+            Defaults to 0.5 for :obj:`"binary_classification"` and
             0.0 for :obj:`"multiclass_classification"`.
 
         return_type (ModelReturnType or str, optional): The return type of the
@@ -152,21 +152,19 @@ class ModelConfig(CastMixin):
     return_type: ModelReturnType
     prediction_threshold: float
 
-    def __init__(
-        self,
-        mode: Union[ModelMode, str],
-        task_level: Union[ModelTaskLevel, str],
-        return_type: Optional[Union[ModelReturnType, str]] = None,
-        prediction_threshold: Optional[float] = None
-    ):
+    def __init__(self, mode: Union[ModelMode,
+                                   str], task_level: Union[ModelTaskLevel,
+                                                           str],
+                 return_type: Optional[Union[ModelReturnType, str]] = None,
+                 prediction_threshold: Optional[float] = None):
         self.mode = ModelMode(mode)
         self.task_level = ModelTaskLevel(task_level)
 
         if return_type is None and self.mode == ModelMode.regression:
             return_type = ModelReturnType.raw
-        
+
         self.return_type = ModelReturnType(return_type)
-        
+
         if prediction_threshold is None and return_type == ModelReturnType.probs:
             prediction_threshold = 0.5
         elif prediction_threshold is None and return_type == ModelReturnType.raw:
@@ -175,7 +173,7 @@ class ModelConfig(CastMixin):
             prediction_threshold = -1.0
         else:
             prediction_threshold = 0.5
-        
+
         self.prediction_threshold = prediction_threshold
         if (self.mode == ModelMode.regression
                 and self.return_type != ModelReturnType.raw):

--- a/torch_geometric/explain/explainer.py
+++ b/torch_geometric/explain/explainer.py
@@ -20,7 +20,6 @@ from torch_geometric.explain.config import (
     MaskType,
     ModelConfig,
     ModelMode,
-    ModelReturnType,
     ThresholdConfig,
 )
 from torch_geometric.typing import EdgeType, NodeType
@@ -260,7 +259,8 @@ class Explainer:
         predicted class label.
         """
         if self.model_config.mode == ModelMode.binary_classification:
-            return (prediction > self.model_config.prediction_threshold).long().view(-1)
+            return (prediction
+                    > self.model_config.prediction_threshold).long().view(-1)
 
         if self.model_config.mode == ModelMode.multiclass_classification:
             return prediction.argmax(dim=-1)

--- a/torch_geometric/explain/explainer.py
+++ b/torch_geometric/explain/explainer.py
@@ -260,12 +260,7 @@ class Explainer:
         predicted class label.
         """
         if self.model_config.mode == ModelMode.binary_classification:
-            # TODO: Allow customization of the thresholds used below.
-            if self.model_config.return_type == ModelReturnType.raw:
-                return (prediction > 0).long().view(-1)
-            if self.model_config.return_type == ModelReturnType.probs:
-                return (prediction > 0.5).long().view(-1)
-            assert False
+            return (prediction > self.model_config.prediction_threshold).long().view(-1)
 
         if self.model_config.mode == ModelMode.multiclass_classification:
             return prediction.argmax(dim=-1)


### PR DESCRIPTION
Added optional threshold parameter to the config for explainer's get_target method. 