### PR TITLE
Adding coreference resolution before chunking text for improved text-to-KG

### DIFF
--- a/torch_geometric/nn/nlp/txt2kg.py
+++ b/torch_geometric/nn/nlp/txt2kg.py
@@ -251,8 +251,7 @@ def chunk_text(text: str, chunk_size: int = 512) -> list[str]:
     return chunks
 
 
-def corefernce_resolution(
-        text: str, nlp_language_pipeline: Language) -> str:
+def corefernce_resolution(text: str, nlp_language_pipeline: Language) -> str:
     """Performs coreference resolution on input text using spaCy's coreferee.
 
     Resolves pronouns and other references to their full entity mentions to improve


### PR DESCRIPTION
Performs coreference resolution on input text using spaCy's coreferee. Currently suppoerted for 'EN'.
Resolves pronouns and other references to their full entity mentions to improve knowledge graph extraction. Also cleans up text formatting post resolution.