### PR TITLE
Adding Multiple Virtual Nodes to Transform module  

### DIFF
--- a/test/transforms/test_multiple_virtual_nodes.py
+++ b/test/transforms/test_multiple_virtual_nodes.py
@@ -1,0 +1,89 @@
+import torch
+
+from torch_geometric.data import Data
+from torch_geometric.transforms import MultipleVirtualNodes
+
+# modified the tests in test_virtual_node.py
+
+def test_multiple_virtual_nodes():
+    print("Test 1: Random assignments")
+    assert str(MultipleVirtualNodes()) == 'MultipleVirtualNodes()'
+
+    x = torch.randn(4, 16)
+    edge_index = torch.tensor([[2, 0, 2], [3, 1, 0]])
+    edge_weight = torch.rand(edge_index.size(1))
+    edge_attr = torch.randn(edge_index.size(1), 8)
+
+    data = Data(x=x, edge_index=edge_index, edge_weight=edge_weight,
+                edge_attr=edge_attr, num_nodes=x.size(0))
+
+    # random assignments and uneven split
+    data = MultipleVirtualNodes(n_to_add=3, clustering=False)(data)
+
+    assert len(data) == 6
+
+    assert data.x.size() == (7, 16)
+    assert torch.allclose(data.x[:4], x)
+    assert data.x[4:].abs().sum() == 0
+
+    first_3_col = [row[:3] for row in data.edge_index.tolist()]
+    assert first_3_col == edge_index # check that the original edges are unchanged
+    assert data.edge_index.size() == (2, 11)
+
+    virtual_nodes = {4, 5, 6}
+
+    def validate_edge_index(edge_index):
+        source_nodes = edge_index[0][3:11]
+        target_nodes = edge_index[1][3:11]
+        source_counts = {0: 0, 1: 0, 2: 0, 3: 0, 4: 0, 5: 0, 6: 0}
+        target_counts = {0: 0, 1: 0, 2: 0, 3: 0, 4: 0, 5: 0, 6: 0}
+        for source in source_nodes:
+            source_counts[source] += 1
+        for target in target_nodes:
+            target_counts[target] += 1
+        assert source_counts[4] + source_counts[5] + source_counts[6] == 4
+        assert target_counts[4] + target_counts[5] + target_counts[6] == 4
+        for virtual in virtual_nodes:
+            assert source_counts[virtual] > 0
+            assert source_counts[virtual] < 3
+            assert target_counts[virtual] > 0
+            assert target_counts[virtual] < 3
+
+    validate_edge_index(data.edge_index.tolist())
+
+    assert data.edge_weight.size() == (11, )
+    assert torch.allclose(data.edge_weight[:3], edge_weight)
+    assert data.edge_weight[3:].abs().sum() == 8
+
+    assert data.edge_attr.size() == (11, 8)
+    assert torch.allclose(data.edge_attr[:3], edge_attr)
+    assert data.edge_attr[3:].abs().sum() == 0
+
+    assert data.num_nodes == 7
+
+    assert data.edge_type.tolist() == [0, 0, 0, 1, 1, 1, 1, 2, 2, 2, 2]
+
+    print("Test 1 passed\nTest 2: Clustering Assignments")
+
+    # clustering assignments and uneven split
+    data = MultipleVirtualNodes(n_to_add=3, clustering=True)(data)
+
+    assert len(data) == 6
+
+    assert data.x.size() == (7, 16)
+    assert torch.allclose(data.x[:4], x)
+    assert data.x[4:].abs().sum() == 0
+
+    validate_edge_index(data.edge_index.tolist())
+
+    assert data.edge_weight.size() == (11, )
+    assert torch.allclose(data.edge_weight[:3], edge_weight)
+    assert data.edge_weight[3:].abs().sum() == 8
+
+    assert data.edge_attr.size() == (11, 8)
+    assert torch.allclose(data.edge_attr[:3], edge_attr)
+    assert data.edge_attr[3:].abs().sum() == 0
+
+    assert data.num_nodes == 7
+
+    assert data.edge_type.tolist() == [0, 0, 0, 1, 1, 1, 1, 2, 2, 2, 2]

