### PR TITLE
Add SubgraphRAG model and example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Allowed users to pass `edge_weight` to `GraphUNet` models ([#9737](https://github.com/pyg-team/pytorch_geometric/pull/9737))
 - Consolidated `examples/ogbn_{papers_100m,products_gat,products_sage}.py` into `examples/ogbn_train.py` ([#9467](https://github.com/pyg-team/pytorch_geometric/pull/9467))
 - Add ComplexWebQuestions (CWQ) dataset ([#9950](https://github.com/pyg-team/pytorch_geometric/pull/9950))
+- Add SubgraphRAG model and example ([#10000](https://github.com/pyg-team/pytorch_geometric/pull/9950))
 
 ### Changed
 

--- a/examples/llm/subgraphrag.py
+++ b/examples/llm/subgraphrag.py
@@ -1,18 +1,16 @@
-import numpy as np
 import os
-import pandas as pd
 import time
+from collections import defaultdict
+
+import numpy as np
 import torch
 import torch.nn.functional as F
-import random
-
-from collections import defaultdict
+from dataset import WebQSPDataset
 from torch.optim import Adam
-from torch_geometric.loader import DataLoader
-from torch_geometric import seed_everything
 from tqdm import tqdm
 
-from dataset import WebQSPDataset
+from torch_geometric import seed_everything
+from torch_geometric.loader import DataLoader
 from torch_geometric.nn.models import SubgraphRAGRetriever
 
 
@@ -28,17 +26,14 @@ def train(device, train_loader, model, optimizer):
             continue
         num_non_text_entities = 0
         sample = prepare_sample(device, sample)
-        pred_triple_logits = model(sample.edge_index,
-                                   sample.q_emb,
-                                   sample.x,
-                                   sample.edge_attr,
-                                   num_non_text_entities,
+        pred_triple_logits = model(sample.edge_index, sample.q_emb, sample.x,
+                                   sample.edge_attr, num_non_text_entities,
                                    sample.topic_entity_one_hot)
 
         target_triple_probs = sample.triple_scores
         target_triple_probs = target_triple_probs.unsqueeze(-1)
-        loss = F.binary_cross_entropy_with_logits(
-            pred_triple_logits, target_triple_probs)
+        loss = F.binary_cross_entropy_with_logits(pred_triple_logits,
+                                                  target_triple_probs)
         optimizer.zero_grad()
         loss.backward()
         optimizer.step()
@@ -51,6 +46,7 @@ def train(device, train_loader, model, optimizer):
     log_dict = {'loss': epoch_loss}
     return log_dict
 
+
 @torch.no_grad()
 def eval(device, data_loader, model):
     model.eval()
@@ -61,19 +57,16 @@ def eval(device, data_loader, model):
         num_non_text_entities = 0
         sample = prepare_sample(device, sample)
 
-        pred_triple_logits = model(sample.edge_index,
-                                   sample.q_emb,
-                                   sample.x,
-                                   sample.edge_attr,
-                                   num_non_text_entities,
+        pred_triple_logits = model(sample.edge_index, sample.q_emb, sample.x,
+                                   sample.edge_attr, num_non_text_entities,
                                    sample.topic_entity_one_hot).reshape(-1)
 
         target_triple_probs = sample.triple_scores
         a_entity_ids = sample.a_entity_ids[0]
 
         # Triple ranking
-        sorted_triple_ids_pred = torch.argsort(
-            pred_triple_logits, descending=True).cpu()
+        sorted_triple_ids_pred = torch.argsort(pred_triple_logits,
+                                               descending=True).cpu()
         triple_ranks_pred = torch.empty_like(sorted_triple_ids_pred)
         triple_ranks_pred[sorted_triple_ids_pred] = torch.arange(
             len(triple_ranks_pred))
@@ -86,26 +79,27 @@ def eval(device, data_loader, model):
 
         num_total_entities = len(sample.x) + num_non_text_entities
 
-        k_list=[100]
+        k_list = [100]
 
         for k in k_list:
-            recall_k_sample = (
-                triple_ranks_pred[target_triple_ids] < k).sum().item()
-            metric_dict[f'triple_recall@{k}'].append(
-                recall_k_sample / num_target_triples)
+            recall_k_sample = (triple_ranks_pred[target_triple_ids]
+                               < k).sum().item()
+            metric_dict[f'triple_recall@{k}'].append(recall_k_sample /
+                                                     num_target_triples)
 
             triple_mask_k = triple_ranks_pred < k
             entity_mask_k = torch.zeros(num_total_entities)
             entity_mask_k[sample.edge_index[0][triple_mask_k]] = 1.
             entity_mask_k[sample.edge_index[1][triple_mask_k]] = 1.
             recall_k_sample_ans = entity_mask_k[a_entity_ids].sum().item()
-            metric_dict[f'ans_recall@{k}'].append(
-                recall_k_sample_ans / len(a_entity_ids))
+            metric_dict[f'ans_recall@{k}'].append(recall_k_sample_ans /
+                                                  len(a_entity_ids))
 
     for key, val in metric_dict.items():
         metric_dict[key] = np.mean(val)
 
     return metric_dict
+
 
 @torch.no_grad()
 def test(device, data_loader, model, checkpoint_dir):
@@ -118,34 +112,32 @@ def test(device, data_loader, model, checkpoint_dir):
         num_non_text_entities = 0
         sample = prepare_sample(device, sample)
 
-        entity_list = sample.entity_list[0] # + raw_sample['non_text_entity_list']
+        entity_list = sample.entity_list[
+            0]  # + raw_sample['non_text_entity_list']
         relation_list = sample.relation_list[0]
         rel_ids = sample.rel_ids[0]
         top_K_triples = []
         target_relevant_triples = []
 
-        pred_triple_logits = model(sample.edge_index,
-                                   sample.q_emb,
-                                   sample.x,
-                                   sample.edge_attr,
-                                   num_non_text_entities,
+        pred_triple_logits = model(sample.edge_index, sample.q_emb, sample.x,
+                                   sample.edge_attr, num_non_text_entities,
                                    sample.topic_entity_one_hot)
 
         pred_triple_scores = torch.sigmoid(pred_triple_logits).reshape(-1)
         top_K_results = torch.topk(pred_triple_scores,
-                                    min(args.max_K, len(pred_triple_scores)))
+                                   min(args.max_K, len(pred_triple_scores)))
         top_K_scores = top_K_results.values.cpu().tolist()
         top_K_triple_IDs = top_K_results.indices.cpu().tolist()
 
         for j, triple_id in enumerate(top_K_triple_IDs):
-            top_K_triples.append((
-                entity_list[sample.edge_index[0][triple_id].item()],
-                relation_list[rel_ids[triple_id]],
-                entity_list[sample.edge_index[1][triple_id].item()],
-                top_K_scores[j]
-            ))
+            top_K_triples.append(
+                (entity_list[sample.edge_index[0][triple_id].item()],
+                 relation_list[rel_ids[triple_id]],
+                 entity_list[sample.edge_index[1][triple_id].item()],
+                 top_K_scores[j]))
 
-        target_relevant_triple_ids = sample.triple_scores.nonzero().reshape(-1).tolist()
+        target_relevant_triple_ids = sample.triple_scores.nonzero().reshape(
+            -1).tolist()
         for triple_id in target_relevant_triple_ids:
             target_relevant_triples.append((
                 entity_list[sample.edge_index[0][triple_id].item()],
@@ -154,14 +146,22 @@ def test(device, data_loader, model, checkpoint_dir):
             ))
 
         sample_dict = {
-            'question': sample.question,
-            'scored_triples': top_K_triples,
-            'q_entity': sample.q_entity,
-            'q_entity_in_graph': [entity_list[e_id] for e_id in sample.q_entity_ids[0]],
-            'a_entity': sample.a_entity,
-            'a_entity_in_graph': [entity_list[e_id] for e_id in sample.a_entity_ids[0]],
-            'max_path_length': sample.max_path_length,
-            'target_relevant_triples': target_relevant_triples
+            'question':
+            sample.question,
+            'scored_triples':
+            top_K_triples,
+            'q_entity':
+            sample.q_entity,
+            'q_entity_in_graph':
+            [entity_list[e_id] for e_id in sample.q_entity_ids[0]],
+            'a_entity':
+            sample.a_entity,
+            'a_entity_in_graph':
+            [entity_list[e_id] for e_id in sample.a_entity_ids[0]],
+            'max_path_length':
+            sample.max_path_length,
+            'target_relevant_triples':
+            target_relevant_triples
         }
 
         pred_dict[sample.id[0]] = sample_dict
@@ -169,8 +169,10 @@ def test(device, data_loader, model, checkpoint_dir):
     torch.save(pred_dict, os.path.join(checkpoint_dir, 'retrieval_result.pth'))
     return pred_dict
 
+
 def reason():
     pass
+
 
 def main(args):
     num_epochs = 10000
@@ -187,30 +189,28 @@ def main(args):
         checkpoint_dir = f'{exp_prefix}_{ts}'
     os.makedirs(checkpoint_dir, exist_ok=True)
 
-
     path = os.path.dirname(os.path.realpath(__file__))
     path = os.path.join(path, 'data', 'WebQSPDataset')
     train_set = WebQSPDataset(path, split='train')
     val_set = WebQSPDataset(path, split='val')
 
-    train_loader = DataLoader(
-        train_set, batch_size=1, pin_memory=True, shuffle=True)
-    val_loader = DataLoader(
-        val_set, batch_size=1, pin_memory=True)
+    train_loader = DataLoader(train_set, batch_size=1, pin_memory=True,
+                              shuffle=True)
+    val_loader = DataLoader(val_set, batch_size=1, pin_memory=True)
 
     test_set = WebQSPDataset(path, split='test')
-    test_loader = DataLoader(
-        test_set, batch_size=1, pin_memory=True)
+    test_loader = DataLoader(test_set, batch_size=1, pin_memory=True)
 
     emb_size = train_set[0]['q_emb'].shape[-1]
     DDE_kwargs = {'num_rounds': 2, 'num_reverse_rounds': 2}
-    model = SubgraphRAGRetriever(emb_size, topic_pe=True, DDE_kwargs=DDE_kwargs).to(device)
+    model = SubgraphRAGRetriever(emb_size, topic_pe=True,
+                                 DDE_kwargs=DDE_kwargs).to(device)
 
     if os.path.exists(os.path.join(checkpoint_dir, "model.pt")):
         print("Loading model from checkpoint...")
-        model.load_state_dict(torch.load(
-            os.path.join(checkpoint_dir, "model.pt"),
-            weights_only=True))
+        model.load_state_dict(
+            torch.load(os.path.join(checkpoint_dir, "model.pt"),
+                       weights_only=True))
     else:
         print("Training model...")
         optimizer = Adam(model.parameters(), lr=1e-3)
@@ -226,7 +226,8 @@ def main(args):
             if target_val_metric > best_val_metric:
                 num_patient_epochs = 0
                 best_val_metric = target_val_metric
-                torch.save(model.state_dict(), os.path.join(checkpoint_dir, "model.pt"))
+                torch.save(model.state_dict(),
+                           os.path.join(checkpoint_dir, "model.pt"))
 
                 val_log = {'val/epoch': epoch}
                 for key, val in val_eval_dict.items():
@@ -244,16 +245,21 @@ def main(args):
             if num_patient_epochs == args.patience:
                 break
     test(device, test_loader, model, checkpoint_dir)
+
+
 if __name__ == '__main__':
     from argparse import ArgumentParser
 
     parser = ArgumentParser()
     parser.add_argument('-d', '--dataset', type=str, default='webqsp',
                         choices=['webqsp', 'cwq'], help='Dataset name')
-    parser.add_argument('--patience', type=int, default=10,
-        help="Number of epochs with no improvement in validation accuracy before stopping")
-    parser.add_argument('--checkpoint_dir', type=str, default='',
-                        help='Directory where the checkpoint and scores will be saved')
+    parser.add_argument(
+        '--patience', type=int, default=10, help=
+        "Number of epochs with no improvement in validation accuracy before stopping"
+    )
+    parser.add_argument(
+        '--checkpoint_dir', type=str, default='',
+        help='Directory where the checkpoint and scores will be saved')
     parser.add_argument('--max_K', type=int, default=500,
                         help='K in top-K triple retrieval')
     args = parser.parse_args()

--- a/examples/llm/subgraphrag.py
+++ b/examples/llm/subgraphrag.py
@@ -8,13 +8,13 @@ from functools import lru_cache
 import numpy as np
 import torch
 import torch.nn.functional as F
-from torch_geometric.datasets import WebQSPDataset
-from torch_geometric.nn.models import SubgraphRAGRetriever
 from torch.optim import Adam
 from tqdm import tqdm
 
 from torch_geometric import seed_everything
+from torch_geometric.datasets import WebQSPDataset
 from torch_geometric.loader import DataLoader
+from torch_geometric.nn.models import SubgraphRAGRetriever
 from torch_geometric.nn.nlp import LLM
 
 SYS_PROMPT = (
@@ -35,8 +35,7 @@ def train(device, train_loader, model, optimizer):
         sample = sample.to(device)
         rel_embeds = rel_emb_table[sample.edge_attr[0]]
         pred_triple_logits = model(sample.edge_index, sample.q_emb, sample.x,
-                                   rel_embeds,
-                                   sample.topic_entity_one_hot)
+                                   rel_embeds, sample.topic_entity_one_hot)
 
         target_triple_probs = sample.target_triple_scores
         target_triple_probs = target_triple_probs.unsqueeze(-1)
@@ -129,8 +128,7 @@ def test(device, data_loader, model, checkpoint_dir):
 
         rel_embeds = rel_emb_table[sample.edge_attr[0]]
         pred_triple_logits = model(sample.edge_index, sample.q_emb, sample.x,
-                                   rel_embeds,
-                                   sample.topic_entity_one_hot)
+                                   rel_embeds, sample.topic_entity_one_hot)
 
         pred_triple_scores = torch.sigmoid(pred_triple_logits).reshape(-1)
         top_K_results = torch.topk(pred_triple_scores,

--- a/examples/llm/subgraphrag.py
+++ b/examples/llm/subgraphrag.py
@@ -1,0 +1,261 @@
+import numpy as np
+import os
+import pandas as pd
+import time
+import torch
+import torch.nn.functional as F
+import random
+
+from collections import defaultdict
+from torch.optim import Adam
+from torch_geometric.loader import DataLoader
+from torch_geometric import seed_everything
+from tqdm import tqdm
+
+from dataset import WebQSPDataset
+from torch_geometric.nn.models import SubgraphRAGRetriever
+
+
+def prepare_sample(device, sample):
+    return sample.to(device)
+
+
+def train(device, train_loader, model, optimizer):
+    model.train()
+    epoch_loss = 0
+    for sample in tqdm(train_loader):
+        if len(sample.x) == 0:
+            continue
+        num_non_text_entities = 0
+        sample = prepare_sample(device, sample)
+        pred_triple_logits = model(sample.edge_index,
+                                   sample.q_emb,
+                                   sample.x,
+                                   sample.edge_attr,
+                                   num_non_text_entities,
+                                   sample.topic_entity_one_hot)
+
+        target_triple_probs = sample.triple_scores
+        target_triple_probs = target_triple_probs.unsqueeze(-1)
+        loss = F.binary_cross_entropy_with_logits(
+            pred_triple_logits, target_triple_probs)
+        optimizer.zero_grad()
+        loss.backward()
+        optimizer.step()
+
+        loss = loss.item()
+        epoch_loss += loss
+
+    epoch_loss /= len(train_loader)
+
+    log_dict = {'loss': epoch_loss}
+    return log_dict
+
+@torch.no_grad()
+def eval(device, data_loader, model):
+    model.eval()
+
+    metric_dict = defaultdict(list)
+
+    for sample in tqdm(data_loader):
+        num_non_text_entities = 0
+        sample = prepare_sample(device, sample)
+
+        pred_triple_logits = model(sample.edge_index,
+                                   sample.q_emb,
+                                   sample.x,
+                                   sample.edge_attr,
+                                   num_non_text_entities,
+                                   sample.topic_entity_one_hot).reshape(-1)
+
+        target_triple_probs = sample.triple_scores
+        a_entity_ids = sample.a_entity_ids[0]
+
+        # Triple ranking
+        sorted_triple_ids_pred = torch.argsort(
+            pred_triple_logits, descending=True).cpu()
+        triple_ranks_pred = torch.empty_like(sorted_triple_ids_pred)
+        triple_ranks_pred[sorted_triple_ids_pred] = torch.arange(
+            len(triple_ranks_pred))
+
+        target_triple_ids = target_triple_probs.nonzero().squeeze(-1).cpu()
+        num_target_triples = len(target_triple_ids)
+
+        if num_target_triples == 0:
+            continue
+
+        num_total_entities = len(sample.x) + num_non_text_entities
+
+        k_list=[100]
+
+        for k in k_list:
+            recall_k_sample = (
+                triple_ranks_pred[target_triple_ids] < k).sum().item()
+            metric_dict[f'triple_recall@{k}'].append(
+                recall_k_sample / num_target_triples)
+
+            triple_mask_k = triple_ranks_pred < k
+            entity_mask_k = torch.zeros(num_total_entities)
+            entity_mask_k[sample.edge_index[0][triple_mask_k]] = 1.
+            entity_mask_k[sample.edge_index[1][triple_mask_k]] = 1.
+            recall_k_sample_ans = entity_mask_k[a_entity_ids].sum().item()
+            metric_dict[f'ans_recall@{k}'].append(
+                recall_k_sample_ans / len(a_entity_ids))
+
+    for key, val in metric_dict.items():
+        metric_dict[key] = np.mean(val)
+
+    return metric_dict
+
+@torch.no_grad()
+def test(device, data_loader, model, checkpoint_dir):
+    model.eval()
+
+    pred_dict = dict()
+    for sample in tqdm(data_loader):
+        if len(sample.x) == 0:
+            continue
+        num_non_text_entities = 0
+        sample = prepare_sample(device, sample)
+
+        entity_list = sample.entity_list[0] # + raw_sample['non_text_entity_list']
+        relation_list = sample.relation_list[0]
+        rel_ids = sample.rel_ids[0]
+        top_K_triples = []
+        target_relevant_triples = []
+
+        pred_triple_logits = model(sample.edge_index,
+                                   sample.q_emb,
+                                   sample.x,
+                                   sample.edge_attr,
+                                   num_non_text_entities,
+                                   sample.topic_entity_one_hot)
+
+        pred_triple_scores = torch.sigmoid(pred_triple_logits).reshape(-1)
+        top_K_results = torch.topk(pred_triple_scores,
+                                    min(args.max_K, len(pred_triple_scores)))
+        top_K_scores = top_K_results.values.cpu().tolist()
+        top_K_triple_IDs = top_K_results.indices.cpu().tolist()
+
+        for j, triple_id in enumerate(top_K_triple_IDs):
+            top_K_triples.append((
+                entity_list[sample.edge_index[0][triple_id].item()],
+                relation_list[rel_ids[triple_id]],
+                entity_list[sample.edge_index[1][triple_id].item()],
+                top_K_scores[j]
+            ))
+
+        target_relevant_triple_ids = sample.triple_scores.nonzero().reshape(-1).tolist()
+        for triple_id in target_relevant_triple_ids:
+            target_relevant_triples.append((
+                entity_list[sample.edge_index[0][triple_id].item()],
+                relation_list[rel_ids[triple_id]],
+                entity_list[sample.edge_index[1][triple_id].item()],
+            ))
+
+        sample_dict = {
+            'question': sample.question,
+            'scored_triples': top_K_triples,
+            'q_entity': sample.q_entity,
+            'q_entity_in_graph': [entity_list[e_id] for e_id in sample.q_entity_ids[0]],
+            'a_entity': sample.a_entity,
+            'a_entity_in_graph': [entity_list[e_id] for e_id in sample.a_entity_ids[0]],
+            'max_path_length': sample.max_path_length,
+            'target_relevant_triples': target_relevant_triples
+        }
+
+        pred_dict[sample.id[0]] = sample_dict
+
+    torch.save(pred_dict, os.path.join(checkpoint_dir, 'retrieval_result.pth'))
+    return pred_dict
+
+def reason():
+    pass
+
+def main(args):
+    num_epochs = 10000
+
+    device = torch.device('cuda:0')
+    torch.set_num_threads(16)
+    seed_everything(42)
+
+    if args.checkpoint_dir:
+        checkpoint_dir = args.checkpoint_dir
+    else:
+        ts = time.strftime('%b%d-%H:%M:%S', time.gmtime())
+        exp_prefix = 'webqsp'
+        checkpoint_dir = f'{exp_prefix}_{ts}'
+    os.makedirs(checkpoint_dir, exist_ok=True)
+
+
+    path = os.path.dirname(os.path.realpath(__file__))
+    path = os.path.join(path, 'data', 'WebQSPDataset')
+    train_set = WebQSPDataset(path, split='train')
+    val_set = WebQSPDataset(path, split='val')
+
+    train_loader = DataLoader(
+        train_set, batch_size=1, pin_memory=True, shuffle=True)
+    val_loader = DataLoader(
+        val_set, batch_size=1, pin_memory=True)
+
+    test_set = WebQSPDataset(path, split='test')
+    test_loader = DataLoader(
+        test_set, batch_size=1, pin_memory=True)
+
+    emb_size = train_set[0]['q_emb'].shape[-1]
+    DDE_kwargs = {'num_rounds': 2, 'num_reverse_rounds': 2}
+    model = SubgraphRAGRetriever(emb_size, topic_pe=True, DDE_kwargs=DDE_kwargs).to(device)
+
+    if os.path.exists(os.path.join(checkpoint_dir, "model.pt")):
+        print("Loading model from checkpoint...")
+        model.load_state_dict(torch.load(
+            os.path.join(checkpoint_dir, "model.pt"),
+            weights_only=True))
+    else:
+        print("Training model...")
+        optimizer = Adam(model.parameters(), lr=1e-3)
+
+        num_patient_epochs = 0
+        best_val_metric = 0
+        for epoch in range(num_epochs):
+            num_patient_epochs += 1
+
+            val_eval_dict = eval(device, val_loader, model)
+            target_val_metric = val_eval_dict['triple_recall@100']
+
+            if target_val_metric > best_val_metric:
+                num_patient_epochs = 0
+                best_val_metric = target_val_metric
+                torch.save(model.state_dict(), os.path.join(checkpoint_dir, "model.pt"))
+
+                val_log = {'val/epoch': epoch}
+                for key, val in val_eval_dict.items():
+                    val_log[f'val/{key}'] = val
+                print(f"{epoch} val: {val_log}")
+
+            train_log_dict = train(device, train_loader, model, optimizer)
+
+            train_log_dict.update({
+                'num_patient_epochs': num_patient_epochs,
+                'epoch': epoch
+            })
+            print(f"train log dict: {train_log_dict}")
+
+            if num_patient_epochs == args.patience:
+                break
+    test(device, test_loader, model, checkpoint_dir)
+if __name__ == '__main__':
+    from argparse import ArgumentParser
+
+    parser = ArgumentParser()
+    parser.add_argument('-d', '--dataset', type=str, default='webqsp',
+                        choices=['webqsp', 'cwq'], help='Dataset name')
+    parser.add_argument('--patience', type=int, default=10,
+        help="Number of epochs with no improvement in validation accuracy before stopping")
+    parser.add_argument('--checkpoint_dir', type=str, default='',
+                        help='Directory where the checkpoint and scores will be saved')
+    parser.add_argument('--max_K', type=int, default=500,
+                        help='K in top-K triple retrieval')
+    args = parser.parse_args()
+
+    main(args)

--- a/examples/llm/subgraphrag.py
+++ b/examples/llm/subgraphrag.py
@@ -1,22 +1,30 @@
+import numpy as np
 import os
 import time
-from collections import defaultdict
-
-import numpy as np
 import torch
 import torch.nn.functional as F
-from dataset import WebQSPDataset
+import re
+import string
+from functools import lru_cache
+
+from collections import defaultdict
 from torch.optim import Adam
+from torch_geometric.loader import DataLoader
 from tqdm import tqdm
 
+from dataset import WebQSPDataset
+from retriever_model import SubgraphRAGRetriever
 from torch_geometric import seed_everything
-from torch_geometric.loader import DataLoader
-from torch_geometric.nn.models import SubgraphRAGRetriever
 
+from torch_geometric.nn.nlp import LLM
+
+SYS_PROMPT = ('Based on the triplets from a knowledge graph, '
+    'please answer the given question. '
+    'Please keep the answers as simple as possible and return all the '
+    'possible answers as a list, each with a prefix "ans:".')
 
 def prepare_sample(device, sample):
     return sample.to(device)
-
 
 def train(device, train_loader, model, optimizer):
     model.train()
@@ -24,13 +32,11 @@ def train(device, train_loader, model, optimizer):
     for sample in tqdm(train_loader):
         if len(sample.x) == 0:
             continue
-        num_non_text_entities = 0
         sample = prepare_sample(device, sample)
         pred_triple_logits = model(sample.edge_index, sample.q_emb, sample.x,
-                                   sample.edge_attr, num_non_text_entities,
-                                   sample.topic_entity_one_hot)
+                                   sample.edge_attr, sample.topic_entity_one_hot)
 
-        target_triple_probs = sample.triple_scores
+        target_triple_probs = sample.target_triple_scores
         target_triple_probs = target_triple_probs.unsqueeze(-1)
         loss = F.binary_cross_entropy_with_logits(pred_triple_logits,
                                                   target_triple_probs)
@@ -54,14 +60,13 @@ def eval(device, data_loader, model):
     metric_dict = defaultdict(list)
 
     for sample in tqdm(data_loader):
-        num_non_text_entities = 0
         sample = prepare_sample(device, sample)
 
         pred_triple_logits = model(sample.edge_index, sample.q_emb, sample.x,
-                                   sample.edge_attr, num_non_text_entities,
+                                   sample.edge_attr,
                                    sample.topic_entity_one_hot).reshape(-1)
 
-        target_triple_probs = sample.triple_scores
+        target_triple_probs = sample.target_triple_scores
         a_entity_ids = sample.a_entity_ids[0]
 
         # Triple ranking
@@ -72,12 +77,12 @@ def eval(device, data_loader, model):
             len(triple_ranks_pred))
 
         target_triple_ids = target_triple_probs.nonzero().squeeze(-1).cpu()
-        num_target_triples = len(target_triple_ids)
+        num_target_triplets = len(target_triple_ids)
 
-        if num_target_triples == 0:
+        if num_target_triplets == 0:
             continue
 
-        num_total_entities = len(sample.x) + num_non_text_entities
+        num_total_entities = len(sample.x)
 
         k_list = [100]
 
@@ -85,7 +90,7 @@ def eval(device, data_loader, model):
             recall_k_sample = (triple_ranks_pred[target_triple_ids]
                                < k).sum().item()
             metric_dict[f'triple_recall@{k}'].append(recall_k_sample /
-                                                     num_target_triples)
+                                                     num_target_triplets)
 
             triple_mask_k = triple_ranks_pred < k
             entity_mask_k = torch.zeros(num_total_entities)
@@ -113,11 +118,11 @@ def test(device, data_loader, model, checkpoint_dir):
         sample = prepare_sample(device, sample)
 
         entity_list = sample.entity_list[
-            0]  # + raw_sample['non_text_entity_list']
+            0]
         relation_list = sample.relation_list[0]
         rel_ids = sample.rel_ids[0]
-        top_K_triples = []
-        target_relevant_triples = []
+        top_K_triplets = []
+        target_relevant_triplets = []
 
         pred_triple_logits = model(sample.edge_index, sample.q_emb, sample.x,
                                    sample.edge_attr, num_non_text_entities,
@@ -130,16 +135,16 @@ def test(device, data_loader, model, checkpoint_dir):
         top_K_triple_IDs = top_K_results.indices.cpu().tolist()
 
         for j, triple_id in enumerate(top_K_triple_IDs):
-            top_K_triples.append(
+            top_K_triplets.append(
                 (entity_list[sample.edge_index[0][triple_id].item()],
                  relation_list[rel_ids[triple_id]],
                  entity_list[sample.edge_index[1][triple_id].item()],
                  top_K_scores[j]))
 
-        target_relevant_triple_ids = sample.triple_scores.nonzero().reshape(
+        target_relevant_triple_ids = sample.target_triple_scores.nonzero().reshape(
             -1).tolist()
         for triple_id in target_relevant_triple_ids:
-            target_relevant_triples.append((
+            target_relevant_triplets.append((
                 entity_list[sample.edge_index[0][triple_id].item()],
                 relation_list[rel_ids[triple_id]],
                 entity_list[sample.edge_index[1][triple_id].item()],
@@ -148,8 +153,8 @@ def test(device, data_loader, model, checkpoint_dir):
         sample_dict = {
             'question':
             sample.question,
-            'scored_triples':
-            top_K_triples,
+            'scored_triplets':
+            top_K_triplets,
             'q_entity':
             sample.q_entity,
             'q_entity_in_graph':
@@ -160,8 +165,8 @@ def test(device, data_loader, model, checkpoint_dir):
             [entity_list[e_id] for e_id in sample.a_entity_ids[0]],
             'max_path_length':
             sample.max_path_length,
-            'target_relevant_triples':
-            target_relevant_triples
+            'target_relevant_triplets':
+            target_relevant_triplets
         }
 
         pred_dict[sample.id[0]] = sample_dict
@@ -169,12 +174,171 @@ def test(device, data_loader, model, checkpoint_dir):
     torch.save(pred_dict, os.path.join(checkpoint_dir, 'retrieval_result.pth'))
     return pred_dict
 
+def llm_infer(llm, user_query, sys_prompt, max_tokens=4096):
+    conversation = [{"role": "system", "content": sys_prompt}]
+    conversation.append({"role": "user", "content": user_query})
+    output = llm.inference([conversation], max_tokens=max_tokens)[0]
+    return output
 
-def reason():
-    pass
+def prepare_prompt(sample, K_triplets, threshold=0.0):
+    question_prompt = "Question:\n" + sample['question'][0]
+    if question_prompt[-1] != '?':
+        question_prompt += '?'
+    if K_triplets > 0:
+        input_triplets = sample['scored_triplets']
+        if threshold > 0.0:
+            input_triplets = [(triplet[0], triplet[1], triplet[2])
+                            for triplet in input_triplets
+                            if triplet[3] >= threshold]
+        # Ensure that triplets are unique
+        input_triplets = list(dict.fromkeys(input_triplets))
+        input_triplets = input_triplets[:K_triplets]
+        input_triplets = [f"({triplet[0]},{triplet[1]},{triplet[2]})"
+                        for triplet in input_triplets]
+        triplet_prompt = "Triplets:\n" + "\n".join(input_triplets)
+    else:
+        triplet_prompt = ''
+
+    if triplet_prompt == '':
+        user_query = question_prompt
+    else:
+        user_query = "\n\n".join([triplet_prompt, question_prompt])
+
+    return user_query
+
+
+
+def reason(pred_dict, model_name, K_triplets, max_tokens=4096):
+    llm = LLM(model_name=model_name, backend='openai')
+    llm.llm.generation_config.pad_token_id = llm.tokenizer.eos_token_id
+
+    llm_preds = []
+    for _, sample in tqdm(pred_dict.items()):
+        user_query = prepare_prompt(sample,
+                                    K_triplets)
+        llm_preds.append(llm_infer(llm, user_query, SYS_PROMPT, max_tokens))
+    return llm_preds
+
+################################
+########## Metrics #############
+################################
+
+@lru_cache(maxsize=1000)
+def normalize(s: str) -> str:
+    s = s.lower()
+    exclude = set(string.punctuation)
+    s = "".join(char for char in s if char not in exclude)
+    s = re.sub(r"\b(a|an|the)\b", " ", s)
+    s = re.sub(r"\b(<pad>)\b", " ", s)
+    s = " ".join(s.split())
+    return s
+
+def compute_scores(pred_dict, llm_preds, double_check=False):
+    hits_any = 0
+    hits_at_1 = 0
+    all_precision = []
+    all_recall = []
+    all_f1 = []
+
+    ans_pattern = re.compile(r'ans:', re.IGNORECASE)
+    total_samples = len(pred_dict)
+
+    for i, (_, sample) in enumerate(tqdm(pred_dict.items())):
+        gt_answers = sample['a_entity'][0]
+        prediction_text = llm_preds[i].lower()
+
+        if not gt_answers or not ans_pattern.search(prediction_text):
+            all_precision.append(0)
+            all_recall.append(0)
+            all_f1.append(0)
+            continue
+
+        all_predictions = [p.strip() for p in prediction_text.split('ans:')[1:]]
+
+        gt_answers = [normalize(answer) for answer in gt_answers]
+        all_predictions = [normalize(pred) for pred in all_predictions]
+
+        first_pred = all_predictions[0]
+        for answer in gt_answers:
+            if (answer in first_pred) or (double_check and first_pred in answer):
+                hits_at_1 += 1
+                break
+
+        matched_indices = set()
+        for pred in all_predictions:
+            for j, answer in enumerate(gt_answers):
+                if j in matched_indices:
+                    continue
+                if (answer in pred) or (double_check and pred in answer):
+                    matched_indices.add(j)
+                    break
+
+        num_matches = len(matched_indices)
+
+        hits_any += (num_matches > 0)
+        precision = num_matches / len(all_predictions)
+        recall = num_matches / len(gt_answers)
+
+        f1 = 0
+        if precision + recall > 0:
+            f1 = 2 * precision * recall / (precision + recall)
+
+        all_precision.append(precision)
+        all_recall.append(recall)
+        all_f1.append(f1)
+
+    hit_rate = hits_any / total_samples
+    hit_at_1 = hits_at_1 / total_samples
+    avg_precision = sum(all_precision) / total_samples
+    avg_recall = sum(all_recall) / total_samples
+    avg_f1 = sum(all_f1) / total_samples
+
+    print("\n" + "="*50)
+    print(f"Evaluation Metrics ({total_samples} samples):")
+    print("-"*50)
+    print(f"Hit (Any): {hit_rate:.4f} ({hits_any}/{total_samples})")
+    print(f"Hit@1:     {hit_at_1:.4f} ({hits_at_1}/{total_samples})")
+    print(f"Precision: {avg_precision:.4f}")
+    print(f"Recall:    {avg_recall:.4f}")
+    print(f"F1 Score:  {avg_f1:.4f}")
+    print("="*50)
+
+    return {
+        'hit_rate': hit_rate,
+        'hit_at_1': hit_at_1,
+        'precision': avg_precision,
+        'recall': avg_recall,
+        'f1': avg_f1,
+        'total_samples': total_samples
+    }
+
+def compute_metrics(pred_dict, llm_preds):
+    print("\n" + "="*50)
+    print(f"Evaluation Metrics Vanilla):")
+    compute_scores(pred_dict, llm_preds, False)
+    print("\n" + "="*50)
+    print(f"Evaluation Metrics with Bidirectional Check):")
+    compute_scores(pred_dict, llm_preds, True)
 
 
 def main(args):
+    pred_file_path = os.path.join(args.checkpoint_dir,
+                                  'retrieval_result.pth')
+    llm_pred_file = os.path.join(args.checkpoint_dir,
+                                    'llm_pred.pt')
+    k_triplets = 0 if args.no_triplets else args.k_triplets
+
+    if os.path.exists(pred_file_path):
+        pred_dict = torch.load(pred_file_path, weights_only=False)
+        print("Retriever prediction file found, proceed to reasoning")
+        if not os.path.exists(llm_pred_file):
+            llm_preds = reason(pred_dict, args.model_name, k_triplets)
+            torch.save(llm_preds, llm_pred_file)
+        else:
+            print("LLM preds found, loading")
+            llm_preds = torch.load(llm_pred_file, weights_only=False)
+        compute_metrics(pred_dict, llm_preds)
+        return
     num_epochs = 10000
 
     device = torch.device('cuda:0')
@@ -191,20 +355,20 @@ def main(args):
 
     path = os.path.dirname(os.path.realpath(__file__))
     path = os.path.join(path, 'data', 'WebQSPDataset')
-    train_set = WebQSPDataset(path, split='train')
-    val_set = WebQSPDataset(path, split='val')
+
+    train_set = WebQSPDataset(path, split='train', subgraphrag=True)
+    val_set = WebQSPDataset(path, split='val', subgraphrag=True)
+    test_set = WebQSPDataset(path, split='test', subgraphrag=True)
 
     train_loader = DataLoader(train_set, batch_size=1, pin_memory=True,
                               shuffle=True)
     val_loader = DataLoader(val_set, batch_size=1, pin_memory=True)
-
-    test_set = WebQSPDataset(path, split='test')
     test_loader = DataLoader(test_set, batch_size=1, pin_memory=True)
 
     emb_size = train_set[0]['q_emb'].shape[-1]
-    DDE_kwargs = {'num_rounds': 2, 'num_reverse_rounds': 2}
     model = SubgraphRAGRetriever(emb_size, topic_pe=True,
-                                 DDE_kwargs=DDE_kwargs).to(device)
+                                 dde_rounds=2,
+                                 rev_dde_rounds=2).to(device)
 
     if os.path.exists(os.path.join(checkpoint_dir, "model.pt")):
         print("Loading model from checkpoint...")
@@ -212,7 +376,7 @@ def main(args):
             torch.load(os.path.join(checkpoint_dir, "model.pt"),
                        weights_only=True))
     else:
-        print("Training model...")
+        print("Training Retriever model...")
         optimizer = Adam(model.parameters(), lr=1e-3)
 
         num_patient_epochs = 0
@@ -240,12 +404,16 @@ def main(args):
                 'num_patient_epochs': num_patient_epochs,
                 'epoch': epoch
             })
-            print(f"train log dict: {train_log_dict}")
+            print(f"{train_log_dict}")
 
             if num_patient_epochs == args.patience:
                 break
-    test(device, test_loader, model, checkpoint_dir)
+    pred_dict = test(device, test_loader, model, checkpoint_dir)
 
+    print("Reasoning with LLM")
+    llm_preds = reason(pred_dict, args.model_name, k_triplets)
+    torch.save(llm_preds, llm_pred_file)
+    compute_metrics(pred_dict, llm_preds)
 
 if __name__ == '__main__':
     from argparse import ArgumentParser
@@ -253,6 +421,7 @@ if __name__ == '__main__':
     parser = ArgumentParser()
     parser.add_argument('-d', '--dataset', type=str, default='webqsp',
                         choices=['webqsp', 'cwq'], help='Dataset name')
+    # Retriever args
     parser.add_argument(
         '--patience', type=int, default=10, help=
         "Number of epochs with no improvement in validation accuracy before stopping"
@@ -262,6 +431,15 @@ if __name__ == '__main__':
         help='Directory where the checkpoint and scores will be saved')
     parser.add_argument('--max_K', type=int, default=500,
                         help='K in top-K triple retrieval')
+
+    # Reasoning args
+    parser.add_argument("-m", "--model_name", type=str, default="meta-llama/Meta-Llama-3.1-8B-Instruct", help="Model name")
+    parser.add_argument("--max_tokens", type=int, default=4000, help="Max tokens")
+    parser.add_argument("--seed", type=int, default=0, help="Seed")
+    parser.add_argument("--temperature", type=float, default=0, help="Temperature")
+    parser.add_argument("--k_triplets", type=int, default=100,
+                        help="Top K triplets used for reasoning")
+    parser.add_argument("--no_triplets", action="store_true", help="Overrides --k_triplets")
     args = parser.parse_args()
 
     main(args)

--- a/torch_geometric/nn/models/__init__.py
+++ b/torch_geometric/nn/models/__init__.py
@@ -33,6 +33,7 @@ from .git_mol import GITMol
 from .molecule_gpt import MoleculeGPT
 from .glem import GLEM
 from .sgformer import SGFormer
+from .subgraphrag import SubgraphRAGRetriever
 # Deprecated:
 from torch_geometric.explain.algorithm.captum import (to_captum_input,
                                                       captum_output_to_dicts)
@@ -84,4 +85,5 @@ __all__ = classes = [
     'MoleculeGPT',
     'GLEM',
     'SGFormer',
+    'SubgraphRAGRetriever',
 ]

--- a/torch_geometric/nn/models/subgraphrag.py
+++ b/torch_geometric/nn/models/subgraphrag.py
@@ -3,6 +3,7 @@ import torch.nn as nn
 
 from torch_geometric.nn import MessagePassing
 
+
 class PEConv(MessagePassing):
     def __init__(self):
         super().__init__(aggr='mean')
@@ -13,114 +14,87 @@ class PEConv(MessagePassing):
     def message(self, x_j):
         return x_j
 
+
 class DDE(nn.Module):
-    def __init__(
-        self,
-        num_rounds,
-        num_reverse_rounds
-    ):
+    def __init__(self, num_rounds, num_reverse_rounds):
         super().__init__()
-        
+
         self.layers = nn.ModuleList()
         for _ in range(num_rounds):
             self.layers.append(PEConv())
-        
+
         self.reverse_layers = nn.ModuleList()
         for _ in range(num_reverse_rounds):
             self.reverse_layers.append(PEConv())
-    
-    def forward(
-        self,
-        topic_entity_one_hot,
-        edge_index,
-        reverse_edge_index
-    ):
+
+    def forward(self, topic_entity_one_hot, edge_index, reverse_edge_index):
         result_list = []
-        
+
         h_pe = topic_entity_one_hot
         for layer in self.layers:
             h_pe = layer(edge_index, h_pe)
             result_list.append(h_pe)
-        
+
         h_pe_rev = topic_entity_one_hot
         for layer in self.reverse_layers:
             h_pe_rev = layer(reverse_edge_index, h_pe_rev)
             result_list.append(h_pe_rev)
-        
+
         return result_list
 
+
 class Retriever(nn.Module):
-    r"""The SubgraphRAG retriever model from the `"Simple Is Effective: The 
-    Roles of Graphs and Large Language Models in Knowledge-Graph-Based 
+    r"""The SubgraphRAG retriever model from the `"Simple Is Effective: The
+    Roles of Graphs and Large Language Models in Knowledge-Graph-Based
     Retrieval-Augmented Generation"
     <https://arxiv.org/abs/2410.20724>`_ paper.
 
     Args:
         emb_size (int): The dimension of the embeddings.
         gnn (torch.nn.Module): The GNN to use.
-        mlp_out_channels (dict, optional): 
+        mlp_out_channels (dict, optional):
     """
-    def __init__(
-        self,
-        emb_size,
-        topic_pe,
-        DDE_kwargs
-    ):
+    def __init__(self, emb_size, topic_pe, DDE_kwargs):
         super().__init__()
-        
+
         self.non_text_entity_emb = nn.Embedding(1, emb_size)
         self.topic_pe = topic_pe
         self.dde = DDE(**DDE_kwargs)
-        
+
         pred_in_size = 4 * emb_size
         if topic_pe:
             pred_in_size += 2 * 2
-        pred_in_size += 2 * 2 * (DDE_kwargs['num_rounds'] + DDE_kwargs['num_reverse_rounds'])
+        pred_in_size += 2 * 2 * (DDE_kwargs['num_rounds'] +
+                                 DDE_kwargs['num_reverse_rounds'])
 
-        self.pred = nn.Sequential(
-            nn.Linear(pred_in_size, emb_size),
-            nn.ReLU(),
-            nn.Linear(emb_size, 1)
-        )
+        self.pred = nn.Sequential(nn.Linear(pred_in_size, emb_size), nn.ReLU(),
+                                  nn.Linear(emb_size, 1))
 
-    def forward(
-        self,
-        edge_index,
-        q_emb,
-        entity_embs,
-        relation_embs,
-        num_non_text_entities,
-        topic_entity_one_hot
-    ):
+    def forward(self, edge_index, q_emb, entity_embs, relation_embs,
+                num_non_text_entities, topic_entity_one_hot):
         device = entity_embs.device
-        
-        h_e = torch.cat(
-            [
-                entity_embs,
-                self.non_text_entity_emb(
-                    torch.LongTensor([0]).to(device)).expand(num_non_text_entities, -1)
-            ]
-        , dim=0)
+
+        h_e = torch.cat([
+            entity_embs,
+            self.non_text_entity_emb(torch.LongTensor([0]).to(device)).expand(
+                num_non_text_entities, -1)
+        ], dim=0)
         h_e_list = [h_e]
         if self.topic_pe:
             h_e_list.append(topic_entity_one_hot)
 
-        reverse_edge_index = torch.stack([
-            edge_index[1],
-            edge_index[0]
-        ], dim=0)
+        reverse_edge_index = torch.stack([edge_index[1], edge_index[0]], dim=0)
 
-        dde_list = self.dde(topic_entity_one_hot, edge_index, reverse_edge_index)
+        dde_list = self.dde(topic_entity_one_hot, edge_index,
+                            reverse_edge_index)
         h_e_list.extend(dde_list)
         h_e = torch.cat(h_e_list, dim=1)
 
         h_q = q_emb
 
         h_triple = torch.cat([
-            h_q.expand(len(relation_embs), -1),
-            h_e[edge_index[0]],
-            relation_embs,
-            h_e[edge_index[1]]
+            h_q.expand(len(relation_embs), -1), h_e[edge_index[0]],
+            relation_embs, h_e[edge_index[1]]
         ], dim=1)
-        
+
         return self.pred(h_triple)

--- a/torch_geometric/nn/models/subgraphrag.py
+++ b/torch_geometric/nn/models/subgraphrag.py
@@ -75,6 +75,7 @@ class DDE(nn.Module):
 
         return result_list
 
+
 class SubgraphRAGRetriever(nn.Module):
     r"""The SubgraphRAG retriever model from the `"Simple Is Effective: The
     Roles of Graphs and Large Language Models in Knowledge-Graph-Based
@@ -99,11 +100,11 @@ class SubgraphRAGRetriever(nn.Module):
             pred_in_size += 2 * 2
         pred_in_size += 2 * 2 * (dde_rounds + rev_dde_rounds)
 
-        self.pred = nn.Sequential(nn.Linear(pred_in_size, emb_size),
-                                  nn.ReLU(),
+        self.pred = nn.Sequential(nn.Linear(pred_in_size, emb_size), nn.ReLU(),
                                   nn.Linear(emb_size, 1))
 
-    def forward(self, edge_index, q_emb, entity_embs, relation_embs, topic_entity_one_hot):
+    def forward(self, edge_index, q_emb, entity_embs, relation_embs,
+                topic_entity_one_hot):
         h_e = torch.cat([
             entity_embs,
         ], dim=0)

--- a/torch_geometric/nn/models/subgraphrag.py
+++ b/torch_geometric/nn/models/subgraphrag.py
@@ -57,7 +57,6 @@ class Retriever(nn.Module):
     def __init__(self, emb_size, topic_pe, DDE_kwargs):
         super().__init__()
 
-        self.non_text_entity_emb = nn.Embedding(1, emb_size)
         self.topic_pe = topic_pe
         self.dde = DDE(**DDE_kwargs)
 
@@ -72,12 +71,8 @@ class Retriever(nn.Module):
 
     def forward(self, edge_index, q_emb, entity_embs, relation_embs,
                 num_non_text_entities, topic_entity_one_hot):
-        device = entity_embs.device
-
         h_e = torch.cat([
             entity_embs,
-            self.non_text_entity_emb(torch.LongTensor([0]).to(device)).expand(
-                num_non_text_entities, -1)
         ], dim=0)
         h_e_list = [h_e]
         if self.topic_pe:

--- a/torch_geometric/nn/models/subgraphrag.py
+++ b/torch_geometric/nn/models/subgraphrag.py
@@ -1,0 +1,126 @@
+import torch
+import torch.nn as nn
+
+from torch_geometric.nn import MessagePassing
+
+class PEConv(MessagePassing):
+    def __init__(self):
+        super().__init__(aggr='mean')
+
+    def forward(self, edge_index, x):
+        return self.propagate(edge_index, x=x)
+
+    def message(self, x_j):
+        return x_j
+
+class DDE(nn.Module):
+    def __init__(
+        self,
+        num_rounds,
+        num_reverse_rounds
+    ):
+        super().__init__()
+        
+        self.layers = nn.ModuleList()
+        for _ in range(num_rounds):
+            self.layers.append(PEConv())
+        
+        self.reverse_layers = nn.ModuleList()
+        for _ in range(num_reverse_rounds):
+            self.reverse_layers.append(PEConv())
+    
+    def forward(
+        self,
+        topic_entity_one_hot,
+        edge_index,
+        reverse_edge_index
+    ):
+        result_list = []
+        
+        h_pe = topic_entity_one_hot
+        for layer in self.layers:
+            h_pe = layer(edge_index, h_pe)
+            result_list.append(h_pe)
+        
+        h_pe_rev = topic_entity_one_hot
+        for layer in self.reverse_layers:
+            h_pe_rev = layer(reverse_edge_index, h_pe_rev)
+            result_list.append(h_pe_rev)
+        
+        return result_list
+
+class Retriever(nn.Module):
+    r"""The SubgraphRAG retriever model from the `"Simple Is Effective: The 
+    Roles of Graphs and Large Language Models in Knowledge-Graph-Based 
+    Retrieval-Augmented Generation"
+    <https://arxiv.org/abs/2410.20724>`_ paper.
+
+    Args:
+        emb_size (int): The dimension of the embeddings.
+        gnn (torch.nn.Module): The GNN to use.
+        mlp_out_channels (dict, optional): 
+    """
+    def __init__(
+        self,
+        emb_size,
+        topic_pe,
+        DDE_kwargs
+    ):
+        super().__init__()
+        
+        self.non_text_entity_emb = nn.Embedding(1, emb_size)
+        self.topic_pe = topic_pe
+        self.dde = DDE(**DDE_kwargs)
+        
+        pred_in_size = 4 * emb_size
+        if topic_pe:
+            pred_in_size += 2 * 2
+        pred_in_size += 2 * 2 * (DDE_kwargs['num_rounds'] + DDE_kwargs['num_reverse_rounds'])
+
+        self.pred = nn.Sequential(
+            nn.Linear(pred_in_size, emb_size),
+            nn.ReLU(),
+            nn.Linear(emb_size, 1)
+        )
+
+    def forward(
+        self,
+        edge_index,
+        q_emb,
+        entity_embs,
+        relation_embs,
+        num_non_text_entities,
+        topic_entity_one_hot
+    ):
+        device = entity_embs.device
+        
+        h_e = torch.cat(
+            [
+                entity_embs,
+                self.non_text_entity_emb(
+                    torch.LongTensor([0]).to(device)).expand(num_non_text_entities, -1)
+            ]
+        , dim=0)
+        h_e_list = [h_e]
+        if self.topic_pe:
+            h_e_list.append(topic_entity_one_hot)
+
+        reverse_edge_index = torch.stack([
+            edge_index[1],
+            edge_index[0]
+        ], dim=0)
+
+        dde_list = self.dde(topic_entity_one_hot, edge_index, reverse_edge_index)
+        h_e_list.extend(dde_list)
+        h_e = torch.cat(h_e_list, dim=1)
+
+        h_q = q_emb
+
+        h_triple = torch.cat([
+            h_q.expand(len(relation_embs), -1),
+            h_e[edge_index[0]],
+            relation_embs,
+            h_e[edge_index[1]]
+        ], dim=1)
+        
+        return self.pred(h_triple)


### PR DESCRIPTION
This PR adds a E2E implementation of [Simple Is Effective: The Roles of Graphs and Large Language Models in Knowledge-Graph-Based Retrieval-Augmented Generation](https://arxiv.org/abs/2410.20724)

## Reproducing

to add

## Results
Metrics with `topk=100` and `model_name=meta-llama/Llama-3.1-8B`

```
==================================================
Evaluation Metrics (1638 samples):
--------------------------------------------------
Hit (Any): 0.8077 (1323/1638)
Hit@1:     0.7613 (1247/1638)
Precision: 0.7062
Recall:    0.6322
F1 Score:  0.5994
==================================================
```

Ablation study, no triplets (question only): `Hit@1:     0.3547`

Bigger LLM (`meta-llama/Llama-3.1-70B-Instruct`) doesn't improve the hit rate: `Hit@1:     0.7608` 

