### PR TITLE
Make computation of mesh laplacian more efficient

### DIFF
--- a/torch_geometric/utils/mesh_laplacian.py
+++ b/torch_geometric/utils/mesh_laplacian.py
@@ -59,7 +59,7 @@ def get_mesh_laplacian(
     # 1. Compute edge vectors of edges opposite to each vertex
     e_21 = pos[face[2]] - pos[face[1]]
     e_02 = pos[face[0]] - pos[face[2]]
-    e_10 = - (e_21 + e_02) # this is equal to pos[face[1]] - pos[face[0]]
+    e_10 = -(e_21 + e_02)  # this is equal to pos[face[1]] - pos[face[0]]
 
     # 2. Compute areas of all triangles
     area_times_four =  2 * torch.norm(torch.cross(e_02, e_10, dim=1), dim=1)
@@ -81,22 +81,10 @@ def get_mesh_laplacian(
 
     if normalization is not None:
 
-        def get_areas(left: Tensor, centre: Tensor, right: Tensor) -> Tensor:
-            central_pos = pos[centre]
-            left_vec = pos[left] - central_pos
-            right_vec = pos[right] - central_pos
-            cross = torch.norm(torch.cross(left_vec, right_vec, dim=1), dim=1)
-            area = cross / 6.0  # one-third of a triangle's area is cross / 6.0
-            return area / 2.0  # since each corresponding area is counted twice
-
         # Like before, but here we only need the diagonal (the mass matrix):
-        area_021 = get_areas(face[0], face[2], face[1])
-        area_102 = get_areas(face[1], face[0], face[2])
-        area_012 = get_areas(face[0], face[1], face[2])
-        area_weight = torch.cat([area_021, area_102, area_012])
-        area_index = torch.cat([face[:2], face[1:], face[::2]], dim=1)
-        area_index, area_weight = to_undirected(area_index, area_weight)
-        area_deg = scatter(area_weight, area_index[0], 0, num_nodes, 'sum')
+        # Attribute a third of the area from a face to each contained vertex and accumulate
+        area_weight = (area_times_four / 12).repeat(3)
+        area_deg = scatter(area_weight, face.flatten(), 0, num_nodes, 'sum')
 
         if normalization == 'sym':
             area_deg_inv_sqrt = area_deg.pow_(-0.5)

--- a/torch_geometric/utils/mesh_laplacian.py
+++ b/torch_geometric/utils/mesh_laplacian.py
@@ -55,20 +55,20 @@ def get_mesh_laplacian(
 
     num_nodes = pos.shape[0]
 
-    def get_cots(left: Tensor, centre: Tensor, right: Tensor) -> Tensor:
-        left_pos, central_pos, right_pos = pos[left], pos[centre], pos[right]
-        left_vec = left_pos - central_pos
-        right_vec = right_pos - central_pos
-        dot = torch.einsum('ij, ij -> i', left_vec, right_vec)
-        cross = torch.norm(torch.cross(left_vec, right_vec, dim=1), dim=1)
-        cot = dot / cross  # cot = cos / sin
-        return cot / 2.0  # by definition
-
     # For each triangle face, get all three cotangents:
-    cot_021 = get_cots(face[0], face[2], face[1])
-    cot_102 = get_cots(face[1], face[0], face[2])
-    cot_012 = get_cots(face[0], face[1], face[2])
-    cot_weight = torch.cat([cot_021, cot_102, cot_012])
+    # 1. Compute edge vectors of edges opposite to each vertex
+    e_21 = pos[face[2]] - pos[face[1]]
+    e_02 = pos[face[0]] - pos[face[2]]
+    e_10 = - (e_21 + e_02) # this is equal to pos[face[1]] - pos[face[0]]
+
+    # 2. Compute areas of all triangles
+    area_times_four =  2 * torch.norm(torch.cross(e_02, e_10, dim=1), dim=1)
+
+    # 3. Compute cotangent weights cot(e_ik, e_kj) = -dot(e_ik, e_kj) / (4 * area)
+    cot_0 = -torch.sum(e_10 * e_02, dim=1) / area_times_four
+    cot_1 = -torch.sum(e_21 * e_10, dim=1) / area_times_four
+    cot_2 = -torch.sum(e_02 * e_21, dim=1) / area_times_four
+    cot_weight = torch.cat([cot_2, cot_0, cot_1])
 
     # Face to edge:
     cot_index = torch.cat([face[:2], face[1:], face[::2]], dim=1)

--- a/torch_geometric/utils/mesh_laplacian.py
+++ b/torch_geometric/utils/mesh_laplacian.py
@@ -62,9 +62,10 @@ def get_mesh_laplacian(
     e_10 = -(e_21 + e_02)  # this is equal to pos[face[1]] - pos[face[0]]
 
     # 2. Compute areas of all triangles
-    area_times_four =  2 * torch.norm(torch.cross(e_02, e_10, dim=1), dim=1)
+    area_times_four = 2 * torch.norm(torch.cross(e_02, e_10, dim=1), dim=1)
 
-    # 3. Compute cotangent weights cot(e_ik, e_kj) = -dot(e_ik, e_kj) / (4 * area)
+    # 3. Compute cotangent weights
+    #    cot(e_ik, e_kj) = -dot(e_ik, e_kj) / (4 * area)
     cot_0 = -torch.sum(e_10 * e_02, dim=1) / area_times_four
     cot_1 = -torch.sum(e_21 * e_10, dim=1) / area_times_four
     cot_2 = -torch.sum(e_02 * e_21, dim=1) / area_times_four
@@ -82,7 +83,8 @@ def get_mesh_laplacian(
     if normalization is not None:
 
         # Like before, but here we only need the diagonal (the mass matrix):
-        # Attribute a third of the area from a face to each contained vertex and accumulate
+        # Attribute a third of the area from a face to each contained vertex
+        # and accumulate
         area_weight = (area_times_four / 12).repeat(3)
         area_deg = scatter(area_weight, face.flatten(), 0, num_nodes, 'sum')
 


### PR DESCRIPTION
This PR slightly changes the computation of the mesh laplacian to be more efficient. In essence, the introduced changes are:
- Remove the redundant computation of the triangle area. The cross product $|e_{ij} \times e_{jk}|$ computes (twice) the area of a triangle for all pairs of edges, but was computed 6 times for all triangles (3x for the stiffness, 3x for the mass).
- Aggregate triangle areas over faces instead of edges.
- Slightly optimize the number of operations in some expressions.

All tests pass. In addition, I tested the validity of the changes with random triangulations with 1e2-1e5 nodes while benchmarking. The corresponding benchmarking script is not included in this PR, but can be found [here](https://github.com/minnerbe/pytorch_geometric/blob/test_changes/test_changes.py). Since this doesn't change the observable behavior of the code, I did not include a line in the changelog.

The performance improvements vary across architectures and with the number of nodes of the triangulation. Below, you can find the speedup for a given architecture (rows) for different normalization methods (columns) with different numbers of nodes in the mesh (tables). This speedup is of course anecdotal, but the fact that there is speedup seems pretty consistent.

```
N=1e2             None    sym    rw
x86_64            1.29x   2.00x  2.02x
aarch64           1.37x   2.16x  2.21x
cuda              1.32x   2.07x  2.07x

N=1e4             None    sym    rw
x86_64            1.19x   2.24x  2.13x
aarch64           1.08x   1.99x  1.96x
cuda              1.28x   2.06x  2.06x

N=1e5             None    sym    rw
x86_64            1.08x   1.75x  1.83x
aarch64           1.03x   1.91x  1.95x
cuda              2.24x   2.95x  2.98x
```