--- a/test/transforms/test_multiple_virtual_nodes.py
+++ b/test/transforms/test_multiple_virtual_nodes.py
@@ -1,15 +1,17 @@
+import copy
+
 import torch
 
 from torch_geometric.data import Data
 from torch_geometric.transforms import MultipleVirtualNodes
 
-import copy 
-
 # modified the tests in test_virtual_node.py
+
 
 def test_multiple_virtual_nodes():
     print("Test 1: Random assignments")
-    assert str(MultipleVirtualNodes(n_to_add=3, clustering=False)) == 'MultipleVirtualNodes()'
+    assert str(MultipleVirtualNodes(
+        n_to_add=3, clustering=False)) == 'MultipleVirtualNodes()'
 
     x = torch.randn(4, 16)
     edge_index = torch.tensor([[2, 0, 2], [3, 1, 0]])
@@ -30,7 +32,9 @@ def test_multiple_virtual_nodes():
     assert data.x[4:].abs().sum() == 0
 
     first_3_col = [row[:3] for row in data.edge_index.tolist()]
-    assert first_3_col == [[2, 0, 2], [3, 1, 0]] # check that the original edges are unchanged
+    assert first_3_col == [[2, 0, 2],
+                           [3, 1,
+                            0]]  # check that the original edges are unchanged
     assert data.edge_index.size() == (2, 11)
 
     virtual_nodes = {4, 5, 6}
@@ -78,7 +82,9 @@ def test_multiple_virtual_nodes():
     assert data.x[4:].abs().sum() == 0
 
     first_3_col = [row[:3] for row in data.edge_index.tolist()]
-    assert first_3_col == [[2, 0, 2], [3, 1, 0]] # check that the original edges are unchanged
+    assert first_3_col == [[2, 0, 2],
+                           [3, 1,
+                            0]]  # check that the original edges are unchanged
     assert data.edge_index.size() == (2, 11)
     validate_edge_index(data.edge_index.tolist())
 

--- a/test/transforms/test_multiple_virtual_nodes.py
+++ b/test/transforms/test_multiple_virtual_nodes.py
@@ -1,17 +1,16 @@
-import copy
 
 import torch
 
 from torch_geometric.data import Data
 from torch_geometric.transforms import MultipleVirtualNodes
 
-# modified the tests in test_virtual_node.py
+import copy 
 
+# modified the tests in test_virtual_node.py
 
 def test_multiple_virtual_nodes():
     print("Test 1: Random assignments")
-    assert str(MultipleVirtualNodes(
-        n_to_add=3, clustering=False)) == 'MultipleVirtualNodes()'
+    assert str(MultipleVirtualNodes(n_to_add=3, clustering=False)) == 'MultipleVirtualNodes()'
 
     x = torch.randn(4, 16)
     edge_index = torch.tensor([[2, 0, 2], [3, 1, 0]])
@@ -32,31 +31,49 @@ def test_multiple_virtual_nodes():
     assert data.x[4:].abs().sum() == 0
 
     first_3_col = [row[:3] for row in data.edge_index.tolist()]
-    assert first_3_col == [[2, 0, 2],
-                           [3, 1,
-                            0]]  # check that the original edges are unchanged
-    assert data.edge_index.size() == (2, 11)
+    assert first_3_col == [[2, 0, 2], [3, 1, 0]] # check that the original edges are unchanged
+    num_total_edges = 11
+    assert data.edge_index.size() == (2, num_total_edges)
 
     virtual_nodes = {4, 5, 6}
 
