### PR TITLE
Add new batch filtering method for efficiency purpose

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Added the `use_pcst` option to `WebQSPDataset` ([#9722](https://github.com/pyg-team/pytorch_geometric/pull/9722))
 - Allowed users to pass `edge_weight` to `GraphUNet` models ([#9737](https://github.com/pyg-team/pytorch_geometric/pull/9737))
 - Consolidated `examples/ogbn_{papers_100m,products_gat,products_sage}.py` into `examples/ogbn_train.py` ([#9467](https://github.com/pyg-team/pytorch_geometric/pull/9467))
+- Added `filter` method for efficient Batch filtering ([#9911](https://github.com/pyg-team/pytorch_geometric/pull/9911))
 
 ### Changed
 

--- a/test/data/test_batch.py
+++ b/test/data/test_batch.py
@@ -636,5 +636,5 @@ def test_batch_filtering():
         'paper'].exist.shape
     assert batch_filtered[1]['author'].x.shape == batch[3]['author'].x.shape
 
-    # Verify the filtered batch supports round-trip conversion to and from a data list
+    # Check if result supports round-trip conversion to and from a data list
     assert Batch.from_data_list(batch_filtered.to_data_list())

--- a/test/data/test_batch.py
+++ b/test/data/test_batch.py
@@ -608,3 +608,33 @@ def test_torch_nested_batch():
         batch.x.to_padded_tensor(0.0),
         expected.to_padded_tensor(0.0),
     )
+
+
+def test_batch_filtering():
+    # Create initial HeteroData object and batch
+    data_list = []
+    for i in range(1, 5):
+        data = HeteroData()
+        data.info_1 = torch.ones(3)  # graph attribute
+        data.info_2 = torch.ones(3)  # graph attribute
+        data['paper'].x = torch.randn(2*i, 16)
+        data['paper'].exist = torch.randn(4*i, 1)  # node attributes of different length than x
+        data['author'].x = torch.randn(3*i, 2)
+        data['author', 'writes', 'paper'].edge_index = torch.stack((
+            torch.arange(3*i).repeat(2),
+            torch.arange(2*i).repeat(3)
+        ))
+        data['author', 'writes', 'paper'].edge_attr = torch.randn(6*i, 3)
+        data_list.append(data)
+    batch = Batch.from_data_list(data_list)
+    batch_filtered = batch.filter([1, 3])
+    assert isinstance(batch, Batch)
+    assert isinstance(batch_filtered, Batch)
+    assert len(batch) == 4
+    assert len(batch_filtered) == 2
+    assert batch_filtered[0]['paper'].x.shape == batch[1]['paper'].x.shape
+    assert batch_filtered[0]['paper'].exist.shape == batch[1]['paper'].exist.shape
+    assert batch_filtered[1]['author'].x.shape == batch[3]['author'].x.shape
+
+    # Verify the filtered batch supports round-trip conversion to and from a data list
+    assert Batch.from_data_list(batch_filtered.to_data_list())

--- a/test/data/test_batch.py
+++ b/test/data/test_batch.py
@@ -624,7 +624,16 @@ def test_batch_filtering():
         data.info = [i]*i  # Add argument of variable size
         data_list.append(data)
     batch = Batch.from_data_list(data_list)
-    batch_filtered = batch.filter([1, 2])
+
+    # Check different filtering methods:
+    assert isinstance(batch[1:], Batch)
+    assert isinstance(batch[torch.tensor([0, 1])], Batch)
+    assert isinstance(batch[torch.tensor([True, False, True, False])], Batch)
+    assert isinstance(batch[np.array([0, 1])], Batch)
+    assert isinstance(batch[np.array([True, False, True, False])], Batch)
+    assert isinstance(batch[[1, 2]], Batch)
+
+    batch_filtered = batch[[False, True, True, False]]
     assert isinstance(batch, Batch)
     assert isinstance(batch_filtered, Batch)
     assert len(batch) == 4
@@ -655,7 +664,7 @@ def test_herero_batch_filtering():
         data['author', 'writes', 'paper'].edge_attr = torch.randn(6 * i, 3)
         data_list.append(data)
     batch = Batch.from_data_list(data_list)
-    batch_filtered = batch.filter([1, 3])
+    batch_filtered = batch[[1, 3]]
     assert isinstance(batch, Batch)
     assert isinstance(batch_filtered, Batch)
     assert len(batch) == 4

--- a/torch_geometric/data/batch.py
+++ b/torch_geometric/data/batch.py
@@ -258,7 +258,8 @@ class Batch(metaclass=DynamicInheritance):
                     new_store[attr] = old_store[attr][:, attr_mask]
                 elif isinstance(old_store[attr], list):
                     new_store[attr] = [
-                        x for x, m in zip(old_store[attr], attr_mask) if m]
+                        x for x, m in zip(old_store[attr], attr_mask) if m
+                    ]
                 else:
                     new_store[attr] = old_store[attr][attr_mask]
 

--- a/torch_geometric/data/batch.py
+++ b/torch_geometric/data/batch.py
@@ -179,7 +179,6 @@ class Batch(metaclass=DynamicInheritance):
         object (e.g., :obj:`[2:5]`), or a :obj:`torch.Tensor`/:obj:`np.ndarray`
         of type long or bool, or any sequence of integers (excluding strings).
         """
-
         mask = torch.zeros(len(self), dtype=torch.bool)
         try:
             mask[idx] = True

--- a/torch_geometric/data/batch.py
+++ b/torch_geometric/data/batch.py
@@ -243,8 +243,9 @@ class Batch(metaclass=DynamicInheritance):
             for attr, slc in slices.items():
                 slice_diff = slc.diff()
 
-                # Reshape mask to align it with attribute shape
-                attr_mask = mask[torch.repeat_interleave(slice_diff)]
+                # Reshape mask to align it with attribute shape.
+                # Since slice_diff often contains only ones, skip useless computation in such cases
+                attr_mask = mask[torch.repeat_interleave(slice_diff)] if torch.any(slice_diff != 1) else mask
 
                 # Apply mask to attribute
                 if attr == 'edge_index':

--- a/torch_geometric/data/batch.py
+++ b/torch_geometric/data/batch.py
@@ -245,7 +245,8 @@ class Batch(metaclass=DynamicInheritance):
 
                 # Reshape mask to align it with attribute shape.
                 # Since slice_diff often contains only ones, skip useless computation in such cases
-                attr_mask = mask[torch.repeat_interleave(slice_diff)] if torch.any(slice_diff != 1) else mask
+                attr_mask = mask[torch.repeat_interleave(
+                    slice_diff)] if torch.any(slice_diff != 1) else mask
 
                 # Apply mask to attribute
                 if attr == 'edge_index':

--- a/torch_geometric/data/batch.py
+++ b/torch_geometric/data/batch.py
@@ -250,10 +250,7 @@ class Batch(metaclass=DynamicInheritance):
                 if attr == 'edge_index':
                     new_store[attr] = old_store[attr][:, attr_mask]
                 elif isinstance(old_store[attr], list):
-                    new_store[attr] = [
-                        item for item, m in zip(old_store[attr], attr_mask)
-                        if m
-                    ]
+                    new_store[attr] = [x for x, m in zip(old_store[attr], attr_mask) if m]
                 else:
                     new_store[attr] = old_store[attr][attr_mask]
 

--- a/torch_geometric/data/batch.py
+++ b/torch_geometric/data/batch.py
@@ -222,6 +222,10 @@ class Batch(metaclass=DynamicInheritance):
         # Update the number of graphs based on the mask
         batch._num_graphs = mask.sum().item()
 
+        # Return empty batch when mask filters all elements
+        if batch._num_graphs == 0:
+            return batch
+
         # Mask application works the same way for all attribute levels (graph, nodes, edges)
         for old_store, new_store in zip(self.stores, batch.stores):
             # We get slices dictionary from key. If key is None then we are dealing with graph level attributes.

--- a/torch_geometric/data/batch.py
+++ b/torch_geometric/data/batch.py
@@ -278,7 +278,7 @@ class Batch(metaclass=DynamicInheritance):
                     new_edge_index_spans = old_edge_index_spans[:, mask]
                     new_inc_tmp = new_edge_index_spans.cumsum(1)
                     new_inc_tmp[:, -1] = 0
-                    new_inc = new_inc.roll(1, dims=1)
+                    new_inc = new_inc_tmp.roll(1, dims=1)
 
                     # Map each edge_index element to its batch position
                     edge_index_batch_map = torch.repeat_interleave(sizes_masked)

--- a/torch_geometric/data/batch.py
+++ b/torch_geometric/data/batch.py
@@ -268,14 +268,13 @@ class Batch(metaclass=DynamicInheritance):
                     # We assume x node attributes to be changed before edge attributes
                     # so that mapping_idx_dict is already available.
                     old_inc = self._inc_dict[key][attr].squeeze(-1).T
-                    old_inc_diff = old_inc.diff(
-                        prepend=torch.zeros((2, 1), dtype=torch.int))[:, mask]
-                    old_inc_diff[:, 0] = 0
-                    new_inc = old_inc_diff.cumsum(1)
-                    shift_inc = new_inc - old_inc[:, mask]
+                    new_inc = old_inc.diff()[:, mask[:-1]].cumsum(1)
+                    new_inc = torch.cat((torch.zeros((2, 1), dtype=torch.int), new_inc), dim=1)
+
+                    shift = new_inc - old_inc[:, mask]
 
                     edge_index_batch = torch.repeat_interleave(sizes_masked)
-                    batch[key].edge_index += shift_inc[:, edge_index_batch]
+                    batch[key].edge_index += shift[:, edge_index_batch]
 
                     new_inc = new_inc.T.unsqueeze(-1)
 

--- a/torch_geometric/data/batch.py
+++ b/torch_geometric/data/batch.py
@@ -243,9 +243,12 @@ class Batch(metaclass=DynamicInheritance):
                 attr_mask = mask[torch.repeat_interleave(slice_diff)]
 
                 # Apply mask to attribute
-                new_store[attr] = old_store[
-                    attr][:, attr_mask] if attr == 'edge_index' else old_store[
-                        attr][attr_mask]
+                if attr == 'edge_index':
+                    new_store[attr] = old_store[attr][:, attr_mask]
+                elif isinstance(old_store[attr], list):
+                    new_store[attr] = [item for item, m in zip(old_store[attr], attr_mask) if m]
+                else:
+                    new_store[attr] = old_store[attr][attr_mask]
 
                 # Compute masked version of slice tensor
                 sizes_masked = slice_diff[mask]


### PR DESCRIPTION
This PR improves `DataBatch` and `HeteroDataBatch` filtering:

- **Keeps Original Batch Type:** Previously, `batch[mask]` used to return a data list, requiring reconversion with `Batch.from_data_list(batch[mask])`. Now, it directly returns a filtered Batch, preserving the original type.

- **Faster Filtering:** The old approach used to split the batch in order to apply the mask, which was inefficient, especially with batch reconstruction afterward. The new implementation applies the mask directly to all batch components, achieving up to 10x speedup.

**Note**: If the user still needs a data list, they can convert the result with batch[mask].to_data_list(), or use the previous method: batch.index_select(mask).