### PR TITLE
Migrate old `pytorch-lightning` imports to modern `lightning` imports

### DIFF
--- a/examples/pytorch_lightning/graph_sage.py
+++ b/examples/pytorch_lightning/graph_sage.py
@@ -1,8 +1,10 @@
 import os.path as osp
 
-import pytorch_lightning as pl
 import torch
 import torch.nn.functional as F
+from lightning import LightningModule, Trainer
+from lightning.pytorch.callbacks import ModelCheckpoint
+from lightning.pytorch.strategies import SingleDeviceStrategy
 from torch.nn import BatchNorm1d
 from torchmetrics import Accuracy
 
@@ -11,7 +13,7 @@ from torch_geometric.datasets import Reddit
 from torch_geometric.nn import GraphSAGE
 
 
-class Model(pl.LightningModule):
+class Model(LightningModule):
     def __init__(self, in_channels: int, out_channels: int,
                  hidden_channels: int = 256, num_layers: int = 2,
                  dropout: float = 0.5):
@@ -71,10 +73,10 @@ if __name__ == '__main__':
 
     model = Model(dataset.num_node_features, dataset.num_classes)
 
-    strategy = pl.strategies.SingleDeviceStrategy('cuda:0')
-    checkpoint = pl.callbacks.ModelCheckpoint(monitor='val_acc', save_top_k=1,
+    strategy = SingleDeviceStrategy('cuda:0')
+    checkpoint = ModelCheckpoint(monitor='val_acc', save_top_k=1,
                                               mode='max')
-    trainer = pl.Trainer(strategy=strategy, devices=1, max_epochs=20,
+    trainer = Trainer(strategy=strategy, devices=1, max_epochs=20,
                          callbacks=[checkpoint])
 
     trainer.fit(model, datamodule)

--- a/examples/pytorch_lightning/relational_gnn.py
+++ b/examples/pytorch_lightning/relational_gnn.py
@@ -1,11 +1,11 @@
 import os.path as osp
 from typing import Dict, List, Tuple
 
-import pytorch_lightning as pl
 import torch
 import torch.nn.functional as F
-from pytorch_lightning import LightningModule, Trainer
-from pytorch_lightning.callbacks import ModelCheckpoint
+from lightning import LightningModule, Trainer
+from lightning.pytorch.callbacks import ModelCheckpoint
+from lightning.pytorch.strategies import SingleDeviceStrategy
 from torch import Tensor
 from torchmetrics import Accuracy
 
@@ -116,7 +116,7 @@ def main():
         batch = next(iter(loader))
         model.common_step(batch)
 
-    strategy = pl.strategies.SingleDeviceStrategy('cuda:0')
+    strategy = SingleDeviceStrategy('cuda:0')
     checkpoint = ModelCheckpoint(monitor='val_acc', save_top_k=1, mode='max')
     trainer = Trainer(strategy=strategy, devices=1, max_epochs=20,
                       log_every_n_steps=5, callbacks=[checkpoint])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ dependencies=[
 [project.optional-dependencies]
 graphgym=[
     "protobuf<4.21",
-    "pytorch-lightning<2.3.0",
+    "lightning<2.3.0",
     "yacs",
 ]
 modelhub=[
@@ -187,7 +187,7 @@ filterwarnings = [
     # Filter `captum` warnings:
     "ignore:Setting backward hooks on ReLU activations:UserWarning",
     "ignore:.*did not already require gradients, required_grads has been set automatically:UserWarning",
-    # Filter `pytorch_lightning` warnings:
+    # Filter `lightning` warnings:
     "ignore:GPU available but not used:UserWarning",
 ]
 

--- a/test/graphgym/test_graphgym.py
+++ b/test/graphgym/test_graphgym.py
@@ -42,7 +42,7 @@ def trivial_metric(true, pred, task_type):
 
 
 @onlyOnline
-@withPackage('yacs', 'pytorch_lightning')
+@withPackage('yacs', 'lightning')
 @pytest.mark.parametrize('auto_resume', [True, False])
 @pytest.mark.parametrize('skip_train_eval', [True, False])
 @pytest.mark.parametrize('use_trivial_metric', [True, False])
@@ -110,9 +110,9 @@ def test_run_single_graphgym(tmp_path, capfd, auto_resume, skip_train_eval,
 
 
 @onlyOnline
-@withPackage('yacs', 'pytorch_lightning')
+@withPackage('yacs', 'lightning')
 def test_graphgym_module(tmp_path):
-    import pytorch_lightning as pl
+    import lightning as L
 
     load_cfg(cfg, args)
     cfg.out_dir = osp.join(tmp_path, 'out_dir')
@@ -131,7 +131,7 @@ def test_graphgym_module(tmp_path):
     assert len(loaders) == 3
 
     model = create_model()
-    assert isinstance(model, pl.LightningModule)
+    assert isinstance(model, L.LightningModule)
 
     optimizer, scheduler = model.configure_optimizers()
     assert isinstance(optimizer[0], torch.optim.Adam)
@@ -172,11 +172,11 @@ def destroy_process_group():
 
 @onlyOnline
 @onlyLinux
-@withPackage('yacs', 'pytorch_lightning')
+@withPackage('yacs', 'lightning')
 def test_train(destroy_process_group, tmp_path, capfd):
     warnings.filterwarnings('ignore', ".*does not have many workers.*")
 
-    import pytorch_lightning as pl
+    import lightning as L
 
     load_cfg(cfg, args)
     cfg.out_dir = osp.join(tmp_path, 'out_dir')
@@ -195,7 +195,7 @@ def test_train(destroy_process_group, tmp_path, capfd):
     model = create_model()
     cfg.params = params_count(model)
     logger = LoggerCallback()
-    trainer = pl.Trainer(max_epochs=1, max_steps=4, callbacks=logger,
+    trainer = L.Trainer(max_epochs=1, max_steps=4, callbacks=logger,
                          log_every_n_steps=1)
     train_loader, val_loader = loaders[0], loaders[1]
     trainer.fit(model, train_loader, val_loader)

--- a/test/graphgym/test_logger.py
+++ b/test/graphgym/test_logger.py
@@ -4,7 +4,7 @@ from torch_geometric.graphgym.logger import Logger, LoggerCallback
 from torch_geometric.testing import withPackage
 
 
-@withPackage('yacs', 'pytorch_lightning')
+@withPackage('yacs', 'lightning')
 def test_logger_callback():
     loaders = create_loader()
     assert len(loaders) == 3

--- a/torch_geometric/data/lightning/datamodule.py
+++ b/torch_geometric/data/lightning/datamodule.py
@@ -11,21 +11,21 @@ from torch_geometric.sampler import BaseSampler, NeighborSampler
 from torch_geometric.typing import InputEdges, InputNodes, OptTensor
 
 try:
-    from pytorch_lightning import LightningDataModule as PLLightningDataModule
-    no_pytorch_lightning = False
+    from lightning import LightningDataModule as PLLightningDataModule
+    no_lightning = False
 except ImportError:
     PLLightningDataModule = object  # type: ignore
-    no_pytorch_lightning = True
+    no_lightning = True
 
 
 class LightningDataModule(PLLightningDataModule):
     def __init__(self, has_val: bool, has_test: bool, **kwargs: Any) -> None:
         super().__init__()
 
-        if no_pytorch_lightning:
+        if no_lightning:
             raise ModuleNotFoundError(
-                "No module named 'pytorch_lightning' found on this machine. "
-                "Run 'pip install pytorch_lightning' to install the library.")
+                "No module named 'lightning' found on this machine. "
+                "Run 'pip install lightning' to install the library.")
 
         if not has_val:
             self.val_dataloader = None  # type: ignore
@@ -204,27 +204,27 @@ class LightningData(LightningDataModule):
 
 class LightningDataset(LightningDataModule):
     r"""Converts a set of :class:`~torch_geometric.data.Dataset` objects into a
-    :class:`pytorch_lightning.LightningDataModule` variant. It can then be
+    :class:`lightning.LightningDataModule` variant. It can then be
     automatically used as a :obj:`datamodule` for multi-GPU graph-level
     training via :lightning:`null`
-    `PyTorch Lightning <https://www.pytorchlightning.ai>`__.
+    `PyTorch Lightning <https://lightning.ai/pytorch-lightning>`__.
     :class:`LightningDataset` will take care of providing mini-batches via
     :class:`~torch_geometric.loader.DataLoader`.
 
     .. note::
 
         Currently only the
-        :class:`pytorch_lightning.strategies.SingleDeviceStrategy` and
-        :class:`pytorch_lightning.strategies.DDPStrategy` training
-        strategies of :lightning:`null` `PyTorch Lightning
-        <https://pytorch-lightning.readthedocs.io/en/latest/guides/
-        speed.html>`__ are supported in order to correctly share data across
-        all devices/processes:
+        :class:`lightning.pytorch.strategies.SingleDeviceStrategy` and
+        :class:`lightning.pytorch.strategies.DDPStrategy` training
+        strategies of :lightning:`null` `Lightning
+        <https://lightning.ai/docs/pytorch/stable/accelerators/gpu_expert.html
+        #what-is-a-strategy>`__ are supported in order to correctly share data
+        across all devices/processes:
 
         .. code-block:: python
 
-            import pytorch_lightning as pl
-            trainer = pl.Trainer(strategy="ddp_spawn", accelerator="gpu",
+            import lightning as L
+            trainer = L.Trainer(strategy="ddp", accelerator="gpu",
                                  devices=4)
             trainer.fit(model, datamodule)
 
@@ -315,27 +315,27 @@ class LightningDataset(LightningDataModule):
 class LightningNodeData(LightningData):
     r"""Converts a :class:`~torch_geometric.data.Data` or
     :class:`~torch_geometric.data.HeteroData` object into a
-    :class:`pytorch_lightning.LightningDataModule` variant. It can then be
+    :class:`lightning.LightningDataModule` variant. It can then be
     automatically used as a :obj:`datamodule` for multi-GPU node-level
     training via :lightning:`null`
-    `PyTorch Lightning <https://www.pytorchlightning.ai>`__.
+    `PyTorch Lightning <https://lightning.ai/pytorch-lightning>`__.
     :class:`LightningDataset` will take care of providing mini-batches via
     :class:`~torch_geometric.loader.NeighborLoader`.
 
     .. note::
 
         Currently only the
-        :class:`pytorch_lightning.strategies.SingleDeviceStrategy` and
-        :class:`pytorch_lightning.strategies.DDPStrategy` training
+        :class:`lightning.pytorch.strategies.SingleDeviceStrategy` and
+        :class:`lightning.pytorch.strategies.DDPStrategy` training
         strategies of :lightning:`null` `PyTorch Lightning
-        <https://pytorch-lightning.readthedocs.io/en/latest/guides/
-        speed.html>`__ are supported in order to correctly share data across
-        all devices/processes:
+        <https://lightning.ai/docs/pytorch/stable/accelerators/gpu_expert.html
+        #what-is-a-strategy>`__ are supported in order to correctly share data
+        across all devices/processes:
 
         .. code-block:: python
 
-            import pytorch_lightning as pl
-            trainer = pl.Trainer(strategy="ddp_spawn", accelerator="gpu",
+            import lightning as L
+            trainer = L.Trainer(strategy="ddp_spawn", accelerator="gpu",
                                  devices=4)
             trainer.fit(model, datamodule)
 
@@ -508,27 +508,27 @@ class LightningNodeData(LightningData):
 class LightningLinkData(LightningData):
     r"""Converts a :class:`~torch_geometric.data.Data` or
     :class:`~torch_geometric.data.HeteroData` object into a
-    :class:`pytorch_lightning.LightningDataModule` variant. It can then be
+    :class:`lightning.LightningDataModule` variant. It can then be
     automatically used as a :obj:`datamodule` for multi-GPU link-level
     training via :lightning:`null`
-    `PyTorch Lightning <https://www.pytorchlightning.ai>`__.
+    `PyTorch Lightning <https://lightning.ai/pytorch-lightning>`__.
     :class:`LightningDataset` will take care of providing mini-batches via
     :class:`~torch_geometric.loader.LinkNeighborLoader`.
 
     .. note::
 
         Currently only the
-        :class:`pytorch_lightning.strategies.SingleDeviceStrategy` and
-        :class:`pytorch_lightning.strategies.DDPStrategy` training
+        :class:`lightning.pytorch.strategies.SingleDeviceStrategy` and
+        :class:`lightning.pytorch.strategies.DDPStrategy` training
         strategies of :lightning:`null` `PyTorch Lightning
-        <https://pytorch-lightning.readthedocs.io/en/latest/guides/
-        speed.html>`__ are supported in order to correctly share data across
-        all devices/processes:
+        <https://lightning.ai/docs/pytorch/stable/accelerators/gpu_expert.html
+        #what-is-a-strategy>`__ are supported in order to correctly share data
+        across all devices/processes:
 
         .. code-block:: python
 
-            import pytorch_lightning as pl
-            trainer = pl.Trainer(strategy="ddp_spawn", accelerator="gpu",
+            import lightning as L
+            trainer = L.Trainer(strategy="ddp_spawn", accelerator="gpu",
                                  devices=4)
             trainer.fit(model, datamodule)
 

--- a/torch_geometric/graphgym/imports.py
+++ b/torch_geometric/graphgym/imports.py
@@ -3,13 +3,13 @@ import warnings
 import torch
 
 try:
-    import pytorch_lightning as pl
-    LightningModule = pl.LightningModule
-    Callback = pl.Callback
+    import lighting as L
+    LightningModule = L.LightningModule
+    Callback = L.Callback
 except ImportError:
-    pl = object
+    L = object
     LightningModule = torch.nn.Module
     Callback = object
 
-    warnings.warn("Please install 'pytorch_lightning' via  "
-                  "'pip install pytorch_lightning' in order to use GraphGym")
+    warnings.warn("Please install 'lightning' via  "
+                  "'pip install lightning' in order to use GraphGym")

--- a/torch_geometric/graphgym/train.py
+++ b/torch_geometric/graphgym/train.py
@@ -8,13 +8,13 @@ from torch_geometric.data.lightning.datamodule import LightningDataModule
 from torch_geometric.graphgym import create_loader
 from torch_geometric.graphgym.checkpoint import get_ckpt_dir
 from torch_geometric.graphgym.config import cfg
-from torch_geometric.graphgym.imports import pl
+from torch_geometric.graphgym.imports import L
 from torch_geometric.graphgym.logger import LoggerCallback
 from torch_geometric.graphgym.model_builder import GraphGymModule
 
 
 class GraphGymDataModule(LightningDataModule):
-    r"""A :class:`pytorch_lightning.LightningDataModule` for handling data
+    r"""A :class:`lightning.LightningDataModule` for handling data
     loading routines in GraphGym.
 
     This class provides data loaders for training, validation, and testing, and
@@ -58,11 +58,11 @@ def train(
     if logger:
         callbacks.append(LoggerCallback())
     if cfg.train.enable_ckpt:
-        ckpt_cbk = pl.callbacks.ModelCheckpoint(dirpath=get_ckpt_dir())
+        ckpt_cbk = L.pytorch.callbacks.ModelCheckpoint(dirpath=get_ckpt_dir())
         callbacks.append(ckpt_cbk)
 
     trainer_config = trainer_config or {}
-    trainer = pl.Trainer(
+    trainer = L.Trainer(
         **trainer_config,
         enable_checkpointing=cfg.train.enable_ckpt,
         callbacks=callbacks,


### PR DESCRIPTION
Fixes #9811.

As the title says. PyTorch Lightning as been recommending a new import style (`import Lightning as L` rather than `import pytorch_lightning as pl`) since early 2023 now.

The old style was/is still supported for backwards compatibility, but both styles cannot be used at the same time (see [here](https://github.com/Lightning-AI/pytorch-lightning/discussions/16688#discussioncomment-8193205)). Since PyG uses the old style, this means that projects using PyG are stuck with the old style. Most importantly, it can cause clashes when projects rely on other dependencies that use the modern import style (see #9811).

Therefore, I would suggest that PyG migrates to the new style, like other projects have done (e.g. Optuna [here](https://github.com/optuna/optuna/issues/4935)).

Since the task didn't seem to massive, I've migrated over all of the Lightning that I found across the project, and standardized the import styles between examples and tests (to use the style recommended in Lightning's own docs).