-    def validate_edge_index(edge_index):
-        source_nodes = edge_index[0][3:11]
-        target_nodes = edge_index[1][3:11]
-        source_counts = {0: 0, 1: 0, 2: 0, 3: 0, 4: 0, 5: 0, 6: 0}
-        target_counts = {0: 0, 1: 0, 2: 0, 3: 0, 4: 0, 5: 0, 6: 0}
-        for source in source_nodes:
-            source_counts[source] += 1
+    def validate_edge_index(edge_index, n_original_nodes, n_added_nodes):
+        source_nodes = edge_index[0][n_original_nodes - 1:num_total_edges]
+        target_nodes = edge_index[1][n_original_nodes - 1:num_total_edges]
+        source_counts = {i: 0 for i in range(n_original_nodes + n_added_nodes)}
+        target_counts = {i: 0 for i in range(n_original_nodes + n_added_nodes)}
+        original_node_indices = [i for i in range(n_original_nodes)]
+        virtual_node_indices = [n_original_nodes + i for i in range(n_added_nodes)]
+
+        for i in range(len(source_nodes)):
+            source_counts[source_nodes[i]] += 1
+            # check that virtual nodes are not connected to each other and original nodes are not connected to each other
+            if source_nodes[i] in virtual_node_indices:
+                assert target_nodes[i] in original_node_indices
+            else:
+                assert target_nodes[i] in virtual_node_indices
         for target in target_nodes:
             target_counts[target] += 1
-        assert source_counts[4] + source_counts[5] + source_counts[6] == 4
-        assert target_counts[4] + target_counts[5] + target_counts[6] == 4
-        for virtual in virtual_nodes:
-            assert source_counts[virtual] > 0
-            assert source_counts[virtual] < 3
-            assert target_counts[virtual] > 0
-            assert target_counts[virtual] < 3
 
-    validate_edge_index(data.edge_index.tolist())
+        total_virtual_source_count = 0
+        total_virtual_target_count = 0
+        # check virtual nodes' edges have been added in the correct way 
+        for i in range(n_added_nodes): 
+            assert source_counts[n_original_nodes + i] > 0 
+            assert source_counts[n_original_nodes + i] < 3
+            assert target_counts[n_original_nodes + i] > 0
+            assert target_counts[n_original_nodes + i] < 3
+            total_virtual_source_count += source_counts[n_original_nodes + i]
+            total_virtual_target_count += target_counts[n_original_nodes + i]
+        # check original nodes 
+        for j in range(n_original_nodes): 
+            assert source_counts[j] == 1
+            assert target_counts[j] == 1
+        
+        assert total_virtual_source_count == n_original_nodes
+        assert total_virtual_target_count == n_original_nodes
+
+    validate_edge_index(data.edge_index.tolist(), 4, 3)
 
     assert data.edge_weight.size() == (11, )
     assert torch.allclose(data.edge_weight[:3], edge_weight)
@@ -72,31 +89,55 @@ def test_multiple_virtual_nodes():
 
     print("Test 1 passed\nTest 2: Clustering Assignments")
 
-    # Test 2: clustering assignments and uneven split
-    data = MultipleVirtualNodes(n_to_add=3, clustering=True)(original_data)
+    # Test 2: clustering assignments 
+    data = MultipleVirtualNodes(n_to_add=2, clustering=True)(original_data)
 
     assert len(data) == 6
-    print(data.x)
-    assert data.x.size() == (7, 16)
+    assert data.x.size() == (6, 16)
     assert torch.allclose(data.x[:4], x)
     assert data.x[4:].abs().sum() == 0
 
     first_3_col = [row[:3] for row in data.edge_index.tolist()]
-    assert first_3_col == [[2, 0, 2],
-                           [3, 1,
-                            0]]  # check that the original edges are unchanged
-    assert data.edge_index.size() == (2, 11)
-    validate_edge_index(data.edge_index.tolist())
+    assert first_3_col == [[2, 0, 2], [3, 1, 0]] # check that the original edges are unchanged
+    assert data.edge_index.size() == (2, num_total_edges)
+    validate_edge_index(data.edge_index.tolist(), 4, 2)
 
-    assert data.edge_weight.size() == (11, )
+    assert data.edge_weight.size() == (num_total_edges, )
     assert torch.allclose(data.edge_weight[:3], edge_weight)
     assert data.edge_weight[3:].abs().sum() == 8
 
