### PR TITLE
Fixing the URL for `InstructMol` dataset.

### DIFF
--- a/torch_geometric/datasets/instruct_mol_dataset.py
+++ b/torch_geometric/datasets/instruct_mol_dataset.py
@@ -32,7 +32,7 @@ class InstructMolDataset(InMemoryDataset):
         force_reload (bool, optional): Whether to re-process the dataset.
             (default: :obj:`False`)
     """
-    raw_url = 'https://huggingface.co/datasets/OpenMol/PubChemSFT/blob/main'
+    raw_url = 'https://huggingface.co/datasets/OpenMol/PubChemSFT/resolve/main'
 
     def __init__(
         self,


### PR DESCRIPTION
The previously used https://huggingface.co/datasets/OpenMol/PubChemSFT/blob/main/all_clean.json is no longer working but a functional alternative can be found on the [webpage](https://huggingface.co/datasets/OpenMol/PubChemSFT/blob/main/all_clean.json) under `Copy download link`: https://huggingface.co/datasets/OpenMol/PubChemSFT/resolve/main/all_clean.json
