### PR TITLE
[Bug] Fixing bug in `llm/glem.py` example.

### DIFF
--- a/examples/llm/glem.py
+++ b/examples/llm/glem.py
@@ -79,7 +79,7 @@ def main(args):
 
     dataset = PygNodePropPredDataset(f'ogbn-{dataset_name}', root=root)
     split_idx = dataset.get_idx_split()
-    data = dataset[0]
+    data = dataset._data
 
     tag_dataset = TAGDataset(root, dataset, hf_model,
                              token_on_disk=token_on_disk)


### PR DESCRIPTION
The fix proposed in [PR#9955](https://github.com/pyg-team/pytorch_geometric/pull/9955) for the warning in the `llm/glem.py` example was incorrect. With that fix this test failed with the following error message:
```
Traceback (most recent call last):
  File "/workspace/examples/llm/glem.py", line 446, in <module>
    main(args)
  File "/workspace/examples/llm/glem.py", line 280, in main
    acc, loss = model.train(pretrain_phase, pretrain_loader, pretrain_opt,
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/torch_geometric/nn/models/glem.py", line 150, in train
    acc, loss = self.train_gnn(train_loader, optimizer, epoch,
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/torch_geometric/nn/models/glem.py", line 243, in train_gnn
    is_gold_batch = batch.is_gold[:batch.batch_size].squeeze()
                    ^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/torch_geometric/data/data.py", line 561, in __getattr__
    return getattr(self._store, key)
           ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/torch_geometric/data/storage.py", line 96, in __getattr__
    raise AttributeError(
AttributeError: 'GlobalStorage' object has no attribute 'is_gold'
```
This PR provides a correct fix for the warning:
```
/usr/local/lib/python3.12/dist-packages/torch_geometric/data/in_memory_dataset.py:300: UserWarning: It is not recommended 
to directly access the internal storage format `data` of an 'InMemoryDataset'. If you are absolutely certain what you are 
doing, access the internal storage via `InMemoryDataset._data` instead to suppress this warning. Alternatively, you can 
access stacked individual attributes of every graph via `dataset.{attr_name}`.
  warnings.warn(msg)
``` 