### PR TITLE
Feature/attract repel wrapper

### DIFF
--- a/examples/ar_link_pred.py
+++ b/examples/ar_link_pred.py
@@ -1,0 +1,211 @@
+import argparse
+import os.path as osp
+
+import torch
+import torch.nn.functional as F
+
+import torch_geometric.transforms as T
+from torch_geometric.datasets import Planetoid
+from torch_geometric.nn import GCNConv
+from torch_geometric.utils import (
+    negative_sampling,
+    train_test_split_edges,
+)
+
+
+class GCNEncoder(torch.nn.Module):
+    def __init__(self, in_channels, hidden_channels, out_channels):
+        super().__init__()
+        self.conv1 = GCNConv(in_channels, hidden_channels)
+        self.conv2 = GCNConv(hidden_channels, out_channels)
+
+    def forward(self, x, edge_index):
+        x = self.conv1(x, edge_index).relu()
+        return self.conv2(x, edge_index)
+
+
+class LinkPredictor(torch.nn.Module):
+    def __init__(self, in_channels, hidden_channels):
+        super().__init__()
+        self.lin1 = torch.nn.Linear(in_channels * 2, hidden_channels)
+        self.lin2 = torch.nn.Linear(hidden_channels, 1)
+
+    def forward(self, z_i, z_j):
+        x = torch.cat([z_i, z_j], dim=1)
+        x = self.lin1(x).relu()
+        x = self.lin2(x)
+        return x.view(-1)
+
+
+class ARLinkPredictor(torch.nn.Module):
+    def __init__(self, in_channels):
+        super().__init__()
+        # Split dimensions between attract and repel
+        self.attract_dim = in_channels // 2
+        self.repel_dim = in_channels - self.attract_dim
+
+    def forward(self, z_i, z_j):
+        # Split into attract and repel parts
+        z_i_attr = z_i[:, :self.attract_dim]
+        z_i_repel = z_i[:, self.attract_dim:]
+        
+        z_j_attr = z_j[:, :self.attract_dim]
+        z_j_repel = z_j[:, self.attract_dim:]
+        
+        # Calculate AR score
+        attract_score = (z_i_attr * z_j_attr).sum(dim=1)
+        repel_score = (z_i_repel * z_j_repel).sum(dim=1)
+        
+        return attract_score - repel_score
+
+
+def train(encoder, predictor, data, optimizer):
+    encoder.train()
+    predictor.train()
+    
+    # Forward pass and calculate loss
+    optimizer.zero_grad()
+    z = encoder(data.x, data.train_pos_edge_index)
+    
+    # Positive edges
+    pos_out = predictor(z[data.train_pos_edge_index[0]], z[data.train_pos_edge_index[1]])
+    
+    # Sample and predict on negative edges
+    neg_edge_index = negative_sampling(
+        edge_index=data.train_pos_edge_index,
+        num_nodes=data.num_nodes,
+        num_neg_samples=data.train_pos_edge_index.size(1),
+    )
+    neg_out = predictor(z[neg_edge_index[0]], z[neg_edge_index[1]])
+
+    # Calculate loss
+    pos_loss = F.binary_cross_entropy_with_logits(
+        pos_out, torch.ones_like(pos_out)
+    )
+    neg_loss = F.binary_cross_entropy_with_logits(
+        neg_out, torch.zeros_like(neg_out)
+    )
+    loss = pos_loss + neg_loss
+    
+    loss.backward()
+    optimizer.step()
+    
+    return loss.item()
+
+
+@torch.no_grad()
+def test(encoder, predictor, data):
+    encoder.eval()
+    predictor.eval()
+    
+    z = encoder(data.x, data.train_pos_edge_index)
+    
+    pos_val_out = predictor(z[data.val_pos_edge_index[0]], z[data.val_pos_edge_index[1]])
+    neg_val_out = predictor(z[data.val_neg_edge_index[0]], z[data.val_neg_edge_index[1]])
+    
+    pos_test_out = predictor(z[data.test_pos_edge_index[0]], z[data.test_pos_edge_index[1]])
+    neg_test_out = predictor(z[data.test_neg_edge_index[0]], z[data.test_neg_edge_index[1]])
+    
+    val_auc = compute_auc(pos_val_out, neg_val_out)
+    test_auc = compute_auc(pos_test_out, neg_test_out)
+    
+    return val_auc, test_auc
+
+
+def compute_auc(pos_out, neg_out):
+    pos_out = torch.sigmoid(pos_out).cpu().numpy()
+    neg_out = torch.sigmoid(neg_out).cpu().numpy()
+    
+    # Simple AUC calculation
+    from sklearn.metrics import roc_auc_score
+    y_true = torch.cat([torch.ones(pos_out.shape[0]), torch.zeros(neg_out.shape[0])])
+    y_score = torch.cat([torch.tensor(pos_out), torch.tensor(neg_out)])
+    
+    return roc_auc_score(y_true, y_score)
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--dataset', type=str, default='Cora', 
+                        choices=['Cora', 'CiteSeer', 'PubMed'])
+    parser.add_argument('--hidden_channels', type=int, default=128)
+    parser.add_argument('--out_channels', type=int, default=64)
+    parser.add_argument('--epochs', type=int, default=200)
+    parser.add_argument('--use_ar', action='store_true', 
+                        help='Use Attract-Repel embeddings')
+    parser.add_argument('--lr', type=float, default=0.01)
+    args = parser.parse_args()
+
+    device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
+    
+    # Load dataset
+    transform = T.Compose([
+        T.NormalizeFeatures(),
+        T.ToDevice(device),
+    ])
+    
+    path = osp.join(osp.dirname(osp.realpath(__file__)), '..', 'data', args.dataset)
+    dataset = Planetoid(path, args.dataset, transform=transform)
+    data = dataset[0]
+
+    # Process data for link prediction
+    data = train_test_split_edges(data)
+
+    # Initialize encoder
+    encoder = GCNEncoder(
+        in_channels=dataset.num_features,
+        hidden_channels=args.hidden_channels,
+        out_channels=args.out_channels,
+    ).to(device)
+    
+    # Choose predictor based on args
+    if args.use_ar:
+        predictor = ARLinkPredictor(in_channels=args.out_channels).to(device)
+        print(f"Running link prediction on {args.dataset} with Attract-Repel embeddings")
+    else:
+        predictor = LinkPredictor(
+            in_channels=args.out_channels, 
+            hidden_channels=args.hidden_channels
+        ).to(device)
+        print(f"Running link prediction on {args.dataset} with Traditional embeddings")
+    
+    optimizer = torch.optim.Adam(
+        list(encoder.parameters()) + list(predictor.parameters()),
+        lr=args.lr
+    )
+
+    best_val_auc = 0
+    final_test_auc = 0
+    
+    for epoch in range(1, args.epochs + 1):
+        loss = train(encoder, predictor, data, optimizer)
+        val_auc, test_auc = test(encoder, predictor, data)
+        
+        if val_auc > best_val_auc:
+            best_val_auc = val_auc
+            final_test_auc = test_auc
+        
+        if epoch % 10 == 0:
+            print(f'Epoch: {epoch:03d}, Loss: {loss:.4f}, Val AUC: {val_auc:.4f}, '
+                  f'Test AUC: {test_auc:.4f}')
+    
+    print(f'Final results - Val AUC: {best_val_auc:.4f}, Test AUC: {final_test_auc:.4f}')
+    
+    # Calculate R-fraction if using AR
+    if args.use_ar:
+        with torch.no_grad():
+            z = encoder(data.x, data.train_pos_edge_index)
+            attr_dim = args.out_channels // 2
+            
+            z_attr = z[:, :attr_dim]
+            z_repel = z[:, attr_dim:]
+            
+            attract_norm_squared = torch.sum(z_attr ** 2)
+            repel_norm_squared = torch.sum(z_repel ** 2)
+            
+            r_fraction = repel_norm_squared / (attract_norm_squared + repel_norm_squared)
+            print(f"R-fraction: {r_fraction.item():.4f}")
+
+
+if __name__ == '__main__':
+    main()

--- a/examples/ar_link_pred.py
+++ b/examples/ar_link_pred.py
@@ -7,10 +7,7 @@ import torch.nn.functional as F
 import torch_geometric.transforms as T
 from torch_geometric.datasets import Planetoid
 from torch_geometric.nn import GCNConv
-from torch_geometric.utils import (
-    negative_sampling,
-    train_test_split_edges,
-)
+from torch_geometric.utils import negative_sampling, train_test_split_edges
 
 
 class GCNEncoder(torch.nn.Module):
@@ -48,28 +45,29 @@ class ARLinkPredictor(torch.nn.Module):
         # Split into attract and repel parts
         z_i_attr = z_i[:, :self.attract_dim]
         z_i_repel = z_i[:, self.attract_dim:]
-        
+
         z_j_attr = z_j[:, :self.attract_dim]
         z_j_repel = z_j[:, self.attract_dim:]
-        
+
         # Calculate AR score
         attract_score = (z_i_attr * z_j_attr).sum(dim=1)
         repel_score = (z_i_repel * z_j_repel).sum(dim=1)
-        
+
         return attract_score - repel_score
 
 
 def train(encoder, predictor, data, optimizer):
     encoder.train()
     predictor.train()
-    
+
     # Forward pass and calculate loss
     optimizer.zero_grad()
     z = encoder(data.x, data.train_pos_edge_index)
-    
+
     # Positive edges
