### PR TITLE
CS224W - Adds TransD KGE, and Bernoulli corruption strategy for all KGE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
-- Add TransD KGE and Bernoulli corruption ([#9864](https://github.com/pyg-team/pytorch_geometric/pull/9864))
+- Add TransD KGE and Bernoulli corruption ([#9866](https://github.com/pyg-team/pytorch_geometric/pull/9866))
 - Update Dockerfile to use latest from NVIDIA ([#9794](https://github.com/pyg-team/pytorch_geometric/pull/9794))
 - Added various GRetriever Architecture Benchmarking examples ([#9666](https://github.com/pyg-team/pytorch_geometric/pull/9666))
 - Added `profiler.nvtxit` with some examples ([#9666](https://github.com/pyg-team/pytorch_geometric/pull/9666))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- Add TransD KGE and Bernoulli corruption ([#9864](https://github.com/pyg-team/pytorch_geometric/pull/9864))
 - Update Dockerfile to use latest from NVIDIA ([#9794](https://github.com/pyg-team/pytorch_geometric/pull/9794))
 - Added various GRetriever Architecture Benchmarking examples ([#9666](https://github.com/pyg-team/pytorch_geometric/pull/9666))
 - Added `profiler.nvtxit` with some examples ([#9666](https://github.com/pyg-team/pytorch_geometric/pull/9666))

--- a/examples/kge_fb15k_237.py
+++ b/examples/kge_fb15k_237.py
@@ -37,7 +37,6 @@ model_arg_map['transd'] = {
     'bern': args.bern,
 }
 
-model_arg_map.update()
 model = model_map[args.model](
     num_nodes=train_data.num_nodes,
     num_relations=train_data.num_edge_types,

--- a/test/nn/kge/test_complex.py
+++ b/test/nn/kge/test_complex.py
@@ -1,3 +1,4 @@
+import pytest
 import torch
 
 from torch_geometric.nn import ComplEx
@@ -37,8 +38,10 @@ def test_complex_scoring():
     assert score.tolist() == [58., 8.]
 
 
-def test_complex():
-    model = ComplEx(num_nodes=10, num_relations=5, hidden_channels=32)
+@pytest.mark.parametrize('bern', [False, True])
+def test_complex(bern):
+    model = ComplEx(num_nodes=10, num_relations=5, hidden_channels=32,
+                    bern=bern)
     assert str(model) == 'ComplEx(10, num_relations=5, hidden_channels=32)'
 
     head_index = torch.tensor([0, 2, 4, 6, 8])

--- a/test/nn/kge/test_distmult.py
+++ b/test/nn/kge/test_distmult.py
@@ -1,10 +1,13 @@
+import pytest
 import torch
 
 from torch_geometric.nn import DistMult
 
 
-def test_distmult():
-    model = DistMult(num_nodes=10, num_relations=5, hidden_channels=32)
+@pytest.mark.parametrize('bern', [False, True])
+def test_distmult(bern):
+    model = DistMult(num_nodes=10, num_relations=5, hidden_channels=32,
+                     bern=bern)
     assert str(model) == 'DistMult(10, num_relations=5, hidden_channels=32)'
 
     head_index = torch.tensor([0, 2, 4, 6, 8])

--- a/test/nn/kge/test_rotate.py
+++ b/test/nn/kge/test_rotate.py
@@ -1,10 +1,13 @@
+import pytest
 import torch
 
 from torch_geometric.nn import RotatE
 
 
-def test_rotate():
-    model = RotatE(num_nodes=10, num_relations=5, hidden_channels=32)
+@pytest.mark.parametrize('bern', [False, True])
+def test_rotate(bern):
+    model = RotatE(num_nodes=10, num_relations=5, hidden_channels=32,
+                   bern=bern)
     assert str(model) == 'RotatE(10, num_relations=5, hidden_channels=32)'
 
     head_index = torch.tensor([0, 2, 4, 6, 8])

--- a/test/nn/kge/test_transd.py
+++ b/test/nn/kge/test_transd.py
@@ -1,0 +1,27 @@
+import torch
+
+from torch_geometric.nn import TransD
+
+
+def test_transe():
+    model = TransD(num_nodes=10, num_relations=5, hidden_channels_node=16,
+                   hidden_channels_rel=32)
+    assert str(model) == ('TransD(10, num_relations=5,'
+                          ' hidden_channels_node=16, hidden_channels_rel=32)')
+
+    head_index = torch.tensor([0, 2, 4, 6, 8])
+    rel_type = torch.tensor([0, 1, 2, 3, 4])
+    tail_index = torch.tensor([1, 3, 5, 7, 9])
+
+    loader = model.loader(head_index, rel_type, tail_index, batch_size=5)
+    for h, r, t in loader:
+        out = model(h, r, t)
+        assert out.size() == (5, )
+
+        loss = model.loss(h, r, t)
+        assert loss >= 0.
+
+        mean_rank, mrr, hits = model.test(h, r, t, batch_size=5, log=False)
+        assert 0 <= mean_rank <= 10
+        assert 0 < mrr <= 1
+        assert hits == 1.0

--- a/test/nn/kge/test_transd.py
+++ b/test/nn/kge/test_transd.py
@@ -6,7 +6,7 @@ from torch_geometric.nn import TransD
 
 @pytest.mark.parametrize('channels_node_rel', [(16, 32), {32, 16}])
 @pytest.mark.parametrize('bern', [False, True])
-def test_transe(channels_node_rel, bern):
+def test_transd(channels_node_rel, bern):
     channels_node, channels_rel = channels_node_rel
     model = TransD(num_nodes=10, num_relations=5,
                    hidden_channels_node=channels_node,

--- a/test/nn/kge/test_transd.py
+++ b/test/nn/kge/test_transd.py
@@ -1,13 +1,19 @@
+import pytest
 import torch
 
 from torch_geometric.nn import TransD
 
 
-def test_transe():
-    model = TransD(num_nodes=10, num_relations=5, hidden_channels_node=16,
-                   hidden_channels_rel=32)
+@pytest.mark.parametrize('channels_node_rel', [(16, 32), {32, 16}])
+@pytest.mark.parametrize('bern', [False, True])
+def test_transe(channels_node_rel, bern):
+    channels_node, channels_rel = channels_node_rel
+    model = TransD(num_nodes=10, num_relations=5,
+                   hidden_channels_node=channels_node,
+                   hidden_channels_rel=channels_rel, bern=bern)
     assert str(model) == ('TransD(10, num_relations=5,'
-                          ' hidden_channels_node=16, hidden_channels_rel=32)')
+                          f' hidden_channels_node={channels_node},'
+                          f' hidden_channels_rel={channels_rel})')
 
     head_index = torch.tensor([0, 2, 4, 6, 8])
     rel_type = torch.tensor([0, 1, 2, 3, 4])

--- a/test/nn/kge/test_transe.py
+++ b/test/nn/kge/test_transe.py
@@ -1,10 +1,13 @@
+import pytest
 import torch
 
 from torch_geometric.nn import TransE
 
 
-def test_transe():
-    model = TransE(num_nodes=10, num_relations=5, hidden_channels=32)
+@pytest.mark.parametrize('bern', [False, True])
+def test_transe(bern):
+    model = TransE(num_nodes=10, num_relations=5, hidden_channels=32,
+                   bern=bern)
     assert str(model) == 'TransE(10, num_relations=5, hidden_channels=32)'
 
     head_index = torch.tensor([0, 2, 4, 6, 8])

--- a/torch_geometric/nn/kge/__init__.py
+++ b/torch_geometric/nn/kge/__init__.py
@@ -1,6 +1,7 @@
 r"""Knowledge Graph Embedding (KGE) package."""
 
 from .base import KGEModel
+from .transd import TransD
 from .transe import TransE
 from .complex import ComplEx
 from .distmult import DistMult
@@ -9,6 +10,7 @@ from .rotate import RotatE
 __all__ = classes = [
     'KGEModel',
     'TransE',
+    'TransD',
     'ComplEx',
     'DistMult',
     'RotatE',

--- a/torch_geometric/nn/kge/base.py
+++ b/torch_geometric/nn/kge/base.py
@@ -10,6 +10,9 @@ from torch_geometric.utils import scatter
 
 
 def _avg_count_per_r(x_idx, r_idx):
+    # Assume no duplicate triples, so e.g. each occurence of a tail index
+    # represents a different head to count for that tail.
+
     # Map the tuple (x_idx, r_idx) to unique indices in a new combined index.
     num_x = x_idx.max() + 1
     rx_idx = r_idx * num_x + x_idx
@@ -182,8 +185,6 @@ class KGEModel(torch.nn.Module):
         # the number of heads per tail and tails per head for each relation.
         # I.e. if there are more tails per head than heads per tail, we should
         # corrupt the head more often to get fewer false negatives.
-        # Assume no duplicate triples, so each occurence of a tail index
-        # represents a different head to count for that tail.
         hpt = _avg_count_per_r(tail_index, rel_type)
         tph = _avg_count_per_r(head_index, rel_type)
         berns = tph / (tph + hpt)

--- a/torch_geometric/nn/kge/complex.py
+++ b/torch_geometric/nn/kge/complex.py
@@ -18,6 +18,14 @@ class ComplEx(KGEModel):
     .. math::
         d(h, r, t) = Re(< \mathbf{e}_h,  \mathbf{e}_r, \mathbf{e}_t>)
 
+    This score is optimized with the :obj:`margin_ranking_loss` by creating
+    corrupted triplets. By default either the head or the tail of is corrupted
+    uniformly at random. When :obj:`bern=True`, the head or tail is chosen
+    proportional to the average number of heads per tail and tails per head for
+    the relation, as described in the `"Knowledge Graph Embedding by
+    Translating on Hyperplanes" <https://cdn.aaai.org/ojs/8870/
+    8870-13-12398-1-2-20201228.pdf>`_ paper.
+
     .. note::
 
         For an example of using the :class:`ComplEx` model, see
@@ -32,14 +40,11 @@ class ComplEx(KGEModel):
         sparse (bool, optional): If set to :obj:`True`, gradients w.r.t. to
             the embedding matrices will be sparse. (default: :obj:`False`)
     """
-    def __init__(
-        self,
-        num_nodes: int,
-        num_relations: int,
-        hidden_channels: int,
-        sparse: bool = False,
-    ):
-        super().__init__(num_nodes, num_relations, hidden_channels, sparse)
+    def __init__(self, num_nodes: int, num_relations: int,
+                 hidden_channels: int, sparse: bool = False,
+                 bern: bool = False):
+        super().__init__(num_nodes, num_relations, hidden_channels, sparse,
+                         bern)
 
         self.node_emb_im = Embedding(num_nodes, hidden_channels, sparse=sparse)
         self.rel_emb_im = Embedding(num_relations, hidden_channels,

--- a/torch_geometric/nn/kge/distmult.py
+++ b/torch_geometric/nn/kge/distmult.py
@@ -17,6 +17,14 @@ class DistMult(KGEModel):
     .. math::
         d(h, r, t) = < \mathbf{e}_h,  \mathbf{e}_r, \mathbf{e}_t >
 
+    This score is optimized with the :obj:`margin_ranking_loss` by creating
+    corrupted triplets. By default either the head or the tail of is corrupted
+    uniformly at random. When :obj:`bern=True`, the head or tail is chosen
+    proportional to the average number of heads per tail and tails per head for
+    the relation, as described in the `"Knowledge Graph Embedding by
+    Translating on Hyperplanes" <https://cdn.aaai.org/ojs/8870/
+    8870-13-12398-1-2-20201228.pdf>`_ paper.
+
     .. note::
 
         For an example of using the :class:`DistMult` model, see
@@ -40,8 +48,10 @@ class DistMult(KGEModel):
         hidden_channels: int,
         margin: float = 1.0,
         sparse: bool = False,
+        bern: bool = False,
     ):
-        super().__init__(num_nodes, num_relations, hidden_channels, sparse)
+        super().__init__(num_nodes, num_relations, hidden_channels, sparse,
+                         bern)
 
         self.margin = margin
 

--- a/torch_geometric/nn/kge/rotate.py
+++ b/torch_geometric/nn/kge/rotate.py
@@ -24,6 +24,14 @@ class RotatE(KGEModel):
     .. math::
         d(h, r, t) = - {\| \mathbf{e}_h \circ \mathbf{e}_r - \mathbf{e}_t \|}_p
 
+    This score is optimized with the :obj:`margin_ranking_loss` by creating
+    corrupted triplets. By default either the head or the tail of is corrupted
+    uniformly at random. When :obj:`bern=True`, the head or tail is chosen
+    proportional to the average number of heads per tail and tails per head for
+    the relation, as described in the `"Knowledge Graph Embedding by
+    Translating on Hyperplanes" <https://cdn.aaai.org/ojs/8870/
+    8870-13-12398-1-2-20201228.pdf>`_ paper.
+
     .. note::
 
         For an example of using the :class:`RotatE` model, see
@@ -39,15 +47,11 @@ class RotatE(KGEModel):
         sparse (bool, optional): If set to :obj:`True`, gradients w.r.t. to
             the embedding matrices will be sparse. (default: :obj:`False`)
     """
-    def __init__(
-        self,
-        num_nodes: int,
-        num_relations: int,
-        hidden_channels: int,
-        margin: float = 1.0,
-        sparse: bool = False,
-    ):
-        super().__init__(num_nodes, num_relations, hidden_channels, sparse)
+    def __init__(self, num_nodes: int, num_relations: int,
+                 hidden_channels: int, margin: float = 1.0,
+                 sparse: bool = False, bern: bool = False):
+        super().__init__(num_nodes, num_relations, hidden_channels, sparse,
+                         bern)
 
         self.margin = margin
         self.node_emb_im = Embedding(num_nodes, hidden_channels, sparse=sparse)

--- a/torch_geometric/nn/kge/transd.py
+++ b/torch_geometric/nn/kge/transd.py
@@ -1,0 +1,99 @@
+import math
+
+import torch
+import torch.nn.functional as F
+from torch import Tensor
+
+from torch_geometric.nn.kge import KGEModel
+
+
+class TransE(KGEModel):
+    r"""The TransE model from the `"Translating Embeddings for Modeling
+    Multi-Relational Data" <https://proceedings.neurips.cc/paper/2013/file/
+    1cecc7a77928ca8133fa24680a88d2f9-Paper.pdf>`_ paper.
+
+    :class:`TransE` models relations as a translation from head to tail
+    entities such that
+
+    .. math::
+        \mathbf{e}_h + \mathbf{e}_r \approx \mathbf{e}_t,
+
+    resulting in the scoring function:
+
+    .. math::
+        d(h, r, t) = - {\| \mathbf{e}_h + \mathbf{e}_r - \mathbf{e}_t \|}_p
+
+    .. note::
+
+        For an example of using the :class:`TransE` model, see
+        `examples/kge_fb15k_237.py
+        <https://github.com/pyg-team/pytorch_geometric/blob/master/examples/
+        kge_fb15k_237.py>`_.
+
+    Args:
+        num_nodes (int): The number of nodes/entities in the graph.
+        num_relations (int): The number of relations in the graph.
+        hidden_channels (int): The hidden embedding size.
+        margin (int, optional): The margin of the ranking loss.
+            (default: :obj:`1.0`)
+        p_norm (int, optional): The order embedding and distance normalization.
+            (default: :obj:`1.0`)
+        sparse (bool, optional): If set to :obj:`True`, gradients w.r.t. to the
+            embedding matrices will be sparse. (default: :obj:`False`)
+    """
+    def __init__(
+        self,
+        num_nodes: int,
+        num_relations: int,
+        hidden_channels: int,
+        margin: float = 1.0,
+        p_norm: float = 1.0,
+        sparse: bool = False,
+    ):
+        super().__init__(num_nodes, num_relations, hidden_channels, sparse)
+
+        self.p_norm = p_norm
+        self.margin = margin
+
+        self.reset_parameters()
+
+    def reset_parameters(self):
+        bound = 6. / math.sqrt(self.hidden_channels)
+        torch.nn.init.uniform_(self.node_emb.weight, -bound, bound)
+        torch.nn.init.uniform_(self.rel_emb.weight, -bound, bound)
+        F.normalize(self.rel_emb.weight.data, p=self.p_norm, dim=-1,
+                    out=self.rel_emb.weight.data)
+
+    def forward(
+        self,
+        head_index: Tensor,
+        rel_type: Tensor,
+        tail_index: Tensor,
+    ) -> Tensor:
+
+        head = self.node_emb(head_index)
+        rel = self.rel_emb(rel_type)
+        tail = self.node_emb(tail_index)
+
+        head = F.normalize(head, p=self.p_norm, dim=-1)
+        tail = F.normalize(tail, p=self.p_norm, dim=-1)
+
+        # Calculate *negative* TransE norm:
+        return -((head + rel) - tail).norm(p=self.p_norm, dim=-1)
+
+    def loss(
+        self,
+        head_index: Tensor,
+        rel_type: Tensor,
+        tail_index: Tensor,
+    ) -> Tensor:
+
+        pos_score = self(head_index, rel_type, tail_index)
+        neg_score = self(*self.random_sample(head_index, rel_type, tail_index))
+
+        return F.margin_ranking_loss(
+            pos_score,
+            neg_score,
+            target=torch.ones_like(pos_score),
+            margin=self.margin,
+        )

--- a/torch_geometric/nn/kge/transd.py
+++ b/torch_geometric/nn/kge/transd.py
@@ -13,26 +13,35 @@ class TransD(KGEModel):
     Mapping Matrix" <https://aclanthology.org/P15-1067.pdf>`_ paper.
 
     :class:`TransD` models relations as a translation from head to tail
-    entities, after a mapping matrix has been applied, such that
+    entities, after a learned mapping matrix has been applied, such that
 
     .. math::
-        \mathbf{h}_\perp + \mathbf{r} \approx \mathbf{t}_perp,
+        \mathbf{h}_\perp + \mathbf{r} \approx \mathbf{t}_\perp,
 
     where
-    .. math::
-        \mathbf{h}_\perp = \mathbf{M}_{rh} h
-        \mathbf{t}_\perp = \mathbf{M}_{th} t
-        \mathbf{M}_{rh} = r_p h_p^\top + \mathbf{I}^{m \times n}
-        \mathbf{M}_{rt} = r_p t_p^\top + \mathbf{I}^{m \times n}
 
-    and :math:`h,  t, h_p, t_p \in \mathcal{R}^n` and
-    :math:`r, r_p \in \mathcal{R}^m` are all learned embeddings.
+    .. math::
+        \mathbf{h}_\perp = \mathbf{M}_{rh} \mathbf{h}
+
+    .. math::
+        \mathbf{t}_\perp = \mathbf{M}_{th} \mathbf{t}
+
+    .. math::
+        \mathbf{M}_{rh} = r_\text{proj} h_\text{proj}^\top +
+        \mathbf{I}^{m \times n}
+
+    .. math::
+        \mathbf{M}_{rt} = r_\text{proj} t_\text{proj}^\top +
+        \mathbf{I}^{m \times n}
+
+    and :math:`h,  t, h_\text{proj}, t_\text{proj} \in \mathcal{R}^n`,
+    :math:`r, r_\text{proj} \in \mathcal{R}^m` are all learned embeddings.
 
     Similar to :obj:`TransE`, this results in the the scoring function:
 
     .. math::
         d(h_\perp, r, t_\perp) =
-            - {\| \mathbf{h}_\perp + \mathbf{r} - \mathbf{t}_\perp \|}_p
+        - {\| \mathbf{h}_\perp + \mathbf{r} - \mathbf{t}_\perp \|}_p
 
     This score is optimized with the :obj:`margin_ranking_loss` by creating
     corrupted triplets. By default either the head or the tail of is corrupted

--- a/torch_geometric/nn/kge/transd.py
+++ b/torch_geometric/nn/kge/transd.py
@@ -113,17 +113,17 @@ class TransD(KGEModel):
 
         # (node^T node_p) rel_p, using efficient batch inner product.
         # TODO inner = (node * node_p).sum(dim=-1, keepdim=True)
-        nt_np_rp = (node.unsqueeze(1) @ node_p.unsqueeze(2)).squeeze(2) * rel_p
+        npt_n_rp = (node_p.unsqueeze(1) @ node.unsqueeze(2)).squeeze(2) * rel_p
 
-        # Efficiently "multiply" node with non-square Identity.
-        if self.hidden_channels_node > self.hidden_channels_rel:
-            id_node = node[:, self.hidden_channels_rel]
+        # Efficiently "multiply" non-square Identity with node.
+        if self.hidden_channels_node >= self.hidden_channels_rel:
+            id_node = node[:, self.hidden_channels_rel:]
         else:
             id_node = torch.zeros(node.size(0), self.hidden_channels_rel,
                                   device=node.device)
             id_node[:, :self.hidden_channels_node] = node
 
-        return nt_np_rp + id_node
+        return npt_n_rp + id_node
 
     def forward(
         self,

--- a/torch_geometric/nn/kge/transd.py
+++ b/torch_geometric/nn/kge/transd.py
@@ -40,7 +40,9 @@ class TransD(KGEModel):
     proportional to the average number of heads per tail and tails per head for
     the relation, as described in the `"Knowledge Graph Embedding by
     Translating on Hyperplanes" <https://cdn.aaai.org/ojs/8870/
-    8870-13-12398-1-2-20201228.pdf>`_ paper.
+    8870-13-12398-1-2-20201228.pdf>`_ paper. You must call the :obj:`loader()`
+    function with your training set to initialize the Bernoulli parameters if
+    you want to use this argument.
 
     .. note::
 

--- a/torch_geometric/nn/kge/transd.py
+++ b/torch_geometric/nn/kge/transd.py
@@ -117,7 +117,7 @@ class TransD(KGEModel):
 
         # Efficiently "multiply" non-square Identity with node.
         if self.hidden_channels_node >= self.hidden_channels_rel:
-            id_node = node[:, self.hidden_channels_rel:]
+            id_node = node[:, :self.hidden_channels_rel]
         else:
             id_node = torch.zeros(node.size(0), self.hidden_channels_rel,
                                   device=node.device)

--- a/torch_geometric/nn/kge/transd.py
+++ b/torch_geometric/nn/kge/transd.py
@@ -40,9 +40,7 @@ class TransD(KGEModel):
     proportional to the average number of heads per tail and tails per head for
     the relation, as described in the `"Knowledge Graph Embedding by
     Translating on Hyperplanes" <https://cdn.aaai.org/ojs/8870/
-    8870-13-12398-1-2-20201228.pdf>`_ paper. You must call the :obj:`loader()`
-    function with your training set to initialize the Bernoulli parameters if
-    you want to use this argument.
+    8870-13-12398-1-2-20201228.pdf>`_ paper.
 
     .. note::
 

--- a/torch_geometric/nn/kge/transd.py
+++ b/torch_geometric/nn/kge/transd.py
@@ -3,29 +3,48 @@ import math
 import torch
 import torch.nn.functional as F
 from torch import Tensor
+from torch.nn import Embedding
 
 from torch_geometric.nn.kge import KGEModel
 
 
-class TransE(KGEModel):
-    r"""The TransE model from the `"Translating Embeddings for Modeling
-    Multi-Relational Data" <https://proceedings.neurips.cc/paper/2013/file/
-    1cecc7a77928ca8133fa24680a88d2f9-Paper.pdf>`_ paper.
+class TransD(KGEModel):
+    r"""The TransD model from the `"Knowledge Graph Embedding via Dynamic
+    Mapping Matrix" <https://aclanthology.org/P15-1067.pdf>`_ paper.
 
-    :class:`TransE` models relations as a translation from head to tail
-    entities such that
-
-    .. math::
-        \mathbf{e}_h + \mathbf{e}_r \approx \mathbf{e}_t,
-
-    resulting in the scoring function:
+    :class:`TransD` models relations as a translation from head to tail
+    entities, after a mapping matrix has been applied, such that
 
     .. math::
-        d(h, r, t) = - {\| \mathbf{e}_h + \mathbf{e}_r - \mathbf{e}_t \|}_p
+        \mathbf{h}_\perp + \mathbf{r} \approx \mathbf{t}_perp,
+
+    where
+    .. math::
+        \mathbf{h}_\perp = \mathbf{M}_{rh} h
+        \mathbf{t}_\perp = \mathbf{M}_{th} t
+        \mathbf{M}_{rh} = r_p h_p^\top + \mathbf{I}^{m \times n}
+        \mathbf{M}_{rt} = r_p t_p^\top + \mathbf{I}^{m \times n}
+
+    and :math:`h,  t, h_p, t_p \in \mathcal{R}^n` and
+    :math:`r, r_p \in \mathcal{R}^m` are all learned embeddings.
+
+    Similar to :obj:`TransE`, this results in the the scoring function:
+
+    .. math::
+        d(h_\perp, r, t_\perp) =
+            - {\| \mathbf{h}_\perp + \mathbf{r} - \mathbf{t}_\perp \|}_p
+
+    This score is optimized with the :obj:`margin_ranking_loss` by creating
+    corrupted triplets. By default either the head or the tail of is corrupted
+    uniformly at random. When :obj:`bern=True`, the head or tail is chosen
+    proportional to the average number of heads per tail and tails per head for
+    the relation, as described in the `"Knowledge Graph Embedding by
+    Translating on Hyperplanes" <https://cdn.aaai.org/ojs/8870/
+    8870-13-12398-1-2-20201228.pdf>`_ paper.
 
     .. note::
 
-        For an example of using the :class:`TransE` model, see
+        For an example of using the :class:`TransD` model, see
         `examples/kge_fb15k_237.py
         <https://github.com/pyg-team/pytorch_geometric/blob/master/examples/
         kge_fb15k_237.py>`_.
@@ -33,36 +52,78 @@ class TransE(KGEModel):
     Args:
         num_nodes (int): The number of nodes/entities in the graph.
         num_relations (int): The number of relations in the graph.
-        hidden_channels (int): The hidden embedding size.
+        hidden_channels_node (int): The node hidden embedding size (:math:`n`).
+        hidden_channels_node (int): The relation hidden embedding size
+            (:math:`m`).
         margin (int, optional): The margin of the ranking loss.
             (default: :obj:`1.0`)
         p_norm (int, optional): The order embedding and distance normalization.
             (default: :obj:`1.0`)
         sparse (bool, optional): If set to :obj:`True`, gradients w.r.t. to the
             embedding matrices will be sparse. (default: :obj:`False`)
+        bern (bool, optional): If true, corrupt triplets using the Bernoulli
+            strategy.  Otherwise, corrupt the head or tail uniformly.
+            (default: :obj:`True`)
     """
-    def __init__(
-        self,
-        num_nodes: int,
-        num_relations: int,
-        hidden_channels: int,
-        margin: float = 1.0,
-        p_norm: float = 1.0,
-        sparse: bool = False,
-    ):
-        super().__init__(num_nodes, num_relations, hidden_channels, sparse)
+    def __init__(self, num_nodes: int, num_relations: int,
+                 hidden_channels_node: int, hidden_channels_rel: int,
+                 margin: float = 1.0, p_norm: float = 1.0,
+                 sparse: bool = False, bern: bool = False):
+        super().__init__(num_nodes, num_relations, hidden_channels_node,
+                         sparse, bern)
+        self.hidden_channels_node = hidden_channels_node
+        self.hidden_channels_rel = hidden_channels_rel
 
+        # self.node_emb initialized in super
+        self.rel_emb = Embedding(num_relations, hidden_channels_rel,
+                                 sparse=sparse)
+        self.rel_proj_emb = Embedding(num_relations, hidden_channels_rel,
+                                      sparse=sparse)
+        self.node_proj_emb = Embedding(num_nodes, hidden_channels_node,
+                                       sparse=sparse)
         self.p_norm = p_norm
         self.margin = margin
 
         self.reset_parameters()
 
     def reset_parameters(self):
-        bound = 6. / math.sqrt(self.hidden_channels)
+        bound = 6. / math.sqrt(self.hidden_channels_node)
         torch.nn.init.uniform_(self.node_emb.weight, -bound, bound)
+        bound = 6. / math.sqrt(self.hidden_channels_rel)
         torch.nn.init.uniform_(self.rel_emb.weight, -bound, bound)
-        F.normalize(self.rel_emb.weight.data, p=self.p_norm, dim=-1,
-                    out=self.rel_emb.weight.data)
+        # Achieve M_{rel node} initialized as Identity.
+        torch.nn.init.zeros_(self.node_proj_emb.weight)
+        torch.nn.init.zeros_(self.rel_proj_emb.weight)
+
+    def _enforce_norm(self, emb):
+        # Enforce norms in emb are <= 1.
+
+        norm = emb.norm(p=self.p_norm, dim=-1, keepdim=True)
+        mask = (norm > 1).view(-1)
+        # We cannot modify emb in place as it's still needed for backprop.
+        emb = emb.clone()
+        emb[mask] = emb[mask] / norm[mask]
+        return emb
+
+    def _compute_perp(self, node_p, node, rel_p):
+        # Compute the product:
+        #   M_{rel node} node
+        # As:
+        #   (node_p^T node) rel_p + I node
+
+        # (node^T node_p) rel_p, using efficient batch inner product.
+        # TODO inner = (node * node_p).sum(dim=-1, keepdim=True)
+        nt_np_rp = (node.unsqueeze(1) @ node_p.unsqueeze(2)).squeeze(2) * rel_p
+
+        # Efficiently "multiply" node with non-square Identity.
+        if self.hidden_channels_node > self.hidden_channels_rel:
+            id_node = node[:, self.hidden_channels_rel]
+        else:
+            id_node = torch.zeros(node.size(0), self.hidden_channels_rel,
+                                  device=node.device)
+            id_node[:, :self.hidden_channels_node] = node
+
+        return nt_np_rp + id_node
 
     def forward(
         self,
@@ -71,15 +132,28 @@ class TransE(KGEModel):
         tail_index: Tensor,
     ) -> Tensor:
 
+        # Lookup the embeddings.
         head = self.node_emb(head_index)
+        head_proj = self.node_proj_emb(head_index)
         rel = self.rel_emb(rel_type)
+        rel_proj = self.rel_proj_emb(rel_type)
         tail = self.node_emb(tail_index)
+        tail_proj = self.node_proj_emb(tail_index)
 
-        head = F.normalize(head, p=self.p_norm, dim=-1)
-        tail = F.normalize(tail, p=self.p_norm, dim=-1)
+        # Unlike TransE, which enforces head and tail norms == 1, TransD
+        # enforces head, head_proj, tail, tail_proj, and rel norms <= 1.
+        head = self._enforce_norm(head)
+        head_proj = self._enforce_norm(head_proj)
+        rel = self._enforce_norm(rel)
+        tail = self._enforce_norm(tail)
+        tail_proj = self._enforce_norm(tail_proj)
 
-        # Calculate *negative* TransE norm:
-        return -((head + rel) - tail).norm(p=self.p_norm, dim=-1)
+        # Compute the projected vectors, notated with \perp.
+        head_perp = self._compute_perp(head_proj, head, rel_proj)
+        tail_perp = self._compute_perp(tail_proj, tail, rel_proj)
+
+        # Now the score is similar to TransE.
+        return -(head_perp + rel - tail_perp).norm(p=self.p_norm, dim=-1)
 
     def loss(
         self,
@@ -97,3 +171,9 @@ class TransE(KGEModel):
             target=torch.ones_like(pos_score),
             margin=self.margin,
         )
+
+    def __repr__(self) -> str:
+        return (f'{self.__class__.__name__}({self.num_nodes}, '
+                f'num_relations={self.num_relations}, '
+                f'hidden_channels_node={self.hidden_channels_node}, '
+                f'hidden_channels_rel={self.hidden_channels_rel})')

--- a/torch_geometric/nn/kge/transe.py
+++ b/torch_geometric/nn/kge/transe.py
@@ -30,6 +30,14 @@ class TransE(KGEModel):
         <https://github.com/pyg-team/pytorch_geometric/blob/master/examples/
         kge_fb15k_237.py>`_.
 
+    This score is optimized with the :obj:`margin_ranking_loss` by creating
+    corrupted triplets. By default either the head or the tail of is corrupted
+    uniformly at random. When :obj:`bern=True`, the head or tail is chosen
+    proportional to the average number of heads per tail and tails per head for
+    the relation, as described in the `"Knowledge Graph Embedding by
+    Translating on Hyperplanes" <https://cdn.aaai.org/ojs/8870/
+    8870-13-12398-1-2-20201228.pdf>`_ paper.
+
     Args:
         num_nodes (int): The number of nodes/entities in the graph.
         num_relations (int): The number of relations in the graph.
@@ -40,6 +48,9 @@ class TransE(KGEModel):
             (default: :obj:`1.0`)
         sparse (bool, optional): If set to :obj:`True`, gradients w.r.t. to the
             embedding matrices will be sparse. (default: :obj:`False`)
+        bern (bool, optional): If true, corrupt triplets using the Bernoulli
+            strategy.  Otherwise, corrupt the head or tail uniformly.
+            (default: :obj:`True`)
     """
     def __init__(
         self,
@@ -49,8 +60,10 @@ class TransE(KGEModel):
         margin: float = 1.0,
         p_norm: float = 1.0,
         sparse: bool = False,
+        bern: bool = False,
     ):
-        super().__init__(num_nodes, num_relations, hidden_channels, sparse)
+        super().__init__(num_nodes, num_relations, hidden_channels, sparse,
+                         bern)
 
         self.p_norm = p_norm
         self.margin = margin


### PR DESCRIPTION
Implements TransD and Bernoulli corruption strategy (used in TransD and TransH papers).

## Details
- Did not see any PRs for these ones yet :)
- Used the KGEModel base and tried to keep consistent with other KGE
- Tried to implement everything as efficiently as possible while following the paper
- Incorporated into `examples/kge_fb15k_237.py`, also adding duration calculation there
- The Bernoulli parameters are currently computed for each batch rather than the whole training set
    - This is a little slower but seemed to work much better in terms of metrics
    - Also seems a little more intuitive for the user to simply flip a bool as opposed to requiring they pass their whole training set for initialization, or requiring they use loader().
    - We might also try cumulating the statistics during training, but these initial experiments suggest this would be the worst of both worlds (slower as we won't know when first epoch has ended, ultimately similar to precomputing in terms of metrics)
- Happy to split Bernoulli into a separate PR, or make any other edits you might prefer.

## Benchmarks 
I was only able to compare it to TransE on `examples/kge_fb15k_237.py` and do 3 runs each, but even without any hyperparameter tuning, findings seem fairly consistent with paper, i.e. significant improvements in all metrics [[colab](https://colab.research.google.com/drive/1FnMzHqnn8db1r4TEnHkBmYr1GHvSWTKx?usp=sharing)]:
| Method/Evalset        | Mean Rank     | MRR           | Hits@10       |
|:----------------------|:--------------|:--------------|:--------------|
| TransD Bernoulli Val  | 176.19 ± 0.74 | 0.223 ± 0.000 | 0.408 ± 0.001 |
| TransD Bernoulli Test | 180.65 ± 0.71 | 0.220 ± 0.001 | 0.401 ± 0.002 |
| TransD Val            | 180.08 ± 0.37 | 0.211 ± 0.003 | 0.400 ± 0.002 |
| TransD Test           | 184.06 ± 1.78 | 0.210 ± 0.003 | 0.396 ± 0.002 |
| TransE Val            | 258.74 ± 5.76 | 0.221 ± 0.000 | 0.366 ± 0.004 |
| TransE Test           | 268.30 ± 6.39 | 0.217 ± 0.001 | 0.362 ± 0.004 |