### PR TITLE
Fix `GlobalStorage.is_node_attr` and `GlobalStorage.is_edge_attr` when passing tuples in `cat_dim`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Fixed the `k_hop_subgraph()` method for directed graphs ([#9756](https://github.com/pyg-team/pytorch_geometric/pull/9756))
 - Fixed `utils.group_cat` concatenating dimension ([#9766](https://github.com/pyg-team/pytorch_geometric/pull/9766))
 - Fixed `WebQSDataset.process` raising exceptions ([#9665](https://github.com/pyg-team/pytorch_geometric/pull/9665))
-- Fixed `GlobalStorage.is_node_attr()` and `GlobalStorage.is_edge_attr()` errors when cat_dim is a tuple ([#9895](https://github.com/pyg-team/pytorch_geometric/issues/9895))
+- Fixed `is_node_attr()` and `is_edge_attr()` errors when `cat_dim` is a tuple ([#9895](https://github.com/pyg-team/pytorch_geometric/issues/9895))
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Fixed the `k_hop_subgraph()` method for directed graphs ([#9756](https://github.com/pyg-team/pytorch_geometric/pull/9756))
 - Fixed `utils.group_cat` concatenating dimension ([#9766](https://github.com/pyg-team/pytorch_geometric/pull/9766))
 - Fixed `WebQSDataset.process` raising exceptions ([#9665](https://github.com/pyg-team/pytorch_geometric/pull/9665))
+- Fixed `GlobalStorage.is_node_attr()` and `GlobalStorage.is_edge_attr()` errors when cat_dim is a tuple ([#9895](https://github.com/pyg-team/pytorch_geometric/issues/9895))
 
 ### Removed
 

--- a/torch_geometric/data/storage.py
+++ b/torch_geometric/data/storage.py
@@ -35,6 +35,7 @@ from torch_geometric.typing import (
 from torch_geometric.utils import (
     coalesce,
     contains_isolated_nodes,
+    is_sparse,
     is_torch_sparse_tensor,
     is_undirected,
     select,
@@ -806,6 +807,10 @@ class GlobalStorage(NodeStorage, EdgeStorage):
             return False
 
         cat_dim = self._parent().__cat_dim__(key, value, self)
+
+        if is_sparse(value) and isinstance(cat_dim, tuple):
+            cat_dim = cat_dim[0]
+
         num_nodes, num_edges = self.num_nodes, self.num_edges
 
         if value.shape[cat_dim] != num_nodes:
@@ -852,6 +857,10 @@ class GlobalStorage(NodeStorage, EdgeStorage):
             return False
 
         cat_dim = self._parent().__cat_dim__(key, value, self)
+
+        if is_sparse(value) and isinstance(cat_dim, tuple):
+            cat_dim = cat_dim[0]
+
         num_nodes, num_edges = self.num_nodes, self.num_edges
 
         if value.shape[cat_dim] != num_edges:

--- a/torch_geometric/data/storage.py
+++ b/torch_geometric/data/storage.py
@@ -35,7 +35,6 @@ from torch_geometric.typing import (
 from torch_geometric.utils import (
     coalesce,
     contains_isolated_nodes,
-    is_sparse,
     is_torch_sparse_tensor,
     is_undirected,
     select,
@@ -808,8 +807,8 @@ class GlobalStorage(NodeStorage, EdgeStorage):
 
         cat_dim = self._parent().__cat_dim__(key, value, self)
 
-        if is_sparse(value) and isinstance(cat_dim, tuple):
-            cat_dim = cat_dim[0]
+        if not isinstance(cat_dim, int):
+            return False
 
         num_nodes, num_edges = self.num_nodes, self.num_edges
 
@@ -858,8 +857,8 @@ class GlobalStorage(NodeStorage, EdgeStorage):
 
         cat_dim = self._parent().__cat_dim__(key, value, self)
 
-        if is_sparse(value) and isinstance(cat_dim, tuple):
-            cat_dim = cat_dim[0]
+        if not isinstance(cat_dim, int):
+            return False
 
         num_nodes, num_edges = self.num_nodes, self.num_edges
 


### PR DESCRIPTION
The PR fixes the issue when calling is_node_attr and is_edge_attr for Data objects with sparse attributes that assume block-diagonal concatenation ( [#9895](https://github.com/pyg-team/pytorch_geometric/issues/9895) and in  [#8709](https://github.com/pyg-team/pytorch_geometric/issues/8709)). These cases raise an error due to cat_dim being a tuple, the change catches this case and looks at the 0-th dimension of the sparse tensor. 

