### PR TITLE
[FutureWarning] Fixing warning triggered by `torch.cuda.reset_max_memory_allocated()` usage.

### DIFF
--- a/examples/llm/molecule_gpt.py
+++ b/examples/llm/molecule_gpt.py
@@ -167,7 +167,7 @@ def train(
                 f'moleculegpt_epoch{best_epoch}_val_loss{best_val_loss:4f}_ckpt.pt'  # noqa: E501
             )
     torch.cuda.empty_cache()
-    torch.cuda.reset_max_memory_allocated()
+    torch.cuda.reset_peak_memory_stats()
 
     print(f"Total Training Time: {time.time() - start_time:2f}s")
     # Test


### PR DESCRIPTION
This PR addresses the following warning that occurs during the
```
/usr/local/lib/python3.12/dist-packages/torch/cuda/memory.py:374: FutureWarning: torch.cuda.reset_max_memory_allocated 
now calls torch.cuda.reset_peak_memory_stats, which resets /all/ peak memory stats. 
```
that occurs during the `molecule_gpt` test:
```
python3 /workspace/examples/llm/molecule_gpt.py
```
