### PR TITLE
Automatic num_params in LLM + update `GRetriever` default llm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Updated Dockerfile to use latest from NVIDIA ([#9794](https://github.com/pyg-team/pytorch_geometric/pull/9794))
 - Dropped Python 3.8 support ([#9696](https://github.com/pyg-team/pytorch_geometric/pull/9606))
 - Added a check that confirms that custom edge types of `NumNeighbors` actually exist in the graph ([#9807](https://github.com/pyg-team/pytorch_geometric/pull/9807))
+- Automatic num_params in LLM + update `GRetriever` default llm ([#9938](https://github.com/pyg-team/pytorch_geometric/pull/9938))
 
 ### Deprecated
 

--- a/examples/llm/g_retriever.py
+++ b/examples/llm/g_retriever.py
@@ -191,7 +191,7 @@ def train(
         batch_size,  # Training batch size
         eval_batch_size,  # Evaluation batch size
         lr,  # Initial learning rate
-        llm_model_name, # `transformers` model name
+        llm_model_name,  # `transformers` model name
         checkpointing=False,  # Whether to checkpoint model
         tiny_llama=False,  # Whether to use tiny LLaMA model
 ):
@@ -268,13 +268,10 @@ def train(
 
     # Create LLaMA model
     if tiny_llama:
-        llm = LLM(
-            model_name='TinyLlama/TinyLlama-1.1B-Chat-v0.1',
-        )
+        llm = LLM(model_name='TinyLlama/TinyLlama-1.1B-Chat-v0.1', )
     else:
         llm = LLM(model_name=llm_model_name)
-    model = GRetriever(llm=llm,
-                       gnn=gnn,
+    model = GRetriever(llm=llm, gnn=gnn,
                        mlp_out_channels=llm.word_embedding.embedding_dim)
 
     # Set model save name
@@ -391,8 +388,7 @@ if __name__ == '__main__':
     parser.add_argument('--eval_batch_size', type=int, default=16)
     parser.add_argument('--checkpointing', action='store_true')
     parser.add_argument('--tiny_llama', action='store_true')
-    parser.add_argument('--llm_model_name',
-                        type=str,
+    parser.add_argument('--llm_model_name', type=str,
                         default="meta-llama/Meta-Llama-3.1-8B-Instruct")
     args = parser.parse_args()
 

--- a/examples/llm/g_retriever.py
+++ b/examples/llm/g_retriever.py
@@ -204,6 +204,7 @@ def train(
         batch_size (int): Training batch size.
         eval_batch_size (int): Evaluation batch size.
         lr (float): Initial learning rate.
+        llm_model_name (str): The name of the LLM to use.
         checkpointing (bool, optional): Whether to checkpoint model.
             Defaults to False.
         tiny_llama (bool, optional): Whether to use tiny LLaMA model.

--- a/examples/llm/g_retriever.py
+++ b/examples/llm/g_retriever.py
@@ -191,6 +191,7 @@ def train(
         batch_size,  # Training batch size
         eval_batch_size,  # Evaluation batch size
         lr,  # Initial learning rate
+        llm_model_name, # `transformers` model name
         checkpointing=False,  # Whether to checkpoint model
         tiny_llama=False,  # Whether to use tiny LLaMA model
 ):
@@ -269,12 +270,12 @@ def train(
     if tiny_llama:
         llm = LLM(
             model_name='TinyLlama/TinyLlama-1.1B-Chat-v0.1',
-            num_params=1,
         )
-        model = GRetriever(llm=llm, gnn=gnn, mlp_out_channels=2048)
     else:
-        llm = LLM(model_name='meta-llama/Llama-2-7b-chat-hf', num_params=7)
-        model = GRetriever(llm=llm, gnn=gnn)
+        llm = LLM(model_name=llm_model_name)
+    model = GRetriever(llm=llm,
+                       gnn=gnn,
+                       mlp_out_channels=llm.word_embedding.embedding_dim)
 
     # Set model save name
     model_save_name = 'gnn_llm' if num_gnn_layers != 0 else 'llm'
@@ -390,6 +391,9 @@ if __name__ == '__main__':
     parser.add_argument('--eval_batch_size', type=int, default=16)
     parser.add_argument('--checkpointing', action='store_true')
     parser.add_argument('--tiny_llama', action='store_true')
+    parser.add_argument('--llm_model_name',
+                        type=str,
+                        default="meta-llama/Meta-Llama-3.1-8B-Instruct")
     args = parser.parse_args()
 
     start_time = time.time()
@@ -400,6 +404,7 @@ if __name__ == '__main__':
         args.batch_size,
         args.eval_batch_size,
         args.lr,
+        args.llm_model_name,
         checkpointing=args.checkpointing,
         tiny_llama=args.tiny_llama,
     )

--- a/torch_geometric/nn/nlp/llm.py
+++ b/torch_geometric/nn/nlp/llm.py
@@ -72,10 +72,10 @@ class LLM(torch.nn.Module):
         from transformers import AutoModelForCausalLM, AutoTokenizer
 
         if num_params is None:
-             from huggingface_hub import get_safetensors_metadata
-             safetensors_metadata = get_safetensors_metadata(model_name)
-             param_count = safetensors_metadata.parameter_count
-             num_params = list(param_count.values())[0] // 10**9
+            from huggingface_hub import get_safetensors_metadata
+            safetensors_metadata = get_safetensors_metadata(model_name)
+            param_count = safetensors_metadata.parameter_count
+            num_params = list(param_count.values())[0] // 10**9
 
         # A rough heuristic on GPU memory requirements, e.g., we found that
         # LLAMA2 (7B parameters) fits on a 85GB GPU.

--- a/torch_geometric/nn/nlp/llm.py
+++ b/torch_geometric/nn/nlp/llm.py
@@ -51,17 +51,18 @@ class LLM(torch.nn.Module):
 
     model_name (str): The HuggingFace model name, *e.g.*, :obj:`"llama2"` or
         :obj:`"gemma"`.
-    num_params (int): An integer representing how many parameters the
+    num_params (int, optional): An integer representing how many parameters the
         HuggingFace model has, in billions. This is used to automatically
         allocate the correct number of GPUs needed, given the available GPU
-        memory of your GPUs.
+        memory of your GPUs. If not specified, the number of parameters
+        is determined using the `huggingface_hub` module.
     dtype (torch.dtype, optional): The data type to use for the LLM.
         (default :obj: `torch.bfloat16`)
     """
     def __init__(
         self,
         model_name: str,
-        num_params: int,
+        num_params: int = None,
         dtype=torch.bfloat16,
     ) -> None:
         super().__init__()
@@ -69,6 +70,12 @@ class LLM(torch.nn.Module):
         self.model_name = model_name
 
         from transformers import AutoModelForCausalLM, AutoTokenizer
+
+        if num_params is None:
+             from huggingface_hub import get_safetensors_metadata
+             safetensors_metadata = get_safetensors_metadata(model_name)
+             param_count = safetensors_metadata.parameter_count
+             num_params = list(param_count.values())[0] // 10**9
 
         # A rough heuristic on GPU memory requirements, e.g., we found that
         # LLAMA2 (7B parameters) fits on a 85GB GPU.


### PR DESCRIPTION
This PR:
- Introduces llm_model_name argument in g_retriever.py to allow specifying the LLM model
- Make `num_params` optional in the `LLM` constructor, automatically determining it using `huggingface_hub` metadata if not provided
- Change the default LLM model to the more recent `meta-llama/Meta-Llama-3.1-8B-Instruct`

Previous model `meta-llama/Llama-2-7b-chat-hf` metrics:
```
Hit: 0.6966
Precision: 0.6250
Recall: 0.5344
F1: 0.5405
Total Training Time: 556.111935s
```

Newer model `meta-llama/Llama-3.1-8B-Instruct` metrics:
```
Hit: 0.7629
Precision: 0.7145
Recall: 0.6027
F1: 0.6190
Total Training Time: 572.248117s
```