-    pos_out = predictor(z[data.train_pos_edge_index[0]], z[data.train_pos_edge_index[1]])
-    
+    pos_out = predictor(z[data.train_pos_edge_index[0]],
+                        z[data.train_pos_edge_index[1]])
+
     # Sample and predict on negative edges
     neg_edge_index = negative_sampling(
         edge_index=data.train_pos_edge_index,
@@ -79,17 +77,15 @@ def train(encoder, predictor, data, optimizer):
     neg_out = predictor(z[neg_edge_index[0]], z[neg_edge_index[1]])
 
     # Calculate loss
-    pos_loss = F.binary_cross_entropy_with_logits(
-        pos_out, torch.ones_like(pos_out)
-    )
-    neg_loss = F.binary_cross_entropy_with_logits(
-        neg_out, torch.zeros_like(neg_out)
-    )
+    pos_loss = F.binary_cross_entropy_with_logits(pos_out,
+                                                  torch.ones_like(pos_out))
+    neg_loss = F.binary_cross_entropy_with_logits(neg_out,
+                                                  torch.zeros_like(neg_out))
     loss = pos_loss + neg_loss
-    
+
     loss.backward()
     optimizer.step()
-    
+
     return loss.item()
 
 
@@ -97,54 +93,61 @@ def train(encoder, predictor, data, optimizer):
 def test(encoder, predictor, data):
     encoder.eval()
     predictor.eval()
-    
+
     z = encoder(data.x, data.train_pos_edge_index)
-    
-    pos_val_out = predictor(z[data.val_pos_edge_index[0]], z[data.val_pos_edge_index[1]])
-    neg_val_out = predictor(z[data.val_neg_edge_index[0]], z[data.val_neg_edge_index[1]])
-    
-    pos_test_out = predictor(z[data.test_pos_edge_index[0]], z[data.test_pos_edge_index[1]])
-    neg_test_out = predictor(z[data.test_neg_edge_index[0]], z[data.test_neg_edge_index[1]])
-    
+
+    pos_val_out = predictor(z[data.val_pos_edge_index[0]],
+                            z[data.val_pos_edge_index[1]])
+    neg_val_out = predictor(z[data.val_neg_edge_index[0]],
+                            z[data.val_neg_edge_index[1]])
+
+    pos_test_out = predictor(z[data.test_pos_edge_index[0]],
+                             z[data.test_pos_edge_index[1]])
+    neg_test_out = predictor(z[data.test_neg_edge_index[0]],
+                             z[data.test_neg_edge_index[1]])
+
     val_auc = compute_auc(pos_val_out, neg_val_out)
     test_auc = compute_auc(pos_test_out, neg_test_out)
-    
+
     return val_auc, test_auc
 
 
 def compute_auc(pos_out, neg_out):
     pos_out = torch.sigmoid(pos_out).cpu().numpy()
     neg_out = torch.sigmoid(neg_out).cpu().numpy()
-    
+
     # Simple AUC calculation
     from sklearn.metrics import roc_auc_score
-    y_true = torch.cat([torch.ones(pos_out.shape[0]), torch.zeros(neg_out.shape[0])])
+    y_true = torch.cat(
+        [torch.ones(pos_out.shape[0]),
+         torch.zeros(neg_out.shape[0])])
     y_score = torch.cat([torch.tensor(pos_out), torch.tensor(neg_out)])
-    
+
     return roc_auc_score(y_true, y_score)
 
 
 def main():
     parser = argparse.ArgumentParser()
-    parser.add_argument('--dataset', type=str, default='Cora', 
+    parser.add_argument('--dataset', type=str, default='Cora',
                         choices=['Cora', 'CiteSeer', 'PubMed'])
     parser.add_argument('--hidden_channels', type=int, default=128)
     parser.add_argument('--out_channels', type=int, default=64)
     parser.add_argument('--epochs', type=int, default=200)
-    parser.add_argument('--use_ar', action='store_true', 
+    parser.add_argument('--use_ar', action='store_true',
                         help='Use Attract-Repel embeddings')
     parser.add_argument('--lr', type=float, default=0.01)
     args = parser.parse_args()
 
     device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
-    
+
     # Load dataset
     transform = T.Compose([
         T.NormalizeFeatures(),
         T.ToDevice(device),
     ])
-    
-    path = osp.join(osp.dirname(osp.realpath(__file__)), '..', 'data', args.dataset)
+
+    path = osp.join(osp.dirname(osp.realpath(__file__)), '..', 'data',
+                    args.dataset)
     dataset = Planetoid(path, args.dataset, transform=transform)
     data = dataset[0]
 
@@ -157,53 +160,58 @@ def main():
         hidden_channels=args.hidden_channels,
         out_channels=args.out_channels,
     ).to(device)
-    
+
     # Choose predictor based on args
     if args.use_ar:
         predictor = ARLinkPredictor(in_channels=args.out_channels).to(device)
-        print(f"Running link prediction on {args.dataset} with Attract-Repel embeddings")
+        print(
+            f"Running link prediction on {args.dataset} with Attract-Repel embeddings"
+        )
     else:
         predictor = LinkPredictor(
-            in_channels=args.out_channels, 
-            hidden_channels=args.hidden_channels
-        ).to(device)
-        print(f"Running link prediction on {args.dataset} with Traditional embeddings")
-    
+            in_channels=args.out_channels,
+            hidden_channels=args.hidden_channels).to(device)
+        print(
+            f"Running link prediction on {args.dataset} with Traditional embeddings"
+        )
+
     optimizer = torch.optim.Adam(
-        list(encoder.parameters()) + list(predictor.parameters()),
-        lr=args.lr
-    )
+        list(encoder.parameters()) + list(predictor.parameters()), lr=args.lr)
 
     best_val_auc = 0
     final_test_auc = 0
-    
+
     for epoch in range(1, args.epochs + 1):
         loss = train(encoder, predictor, data, optimizer)
         val_auc, test_auc = test(encoder, predictor, data)
-        
+
         if val_auc > best_val_auc:
             best_val_auc = val_auc
             final_test_auc = test_auc
-        
+
         if epoch % 10 == 0:
-            print(f'Epoch: {epoch:03d}, Loss: {loss:.4f}, Val AUC: {val_auc:.4f}, '
-                  f'Test AUC: {test_auc:.4f}')
-    
-    print(f'Final results - Val AUC: {best_val_auc:.4f}, Test AUC: {final_test_auc:.4f}')
-    
+            print(
+                f'Epoch: {epoch:03d}, Loss: {loss:.4f}, Val AUC: {val_auc:.4f}, '
+                f'Test AUC: {test_auc:.4f}')
+
+    print(
+        f'Final results - Val AUC: {best_val_auc:.4f}, Test AUC: {final_test_auc:.4f}'
+    )
+
     # Calculate R-fraction if using AR
     if args.use_ar:
         with torch.no_grad():
             z = encoder(data.x, data.train_pos_edge_index)
             attr_dim = args.out_channels // 2
-            
+
             z_attr = z[:, :attr_dim]
             z_repel = z[:, attr_dim:]
-            
-            attract_norm_squared = torch.sum(z_attr ** 2)
-            repel_norm_squared = torch.sum(z_repel ** 2)
-            
-            r_fraction = repel_norm_squared / (attract_norm_squared + repel_norm_squared)
+
+            attract_norm_squared = torch.sum(z_attr**2)
+            repel_norm_squared = torch.sum(z_repel**2)
+
+            r_fraction = repel_norm_squared / (attract_norm_squared +
+                                               repel_norm_squared)
             print(f"R-fraction: {r_fraction.item():.4f}")
 
 

