### PR TITLE
Address `FutureWarning` on `nx.node_link_graph(..., edges="links")`

### DIFF
--- a/torch_geometric/datasets/ppi.py
+++ b/torch_geometric/datasets/ppi.py
@@ -107,7 +107,7 @@ class PPI(InMemoryDataset):
         for s, split in enumerate(['train', 'valid', 'test']):
             path = osp.join(self.raw_dir, f'{split}_graph.json')
             with open(path) as f:
-                G = nx.DiGraph(json_graph.node_link_graph(json.load(f)))
+                G = nx.DiGraph(json_graph.node_link_graph(json.load(f), edges="links"))
 
             x = np.load(osp.join(self.raw_dir, f'{split}_feats.npy'))
             x = torch.from_numpy(x).to(torch.float)

--- a/torch_geometric/datasets/ppi.py
+++ b/torch_geometric/datasets/ppi.py
@@ -107,7 +107,8 @@ class PPI(InMemoryDataset):
         for s, split in enumerate(['train', 'valid', 'test']):
             path = osp.join(self.raw_dir, f'{split}_graph.json')
             with open(path) as f:
-                G = nx.DiGraph(json_graph.node_link_graph(json.load(f), edges="links"))
+                G = nx.DiGraph(
+                    json_graph.node_link_graph(json.load(f), edges="links"))
 
             x = np.load(osp.join(self.raw_dir, f'{split}_feats.npy'))
             x = torch.from_numpy(x).to(torch.float)


### PR DESCRIPTION
…parameter of the `nx.node_link_graph` function.


This PR resolves the following warning:
```
/usr/local/lib/python3.12/dist-packages/networkx/readwrite/json_graph/node_link.py:287: FutureWarning:
The default value will be changed to `edges="edges" in NetworkX 3.6.

To make this warning go away, explicitly set the edges kwarg, e.g.:

  nx.node_link_graph(data, edges="links") to preserve current behavior, or
  nx.node_link_graph(data, edges="edges") for forward compatibility.
  warnings.warn(
```
generated by `examples/graph_sage_unsup_ppi.py` script.

