### PR TITLE
Add ComplexWebQuestions (CWQ) dataset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
-## [2.7.0] - 2024-MM-DD
+## [2.7.0] - 2025-MM-DD
 
 ### Added
 
@@ -25,6 +25,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Added the `use_pcst` option to `WebQSPDataset` ([#9722](https://github.com/pyg-team/pytorch_geometric/pull/9722))
 - Allowed users to pass `edge_weight` to `GraphUNet` models ([#9737](https://github.com/pyg-team/pytorch_geometric/pull/9737))
 - Consolidated `examples/ogbn_{papers_100m,products_gat,products_sage}.py` into `examples/ogbn_train.py` ([#9467](https://github.com/pyg-team/pytorch_geometric/pull/9467))
+- Add ComplexWebQuestions (CWQ) dataset ([#9950](https://github.com/pyg-team/pytorch_geometric/pull/9950))
 
 ### Changed
 

--- a/examples/llm/g_retriever.py
+++ b/examples/llm/g_retriever.py
@@ -24,7 +24,7 @@ from torch.nn.utils import clip_grad_norm_
 from tqdm import tqdm
 
 from torch_geometric import seed_everything
-from torch_geometric.datasets import WebQSPDataset
+from torch_geometric.datasets import WebQSPDataset, CWQDataset
 from torch_geometric.loader import DataLoader
 from torch_geometric.nn.models import GAT, GRetriever
 from torch_geometric.nn.nlp import LLM
@@ -89,7 +89,7 @@ def compute_metrics(eval_output):
     f1 = sum(all_f1) / len(all_f1)
 
     # Print metrics to console
-    print(f'Hit: {hit:.4f}')
+    print(f'Hit@1: {hit:.4f}')
     print(f'Precision: {precision:.4f}')
     print(f'Recall: {recall:.4f}')
     print(f'F1: {f1:.4f}')
@@ -193,9 +193,10 @@ def train(
         lr,  # Initial learning rate
         llm_model_name,  # `transformers` model name
         checkpointing=False,  # Whether to checkpoint model
+        cwq=False, # Whether to train on the CWQ dataset
         tiny_llama=False,  # Whether to use tiny LLaMA model
 ):
-    """Train a GNN+LLM model on WebQSP dataset.
+    """Train a GNN+LLM model on WebQSP or CWQ dataset.
 
     Args:
         num_epochs (int): Total number of training epochs.
@@ -207,6 +208,8 @@ def train(
         llm_model_name (str): The name of the LLM to use.
         checkpointing (bool, optional): Whether to checkpoint model.
             Defaults to False.
+        cwq (bool, optional): Whether to train on the CWQ dataset
+            instead of WebQSP.
         tiny_llama (bool, optional): Whether to use tiny LLaMA model.
             Defaults to False.
 
@@ -240,10 +243,16 @@ def train(
 
     # Load dataset and create data loaders
     path = osp.dirname(osp.realpath(__file__))
-    path = osp.join(path, '..', '..', 'data', 'WebQSPDataset')
-    train_dataset = WebQSPDataset(path, split='train')
-    val_dataset = WebQSPDataset(path, split='val')
-    test_dataset = WebQSPDataset(path, split='test')
+    if not cwq:
+        path = osp.join(path, '..', '..', 'data', 'WebQSPDataset')
+        train_dataset = WebQSPDataset(path, split='train')
+        val_dataset = WebQSPDataset(path, split='val')
+        test_dataset = WebQSPDataset(path, split='test')
+    else:
+        path = osp.join(path, '..', '..', 'data', 'CWQDataset')
+        train_dataset = CWQDataset(path, split='train')
+        val_dataset = CWQDataset(path, split='val')
+        test_dataset = CWQDataset(path, split='test')
 
     seed_everything(42)
 
@@ -388,6 +397,7 @@ if __name__ == '__main__':
     parser.add_argument('--batch_size', type=int, default=8)
     parser.add_argument('--eval_batch_size', type=int, default=16)
     parser.add_argument('--checkpointing', action='store_true')
+    parser.add_argument('--cwq', action='store_true')
     parser.add_argument('--tiny_llama', action='store_true')
     parser.add_argument('--llm_model_name', type=str,
                         default="meta-llama/Meta-Llama-3.1-8B-Instruct")

--- a/examples/llm/g_retriever.py
+++ b/examples/llm/g_retriever.py
@@ -24,7 +24,7 @@ from torch.nn.utils import clip_grad_norm_
 from tqdm import tqdm
 
 from torch_geometric import seed_everything
-from torch_geometric.datasets import WebQSPDataset, CWQDataset
+from torch_geometric.datasets import CWQDataset, WebQSPDataset
 from torch_geometric.loader import DataLoader
 from torch_geometric.nn.models import GAT, GRetriever
 from torch_geometric.nn.nlp import LLM
@@ -193,7 +193,7 @@ def train(
         lr,  # Initial learning rate
         llm_model_name,  # `transformers` model name
         checkpointing=False,  # Whether to checkpoint model
-        cwq=False, # Whether to train on the CWQ dataset
+        cwq=False,  # Whether to train on the CWQ dataset
         tiny_llama=False,  # Whether to use tiny LLaMA model
 ):
     """Train a GNN+LLM model on WebQSP or CWQ dataset.

--- a/torch_geometric/datasets/__init__.py
+++ b/torch_geometric/datasets/__init__.py
@@ -76,7 +76,7 @@ from .wikidata import Wikidata5M
 from .myket import MyketDataset
 from .brca_tgca import BrcaTcga
 from .neurograph import NeuroGraphDataset
-from .web_qsp_dataset import WebQSPDataset
+from .web_qsp_dataset import WebQSPDataset, CWQDataset
 from .git_mol_dataset import GitMolDataset
 from .molecule_gpt_dataset import MoleculeGPTDataset
 from .tag_dataset import TAGDataset
@@ -193,6 +193,7 @@ homo_datasets = [
     'BrcaTcga',
     'NeuroGraphDataset',
     'WebQSPDataset',
+    'CWQDataset',
     'GitMolDataset',
     'MoleculeGPTDataset',
     'TAGDataset',

--- a/torch_geometric/datasets/web_qsp_dataset.py
+++ b/torch_geometric/datasets/web_qsp_dataset.py
@@ -116,13 +116,13 @@ def retrieval_via_pcst(
 
     return data, desc
 
-
-class WebQSPDataset(InMemoryDataset):
-    r"""The WebQuestionsSP dataset of the `"The Value of Semantic Parse
-    Labeling for Knowledge Base Question Answering"
-    <https://aclanthology.org/P16-2033/>`_ paper.
+class KGQABaseDataset(InMemoryDataset):
+    r"""Base class for the 2 KGQA datasets used in `"Reasoning on Graphs:
+    Faithful and Interpretable Large Language Model Reasoning"
+    <https://arxiv.org/pdf/2310.01061>`_ paper.
 
     Args:
+        dataset_name (str): HuggingFace `dataset` name.
         root (str): Root directory where the dataset should be saved.
         split (str, optional): If :obj:`"train"`, loads the training dataset.
             If :obj:`"val"`, loads the validation dataset.
@@ -134,11 +134,14 @@ class WebQSPDataset(InMemoryDataset):
     """
     def __init__(
         self,
+        dataset_name: str,
         root: str,
         split: str = "train",
         force_reload: bool = False,
         use_pcst: bool = True,
+        use_cwq: bool = True,
     ) -> None:
+        self.dataset_name = dataset_name
         self.use_pcst = use_pcst
         super().__init__(root, force_reload=force_reload)
 
@@ -156,7 +159,7 @@ class WebQSPDataset(InMemoryDataset):
         import datasets
         import pandas as pd
 
-        datasets = datasets.load_dataset('rmanluo/RoG-webqsp')
+        datasets = datasets.load_dataset(self.dataset_name)
 
         device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
         model_name = 'sentence-transformers/all-roberta-large-v1'
@@ -244,3 +247,53 @@ class WebQSPDataset(InMemoryDataset):
                 data_list.append(data)
 
             self.save(data_list, path)
+
+class WebQSPDataset(KGQABaseDataset):
+    r"""The WebQuestionsSP dataset of the `"The Value of Semantic Parse
+    Labeling for Knowledge Base Question Answering"
+    <https://aclanthology.org/P16-2033/>`_ paper.
+
+    Args:
+        root (str): Root directory where the dataset should be saved.
+        split (str, optional): If :obj:`"train"`, loads the training dataset.
+            If :obj:`"val"`, loads the validation dataset.
+            If :obj:`"test"`, loads the test dataset. (default: :obj:`"train"`)
+        force_reload (bool, optional): Whether to re-process the dataset.
+            (default: :obj:`False`)
+        use_pcst (bool, optional): Whether to preprocess the dataset's graph
+            with PCST or return the full graphs. (default: :obj:`True`)
+    """
+    def __init__(
+        self,
+        root: str,
+        split: str = "train",
+        force_reload: bool = False,
+        use_pcst: bool = True
+    ) -> None:
+        dataset_name = 'rmanluo/RoG-webqsp'
+        super().__init__(dataset_name, root, split, force_reload, use_pcst)
+
+class CWQDataset(KGQABaseDataset):
+    r"""The ComplexWebQuestions (CWQ) dataset of the `"The Web as a
+    Knowledge-base forAnswering Complex Questions"
+    <https://arxiv.org/pdf/1803.06643>`_ paper.
+
+    Args:
+        root (str): Root directory where the dataset should be saved.
+        split (str, optional): If :obj:`"train"`, loads the training dataset.
+            If :obj:`"val"`, loads the validation dataset.
+            If :obj:`"test"`, loads the test dataset. (default: :obj:`"train"`)
+        force_reload (bool, optional): Whether to re-process the dataset.
+            (default: :obj:`False`)
+        use_pcst (bool, optional): Whether to preprocess the dataset's graph
+            with PCST or return the full graphs. (default: :obj:`True`)
+    """
+    def __init__(
+        self,
+        root: str,
+        split: str = "train",
+        force_reload: bool = False,
+        use_pcst: bool = True
+    ) -> None:
+        dataset_name = 'rmanluo/RoG-cwq'
+        super().__init__(dataset_name, root, split, force_reload, use_pcst)

--- a/torch_geometric/datasets/web_qsp_dataset.py
+++ b/torch_geometric/datasets/web_qsp_dataset.py
@@ -116,6 +116,7 @@ def retrieval_via_pcst(
 
     return data, desc
 
+
 class KGQABaseDataset(InMemoryDataset):
     r"""Base class for the 2 KGQA datasets used in `"Reasoning on Graphs:
     Faithful and Interpretable Large Language Model Reasoning"
@@ -248,6 +249,7 @@ class KGQABaseDataset(InMemoryDataset):
 
             self.save(data_list, path)
 
+
 class WebQSPDataset(KGQABaseDataset):
     r"""The WebQuestionsSP dataset of the `"The Value of Semantic Parse
     Labeling for Knowledge Base Question Answering"
@@ -263,15 +265,11 @@ class WebQSPDataset(KGQABaseDataset):
         use_pcst (bool, optional): Whether to preprocess the dataset's graph
             with PCST or return the full graphs. (default: :obj:`True`)
     """
-    def __init__(
-        self,
-        root: str,
-        split: str = "train",
-        force_reload: bool = False,
-        use_pcst: bool = True
-    ) -> None:
+    def __init__(self, root: str, split: str = "train",
+                 force_reload: bool = False, use_pcst: bool = True) -> None:
         dataset_name = 'rmanluo/RoG-webqsp'
         super().__init__(dataset_name, root, split, force_reload, use_pcst)
+
 
 class CWQDataset(KGQABaseDataset):
     r"""The ComplexWebQuestions (CWQ) dataset of the `"The Web as a
@@ -288,12 +286,7 @@ class CWQDataset(KGQABaseDataset):
         use_pcst (bool, optional): Whether to preprocess the dataset's graph
             with PCST or return the full graphs. (default: :obj:`True`)
     """
-    def __init__(
-        self,
-        root: str,
-        split: str = "train",
-        force_reload: bool = False,
-        use_pcst: bool = True
-    ) -> None:
+    def __init__(self, root: str, split: str = "train",
+                 force_reload: bool = False, use_pcst: bool = True) -> None:
         dataset_name = 'rmanluo/RoG-cwq'
         super().__init__(dataset_name, root, split, force_reload, use_pcst)


### PR DESCRIPTION
This PR adds the CWQ dataset, which is similar to WebQSP but larger and featuring more complex multi-hop questions

Comparing the datasets:

| Datasets | #Train | #Test | Max #hop |
|----------|--------|-------|----------|
| WebQSP   | 2,826  | 1,628 | 2        |
| CWQ      | 27,639 | 3,531 | 4        |

GRetriever performance:
```
LLM: meta-llama/Llama-3.1-8B-Instruct

Hit@1: 0.5675
Precision: 0.5444
Recall: 0.5435
F1: 0.5310
Total Training Time: 4337.614916s
```