--- a/examples/attract_repel_wrapper.py
+++ b/examples/attract_repel_wrapper.py
@@ -1,0 +1,138 @@
+import torch
+import argparse
+import os.path as osp
+
+from torch_geometric.datasets import Planetoid
+import torch_geometric.transforms as T
+from torch_geometric.utils import train_test_split_edges, negative_sampling
+from torch_geometric.nn.models import AttractRepel
+
+
+def train(model, data, optimizer):
+    model.train()
+    
+    # Zero gradients
+    optimizer.zero_grad()
+    
+    # Forward pass
+    z = model(data.x, data.train_pos_edge_index)
+    
+    # Link prediction on positive edges
+    pos_out = model(data.x, data.train_pos_edge_index, 
+                   edge_index=data.train_pos_edge_index)
+    
+    # Sample negative edges and predict
+    neg_edge_index = negative_sampling(
+        edge_index=data.train_pos_edge_index,
+        num_nodes=data.num_nodes,
+        num_neg_samples=data.train_pos_edge_index.size(1),
+    )
+    
+    neg_out = model(data.x, data.train_pos_edge_index, 
+                   edge_index=neg_edge_index)
+    
+    # Compute loss
+    pos_loss = -torch.log(torch.sigmoid(pos_out) + 1e-15).mean()
+    neg_loss = -torch.log(1 - torch.sigmoid(neg_out) + 1e-15).mean()
+    loss = pos_loss + neg_loss
+    
+    # Backward pass
+    loss.backward()
+    optimizer.step()
+    
+    return loss.item()
+
+
+@torch.no_grad()
+def test(model, data):
+    model.eval()
+    
+    # Get embeddings
+    attract_z, repel_z = model.encode(data.x, data.train_pos_edge_index)
+    
+    # Link prediction on validation set
+    pos_val_out = model.decode(attract_z, repel_z, data.val_pos_edge_index)
+    neg_val_out = model.decode(attract_z, repel_z, data.val_neg_edge_index)
+    
+    # Link prediction on test set
+    pos_test_out = model.decode(attract_z, repel_z, data.test_pos_edge_index)
+    neg_test_out = model.decode(attract_z, repel_z, data.test_neg_edge_index)
+    
+    # Calculate AUC
+    from sklearn.metrics import roc_auc_score
+    
+    val_preds = torch.cat([torch.sigmoid(pos_val_out), torch.sigmoid(neg_val_out)])
+    val_labels = torch.cat([torch.ones_like(pos_val_out), torch.zeros_like(neg_val_out)])
+    val_auc = roc_auc_score(val_labels.cpu(), val_preds.cpu())
+    
+    test_preds = torch.cat([torch.sigmoid(pos_test_out), torch.sigmoid(neg_test_out)])
+    test_labels = torch.cat([torch.ones_like(pos_test_out), torch.zeros_like(neg_test_out)])
+    test_auc = roc_auc_score(test_labels.cpu(), test_preds.cpu())
+    
+    return val_auc, test_auc, model.calculate_r_fraction(attract_z, repel_z)
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--dataset', type=str, default='Cora', 
+                        choices=['Cora', 'CiteSeer', 'PubMed'])
+    parser.add_argument('--base_model', type=str, default='GCN',
+                        choices=['GCN', 'GAT', 'GraphSAGE'])
+    parser.add_argument('--hidden_channels', type=int, default=64)
+    parser.add_argument('--out_channels', type=int, default=32)
+    parser.add_argument('--num_layers', type=int, default=2)
+    parser.add_argument('--attract_ratio', type=float, default=0.5)
+    parser.add_argument('--epochs', type=int, default=200)
+    parser.add_argument('--lr', type=float, default=0.01)
+    args = parser.parse_args()
+    
+    device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
+    
+    # Load dataset
+    path = osp.join(osp.dirname(osp.realpath(__file__)), '..', 'data', args.dataset)
+    dataset = Planetoid(path, args.dataset, transform=T.NormalizeFeatures())
+    data = dataset[0].to(device)
+    
+    # Process data for link prediction
+    data = train_test_split_edges(data)
+    
+    # Create AttractRepel model with specified base model
+    model = AttractRepel(
+        args.base_model,
+        in_channels=dataset.num_features,
+        hidden_channels=args.hidden_channels,
+        out_channels=args.out_channels,
+        num_layers=args.num_layers,
+        attract_ratio=args.attract_ratio
+    ).to(device)
+    
+    print(f"Testing AttractRepel with {args.base_model} on {args.dataset} dataset")
+    print(f"Attract ratio: {args.attract_ratio}, Dimensions: {model.attract_dim} attract, {model.repel_dim} repel")
+    
+    # Optimizer
+    optimizer = torch.optim.Adam(model.parameters(), lr=args.lr)
+    
+    # Training loop
+    best_val_auc = 0
+    best_test_auc = 0
+    best_r_fraction = 0
+    
+    for epoch in range(1, args.epochs + 1):
+        loss = train(model, data, optimizer)
+        val_auc, test_auc, r_fraction = test(model, data)
+        
+        if val_auc > best_val_auc:
+            best_val_auc = val_auc
+            best_test_auc = test_auc
+            best_r_fraction = r_fraction
+        
+        if epoch % 10 == 0:
+            print(f'Epoch: {epoch:03d}, Loss: {loss:.4f}, Val AUC: {val_auc:.4f}, '
+                  f'Test AUC: {test_auc:.4f}, R-fraction: {r_fraction:.4f}')
+    
+    print(f"Final results for {args.base_model} on {args.dataset}:")
+    print(f"Test AUC: {best_test_auc:.4f}, R-fraction: {best_r_fraction:.4f}")
+
+
+if __name__ == '__main__':
+    main()

--- a/examples/attract_repel_wrapper.py
+++ b/examples/attract_repel_wrapper.py
@@ -1,80 +1,89 @@
-import torch
 import argparse
 import os.path as osp
 
-from torch_geometric.datasets import Planetoid
+import torch
+
 import torch_geometric.transforms as T
-from torch_geometric.utils import train_test_split_edges, negative_sampling
+from torch_geometric.datasets import Planetoid
 from torch_geometric.nn.models import AttractRepel
+from torch_geometric.utils import negative_sampling, train_test_split_edges
 
 
 def train(model, data, optimizer):
     model.train()
-    
+
     # Zero gradients
     optimizer.zero_grad()
-    
+
     # Forward pass
-    z = model(data.x, data.train_pos_edge_index)
-    
+    model(data.x, data.train_pos_edge_index)
+
     # Link prediction on positive edges
-    pos_out = model(data.x, data.train_pos_edge_index, 
-                   edge_index=data.train_pos_edge_index)
-    
+    pos_out = model(data.x, data.train_pos_edge_index,
+                    edge_index=data.train_pos_edge_index)
+
     # Sample negative edges and predict
     neg_edge_index = negative_sampling(
         edge_index=data.train_pos_edge_index,
         num_nodes=data.num_nodes,
         num_neg_samples=data.train_pos_edge_index.size(1),
     )
-    
-    neg_out = model(data.x, data.train_pos_edge_index, 
-                   edge_index=neg_edge_index)
-    
+
+    neg_out = model(data.x, data.train_pos_edge_index,
+                    edge_index=neg_edge_index)
+
     # Compute loss
     pos_loss = -torch.log(torch.sigmoid(pos_out) + 1e-15).mean()
     neg_loss = -torch.log(1 - torch.sigmoid(neg_out) + 1e-15).mean()
     loss = pos_loss + neg_loss
-    
+
     # Backward pass
     loss.backward()
     optimizer.step()
-    
+
     return loss.item()
 
 
 @torch.no_grad()
 def test(model, data):
     model.eval()
-    
+
     # Get embeddings
     attract_z, repel_z = model.encode(data.x, data.train_pos_edge_index)
-    
+
     # Link prediction on validation set
     pos_val_out = model.decode(attract_z, repel_z, data.val_pos_edge_index)
     neg_val_out = model.decode(attract_z, repel_z, data.val_neg_edge_index)
-    
+
     # Link prediction on test set
     pos_test_out = model.decode(attract_z, repel_z, data.test_pos_edge_index)
     neg_test_out = model.decode(attract_z, repel_z, data.test_neg_edge_index)
-    
+
     # Calculate AUC
     from sklearn.metrics import roc_auc_score
-    
-    val_preds = torch.cat([torch.sigmoid(pos_val_out), torch.sigmoid(neg_val_out)])
-    val_labels = torch.cat([torch.ones_like(pos_val_out), torch.zeros_like(neg_val_out)])
+
+    val_preds = torch.cat(
+        [torch.sigmoid(pos_val_out),
+         torch.sigmoid(neg_val_out)])
+    val_labels = torch.cat(
+        [torch.ones_like(pos_val_out),
+         torch.zeros_like(neg_val_out)])
     val_auc = roc_auc_score(val_labels.cpu(), val_preds.cpu())
-    
-    test_preds = torch.cat([torch.sigmoid(pos_test_out), torch.sigmoid(neg_test_out)])
-    test_labels = torch.cat([torch.ones_like(pos_test_out), torch.zeros_like(neg_test_out)])
+
+    test_preds = torch.cat(
+        [torch.sigmoid(pos_test_out),
+         torch.sigmoid(neg_test_out)])
+    test_labels = torch.cat(
+        [torch.ones_like(pos_test_out),
+         torch.zeros_like(neg_test_out)])
     test_auc = roc_auc_score(test_labels.cpu(), test_preds.cpu())
-    
+
     return val_auc, test_auc, model.calculate_r_fraction(attract_z, repel_z)
 
 
 def main():
     parser = argparse.ArgumentParser()
