### PR TITLE
[BugFix] Fixing two `lightning` tests.

### DIFF
--- a/test/data/lightning/test_datamodule.py
+++ b/test/data/lightning/test_datamodule.py
@@ -18,12 +18,12 @@ from torch_geometric.testing import (
     MyFeatureStore,
     MyGraphStore,
     get_random_edge_index,
+    has_package,
     onlyCUDA,
     onlyFullTest,
     onlyNeighborSampler,
     onlyOnline,
     withPackage,
-    has_package,
 )
 
 try:
@@ -116,19 +116,16 @@ def test_lightning_dataset(get_dataset, strategy_type):
         assert 'shuffle' not in datamodule.kwargs
     old_x = train_dataset._data.x.clone()
     new_datamodule_repr = has_package('pytorch_lightning>=2.5.0')
-    datamodule_repr = (
-        '{Train dataloader: size=50}\n'
-        '{Validation dataloader: size=30}\n'
-        '{Test dataloader: size=10}\n'
-        '{Predict dataloader: size=98}'
-        if new_datamodule_repr else
-        'LightningDataset(train_dataset=MUTAG(50), '
-        'val_dataset=MUTAG(30), '
-        'test_dataset=MUTAG(10), '
-        'pred_dataset=MUTAG(98), batch_size=5, '
-        'num_workers=3, pin_memory=True, '
-        'persistent_workers=True)'
-    )
+    datamodule_repr = ('{Train dataloader: size=50}\n'
+                       '{Validation dataloader: size=30}\n'
+                       '{Test dataloader: size=10}\n'
+                       '{Predict dataloader: size=98}' if new_datamodule_repr
+                       else 'LightningDataset(train_dataset=MUTAG(50), '
+                       'val_dataset=MUTAG(30), '
+                       'test_dataset=MUTAG(10), '
+                       'pred_dataset=MUTAG(98), batch_size=5, '
+                       'num_workers=3, pin_memory=True, '
+                       'persistent_workers=True)')
     assert str(datamodule) == datamodule_repr
 
     trainer.fit(model, datamodule)
@@ -144,17 +141,14 @@ def test_lightning_dataset(get_dataset, strategy_type):
                              log_every_n_steps=1)
 
         datamodule = LightningDataset(train_dataset, batch_size=5)
-        datamodule_repr = (
-            '{Train dataloader: size=50}\n'
-            '{Validation dataloader: None}\n'
-            '{Test dataloader: None}\n{'
-            'Predict dataloader: None}'
-            if new_datamodule_repr else
-            'LightningDataset(train_dataset=MUTAG(50), '
-            'batch_size=5, num_workers=0, '
-            'pin_memory=True, '
-            'persistent_workers=False)'
-        )
+        datamodule_repr = ('{Train dataloader: size=50}\n'
+                           '{Validation dataloader: None}\n'
+                           '{Test dataloader: None}\n{'
+                           'Predict dataloader: None}' if new_datamodule_repr
+                           else 'LightningDataset(train_dataset=MUTAG(50), '
+                           'batch_size=5, num_workers=0, '
+                           'pin_memory=True, '
+                           'persistent_workers=False)')
         assert str(datamodule) == datamodule_repr
 
         with expect_rank_zero_user_warning("defined a `validation_step`"):
@@ -256,14 +250,12 @@ def test_lightning_node_data(get_dataset, strategy_type, loader):
         '{Train dataloader: ' + f'size={140 if flag else 1}' + '}\n'
         '{Validation dataloader: ' + f'size={500 if flag else 1}' + '}\n'
         '{Test dataloader: ' + f'size={1000 if flag else 1}' + '}\n'
-        '{Predict dataloader: ' + f'size={2708 if flag else 1}' + '}'
-        if new_datamodule_repr else
-        f'LightningNodeData(data={data_repr}, '
+        '{Predict dataloader: ' + f'size={2708 if flag else 1}' +
+        '}' if new_datamodule_repr else f'LightningNodeData(data={data_repr}, '
         f'loader={loader}, batch_size={batch_size}, '
         f'num_workers={num_workers}, {kwargs_repr}'
         f'pin_memory={flag}, '
-        f'persistent_workers={flag})'
-    )
+        f'persistent_workers={flag})')
     assert str(datamodule) == datamodule_repr
 
     trainer.fit(model, datamodule)

--- a/test/data/lightning/test_datamodule.py
+++ b/test/data/lightning/test_datamodule.py
@@ -23,6 +23,7 @@ from torch_geometric.testing import (
     onlyNeighborSampler,
     onlyOnline,
     withPackage,
+    has_package,
 )
 
 try:
@@ -114,12 +115,22 @@ def test_lightning_dataset(get_dataset, strategy_type):
                                       num_workers=3, shuffle=True)
         assert 'shuffle' not in datamodule.kwargs
     old_x = train_dataset._data.x.clone()
