### PR TITLE
fix: update `__reduce__` for `EdgeTypeStr`

### DIFF
--- a/torch_geometric/typing.py
+++ b/torch_geometric/typing.py
@@ -345,6 +345,9 @@ class EdgeTypeStr(str):
                              f"tuple since it holds invalid characters")
         return self.edge_type
 
+    def __reduce__(self) -> str | tuple[Any, ...]:
+        return (self.__class__, (self.edge_type, ))
+
 
 # There exist some short-cuts to query edge-types (given that the full triplet
 # can be uniquely reconstructed, e.g.:

--- a/torch_geometric/typing.py
+++ b/torch_geometric/typing.py
@@ -345,7 +345,7 @@ class EdgeTypeStr(str):
                              f"tuple since it holds invalid characters")
         return self.edge_type
 
-    def __reduce__(self) -> str | tuple[Any, ...]:
+    def __reduce__(self) -> tuple[Any, Any]:
         return (self.__class__, (self.edge_type, ))
 
 


### PR DESCRIPTION
Supports `deepcopy` on `EdgeTypeStr`.