-    parser.add_argument('--dataset', type=str, default='Cora', 
+    parser.add_argument('--dataset', type=str, default='Cora',
                         choices=['Cora', 'CiteSeer', 'PubMed'])
     parser.add_argument('--base_model', type=str, default='GCN',
                         choices=['GCN', 'GAT', 'GraphSAGE'])
@@ -85,51 +94,54 @@ def main():
     parser.add_argument('--epochs', type=int, default=200)
     parser.add_argument('--lr', type=float, default=0.01)
     args = parser.parse_args()
-    
+
     device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
-    
+
     # Load dataset
-    path = osp.join(osp.dirname(osp.realpath(__file__)), '..', 'data', args.dataset)
+    path = osp.join(osp.dirname(osp.realpath(__file__)), '..', 'data',
+                    args.dataset)
     dataset = Planetoid(path, args.dataset, transform=T.NormalizeFeatures())
     data = dataset[0].to(device)
-    
+
     # Process data for link prediction
     data = train_test_split_edges(data)
-    
+
     # Create AttractRepel model with specified base model
-    model = AttractRepel(
-        args.base_model,
-        in_channels=dataset.num_features,
-        hidden_channels=args.hidden_channels,
-        out_channels=args.out_channels,
-        num_layers=args.num_layers,
-        attract_ratio=args.attract_ratio
-    ).to(device)
-    
-    print(f"Testing AttractRepel with {args.base_model} on {args.dataset} dataset")
-    print(f"Attract ratio: {args.attract_ratio}, Dimensions: {model.attract_dim} attract, {model.repel_dim} repel")
-    
+    model = AttractRepel(args.base_model, in_channels=dataset.num_features,
+                         hidden_channels=args.hidden_channels,
+                         out_channels=args.out_channels,
+                         num_layers=args.num_layers,
+                         attract_ratio=args.attract_ratio).to(device)
+
+    print(
+        f"Testing AttractRepel with {args.base_model} on {args.dataset} dataset"
+    )
+    print(
+        f"Attract ratio: {args.attract_ratio}, Dimensions: {model.attract_dim} attract, {model.repel_dim} repel"
+    )
+
     # Optimizer
     optimizer = torch.optim.Adam(model.parameters(), lr=args.lr)
-    
+
     # Training loop
     best_val_auc = 0
     best_test_auc = 0
     best_r_fraction = 0
-    
+
     for epoch in range(1, args.epochs + 1):
         loss = train(model, data, optimizer)
         val_auc, test_auc, r_fraction = test(model, data)
-        
+
         if val_auc > best_val_auc:
             best_val_auc = val_auc
             best_test_auc = test_auc
             best_r_fraction = r_fraction
-        
+
         if epoch % 10 == 0:
-            print(f'Epoch: {epoch:03d}, Loss: {loss:.4f}, Val AUC: {val_auc:.4f}, '
-                  f'Test AUC: {test_auc:.4f}, R-fraction: {r_fraction:.4f}')
-    
+            print(
+                f'Epoch: {epoch:03d}, Loss: {loss:.4f}, Val AUC: {val_auc:.4f}, '
+                f'Test AUC: {test_auc:.4f}, R-fraction: {r_fraction:.4f}')
+
     print(f"Final results for {args.base_model} on {args.dataset}:")
     print(f"Test AUC: {best_test_auc:.4f}, R-fraction: {best_r_fraction:.4f}")
 

--- a/examples/attract_repel_wrapper.py
+++ b/examples/attract_repel_wrapper.py
@@ -1,111 +1,127 @@
-import torch
 import argparse
 import os.path as osp
 
-from torch_geometric.datasets import Planetoid
+import torch
+
 import torch_geometric.transforms as T
-from torch_geometric.utils import train_test_split_edges, negative_sampling
+from torch_geometric.datasets import Planetoid
 from torch_geometric.nn.models import AttractRepel
+from torch_geometric.utils import negative_sampling, train_test_split_edges
 
 
 def train(model, data, optimizer, is_ar=True):
     model.train()
-    
+
     # Zero gradients
     optimizer.zero_grad()
-    
+
     # Forward pass
     if is_ar:
         z = model(data.x, data.train_pos_edge_index)
-        
+
         # Link prediction on positive edges
-        pos_out = model(data.x, data.train_pos_edge_index, 
-                       edge_index=data.train_pos_edge_index)
-        
+        pos_out = model(data.x, data.train_pos_edge_index,
+                        edge_index=data.train_pos_edge_index)
+
         # Sample negative edges and predict
         neg_edge_index = negative_sampling(
             edge_index=data.train_pos_edge_index,
             num_nodes=data.num_nodes,
             num_neg_samples=data.train_pos_edge_index.size(1),
         )
-        
-        neg_out = model(data.x, data.train_pos_edge_index, 
-                       edge_index=neg_edge_index)
+
+        neg_out = model(data.x, data.train_pos_edge_index,
+                        edge_index=neg_edge_index)
     else:
         # For base models, use a simple dot product for link prediction
         z = model(data.x, data.train_pos_edge_index)
-        
+
         # Link prediction on positive edges
-        pos_out = (z[data.train_pos_edge_index[0]] * z[data.train_pos_edge_index[1]]).sum(dim=1)
-        
+        pos_out = (z[data.train_pos_edge_index[0]] *
+                   z[data.train_pos_edge_index[1]]).sum(dim=1)
+
         # Sample negative edges and predict
         neg_edge_index = negative_sampling(
             edge_index=data.train_pos_edge_index,
             num_nodes=data.num_nodes,
             num_neg_samples=data.train_pos_edge_index.size(1),
         )
-        
+
         neg_out = (z[neg_edge_index[0]] * z[neg_edge_index[1]]).sum(dim=1)
-    
+
     # Compute loss
     pos_loss = -torch.log(torch.sigmoid(pos_out) + 1e-15).mean()
     neg_loss = -torch.log(1 - torch.sigmoid(neg_out) + 1e-15).mean()
     loss = pos_loss + neg_loss
-    
+
     # Backward pass
     loss.backward()
     optimizer.step()
-    
+
     return loss.item()
 
 
 @torch.no_grad()
 def test(model, data, is_ar=True):
     model.eval()
-    
+
     if is_ar:
         # Get embeddings for attract-repel model
         attract_z, repel_z = model.encode(data.x, data.train_pos_edge_index)
-        
+
         # Link prediction on validation set
         pos_val_out = model.decode(attract_z, repel_z, data.val_pos_edge_index)
         neg_val_out = model.decode(attract_z, repel_z, data.val_neg_edge_index)
-        
+
         # Link prediction on test set
-        pos_test_out = model.decode(attract_z, repel_z, data.test_pos_edge_index)
-        neg_test_out = model.decode(attract_z, repel_z, data.test_neg_edge_index)
-        
+        pos_test_out = model.decode(attract_z, repel_z,
+                                    data.test_pos_edge_index)
+        neg_test_out = model.decode(attract_z, repel_z,
+                                    data.test_neg_edge_index)
+
         r_fraction = model.calculate_r_fraction(attract_z, repel_z)
     else:
         # For base models, get embeddings and use dot product
         z = model(data.x, data.train_pos_edge_index)
-        
+
         # Link prediction using dot product
-        pos_val_out = (z[data.val_pos_edge_index[0]] * z[data.val_pos_edge_index[1]]).sum(dim=1)
-        neg_val_out = (z[data.val_neg_edge_index[0]] * z[data.val_neg_edge_index[1]]).sum(dim=1)
-        
-        pos_test_out = (z[data.test_pos_edge_index[0]] * z[data.test_pos_edge_index[1]]).sum(dim=1)
-        neg_test_out = (z[data.test_neg_edge_index[0]] * z[data.test_neg_edge_index[1]]).sum(dim=1)
-        
+        pos_val_out = (z[data.val_pos_edge_index[0]] *
+                       z[data.val_pos_edge_index[1]]).sum(dim=1)
+        neg_val_out = (z[data.val_neg_edge_index[0]] *
+                       z[data.val_neg_edge_index[1]]).sum(dim=1)
+
+        pos_test_out = (z[data.test_pos_edge_index[0]] *
+                        z[data.test_pos_edge_index[1]]).sum(dim=1)
+        neg_test_out = (z[data.test_neg_edge_index[0]] *
+                        z[data.test_neg_edge_index[1]]).sum(dim=1)
+
         r_fraction = 0.0  # No R-fraction for base models
-    
+
     # Calculate AUC
     from sklearn.metrics import roc_auc_score
-    
-    val_preds = torch.cat([torch.sigmoid(pos_val_out), torch.sigmoid(neg_val_out)])
-    val_labels = torch.cat([torch.ones_like(pos_val_out), torch.zeros_like(neg_val_out)])
+
+    val_preds = torch.cat(
+        [torch.sigmoid(pos_val_out),
+         torch.sigmoid(neg_val_out)])
+    val_labels = torch.cat(
+        [torch.ones_like(pos_val_out),
+         torch.zeros_like(neg_val_out)])
     val_auc = roc_auc_score(val_labels.cpu(), val_preds.cpu())
-    
-    test_preds = torch.cat([torch.sigmoid(pos_test_out), torch.sigmoid(neg_test_out)])
-    test_labels = torch.cat([torch.ones_like(pos_test_out), torch.zeros_like(neg_test_out)])
+
+    test_preds = torch.cat(
+        [torch.sigmoid(pos_test_out),
+         torch.sigmoid(neg_test_out)])
+    test_labels = torch.cat(
+        [torch.ones_like(pos_test_out),
+         torch.zeros_like(neg_test_out)])
     test_auc = roc_auc_score(test_labels.cpu(), test_preds.cpu())
-    
+
     return val_auc, test_auc, r_fraction
 
 
 def main():
     parser = argparse.ArgumentParser()
-    parser.add_argument('--dataset', type=str, default='Cora', 
+    parser.add_argument('--dataset', type=str, default='Cora',
                         choices=['Cora', 'CiteSeer', 'PubMed'])
     parser.add_argument('--base_model', type=str, default='GCN',
                         choices=['GCN', 'GAT', 'GraphSAGE'])
@@ -115,81 +131,90 @@ def main():
     parser.add_argument('--attract_ratio', type=float, default=0.5)
     parser.add_argument('--epochs', type=int, default=200)
     parser.add_argument('--lr', type=float, default=0.01)
-    parser.add_argument('--no_ar', action='store_true', help='Use base model without attract-repel')
+    parser.add_argument('--no_ar', action='store_true',
+                        help='Use base model without attract-repel')
     args = parser.parse_args()
-    
+
     device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
-    
+
     # Load dataset
-    path = osp.join(osp.dirname(osp.realpath(__file__)), '..', 'data', args.dataset)
+    path = osp.join(osp.dirname(osp.realpath(__file__)), '..', 'data',
+                    args.dataset)
     dataset = Planetoid(path, args.dataset, transform=T.NormalizeFeatures())
     data = dataset[0].to(device)
-    
+
     # Process data for link prediction
     data = train_test_split_edges(data)
-    
+
     if args.no_ar:
         # Import base models
-        from torch_geometric.nn.models.basic_gnn import GCN, GAT, GraphSAGE
-        
+        from torch_geometric.nn.models.basic_gnn import GAT, GCN, GraphSAGE
+
         # Create base model directly
         if args.base_model == 'GCN':
-            model = GCN(in_channels=dataset.num_features, 
-                       hidden_channels=args.hidden_channels,
-                       out_channels=args.out_channels,
-                       num_layers=args.num_layers).to(device)
+            model = GCN(in_channels=dataset.num_features,
+                        hidden_channels=args.hidden_channels,
+                        out_channels=args.out_channels,
+                        num_layers=args.num_layers).to(device)
         elif args.base_model == 'GAT':
             model = GAT(in_channels=dataset.num_features,
-                       hidden_channels=args.hidden_channels,
-                       out_channels=args.out_channels,
-                       num_layers=args.num_layers).to(device)
+                        hidden_channels=args.hidden_channels,
+                        out_channels=args.out_channels,
+                        num_layers=args.num_layers).to(device)
         elif args.base_model == 'GraphSAGE':
             model = GraphSAGE(in_channels=dataset.num_features,
-                             hidden_channels=args.hidden_channels,
-                             out_channels=args.out_channels,
-                             num_layers=args.num_layers).to(device)
-        print(f"Testing base {args.base_model} model on {args.dataset} dataset")
+                              hidden_channels=args.hidden_channels,
+                              out_channels=args.out_channels,
+                              num_layers=args.num_layers).to(device)
+        print(
+            f"Testing base {args.base_model} model on {args.dataset} dataset")
     else:
         # Create AttractRepel model with specified base model
