### PR TITLE
Removed `SAMPLED_OP` flag from `torch_geometric/typing.py`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,8 +53,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Fixed `is_node_attr()` and `is_edge_attr()` errors when `cat_dim` is a tuple ([#9895](https://github.com/pyg-team/pytorch_geometric/issues/9895))
 
 ### Removed
-- Removed `SAMPLED_OP` flag from `torch_geometric/typing.py` ([#10023](https://github.com/pyg-team/pytorch_geometric/pull/10023))
 
+- Removed `SAMPLED_OP` flag from `torch_geometric/typing.py` ([#10023](https://github.com/pyg-team/pytorch_geometric/pull/10023))
 
 ## [2.6.0] - 2024-09-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Fixed `is_node_attr()` and `is_edge_attr()` errors when `cat_dim` is a tuple ([#9895](https://github.com/pyg-team/pytorch_geometric/issues/9895))
 
 ### Removed
+- Removed `SAMPLED_OP` flag from `torch_geometric/typing.py` ([#10023](https://github.com/pyg-team/pytorch_geometric/pull/10023))
+
 
 ## [2.6.0] - 2024-09-13
 

--- a/torch_geometric/typing.py
+++ b/torch_geometric/typing.py
@@ -56,7 +56,6 @@ try:
         except RuntimeError:
             WITH_GMM = False
             WITH_SEGMM = False
-    WITH_SAMPLED_OP = hasattr(pyg_lib.ops, 'sampled_add')
     WITH_SOFTMAX = hasattr(pyg_lib.ops, 'softmax_csr')
     WITH_INDEX_SORT = hasattr(pyg_lib.ops, 'index_sort')
     WITH_METIS = hasattr(pyg_lib, 'partition')
@@ -72,7 +71,6 @@ except Exception as e:
     WITH_PYG_LIB = False
     WITH_GMM = False
     WITH_SEGMM = False
-    WITH_SAMPLED_OP = False
     WITH_SOFTMAX = False
     WITH_INDEX_SORT = False
     WITH_METIS = False


### PR DESCRIPTION
The `SAMPLED_OP` flag was used some time ago in the softmax implementation (`torch_geometrics/utils/softmax.py`) and with commit: https://github.com/pyg-team/pytorch_geometric/commit/d7e03c71cda21d62bb465984fe9bf4488c6c6a5a its usage was removed. However, the flag is still present in the `torch_geometric/typing.py` file.