### PR TITLE
Fix Mean Rank to Start from 1 in `KGEModel`

### DIFF
--- a/torch_geometric/nn/kge/base.py
+++ b/torch_geometric/nn/kge/base.py
@@ -125,7 +125,7 @@ class KGEModel(torch.nn.Module):
                 scores.append(self(h.expand_as(ts), r.expand_as(ts), ts))
             rank = int((torch.cat(scores).argsort(
                 descending=True) == t).nonzero().view(-1))
-            mean_ranks.append(rank)
+            mean_ranks.append(rank + 1)
             reciprocal_ranks.append(1 / (rank + 1))
             hits_at_k.append(rank < k)
 


### PR DESCRIPTION
Mean Rank (MR) metrics should always be ≥ 1, but the current implementation allows rank values to start from 0, leading to incorrect mean rank scores. While adding +1 to the calculated mean_rank produces the correct MR, this approach might be misleading for users.
If my concern is incorrect or if this fix is minor, please feel free to close this PR.
Thanks!