-        model = AttractRepel(
-            args.base_model,
-            in_channels=dataset.num_features,
-            hidden_channels=args.hidden_channels,
-            out_channels=args.out_channels,
-            num_layers=args.num_layers,
-            attract_ratio=args.attract_ratio
-        ).to(device)
-        
-        print(f"Testing AttractRepel with {args.base_model} on {args.dataset} dataset")
-        print(f"Attract ratio: {args.attract_ratio}, Dimensions: {model.attract_dim} attract, {model.repel_dim} repel")
-    
+        model = AttractRepel(args.base_model, in_channels=dataset.num_features,
+                             hidden_channels=args.hidden_channels,
+                             out_channels=args.out_channels,
+                             num_layers=args.num_layers,
+                             attract_ratio=args.attract_ratio).to(device)
+
+        print(
+            f"Testing AttractRepel with {args.base_model} on {args.dataset} dataset"
+        )
+        print(
+            f"Attract ratio: {args.attract_ratio}, Dimensions: {model.attract_dim} attract, {model.repel_dim} repel"
+        )
+
     # Optimizer
     optimizer = torch.optim.Adam(model.parameters(), lr=args.lr)
-    
+
     # Training loop
     best_val_auc = 0
     best_test_auc = 0
     best_r_fraction = 0
-    
+
     for epoch in range(1, args.epochs + 1):
         loss = train(model, data, optimizer, is_ar=not args.no_ar)
         val_auc, test_auc, r_fraction = test(model, data, is_ar=not args.no_ar)
-        
+
         if val_auc > best_val_auc:
             best_val_auc = val_auc
             best_test_auc = test_auc
             best_r_fraction = r_fraction
-        
+
         if epoch % 10 == 0:
-            print(f'Epoch: {epoch:03d}, Loss: {loss:.4f}, Val AUC: {val_auc:.4f}, '
-                  f'Test AUC: {test_auc:.4f}, R-fraction: {r_fraction:.4f}')
-    
+            print(
+                f'Epoch: {epoch:03d}, Loss: {loss:.4f}, Val AUC: {val_auc:.4f}, '
+                f'Test AUC: {test_auc:.4f}, R-fraction: {r_fraction:.4f}')
+
     if args.no_ar:
         print(f"Final results for base {args.base_model} on {args.dataset}:")
         print(f"Test AUC: {best_test_auc:.4f}")
     else:
-        print(f"Final results for AttractRepel with {args.base_model} on {args.dataset}:")
-        print(f"Test AUC: {best_test_auc:.4f}, R-fraction: {best_r_fraction:.4f}")
+        print(
+            f"Final results for AttractRepel with {args.base_model} on {args.dataset}:"
+        )
+        print(
+            f"Test AUC: {best_test_auc:.4f}, R-fraction: {best_r_fraction:.4f}"
+        )
 
 
 if __name__ == '__main__':

--- a/examples/attract_repel_wrapper.py
+++ b/examples/attract_repel_wrapper.py
@@ -1,89 +1,111 @@
+import torch
 import argparse
 import os.path as osp
 
-import torch
-
-import torch_geometric.transforms as T
 from torch_geometric.datasets import Planetoid
+import torch_geometric.transforms as T
+from torch_geometric.utils import train_test_split_edges, negative_sampling
 from torch_geometric.nn.models import AttractRepel
-from torch_geometric.utils import negative_sampling, train_test_split_edges
 
 
-def train(model, data, optimizer):
+def train(model, data, optimizer, is_ar=True):
     model.train()
-
+    
     # Zero gradients
     optimizer.zero_grad()
-
+    
     # Forward pass
-    model(data.x, data.train_pos_edge_index)
-
-    # Link prediction on positive edges
-    pos_out = model(data.x, data.train_pos_edge_index,
-                    edge_index=data.train_pos_edge_index)
-
-    # Sample negative edges and predict
-    neg_edge_index = negative_sampling(
-        edge_index=data.train_pos_edge_index,
-        num_nodes=data.num_nodes,
-        num_neg_samples=data.train_pos_edge_index.size(1),
-    )
-
-    neg_out = model(data.x, data.train_pos_edge_index,
-                    edge_index=neg_edge_index)
-
+    if is_ar:
+        z = model(data.x, data.train_pos_edge_index)
+        
+        # Link prediction on positive edges
+        pos_out = model(data.x, data.train_pos_edge_index, 
+                       edge_index=data.train_pos_edge_index)
+        
+        # Sample negative edges and predict
+        neg_edge_index = negative_sampling(
+            edge_index=data.train_pos_edge_index,
+            num_nodes=data.num_nodes,
+            num_neg_samples=data.train_pos_edge_index.size(1),
+        )
+        
+        neg_out = model(data.x, data.train_pos_edge_index, 
+                       edge_index=neg_edge_index)
+    else:
+        # For base models, use a simple dot product for link prediction
+        z = model(data.x, data.train_pos_edge_index)
+        
+        # Link prediction on positive edges
+        pos_out = (z[data.train_pos_edge_index[0]] * z[data.train_pos_edge_index[1]]).sum(dim=1)
+        
+        # Sample negative edges and predict
+        neg_edge_index = negative_sampling(
+            edge_index=data.train_pos_edge_index,
+            num_nodes=data.num_nodes,
+            num_neg_samples=data.train_pos_edge_index.size(1),
+        )
+        
+        neg_out = (z[neg_edge_index[0]] * z[neg_edge_index[1]]).sum(dim=1)
+    
     # Compute loss
     pos_loss = -torch.log(torch.sigmoid(pos_out) + 1e-15).mean()
     neg_loss = -torch.log(1 - torch.sigmoid(neg_out) + 1e-15).mean()
     loss = pos_loss + neg_loss
-
+    
     # Backward pass
     loss.backward()
     optimizer.step()
-
+    
     return loss.item()
 
 
 @torch.no_grad()
-def test(model, data):
+def test(model, data, is_ar=True):
     model.eval()
-
-    # Get embeddings
-    attract_z, repel_z = model.encode(data.x, data.train_pos_edge_index)
-
-    # Link prediction on validation set
-    pos_val_out = model.decode(attract_z, repel_z, data.val_pos_edge_index)
-    neg_val_out = model.decode(attract_z, repel_z, data.val_neg_edge_index)
-
-    # Link prediction on test set
-    pos_test_out = model.decode(attract_z, repel_z, data.test_pos_edge_index)
-    neg_test_out = model.decode(attract_z, repel_z, data.test_neg_edge_index)
-
+    
+    if is_ar:
+        # Get embeddings for attract-repel model
+        attract_z, repel_z = model.encode(data.x, data.train_pos_edge_index)
+        
+        # Link prediction on validation set
+        pos_val_out = model.decode(attract_z, repel_z, data.val_pos_edge_index)
+        neg_val_out = model.decode(attract_z, repel_z, data.val_neg_edge_index)
+        
+        # Link prediction on test set
+        pos_test_out = model.decode(attract_z, repel_z, data.test_pos_edge_index)
+        neg_test_out = model.decode(attract_z, repel_z, data.test_neg_edge_index)
+        
+        r_fraction = model.calculate_r_fraction(attract_z, repel_z)
+    else:
+        # For base models, get embeddings and use dot product
+        z = model(data.x, data.train_pos_edge_index)
+        
+        # Link prediction using dot product
+        pos_val_out = (z[data.val_pos_edge_index[0]] * z[data.val_pos_edge_index[1]]).sum(dim=1)
+        neg_val_out = (z[data.val_neg_edge_index[0]] * z[data.val_neg_edge_index[1]]).sum(dim=1)
+        
+        pos_test_out = (z[data.test_pos_edge_index[0]] * z[data.test_pos_edge_index[1]]).sum(dim=1)
+        neg_test_out = (z[data.test_neg_edge_index[0]] * z[data.test_neg_edge_index[1]]).sum(dim=1)
+        
+        r_fraction = 0.0  # No R-fraction for base models
+    
     # Calculate AUC
     from sklearn.metrics import roc_auc_score
-
-    val_preds = torch.cat(
-        [torch.sigmoid(pos_val_out),
-         torch.sigmoid(neg_val_out)])
-    val_labels = torch.cat(
-        [torch.ones_like(pos_val_out),
-         torch.zeros_like(neg_val_out)])
+    
+    val_preds = torch.cat([torch.sigmoid(pos_val_out), torch.sigmoid(neg_val_out)])
+    val_labels = torch.cat([torch.ones_like(pos_val_out), torch.zeros_like(neg_val_out)])
     val_auc = roc_auc_score(val_labels.cpu(), val_preds.cpu())