-    assert data.edge_attr.size() == (11, 8)
+    assert data.edge_attr.size() == (num_total_edges, 8)
     assert torch.allclose(data.edge_attr[:3], edge_attr)
     assert data.edge_attr[3:].abs().sum() == 0
 
-    assert data.num_nodes == 7
+    assert data.num_nodes == 6
+
+    assert data.edge_type.tolist() == [0, 0, 0, 1, 1, 1, 1, 2, 2, 2, 2]
+
+    print("Test 2 passed\nTest 3: Clustering Assignments with an empty cluster. Should add 2 virtual nodes instead of the specified 3")
+
+    # Test 2: clustering assignments 
+    data = MultipleVirtualNodes(n_to_add=3, clustering=True)(original_data)
+
+    assert len(data) == 6
+    assert data.x.size() == (6, 16)
+    assert torch.allclose(data.x[:4], x)
+    assert data.x[4:].abs().sum() == 0
+
+    first_3_col = [row[:3] for row in data.edge_index.tolist()]
+    assert first_3_col == [[2, 0, 2], [3, 1, 0]] # check that the original edges are unchanged
+    assert data.edge_index.size() == (2, num_total_edges)
+    validate_edge_index(data.edge_index.tolist(), 4, 2)
+
+    assert data.edge_weight.size() == (num_total_edges, )
+    assert torch.allclose(data.edge_weight[:3], edge_weight)
+    assert data.edge_weight[3:].abs().sum() == 8
+
+    assert data.edge_attr.size() == (num_total_edges, 8)
+    assert torch.allclose(data.edge_attr[:3], edge_attr)
+    assert data.edge_attr[3:].abs().sum() == 0
+
+    assert data.num_nodes == 6
 
     assert data.edge_type.tolist() == [0, 0, 0, 1, 1, 1, 1, 2, 2, 2, 2]
 

--- a/test/transforms/test_multiple_virtual_nodes.py
+++ b/test/transforms/test_multiple_virtual_nodes.py
@@ -74,6 +74,9 @@ def test_multiple_virtual_nodes():
     assert torch.allclose(data.x[:4], x)
     assert data.x[4:].abs().sum() == 0
 
+    first_3_col = [row[:3] for row in data.edge_index.tolist()]
+    assert first_3_col == edge_index # check that the original edges are unchanged
+    assert data.edge_index.size() == (2, 11)
     validate_edge_index(data.edge_index.tolist())
 
     assert data.edge_weight.size() == (11, )

--- a/test/transforms/test_multiple_virtual_nodes.py
+++ b/test/transforms/test_multiple_virtual_nodes.py
@@ -1,16 +1,17 @@
+import copy
 
 import torch
 
 from torch_geometric.data import Data
 from torch_geometric.transforms import MultipleVirtualNodes
 
-import copy 
-
 # modified the tests in test_virtual_node.py
+
 
 def test_multiple_virtual_nodes():
     print("Test 1: Random assignments")
-    assert str(MultipleVirtualNodes(n_to_add=3, clustering=False)) == 'MultipleVirtualNodes()'
+    assert str(MultipleVirtualNodes(
+        n_to_add=3, clustering=False)) == 'MultipleVirtualNodes()'
 
     x = torch.randn(4, 16)
     edge_index = torch.tensor([[2, 0, 2], [3, 1, 0]])
@@ -31,11 +32,11 @@ def test_multiple_virtual_nodes():
     assert data.x[4:].abs().sum() == 0
 
     first_3_col = [row[:3] for row in data.edge_index.tolist()]
-    assert first_3_col == [[2, 0, 2], [3, 1, 0]] # check that the original edges are unchanged
+    assert first_3_col == [[2, 0, 2],
+                           [3, 1,
+                            0]]  # check that the original edges are unchanged
     num_total_edges = 11
     assert data.edge_index.size() == (2, num_total_edges)
-
-    virtual_nodes = {4, 5, 6}
 
     def validate_edge_index(edge_index, n_original_nodes, n_added_nodes):
         source_nodes = edge_index[0][n_original_nodes - 1:num_total_edges]