-    assert str(datamodule) == ('LightningDataset(train_dataset=MUTAG(50), '
-                               'val_dataset=MUTAG(30), '
-                               'test_dataset=MUTAG(10), '
-                               'pred_dataset=MUTAG(98), batch_size=5, '
-                               'num_workers=3, pin_memory=True, '
-                               'persistent_workers=True)')
+    new_datamodule_repr = has_package('pytorch_lightning>=2.5.0')
+    datamodule_repr = (
+        '{Train dataloader: size=50}\n'
+        '{Validation dataloader: size=30}\n'
+        '{Test dataloader: size=10}\n'
+        '{Predict dataloader: size=98}'
+        if new_datamodule_repr else
+        'LightningDataset(train_dataset=MUTAG(50), '
+        'val_dataset=MUTAG(30), '
+        'test_dataset=MUTAG(10), '
+        'pred_dataset=MUTAG(98), batch_size=5, '
+        'num_workers=3, pin_memory=True, '
+        'persistent_workers=True)'
+    )
+    assert str(datamodule) == datamodule_repr
+
     trainer.fit(model, datamodule)
     trainer.test(model, datamodule)
     new_x = train_dataset._data.x
@@ -133,10 +144,18 @@ def test_lightning_dataset(get_dataset, strategy_type):
                              log_every_n_steps=1)
 
         datamodule = LightningDataset(train_dataset, batch_size=5)
-        assert str(datamodule) == ('LightningDataset(train_dataset=MUTAG(50), '
-                                   'batch_size=5, num_workers=0, '
-                                   'pin_memory=True, '
-                                   'persistent_workers=False)')
+        datamodule_repr = (
+            '{Train dataloader: size=50}\n'
+            '{Validation dataloader: None}\n'
+            '{Test dataloader: None}\n{'
+            'Predict dataloader: None}'
+            if new_datamodule_repr else
+            'LightningDataset(train_dataset=MUTAG(50), '
+            'batch_size=5, num_workers=0, '
+            'pin_memory=True, '
+            'persistent_workers=False)'
+        )
+        assert str(datamodule) == datamodule_repr
 
         with expect_rank_zero_user_warning("defined a `validation_step`"):
             trainer.fit(model, datamodule)
@@ -231,11 +250,22 @@ def test_lightning_node_data(get_dataset, strategy_type, loader):
                                    num_workers=num_workers, **kwargs)
 
     old_x = data.x.clone().cpu()
-    assert str(datamodule) == (f'LightningNodeData(data={data_repr}, '
-                               f'loader={loader}, batch_size={batch_size}, '
-                               f'num_workers={num_workers}, {kwargs_repr}'
-                               f'pin_memory={loader != "full"}, '
-                               f'persistent_workers={loader != "full"})')
+    new_datamodule_repr = has_package('pytorch_lightning>=2.5.0')
+    flag = loader != 'full'
+    datamodule_repr = (
+        '{Train dataloader: ' + f'size={140 if flag else 1}' + '}\n'
+        '{Validation dataloader: ' + f'size={500 if flag else 1}' + '}\n'
+        '{Test dataloader: ' + f'size={1000 if flag else 1}' + '}\n'
+        '{Predict dataloader: ' + f'size={2708 if flag else 1}' + '}'
+        if new_datamodule_repr else
+        f'LightningNodeData(data={data_repr}, '
+        f'loader={loader}, batch_size={batch_size}, '
+        f'num_workers={num_workers}, {kwargs_repr}'
+        f'pin_memory={flag}, '
+        f'persistent_workers={flag})'
+    )
+    assert str(datamodule) == datamodule_repr
+
     trainer.fit(model, datamodule)
     trainer.test(model, datamodule)
     new_x = data.x.cpu()


### PR DESCRIPTION
The tests `test_lightning_dataset` and `test_lightning_node_data` began failing after the recent update of `pytorch_lightning` to version 2.5. The cause of these failures is the new way for calculation of `str(datamodule)`

Since 2024-12-10 they have started to use a new method:
```
~/Projects/pytorch-lightning$ git blame src/lightning/pytorch/core/datamodule.py -L 249,253
9709c645c8 (Nikita Tatsch 2024-12-10 19:39:25 -0500 249)     def __str__(self) -> str:
9709c645c8 (Nikita Tatsch 2024-12-10 19:39:25 -0500 250)         """Return a string representation of the datasets that are set up.
9709c645c8 (Nikita Tatsch 2024-12-10 19:39:25 -0500 251) 
9709c645c8 (Nikita Tatsch 2024-12-10 19:39:25 -0500 252)         Returns:
9709c645c8 (Nikita Tatsch 2024-12-10 19:39:25 -0500 253)             A string representation of the datasets that are setup.
```

In 2.4 the operation `str(datamodule)` was performed by
```
304         def __repr__(self) -> str:
305  ->         kwargs = kwargs_repr(
306                 train_dataset=self.train_dataset,
307                 val_dataset=self.val_dataset,
308                 test_dataset=self.test_dataset,
309                 pred_dataset=self.pred_dataset,
310                 **self.kwargs,
311             )
312             return f'{self.__class__.__name__}({kwargs})'
```

This PR addresses the issue while maintaining backward compatibility, ensuring that these tests run correctly with `pytorch_lightning` versions earlier than 2.5.