-
-    test_preds = torch.cat(
-        [torch.sigmoid(pos_test_out),
-         torch.sigmoid(neg_test_out)])
-    test_labels = torch.cat(
-        [torch.ones_like(pos_test_out),
-         torch.zeros_like(neg_test_out)])
+    
+    test_preds = torch.cat([torch.sigmoid(pos_test_out), torch.sigmoid(neg_test_out)])
+    test_labels = torch.cat([torch.ones_like(pos_test_out), torch.zeros_like(neg_test_out)])
     test_auc = roc_auc_score(test_labels.cpu(), test_preds.cpu())
-
-    return val_auc, test_auc, model.calculate_r_fraction(attract_z, repel_z)
+    
+    return val_auc, test_auc, r_fraction
 
 
 def main():
     parser = argparse.ArgumentParser()
-    parser.add_argument('--dataset', type=str, default='Cora',
+    parser.add_argument('--dataset', type=str, default='Cora', 
                         choices=['Cora', 'CiteSeer', 'PubMed'])
     parser.add_argument('--base_model', type=str, default='GCN',
                         choices=['GCN', 'GAT', 'GraphSAGE'])
@@ -93,57 +115,81 @@ def main():
     parser.add_argument('--attract_ratio', type=float, default=0.5)
     parser.add_argument('--epochs', type=int, default=200)
     parser.add_argument('--lr', type=float, default=0.01)
+    parser.add_argument('--no_ar', action='store_true', help='Use base model without attract-repel')
     args = parser.parse_args()
-
+    
     device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
-
+    
     # Load dataset
-    path = osp.join(osp.dirname(osp.realpath(__file__)), '..', 'data',
-                    args.dataset)
+    path = osp.join(osp.dirname(osp.realpath(__file__)), '..', 'data', args.dataset)
     dataset = Planetoid(path, args.dataset, transform=T.NormalizeFeatures())
     data = dataset[0].to(device)
-
+    
     # Process data for link prediction
     data = train_test_split_edges(data)
-
-    # Create AttractRepel model with specified base model
-    model = AttractRepel(args.base_model, in_channels=dataset.num_features,
-                         hidden_channels=args.hidden_channels,
-                         out_channels=args.out_channels,
-                         num_layers=args.num_layers,
-                         attract_ratio=args.attract_ratio).to(device)
-
-    print(
-        f"Testing AttractRepel with {args.base_model} on {args.dataset} dataset"
-    )
-    print(
-        f"Attract ratio: {args.attract_ratio}, Dimensions: {model.attract_dim} attract, {model.repel_dim} repel"
-    )
-
+    
+    if args.no_ar:
+        # Import base models
+        from torch_geometric.nn.models.basic_gnn import GCN, GAT, GraphSAGE
+        
+        # Create base model directly
+        if args.base_model == 'GCN':
+            model = GCN(in_channels=dataset.num_features, 
+                       hidden_channels=args.hidden_channels,
+                       out_channels=args.out_channels,
+                       num_layers=args.num_layers).to(device)
+        elif args.base_model == 'GAT':
+            model = GAT(in_channels=dataset.num_features,
+                       hidden_channels=args.hidden_channels,
+                       out_channels=args.out_channels,
+                       num_layers=args.num_layers).to(device)
+        elif args.base_model == 'GraphSAGE':
+            model = GraphSAGE(in_channels=dataset.num_features,
+                             hidden_channels=args.hidden_channels,
+                             out_channels=args.out_channels,
+                             num_layers=args.num_layers).to(device)
+        print(f"Testing base {args.base_model} model on {args.dataset} dataset")
+    else:
+        # Create AttractRepel model with specified base model
+        model = AttractRepel(
+            args.base_model,
+            in_channels=dataset.num_features,
+            hidden_channels=args.hidden_channels,
+            out_channels=args.out_channels,
+            num_layers=args.num_layers,
+            attract_ratio=args.attract_ratio
+        ).to(device)
+        
+        print(f"Testing AttractRepel with {args.base_model} on {args.dataset} dataset")
+        print(f"Attract ratio: {args.attract_ratio}, Dimensions: {model.attract_dim} attract, {model.repel_dim} repel")
+    
     # Optimizer
     optimizer = torch.optim.Adam(model.parameters(), lr=args.lr)
-
+    
     # Training loop
     best_val_auc = 0
     best_test_auc = 0
     best_r_fraction = 0
-
+    
     for epoch in range(1, args.epochs + 1):
-        loss = train(model, data, optimizer)
-        val_auc, test_auc, r_fraction = test(model, data)
-
+        loss = train(model, data, optimizer, is_ar=not args.no_ar)
+        val_auc, test_auc, r_fraction = test(model, data, is_ar=not args.no_ar)
+        
         if val_auc > best_val_auc:
             best_val_auc = val_auc
             best_test_auc = test_auc
             best_r_fraction = r_fraction
-
+        
         if epoch % 10 == 0:
-            print(
-                f'Epoch: {epoch:03d}, Loss: {loss:.4f}, Val AUC: {val_auc:.4f}, '
-                f'Test AUC: {test_auc:.4f}, R-fraction: {r_fraction:.4f}')
-
-    print(f"Final results for {args.base_model} on {args.dataset}:")
-    print(f"Test AUC: {best_test_auc:.4f}, R-fraction: {best_r_fraction:.4f}")
+            print(f'Epoch: {epoch:03d}, Loss: {loss:.4f}, Val AUC: {val_auc:.4f}, '
+                  f'Test AUC: {test_auc:.4f}, R-fraction: {r_fraction:.4f}')
+    
+    if args.no_ar:
+        print(f"Final results for base {args.base_model} on {args.dataset}:")
+        print(f"Test AUC: {best_test_auc:.4f}")
+    else:
+        print(f"Final results for AttractRepel with {args.base_model} on {args.dataset}:")
+        print(f"Test AUC: {best_test_auc:.4f}, R-fraction: {best_r_fraction:.4f}")
 
 
 if __name__ == '__main__':

--- a/test/nn/models/test_attract_repel.py
+++ b/test/nn/models/test_attract_repel.py
@@ -1,0 +1,73 @@
+import torch
+from torch_geometric.nn import GCN, GAT, GraphSAGE
+from torch_geometric.nn.models import AttractRepel
+
+
+def test_attract_repel_initialization():
+    # Test initialization with string model name
+    model1 = AttractRepel('GCN', in_channels=16, hidden_channels=32, out_channels=8)
+    assert model1.attract_dim == 4  # Default attract_ratio=0.5
+    assert model1.repel_dim == 4
+    
+    # Test initialization with model instance
+    base_model = GCN(in_channels=16, hidden_channels=32, out_channels=64)
+    model2 = AttractRepel(base_model, out_channels=10, attract_ratio=0.7)
+    assert model2.attract_dim == 7  # 70% of 10
+    assert model2.repel_dim == 3
+
+
+def test_attract_repel_forward():
+    model = AttractRepel('GCN', in_channels=16, hidden_channels=32, out_channels=8)
+    
+    # Create dummy data
+    x = torch.randn(4, 16)  # 4 nodes with 16 features
+    edge_index = torch.tensor([[0, 1, 2], [1, 2, 3]])  # 3 edges
+    
+    # Test encode function
+    attract_z, repel_z = model.encode(x, edge_index)
+    assert attract_z.size() == (4, 4)
+    assert repel_z.size() == (4, 4)
+    
+    # Test forward pass with edge_index
+    scores = model(x, edge_index, edge_index=edge_index)
+    assert scores.size(0) == edge_index.size(1)
+    
+    # Test forward pass without edge_index
+    embeddings = model(x, edge_index)
+    assert embeddings.size() == (4, 8)
+
+
+def test_attract_repel_with_different_models():
+    # Test with GAT
+    gat_model = AttractRepel('GAT', in_channels=16, hidden_channels=32, out_channels=8)
+    
+    # Test with GraphSAGE
+    sage_model = AttractRepel('GraphSAGE', in_channels=16, hidden_channels=32, out_channels=8)
+    
+    # Create dummy data
+    x = torch.randn(4, 16)
+    edge_index = torch.tensor([[0, 1, 2], [1, 2, 3]])
+    
+    # Verify both models work
+    gat_scores = gat_model(x, edge_index, edge_index=edge_index)
+    sage_scores = sage_model(x, edge_index, edge_index=edge_index)
+    
+    assert gat_scores.size(0) == edge_index.size(1)
+    assert sage_scores.size(0) == edge_index.size(1)
+
+
+def test_r_fraction_calculation():
+    model = AttractRepel('GCN', in_channels=16, hidden_channels=32, out_channels=8)
+    
+    # Create dummy data
+    x = torch.randn(4, 16)
+    edge_index = torch.tensor([[0, 1, 2], [1, 2, 3]])
+    
+    # Get embeddings
+    attract_z, repel_z = model.encode(x, edge_index)
+    
+    # Calculate R-fraction
+    r_fraction = model.calculate_r_fraction(attract_z, repel_z)
+    
+    # Check it's a valid fraction
+    assert 0 <= r_fraction <= 1

--- a/test/nn/models/test_attract_repel.py
+++ b/test/nn/models/test_attract_repel.py
@@ -1,14 +1,16 @@
 import torch
-from torch_geometric.nn import GCN, GAT, GraphSAGE
+
+from torch_geometric.nn import GCN
 from torch_geometric.nn.models import AttractRepel
 
 
 def test_attract_repel_initialization():
     # Test initialization with string model name
-    model1 = AttractRepel('GCN', in_channels=16, hidden_channels=32, out_channels=8)
+    model1 = AttractRepel('GCN', in_channels=16, hidden_channels=32,
+                          out_channels=8)
     assert model1.attract_dim == 4  # Default attract_ratio=0.5
     assert model1.repel_dim == 4
-    
+
     # Test initialization with model instance
     base_model = GCN(in_channels=16, hidden_channels=32, out_channels=64)
     model2 = AttractRepel(base_model, out_channels=10, attract_ratio=0.7)
@@ -17,21 +19,22 @@ def test_attract_repel_initialization():
 
 
 def test_attract_repel_forward():
-    model = AttractRepel('GCN', in_channels=16, hidden_channels=32, out_channels=8)
-    
+    model = AttractRepel('GCN', in_channels=16, hidden_channels=32,
+                         out_channels=8)
+
     # Create dummy data
     x = torch.randn(4, 16)  # 4 nodes with 16 features
     edge_index = torch.tensor([[0, 1, 2], [1, 2, 3]])  # 3 edges
-    
+
     # Test encode function
     attract_z, repel_z = model.encode(x, edge_index)
     assert attract_z.size() == (4, 4)
     assert repel_z.size() == (4, 4)
-    
+
     # Test forward pass with edge_index
     scores = model(x, edge_index, edge_index=edge_index)
     assert scores.size(0) == edge_index.size(1)
-    
+
     # Test forward pass without edge_index
     embeddings = model(x, edge_index)
     assert embeddings.size() == (4, 8)
@@ -39,35 +42,38 @@ def test_attract_repel_forward():
 
 def test_attract_repel_with_different_models():
     # Test with GAT
-    gat_model = AttractRepel('GAT', in_channels=16, hidden_channels=32, out_channels=8)
-    
+    gat_model = AttractRepel('GAT', in_channels=16, hidden_channels=32,
+                             out_channels=8)
+
     # Test with GraphSAGE
-    sage_model = AttractRepel('GraphSAGE', in_channels=16, hidden_channels=32, out_channels=8)
-    
+    sage_model = AttractRepel('GraphSAGE', in_channels=16, hidden_channels=32,
+                              out_channels=8)
+
     # Create dummy data
     x = torch.randn(4, 16)
     edge_index = torch.tensor([[0, 1, 2], [1, 2, 3]])
-    
+
     # Verify both models work
     gat_scores = gat_model(x, edge_index, edge_index=edge_index)
     sage_scores = sage_model(x, edge_index, edge_index=edge_index)
-    
+
     assert gat_scores.size(0) == edge_index.size(1)
     assert sage_scores.size(0) == edge_index.size(1)
 
 
 def test_r_fraction_calculation():
-    model = AttractRepel('GCN', in_channels=16, hidden_channels=32, out_channels=8)
-    
+    model = AttractRepel('GCN', in_channels=16, hidden_channels=32,
+                         out_channels=8)
+
     # Create dummy data
     x = torch.randn(4, 16)
     edge_index = torch.tensor([[0, 1, 2], [1, 2, 3]])
-    
+
     # Get embeddings
     attract_z, repel_z = model.encode(x, edge_index)
-    
+
     # Calculate R-fraction
     r_fraction = model.calculate_r_fraction(attract_z, repel_z)
-    
+
     # Check it's a valid fraction
     assert 0 <= r_fraction <= 1

--- a/torch_geometric/nn/models/__init__.py
+++ b/torch_geometric/nn/models/__init__.py
@@ -33,6 +33,7 @@ from .git_mol import GITMol
 from .molecule_gpt import MoleculeGPT
 from .glem import GLEM
 from .sgformer import SGFormer
+from .attract_repel import AttractRepel
 # Deprecated:
 from torch_geometric.explain.algorithm.captum import (to_captum_input,
                                                       captum_output_to_dicts)

--- a/torch_geometric/nn/models/attract_repel.py
+++ b/torch_geometric/nn/models/attract_repel.py
@@ -1,0 +1,147 @@
+import torch
+import torch.nn as nn
+from torch_geometric.nn.models.basic_gnn import GCN, GAT, GraphSAGE
+
+class AttractRepel(torch.nn.Module):
+    def __init__(self, base_model, in_channels=None, hidden_channels=None, 
+                 out_channels=None, num_layers=2, attract_ratio=0.5, **kwargs):
+        super(AttractRepel, self).__init__()
+        
+        # Store parameters
+        self.attract_ratio = attract_ratio
+        
+        # Initialize base model
+        if isinstance(base_model, str):
+            # Verify required parameters
+            if in_channels is None or hidden_channels is None:
+                raise ValueError("in_channels and hidden_channels must be provided when base_model is a string")
+            
+            # Create model based on string name
+            if base_model == 'GCN':
+                from torch_geometric.nn.models.basic_gnn import GCN
+                self.base_model = GCN(in_channels=in_channels, 
+                                     hidden_channels=hidden_channels,
+                                     num_layers=num_layers,
+                                     out_channels=hidden_channels,  # Set output to hidden_channels
+                                     **kwargs)
+            elif base_model == 'GAT':
+                from torch_geometric.nn.models.basic_gnn import GAT
+                self.base_model = GAT(in_channels=in_channels, 
+                                     hidden_channels=hidden_channels,
+                                     num_layers=num_layers,
+                                     out_channels=hidden_channels,  # Set output to hidden_channels
+                                     **kwargs)
+            elif base_model == 'GraphSAGE':
+                from torch_geometric.nn.models.basic_gnn import GraphSAGE
+                self.base_model = GraphSAGE(in_channels=in_channels, 
+                                           hidden_channels=hidden_channels,
+                                           num_layers=num_layers,
+                                           out_channels=hidden_channels,  # Set output to hidden_channels
+                                           **kwargs)
+            else:
+                raise ValueError(f"Unknown model: {base_model}. "
+                                f"Supported models: 'GCN', 'GAT', 'GraphSAGE'")
+        else:
+            self.base_model = base_model
+        
+        # Set output dimensions
+        base_out_channels = hidden_channels  # Use hidden_channels as safe default
+        self.out_channels = out_channels if out_channels is not None else base_out_channels
+        
+        # Calculate dimensions for attract and repel components
+        self.attract_dim = int(self.out_channels * attract_ratio)
+        self.repel_dim = self.out_channels - self.attract_dim
+        
+        # Create projection layers
+        self.proj_attract = nn.Linear(base_out_channels, self.attract_dim)
+        self.proj_repel = nn.Linear(base_out_channels, self.repel_dim)
+        
+        print(f"Debug: Model initialized with: out_channels={self.out_channels}, "
+              f"attract_dim={self.attract_dim}, repel_dim={self.repel_dim}")
+    def encode(self, *args, **kwargs):
+        """
+        Encode inputs using the base model and project to attract-repel space.
+        
+        Args:
+            *args: Arguments to pass to the base model
+            **kwargs: Keyword arguments to pass to the base model
+            
+        Returns:
+            tuple[torch.Tensor, torch.Tensor]: Attract and repel embeddings
+        """
+        # Get embeddings from base model
+        x = self.base_model(*args, **kwargs)
+        
+        # Project to attract and repel spaces
+        attract_emb = self.proj_attract(x)
+        repel_emb = self.proj_repel(x)
+        
+        return attract_emb, repel_emb
+    
+    def decode(self, attract_z, repel_z, edge_index):
+        """
+        Compute link prediction scores for given edges.
+        
+        Args:
+            attract_z (torch.Tensor): Attract embeddings of shape [num_nodes, attract_dim]
+            repel_z (torch.Tensor): Repel embeddings of shape [num_nodes, repel_dim]
+            edge_index (torch.Tensor): Edge indices of shape [2, num_edges]
+            
+        Returns:
+            torch.Tensor: Link prediction scores for each edge
+        """
+        # Get node pairs
+        row, col = edge_index
+        
+        # Get embeddings for the node pairs
+        attract_z_i, attract_z_j = attract_z[row], attract_z[col]
+        repel_z_i, repel_z_j = repel_z[row], repel_z[col]
+        
+        # Compute the attract-repel dot products
+        attract_score = (attract_z_i * attract_z_j).sum(dim=1)
+        repel_score = (repel_z_i * repel_z_j).sum(dim=1)
+        
+        # Return the final score
+        return attract_score - repel_score
+    
+    def forward(self, *args, edge_index=None, **kwargs):
+        """
+        Forward pass for link prediction.
+        
+        Args:
+            *args: Arguments to pass to the base model
+            edge_index (torch.Tensor, optional): Edge indices to predict.
+                If not provided, returns node embeddings.
+            **kwargs: Keyword arguments to pass to the base model
+            
+        Returns:
+            torch.Tensor or tuple: If edge_index is provided, returns link prediction
+                scores for each edge. Otherwise, returns node embeddings.
+        """
+        # Get node embeddings
+        attract_z, repel_z = self.encode(*args, **kwargs)
+        
+        # If edge_index is provided, decode edges
+        if edge_index is not None:
+            return self.decode(attract_z, repel_z, edge_index)
+        
+        # Otherwise, return embeddings
+        return torch.cat([attract_z, repel_z], dim=1)
+    
+    def calculate_r_fraction(self, attract_z, repel_z):
+        """
+        Calculate the R-fraction of the embeddings.
+        
+        Args:
+            attract_z (torch.Tensor): Attract embeddings
+            repel_z (torch.Tensor): Repel embeddings
+            
+        Returns:
+            float: R-fraction value
+        """
+        attract_norm_squared = torch.sum(attract_z ** 2)
+        repel_norm_squared = torch.sum(repel_z ** 2)
+        
+        r_fraction = repel_norm_squared / (attract_norm_squared + repel_norm_squared + 1e-10)
+        
+        return r_fraction.item()

--- a/torch_geometric/nn/models/attract_repel.py
+++ b/torch_geometric/nn/models/attract_repel.py
@@ -1,147 +1,155 @@
 import torch
 import torch.nn as nn
-from torch_geometric.nn.models.basic_gnn import GCN, GAT, GraphSAGE
+
 
 class AttractRepel(torch.nn.Module):
-    def __init__(self, base_model, in_channels=None, hidden_channels=None, 
+    def __init__(self, base_model, in_channels=None, hidden_channels=None,
                  out_channels=None, num_layers=2, attract_ratio=0.5, **kwargs):
-        super(AttractRepel, self).__init__()
-        
+        super().__init__()
+
         # Store parameters
         self.attract_ratio = attract_ratio
-        
+
         # Initialize base model
         if isinstance(base_model, str):
             # Verify required parameters
             if in_channels is None or hidden_channels is None:
-                raise ValueError("in_channels and hidden_channels must be provided when base_model is a string")
-            
+                raise ValueError(
+                    "in_channels and hidden_channels must be provided when base_model is a string"
+                )
+
             # Create model based on string name
             if base_model == 'GCN':
                 from torch_geometric.nn.models.basic_gnn import GCN
-                self.base_model = GCN(in_channels=in_channels, 
-                                     hidden_channels=hidden_channels,
-                                     num_layers=num_layers,
-                                     out_channels=hidden_channels,  # Set output to hidden_channels
-                                     **kwargs)
+                self.base_model = GCN(
+                    in_channels=in_channels,
+                    hidden_channels=hidden_channels,
+                    num_layers=num_layers,
+                    out_channels=
+                    hidden_channels,  # Set output to hidden_channels
+                    **kwargs)
             elif base_model == 'GAT':
                 from torch_geometric.nn.models.basic_gnn import GAT
-                self.base_model = GAT(in_channels=in_channels, 
-                                     hidden_channels=hidden_channels,
-                                     num_layers=num_layers,
-                                     out_channels=hidden_channels,  # Set output to hidden_channels
-                                     **kwargs)
+                self.base_model = GAT(
+                    in_channels=in_channels,
+                    hidden_channels=hidden_channels,
+                    num_layers=num_layers,
+                    out_channels=
+                    hidden_channels,  # Set output to hidden_channels
+                    **kwargs)
             elif base_model == 'GraphSAGE':
                 from torch_geometric.nn.models.basic_gnn import GraphSAGE
-                self.base_model = GraphSAGE(in_channels=in_channels, 
-                                           hidden_channels=hidden_channels,
-                                           num_layers=num_layers,
-                                           out_channels=hidden_channels,  # Set output to hidden_channels
-                                           **kwargs)
+                self.base_model = GraphSAGE(
+                    in_channels=in_channels,
+                    hidden_channels=hidden_channels,
+                    num_layers=num_layers,
+                    out_channels=
+                    hidden_channels,  # Set output to hidden_channels
+                    **kwargs)
             else:
-                raise ValueError(f"Unknown model: {base_model}. "
-                                f"Supported models: 'GCN', 'GAT', 'GraphSAGE'")
+                raise ValueError(
+                    f"Unknown model: {base_model}. "
+                    f"Supported models: 'GCN', 'GAT', 'GraphSAGE'")
         else:
             self.base_model = base_model
-        
+
         # Set output dimensions
         base_out_channels = hidden_channels  # Use hidden_channels as safe default
         self.out_channels = out_channels if out_channels is not None else base_out_channels
-        
+
         # Calculate dimensions for attract and repel components
         self.attract_dim = int(self.out_channels * attract_ratio)
         self.repel_dim = self.out_channels - self.attract_dim
-        
+
         # Create projection layers
         self.proj_attract = nn.Linear(base_out_channels, self.attract_dim)
         self.proj_repel = nn.Linear(base_out_channels, self.repel_dim)
-        
-        print(f"Debug: Model initialized with: out_channels={self.out_channels}, "
-              f"attract_dim={self.attract_dim}, repel_dim={self.repel_dim}")
+
+        print(
+            f"Debug: Model initialized with: out_channels={self.out_channels}, "
+            f"attract_dim={self.attract_dim}, repel_dim={self.repel_dim}")
+
     def encode(self, *args, **kwargs):
-        """
-        Encode inputs using the base model and project to attract-repel space.
-        
+        """Encode inputs using the base model and project to attract-repel space.
+
         Args:
             *args: Arguments to pass to the base model
             **kwargs: Keyword arguments to pass to the base model
-            
+
         Returns:
             tuple[torch.Tensor, torch.Tensor]: Attract and repel embeddings
         """
         # Get embeddings from base model
         x = self.base_model(*args, **kwargs)
-        
+
         # Project to attract and repel spaces
         attract_emb = self.proj_attract(x)
         repel_emb = self.proj_repel(x)
-        
+
         return attract_emb, repel_emb
-    
+
     def decode(self, attract_z, repel_z, edge_index):
-        """
-        Compute link prediction scores for given edges.
-        
+        """Compute link prediction scores for given edges.
+
         Args:
             attract_z (torch.Tensor): Attract embeddings of shape [num_nodes, attract_dim]
             repel_z (torch.Tensor): Repel embeddings of shape [num_nodes, repel_dim]
             edge_index (torch.Tensor): Edge indices of shape [2, num_edges]
-            
+
         Returns:
             torch.Tensor: Link prediction scores for each edge
         """
         # Get node pairs
         row, col = edge_index
-        
+
         # Get embeddings for the node pairs
         attract_z_i, attract_z_j = attract_z[row], attract_z[col]
         repel_z_i, repel_z_j = repel_z[row], repel_z[col]
-        
+
         # Compute the attract-repel dot products
         attract_score = (attract_z_i * attract_z_j).sum(dim=1)
         repel_score = (repel_z_i * repel_z_j).sum(dim=1)
-        
+
         # Return the final score
         return attract_score - repel_score
-    
+
     def forward(self, *args, edge_index=None, **kwargs):
-        """
-        Forward pass for link prediction.
-        
+        """Forward pass for link prediction.
+
         Args:
             *args: Arguments to pass to the base model
             edge_index (torch.Tensor, optional): Edge indices to predict.
                 If not provided, returns node embeddings.
             **kwargs: Keyword arguments to pass to the base model
-            
+
         Returns:
             torch.Tensor or tuple: If edge_index is provided, returns link prediction
                 scores for each edge. Otherwise, returns node embeddings.
         """
         # Get node embeddings
         attract_z, repel_z = self.encode(*args, **kwargs)
-        
+
         # If edge_index is provided, decode edges
         if edge_index is not None:
             return self.decode(attract_z, repel_z, edge_index)
-        
+
         # Otherwise, return embeddings
         return torch.cat([attract_z, repel_z], dim=1)
-    
+
     def calculate_r_fraction(self, attract_z, repel_z):
-        """
-        Calculate the R-fraction of the embeddings.
-        
+        """Calculate the R-fraction of the embeddings.
+
         Args:
             attract_z (torch.Tensor): Attract embeddings
             repel_z (torch.Tensor): Repel embeddings
-            
+
         Returns:
             float: R-fraction value
         """
-        attract_norm_squared = torch.sum(attract_z ** 2)
-        repel_norm_squared = torch.sum(repel_z ** 2)
-        
-        r_fraction = repel_norm_squared / (attract_norm_squared + repel_norm_squared + 1e-10)
-        
+        attract_norm_squared = torch.sum(attract_z**2)
+        repel_norm_squared = torch.sum(repel_z**2)
+
+        r_fraction = repel_norm_squared / (attract_norm_squared +
+                                           repel_norm_squared + 1e-10)
+
         return r_fraction.item()


### PR DESCRIPTION
# AttractRepel Wrapper for Existing GNN Models

This PR adds a flexible `AttractRepel` wrapper that can enhance any existing GNN model with attract-repel embeddings for link prediction. This is a follow-up to PR #10105 which implemented the core ARLinkPredictor.

## Overview

The `AttractRepel` wrapper:
- Takes any GNN model (by name or instance) and wraps it with attract-repel capabilities
- Splits embeddings into attract and repel components
- Provides encode/decode methods for link prediction
- Calculates R-fraction to analyze network structure
- Works with standard GNN models (GCN, GAT, GraphSAGE)

## Implementation

The implementation includes:
- `AttractRepel` wrapper class in `torch_geometric.nn.models`
- Test file with unit tests to verify functionality
- Example script demonstrating usage with different models

## Results

The wrapper was tested on citation networks with different GNN architectures. Interestingly, our experiments revealed that traditional embeddings sometimes outperform attract-repel for certain datasets:

| Dataset | Base Model | Base AUC | AR AUC | R-fraction |
|---------|------------|----------|--------|------------|
| Cora    | GCN        | 0.9192   | 0.8143 | 0.4568     |
| Cora    | GAT        | 0.9014   | 0.8078 | 0.4582     |
| Cora    | GraphSAGE  | 0.8898   | 0.8079 | 0.5998     |

This suggests that traditional embeddings are still highly effective for datasets like Cora where transitive relationships are common. However, the non-zero R-fractions indicate that the repel component is capturing meaningful information.

The attract-repel approach is expected to be most beneficial for networks with strong non-transitive relationships ("forbidden triads"), where traditional embeddings struggle. The R-fraction can serve as an indicator of when this approach might be valuable.

## Usage Example

```python
# Create an AttractRepel model with a GCN base
model = AttractRepel(
    'GCN',
    in_channels=dataset.num_features,
    hidden_channels=64,
    out_channels=32,
    num_layers=2
)

# Or wrap an existing model instance
base_model = GAT(in_channels=dataset.num_features, hidden_channels=64)
model = AttractRepel(base_model, out_channels=32)