@@ -43,7 +44,9 @@ def test_multiple_virtual_nodes():
         source_counts = {i: 0 for i in range(n_original_nodes + n_added_nodes)}
         target_counts = {i: 0 for i in range(n_original_nodes + n_added_nodes)}
         original_node_indices = [i for i in range(n_original_nodes)]
-        virtual_node_indices = [n_original_nodes + i for i in range(n_added_nodes)]
+        virtual_node_indices = [
+            n_original_nodes + i for i in range(n_added_nodes)
+        ]
 
         for i in range(len(source_nodes)):
             source_counts[source_nodes[i]] += 1
@@ -57,19 +60,19 @@ def test_multiple_virtual_nodes():
 
         total_virtual_source_count = 0
         total_virtual_target_count = 0
-        # check virtual nodes' edges have been added in the correct way 
-        for i in range(n_added_nodes): 
-            assert source_counts[n_original_nodes + i] > 0 
+        # check virtual nodes' edges have been added in the correct way
+        for i in range(n_added_nodes):
+            assert source_counts[n_original_nodes + i] > 0
             assert source_counts[n_original_nodes + i] < 3
             assert target_counts[n_original_nodes + i] > 0
             assert target_counts[n_original_nodes + i] < 3
             total_virtual_source_count += source_counts[n_original_nodes + i]
             total_virtual_target_count += target_counts[n_original_nodes + i]
-        # check original nodes 
-        for j in range(n_original_nodes): 
+        # check original nodes
+        for j in range(n_original_nodes):
             assert source_counts[j] == 1
             assert target_counts[j] == 1
-        
+
         assert total_virtual_source_count == n_original_nodes
         assert total_virtual_target_count == n_original_nodes
 
@@ -89,7 +92,7 @@ def test_multiple_virtual_nodes():
 
     print("Test 1 passed\nTest 2: Clustering Assignments")
 
-    # Test 2: clustering assignments 
+    # Test 2: clustering assignments
     data = MultipleVirtualNodes(n_to_add=2, clustering=True)(original_data)
 
     assert len(data) == 6
@@ -98,7 +101,9 @@ def test_multiple_virtual_nodes():
     assert data.x[4:].abs().sum() == 0
 
     first_3_col = [row[:3] for row in data.edge_index.tolist()]
-    assert first_3_col == [[2, 0, 2], [3, 1, 0]] # check that the original edges are unchanged
+    assert first_3_col == [[2, 0, 2],
+                           [3, 1,
+                            0]]  # check that the original edges are unchanged
     assert data.edge_index.size() == (2, num_total_edges)
     validate_edge_index(data.edge_index.tolist(), 4, 2)
 
@@ -114,9 +119,11 @@ def test_multiple_virtual_nodes():
 
     assert data.edge_type.tolist() == [0, 0, 0, 1, 1, 1, 1, 2, 2, 2, 2]
 
-    print("Test 2 passed\nTest 3: Clustering Assignments with an empty cluster. Should add 2 virtual nodes instead of the specified 3")
+    print(
+        "Test 2 passed\nTest 3: Clustering Assignments with an empty cluster. Should add 2 virtual nodes instead of the specified 3"
+    )
 
-    # Test 2: clustering assignments 
+    # Test 2: clustering assignments
     data = MultipleVirtualNodes(n_to_add=3, clustering=True)(original_data)
 
     assert len(data) == 6
@@ -125,7 +132,9 @@ def test_multiple_virtual_nodes():
     assert data.x[4:].abs().sum() == 0
 
     first_3_col = [row[:3] for row in data.edge_index.tolist()]
-    assert first_3_col == [[2, 0, 2], [3, 1, 0]] # check that the original edges are unchanged
+    assert first_3_col == [[2, 0, 2],
+                           [3, 1,
+                            0]]  # check that the original edges are unchanged
     assert data.edge_index.size() == (2, num_total_edges)
     validate_edge_index(data.edge_index.tolist(), 4, 2)
 

