### PR TITLE
Fix negative_sampling leading to runtime error because of zero sample size

### DIFF
--- a/test/utils/test_negative_sampling.py
+++ b/test/utils/test_negative_sampling.py
@@ -77,6 +77,10 @@ def test_negative_sampling():
     assert neg_edge_index.size(1) == 2
     assert is_negative(edge_index, neg_edge_index, (4, 4), bipartite=False)
 
+    neg_edge_index = negative_sampling(edge_index, num_neg_samples=1,
+                                       force_undirected=True)
+    assert neg_edge_index.size(1) == 0
+
     edge_index = to_undirected(edge_index)
     neg_edge_index = negative_sampling(edge_index, force_undirected=True)
     assert neg_edge_index.size(1) == edge_index.size(1) - 1

--- a/torch_geometric/utils/_negative_sampling.py
+++ b/torch_geometric/utils/_negative_sampling.py
@@ -69,13 +69,13 @@ def negative_sampling(
     idx, population = edge_index_to_vector(edge_index, size, bipartite,
                                            force_undirected)
 
-    if idx.numel() >= population:
-        return edge_index.new_empty((2, 0))
-
     if num_neg_samples is None:
         num_neg_samples = edge_index.size(1)
     if force_undirected:
         num_neg_samples = num_neg_samples // 2
+
+    if idx.numel() >= population or num_neg_samples == 0:
+        return edge_index.new_empty((2, 0))
 
     prob = 1. - idx.numel() / population  # Probability to sample a negative.
     sample_size = int(1.1 * num_neg_samples / prob)  # (Over)-sample size.


### PR DESCRIPTION
Fixes `negative_sampling` leading to runtime error when the `sample_size` is 0 (for example when only 1 undirected edge is sampled [https://github.com/pyg-team/pytorch_geometric/issues/9709](https://github.com/pyg-team/pytorch_geometric/issues/9709) )