--- a/torch_geometric/transforms/__init__.py
+++ b/torch_geometric/transforms/__init__.py
@@ -36,6 +36,7 @@ from .add_metapaths import AddMetaPaths, AddRandomMetaPaths
 from .rooted_subgraph import RootedEgoNets, RootedRWSubgraph
 from .largest_connected_components import LargestConnectedComponents
 from .virtual_node import VirtualNode
+from .multiple_virtual_nodes import MultipleVirtualNodes
 from .add_positional_encoding import AddLaplacianEigenvectorPE, AddRandomWalkPE
 from .feature_propagation import FeaturePropagation
 from .half_hop import HalfHop
@@ -106,6 +107,7 @@ graph_transforms = [
     'RootedRWSubgraph',
     'LargestConnectedComponents',
     'VirtualNode',
+    'MultipleVirtualNodes',
     'AddLaplacianEigenvectorPE',
     'AddRandomWalkPE',
     'FeaturePropagation',

--- a/torch_geometric/transforms/multiple_virtual_nodes.py
+++ b/torch_geometric/transforms/multiple_virtual_nodes.py
@@ -63,6 +63,7 @@ class MultipleVirtualNodes(BaseTransform):
                 adjacency_list[node1.item()] = np.append(adjacency_list[node1.item()], node2.item())
             # membership is a list like [1, 1, 1, 0, 1, 0,...] for self.n = 2
             n_cuts, membership = pymetis.part_graph(self.n, adjacency=adjacency_list)
+            membership = np.array(membership)
             assignments = [np.where(membership == v_node)[0] for v_node in range(self.n)]
 
         arange = torch.from_numpy(np.concatenate(assignments))

--- a/torch_geometric/transforms/multiple_virtual_nodes.py
+++ b/torch_geometric/transforms/multiple_virtual_nodes.py
@@ -1,0 +1,118 @@
+import copy
+import numpy as np
+
+import torch
+from torch import Tensor
+
+from torch_geometric.data import Data
+from torch_geometric.data.datapipes import functional_transform
+from torch_geometric.transforms import BaseTransform
+
+import pymetis
+
+@functional_transform('multiple_virtual_nodes')
+class MultipleVirtualNodes(BaseTransform):
+    r"""Appends a set of virtual node to the given homogeneous graph that is connected
+    to subsets of the nodes in the original graph. The assignment of original nodes to
+    virtual nodes is determined by either Randomness or Clustering, as described in the
+    paper `"An Analysis of Virtual Nodes in Graph Neural Networks for Link Prediction"
+    <https://openreview.net/pdf?id=dI6KBKNRp7>`_ paper
+    (functional name: :obj:`multiple_virtual_nodes`).
+    The virtual nodes serve as global scratch space that each node assigned to it both reads
+    from and writes to in every step of message passing.
+
+    Node and edge features of virtual nodes are added as zero-filled input
+    features.
+    Furthermore, special edge types will be added both for in-coming and
+    out-going information to and from each virtual node. (shared between virtual nodes)
+
+    Hyperparameters:
+    n_to_add: number of virtual nodes (int). default = 1
+    clustering: whether the clustering algorithm is used to assign virtual nodes (bool). default = False, means that assignment is random.
+
+    modified from VirtualNode class
+    """
+    def __init__(
+        self,
+        n_to_add: int,
+        clustering: bool
+    ) -> None:
+        self.n = n_to_add
+        self.clustering = clustering
+
+    def forward(self, data: Data) -> Data:
+        assert data.edge_index is not None
+        row, col = data.edge_index
+        edge_type = data.get('edge_type', torch.zeros_like(row))
+        num_nodes = data.num_nodes
+        assert num_nodes is not None
+        # ensure we are adding at least 1 virtual node
+        assert self.n > 0
+        assert self.n <= num_nodes
+
+        # Perform random assignment or clustering of virtual nodes
+        num_virtual_edges = num_nodes * 2
+        if not self.clustering:
+            # random assignment of virtual nodes
+            permute = np.random.permutation(num_nodes)
+            assignments = np.array_split(permute, self.n)
+        else:
+            # Run METIS, as suggested in the paper. each node is assigned to 1 partition
+            adjacency_list = [np.array([], dtype=int) for _ in range(num_nodes)]
+            for node1, node2 in zip(row, col):
+                adjacency_list[node1.item()] = np.append(adjacency_list[node1.item()], node2.item())
+            # membership is a list like [1, 1, 1, 0, 1, 0,...] for self.n = 2
+            n_cuts, membership = pymetis.part_graph(self.n, adjacency=adjacency_list)
+            assignments = [np.where(membership == v_node)[0] for v_node in range(self.n)]
+
+        arange = torch.from_numpy(np.concatenate(assignments))
+        # accounts for uneven splitting
+        full = torch.cat([torch.full((len(assignments[i]),), num_nodes + i, device=row.device) for i in range(self.n)],
+                         dim=-1)
+
+        # Update edge index
+        row = torch.cat([row, arange, full], dim=0)
+        col = torch.cat([col, full, arange], dim=0)
+        edge_index = torch.stack([row, col], dim=0)
+
+        # add new virtual edge types
+        num_edge_types = int(edge_type.max()) if edge_type.numel() > 0 else 0
+        new_type = edge_type.new_full((num_nodes, ), num_edge_types + 1)
+        edge_type = torch.cat([edge_type, new_type, new_type + 1], dim=0)
+
+        old_data = copy.copy(data)
+        for key, value in old_data.items():
+            # updating these attributes is handled above
+            if key == 'edge_index' or key == 'edge_type':
+                continue
+
+            if isinstance(value, Tensor):
+                dim = old_data.__cat_dim__(key, value)
+                size = list(value.size())
+
+                fill_value = None
+                if key == 'edge_weight':
+                    size[dim] = num_virtual_edges
+                    fill_value = 1.
+                elif key == 'batch':
+                    size[dim] = self.n
+                    fill_value = int(value[0])
+                elif old_data.is_edge_attr(key):
+                    size[dim] = num_virtual_edges
+                    fill_value = 0.
+                elif old_data.is_node_attr(key):
+                    # add virtual node features (zeros)
+                    size[dim] = self.n
+                    fill_value = 0.
+
+                if fill_value is not None:
+                    new_value = value.new_full(size, fill_value)
+                    data[key] = torch.cat([value, new_value], dim=dim)
+
+        data.edge_index = edge_index
+        data.edge_type = edge_type
+
+        if 'num_nodes' in data:
+            data.num_nodes = num_nodes + self.n
+
+        return data


### PR DESCRIPTION
Currently, PyG Transforms module supports adding a single Virtual Node connected to all nodes in the graph, implemented in torch_geometric/transforms/virtual_node.py. Motivated by the paper ["An Analysis of Virtual Nodes in Graph Neural Networks for Link Prediction" ](https://openreview.net/pdf?id=dI6KBKNRp7), which finds that adding multiple or more virtual nodes to the graph improves performance, I added / modified 3 files to support adding multiple virtual nodes to the graph within the Transforms module: 

1. Added torch_geometric/transforms/multiple_virtual_nodes.py:
-  creates the MultipleVirtualNodes class, which can be initialized with 3 parameters, num_to_add: int number of virtual nodes to add to graph, clustering: bool that specifies if the user wants to perform the PyG METIS clustering on the graph to assign virtual nodes to current nodes, or wants to assign them randomly, and recursive: bool to specify if PyG clustering is multi-level bisection (True) or k-way multilevel clustering (False). ***Note: ClusterData requires either 'pyg-lib' or 'torch-sparse'***
- modifies data.edge_index, x, edge_index, edge_type, etc to reflect these changes to the graph. 
2. Added test/transforms/test_multiple_virtual_nodes.py to validate the changes. 
3. Updated torch_geometric/transforms/__init__.py to reflect the new transform. 
I referred to the current VirtualNode implementations. 