### PR TITLE
Attract Repel wrapper around existing GNN models (GCN, GAT, GraphSage)

### DIFF
--- a/examples/ar_link_pred.py
+++ b/examples/ar_link_pred.py
@@ -1,0 +1,211 @@
+import argparse
+import os.path as osp
+
+import torch
+import torch.nn.functional as F
+
+import torch_geometric.transforms as T
+from torch_geometric.datasets import Planetoid
+from torch_geometric.nn import GCNConv
+from torch_geometric.utils import (
+    negative_sampling,
+    train_test_split_edges,
+)
+
+
+class GCNEncoder(torch.nn.Module):
+    def __init__(self, in_channels, hidden_channels, out_channels):
+        super().__init__()
+        self.conv1 = GCNConv(in_channels, hidden_channels)
+        self.conv2 = GCNConv(hidden_channels, out_channels)
+
+    def forward(self, x, edge_index):
+        x = self.conv1(x, edge_index).relu()
+        return self.conv2(x, edge_index)
+
+
+class LinkPredictor(torch.nn.Module):
+    def __init__(self, in_channels, hidden_channels):
+        super().__init__()
+        self.lin1 = torch.nn.Linear(in_channels * 2, hidden_channels)
+        self.lin2 = torch.nn.Linear(hidden_channels, 1)
+
+    def forward(self, z_i, z_j):
+        x = torch.cat([z_i, z_j], dim=1)
+        x = self.lin1(x).relu()
+        x = self.lin2(x)
+        return x.view(-1)
+
+
+class ARLinkPredictor(torch.nn.Module):
+    def __init__(self, in_channels):
+        super().__init__()
+        # Split dimensions between attract and repel
+        self.attract_dim = in_channels // 2
+        self.repel_dim = in_channels - self.attract_dim
+
+    def forward(self, z_i, z_j):
+        # Split into attract and repel parts
+        z_i_attr = z_i[:, :self.attract_dim]
+        z_i_repel = z_i[:, self.attract_dim:]
+        
+        z_j_attr = z_j[:, :self.attract_dim]
+        z_j_repel = z_j[:, self.attract_dim:]
+        
+        # Calculate AR score
+        attract_score = (z_i_attr * z_j_attr).sum(dim=1)
+        repel_score = (z_i_repel * z_j_repel).sum(dim=1)
+        
+        return attract_score - repel_score
+
+
+def train(encoder, predictor, data, optimizer):
+    encoder.train()
+    predictor.train()
+    
+    # Forward pass and calculate loss
+    optimizer.zero_grad()
+    z = encoder(data.x, data.train_pos_edge_index)
+    
+    # Positive edges
+    pos_out = predictor(z[data.train_pos_edge_index[0]], z[data.train_pos_edge_index[1]])
+    
+    # Sample and predict on negative edges
+    neg_edge_index = negative_sampling(
+        edge_index=data.train_pos_edge_index,
+        num_nodes=data.num_nodes,
+        num_neg_samples=data.train_pos_edge_index.size(1),
+    )
+    neg_out = predictor(z[neg_edge_index[0]], z[neg_edge_index[1]])
+
+    # Calculate loss
+    pos_loss = F.binary_cross_entropy_with_logits(
+        pos_out, torch.ones_like(pos_out)
+    )
+    neg_loss = F.binary_cross_entropy_with_logits(
+        neg_out, torch.zeros_like(neg_out)
+    )
+    loss = pos_loss + neg_loss
+    
+    loss.backward()
+    optimizer.step()
+    
+    return loss.item()
+
+
+@torch.no_grad()
+def test(encoder, predictor, data):
+    encoder.eval()
+    predictor.eval()
+    
+    z = encoder(data.x, data.train_pos_edge_index)
+    
+    pos_val_out = predictor(z[data.val_pos_edge_index[0]], z[data.val_pos_edge_index[1]])
+    neg_val_out = predictor(z[data.val_neg_edge_index[0]], z[data.val_neg_edge_index[1]])
+    
+    pos_test_out = predictor(z[data.test_pos_edge_index[0]], z[data.test_pos_edge_index[1]])
+    neg_test_out = predictor(z[data.test_neg_edge_index[0]], z[data.test_neg_edge_index[1]])
+    
+    val_auc = compute_auc(pos_val_out, neg_val_out)
+    test_auc = compute_auc(pos_test_out, neg_test_out)
+    
+    return val_auc, test_auc
+
+
+def compute_auc(pos_out, neg_out):
+    pos_out = torch.sigmoid(pos_out).cpu().numpy()
+    neg_out = torch.sigmoid(neg_out).cpu().numpy()
+    
+    # Simple AUC calculation
+    from sklearn.metrics import roc_auc_score
+    y_true = torch.cat([torch.ones(pos_out.shape[0]), torch.zeros(neg_out.shape[0])])
+    y_score = torch.cat([torch.tensor(pos_out), torch.tensor(neg_out)])
+    
+    return roc_auc_score(y_true, y_score)
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--dataset', type=str, default='Cora', 
+                        choices=['Cora', 'CiteSeer', 'PubMed'])
+    parser.add_argument('--hidden_channels', type=int, default=128)
+    parser.add_argument('--out_channels', type=int, default=64)
+    parser.add_argument('--epochs', type=int, default=200)
+    parser.add_argument('--use_ar', action='store_true', 
+                        help='Use Attract-Repel embeddings')
+    parser.add_argument('--lr', type=float, default=0.01)
+    args = parser.parse_args()
+
+    device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
+    
+    # Load dataset
+    transform = T.Compose([
+        T.NormalizeFeatures(),
+        T.ToDevice(device),
+    ])
+    
+    path = osp.join(osp.dirname(osp.realpath(__file__)), '..', 'data', args.dataset)
+    dataset = Planetoid(path, args.dataset, transform=transform)
+    data = dataset[0]
+
+    # Process data for link prediction
+    data = train_test_split_edges(data)
+
+    # Initialize encoder
+    encoder = GCNEncoder(
+        in_channels=dataset.num_features,
+        hidden_channels=args.hidden_channels,
+        out_channels=args.out_channels,
+    ).to(device)
+    
+    # Choose predictor based on args
+    if args.use_ar:
+        predictor = ARLinkPredictor(in_channels=args.out_channels).to(device)
+        print(f"Running link prediction on {args.dataset} with Attract-Repel embeddings")
+    else:
+        predictor = LinkPredictor(
+            in_channels=args.out_channels, 
+            hidden_channels=args.hidden_channels
+        ).to(device)
+        print(f"Running link prediction on {args.dataset} with Traditional embeddings")
+    
+    optimizer = torch.optim.Adam(
+        list(encoder.parameters()) + list(predictor.parameters()),
+        lr=args.lr
+    )
+
+    best_val_auc = 0
+    final_test_auc = 0
+    
+    for epoch in range(1, args.epochs + 1):
+        loss = train(encoder, predictor, data, optimizer)
+        val_auc, test_auc = test(encoder, predictor, data)
+        
+        if val_auc > best_val_auc:
+            best_val_auc = val_auc
+            final_test_auc = test_auc
+        
+        if epoch % 10 == 0:
+            print(f'Epoch: {epoch:03d}, Loss: {loss:.4f}, Val AUC: {val_auc:.4f}, '
+                  f'Test AUC: {test_auc:.4f}')
+    
+    print(f'Final results - Val AUC: {best_val_auc:.4f}, Test AUC: {final_test_auc:.4f}')
+    
+    # Calculate R-fraction if using AR
+    if args.use_ar:
+        with torch.no_grad():
+            z = encoder(data.x, data.train_pos_edge_index)
+            attr_dim = args.out_channels // 2
+            
+            z_attr = z[:, :attr_dim]
+            z_repel = z[:, attr_dim:]
+            
+            attract_norm_squared = torch.sum(z_attr ** 2)
+            repel_norm_squared = torch.sum(z_repel ** 2)
+            
+            r_fraction = repel_norm_squared / (attract_norm_squared + repel_norm_squared)
+            print(f"R-fraction: {r_fraction.item():.4f}")
+
+
+if __name__ == '__main__':
+    main()

--- a/examples/ar_link_pred.py
+++ b/examples/ar_link_pred.py
@@ -7,10 +7,7 @@ import torch.nn.functional as F
 import torch_geometric.transforms as T
 from torch_geometric.datasets import Planetoid
 from torch_geometric.nn import GCNConv
-from torch_geometric.utils import (
-    negative_sampling,
-    train_test_split_edges,
-)
+from torch_geometric.utils import negative_sampling, train_test_split_edges
 
 
 class GCNEncoder(torch.nn.Module):
@@ -48,28 +45,29 @@ class ARLinkPredictor(torch.nn.Module):
         # Split into attract and repel parts
         z_i_attr = z_i[:, :self.attract_dim]
         z_i_repel = z_i[:, self.attract_dim:]
-        
+
         z_j_attr = z_j[:, :self.attract_dim]
         z_j_repel = z_j[:, self.attract_dim:]
-        
+
         # Calculate AR score
         attract_score = (z_i_attr * z_j_attr).sum(dim=1)
         repel_score = (z_i_repel * z_j_repel).sum(dim=1)
-        
+
         return attract_score - repel_score
 
 
 def train(encoder, predictor, data, optimizer):
     encoder.train()
     predictor.train()
-    
+
     # Forward pass and calculate loss
     optimizer.zero_grad()
     z = encoder(data.x, data.train_pos_edge_index)
-    
+
     # Positive edges
-    pos_out = predictor(z[data.train_pos_edge_index[0]], z[data.train_pos_edge_index[1]])
-    
+    pos_out = predictor(z[data.train_pos_edge_index[0]],
+                        z[data.train_pos_edge_index[1]])
+
     # Sample and predict on negative edges
     neg_edge_index = negative_sampling(
         edge_index=data.train_pos_edge_index,
@@ -79,17 +77,15 @@ def train(encoder, predictor, data, optimizer):
     neg_out = predictor(z[neg_edge_index[0]], z[neg_edge_index[1]])
 
     # Calculate loss
-    pos_loss = F.binary_cross_entropy_with_logits(
-        pos_out, torch.ones_like(pos_out)
-    )
-    neg_loss = F.binary_cross_entropy_with_logits(
-        neg_out, torch.zeros_like(neg_out)
-    )
+    pos_loss = F.binary_cross_entropy_with_logits(pos_out,
+                                                  torch.ones_like(pos_out))
+    neg_loss = F.binary_cross_entropy_with_logits(neg_out,
+                                                  torch.zeros_like(neg_out))
     loss = pos_loss + neg_loss
-    
+
     loss.backward()
     optimizer.step()
-    
+
     return loss.item()
 
 
@@ -97,54 +93,61 @@ def train(encoder, predictor, data, optimizer):
 def test(encoder, predictor, data):
     encoder.eval()
     predictor.eval()
-    
+
     z = encoder(data.x, data.train_pos_edge_index)
-    
-    pos_val_out = predictor(z[data.val_pos_edge_index[0]], z[data.val_pos_edge_index[1]])
-    neg_val_out = predictor(z[data.val_neg_edge_index[0]], z[data.val_neg_edge_index[1]])
-    
-    pos_test_out = predictor(z[data.test_pos_edge_index[0]], z[data.test_pos_edge_index[1]])
-    neg_test_out = predictor(z[data.test_neg_edge_index[0]], z[data.test_neg_edge_index[1]])
-    
+
+    pos_val_out = predictor(z[data.val_pos_edge_index[0]],
+                            z[data.val_pos_edge_index[1]])
+    neg_val_out = predictor(z[data.val_neg_edge_index[0]],
+                            z[data.val_neg_edge_index[1]])
+
+    pos_test_out = predictor(z[data.test_pos_edge_index[0]],
+                             z[data.test_pos_edge_index[1]])
+    neg_test_out = predictor(z[data.test_neg_edge_index[0]],
+                             z[data.test_neg_edge_index[1]])
+
     val_auc = compute_auc(pos_val_out, neg_val_out)
     test_auc = compute_auc(pos_test_out, neg_test_out)
-    
+
     return val_auc, test_auc
 
 
 def compute_auc(pos_out, neg_out):
     pos_out = torch.sigmoid(pos_out).cpu().numpy()
     neg_out = torch.sigmoid(neg_out).cpu().numpy()
-    
+
     # Simple AUC calculation
     from sklearn.metrics import roc_auc_score
-    y_true = torch.cat([torch.ones(pos_out.shape[0]), torch.zeros(neg_out.shape[0])])
+    y_true = torch.cat(
+        [torch.ones(pos_out.shape[0]),
+         torch.zeros(neg_out.shape[0])])
     y_score = torch.cat([torch.tensor(pos_out), torch.tensor(neg_out)])
-    
+
     return roc_auc_score(y_true, y_score)
 
 
 def main():
     parser = argparse.ArgumentParser()
-    parser.add_argument('--dataset', type=str, default='Cora', 
+    parser.add_argument('--dataset', type=str, default='Cora',
                         choices=['Cora', 'CiteSeer', 'PubMed'])
     parser.add_argument('--hidden_channels', type=int, default=128)
     parser.add_argument('--out_channels', type=int, default=64)
     parser.add_argument('--epochs', type=int, default=200)
-    parser.add_argument('--use_ar', action='store_true', 
+    parser.add_argument('--use_ar', action='store_true',
                         help='Use Attract-Repel embeddings')
     parser.add_argument('--lr', type=float, default=0.01)
     args = parser.parse_args()
 
     device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
-    
+
     # Load dataset
     transform = T.Compose([
         T.NormalizeFeatures(),
         T.ToDevice(device),
     ])
-    
-    path = osp.join(osp.dirname(osp.realpath(__file__)), '..', 'data', args.dataset)
+
+    path = osp.join(osp.dirname(osp.realpath(__file__)), '..', 'data',
+                    args.dataset)
     dataset = Planetoid(path, args.dataset, transform=transform)
     data = dataset[0]
 
@@ -157,53 +160,58 @@ def main():
         hidden_channels=args.hidden_channels,
         out_channels=args.out_channels,
     ).to(device)
-    
+
     # Choose predictor based on args
     if args.use_ar:
         predictor = ARLinkPredictor(in_channels=args.out_channels).to(device)
-        print(f"Running link prediction on {args.dataset} with Attract-Repel embeddings")
+        print(
+            f"Running link prediction on {args.dataset} with Attract-Repel embeddings"
+        )
     else:
         predictor = LinkPredictor(
-            in_channels=args.out_channels, 
-            hidden_channels=args.hidden_channels
-        ).to(device)
-        print(f"Running link prediction on {args.dataset} with Traditional embeddings")
-    
+            in_channels=args.out_channels,
+            hidden_channels=args.hidden_channels).to(device)
+        print(
+            f"Running link prediction on {args.dataset} with Traditional embeddings"
+        )
+
     optimizer = torch.optim.Adam(
-        list(encoder.parameters()) + list(predictor.parameters()),
-        lr=args.lr
-    )
+        list(encoder.parameters()) + list(predictor.parameters()), lr=args.lr)
 
     best_val_auc = 0
     final_test_auc = 0
-    
+
     for epoch in range(1, args.epochs + 1):
         loss = train(encoder, predictor, data, optimizer)
         val_auc, test_auc = test(encoder, predictor, data)
-        
+
         if val_auc > best_val_auc:
             best_val_auc = val_auc
             final_test_auc = test_auc
-        
+
         if epoch % 10 == 0:
-            print(f'Epoch: {epoch:03d}, Loss: {loss:.4f}, Val AUC: {val_auc:.4f}, '
-                  f'Test AUC: {test_auc:.4f}')
-    
-    print(f'Final results - Val AUC: {best_val_auc:.4f}, Test AUC: {final_test_auc:.4f}')
-    
+            print(
+                f'Epoch: {epoch:03d}, Loss: {loss:.4f}, Val AUC: {val_auc:.4f}, '
+                f'Test AUC: {test_auc:.4f}')
+
+    print(
+        f'Final results - Val AUC: {best_val_auc:.4f}, Test AUC: {final_test_auc:.4f}'
+    )
+
     # Calculate R-fraction if using AR
     if args.use_ar:
         with torch.no_grad():
             z = encoder(data.x, data.train_pos_edge_index)
             attr_dim = args.out_channels // 2
-            
+
             z_attr = z[:, :attr_dim]
             z_repel = z[:, attr_dim:]
-            
-            attract_norm_squared = torch.sum(z_attr ** 2)
-            repel_norm_squared = torch.sum(z_repel ** 2)
-            
-            r_fraction = repel_norm_squared / (attract_norm_squared + repel_norm_squared)
+
+            attract_norm_squared = torch.sum(z_attr**2)
+            repel_norm_squared = torch.sum(z_repel**2)
+
+            r_fraction = repel_norm_squared / (attract_norm_squared +
+                                               repel_norm_squared)
             print(f"R-fraction: {r_fraction.item():.4f}")
 
 

--- a/examples/attract_repel_wrapper.py
+++ b/examples/attract_repel_wrapper.py
@@ -1,0 +1,138 @@
+import torch
+import argparse
+import os.path as osp
+
+from torch_geometric.datasets import Planetoid
+import torch_geometric.transforms as T
+from torch_geometric.utils import train_test_split_edges, negative_sampling
+from torch_geometric.nn.models import AttractRepel
+
+
+def train(model, data, optimizer):
+    model.train()
+    
+    # Zero gradients
+    optimizer.zero_grad()
+    
+    # Forward pass
+    z = model(data.x, data.train_pos_edge_index)
+    
+    # Link prediction on positive edges
+    pos_out = model(data.x, data.train_pos_edge_index, 
+                   edge_index=data.train_pos_edge_index)
+    
+    # Sample negative edges and predict
+    neg_edge_index = negative_sampling(
+        edge_index=data.train_pos_edge_index,
+        num_nodes=data.num_nodes,
+        num_neg_samples=data.train_pos_edge_index.size(1),
+    )
+    
+    neg_out = model(data.x, data.train_pos_edge_index, 
+                   edge_index=neg_edge_index)
+    
+    # Compute loss
+    pos_loss = -torch.log(torch.sigmoid(pos_out) + 1e-15).mean()
+    neg_loss = -torch.log(1 - torch.sigmoid(neg_out) + 1e-15).mean()
+    loss = pos_loss + neg_loss
+    
+    # Backward pass
+    loss.backward()
+    optimizer.step()
+    
+    return loss.item()
+
+
+@torch.no_grad()
+def test(model, data):
+    model.eval()
+    
+    # Get embeddings
+    attract_z, repel_z = model.encode(data.x, data.train_pos_edge_index)
+    
+    # Link prediction on validation set
+    pos_val_out = model.decode(attract_z, repel_z, data.val_pos_edge_index)
+    neg_val_out = model.decode(attract_z, repel_z, data.val_neg_edge_index)
+    
+    # Link prediction on test set
+    pos_test_out = model.decode(attract_z, repel_z, data.test_pos_edge_index)
+    neg_test_out = model.decode(attract_z, repel_z, data.test_neg_edge_index)
+    
+    # Calculate AUC
+    from sklearn.metrics import roc_auc_score
+    
+    val_preds = torch.cat([torch.sigmoid(pos_val_out), torch.sigmoid(neg_val_out)])
+    val_labels = torch.cat([torch.ones_like(pos_val_out), torch.zeros_like(neg_val_out)])
+    val_auc = roc_auc_score(val_labels.cpu(), val_preds.cpu())
+    
+    test_preds = torch.cat([torch.sigmoid(pos_test_out), torch.sigmoid(neg_test_out)])
+    test_labels = torch.cat([torch.ones_like(pos_test_out), torch.zeros_like(neg_test_out)])
+    test_auc = roc_auc_score(test_labels.cpu(), test_preds.cpu())
+    
+    return val_auc, test_auc, model.calculate_r_fraction(attract_z, repel_z)
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--dataset', type=str, default='Cora', 
+                        choices=['Cora', 'CiteSeer', 'PubMed'])
+    parser.add_argument('--base_model', type=str, default='GCN',
+                        choices=['GCN', 'GAT', 'GraphSAGE'])
+    parser.add_argument('--hidden_channels', type=int, default=64)
+    parser.add_argument('--out_channels', type=int, default=32)
+    parser.add_argument('--num_layers', type=int, default=2)
+    parser.add_argument('--attract_ratio', type=float, default=0.5)
+    parser.add_argument('--epochs', type=int, default=200)
+    parser.add_argument('--lr', type=float, default=0.01)
+    args = parser.parse_args()
+    
+    device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
+    
+    # Load dataset
+    path = osp.join(osp.dirname(osp.realpath(__file__)), '..', 'data', args.dataset)
+    dataset = Planetoid(path, args.dataset, transform=T.NormalizeFeatures())
+    data = dataset[0].to(device)
+    
+    # Process data for link prediction
+    data = train_test_split_edges(data)
+    
+    # Create AttractRepel model with specified base model
+    model = AttractRepel(
+        args.base_model,
+        in_channels=dataset.num_features,
+        hidden_channels=args.hidden_channels,
+        out_channels=args.out_channels,
+        num_layers=args.num_layers,
+        attract_ratio=args.attract_ratio
+    ).to(device)
+    
+    print(f"Testing AttractRepel with {args.base_model} on {args.dataset} dataset")
+    print(f"Attract ratio: {args.attract_ratio}, Dimensions: {model.attract_dim} attract, {model.repel_dim} repel")
+    
+    # Optimizer
+    optimizer = torch.optim.Adam(model.parameters(), lr=args.lr)
+    
+    # Training loop
+    best_val_auc = 0
+    best_test_auc = 0
+    best_r_fraction = 0
+    
+    for epoch in range(1, args.epochs + 1):
+        loss = train(model, data, optimizer)
+        val_auc, test_auc, r_fraction = test(model, data)
+        
+        if val_auc > best_val_auc:
+            best_val_auc = val_auc
+            best_test_auc = test_auc
+            best_r_fraction = r_fraction
+        
+        if epoch % 10 == 0:
+            print(f'Epoch: {epoch:03d}, Loss: {loss:.4f}, Val AUC: {val_auc:.4f}, '
+                  f'Test AUC: {test_auc:.4f}, R-fraction: {r_fraction:.4f}')
+    
+    print(f"Final results for {args.base_model} on {args.dataset}:")
+    print(f"Test AUC: {best_test_auc:.4f}, R-fraction: {best_r_fraction:.4f}")
+
+
+if __name__ == '__main__':
+    main()

--- a/examples/attract_repel_wrapper.py
+++ b/examples/attract_repel_wrapper.py
@@ -1,80 +1,89 @@
-import torch
 import argparse
 import os.path as osp
 
-from torch_geometric.datasets import Planetoid
+import torch
+
 import torch_geometric.transforms as T
-from torch_geometric.utils import train_test_split_edges, negative_sampling
+from torch_geometric.datasets import Planetoid
 from torch_geometric.nn.models import AttractRepel
+from torch_geometric.utils import negative_sampling, train_test_split_edges
 
 
 def train(model, data, optimizer):
     model.train()
-    
+
     # Zero gradients
     optimizer.zero_grad()
-    
+
     # Forward pass
-    z = model(data.x, data.train_pos_edge_index)
-    
+    model(data.x, data.train_pos_edge_index)
+
     # Link prediction on positive edges
-    pos_out = model(data.x, data.train_pos_edge_index, 
-                   edge_index=data.train_pos_edge_index)
-    
+    pos_out = model(data.x, data.train_pos_edge_index,
+                    edge_index=data.train_pos_edge_index)
+
     # Sample negative edges and predict
     neg_edge_index = negative_sampling(
         edge_index=data.train_pos_edge_index,
         num_nodes=data.num_nodes,
         num_neg_samples=data.train_pos_edge_index.size(1),
     )
-    
-    neg_out = model(data.x, data.train_pos_edge_index, 
-                   edge_index=neg_edge_index)
-    
+
+    neg_out = model(data.x, data.train_pos_edge_index,
+                    edge_index=neg_edge_index)
+
     # Compute loss
     pos_loss = -torch.log(torch.sigmoid(pos_out) + 1e-15).mean()
     neg_loss = -torch.log(1 - torch.sigmoid(neg_out) + 1e-15).mean()
     loss = pos_loss + neg_loss
-    
+
     # Backward pass
     loss.backward()
     optimizer.step()
-    
+
     return loss.item()
 
 
 @torch.no_grad()
 def test(model, data):
     model.eval()
-    
+
     # Get embeddings
     attract_z, repel_z = model.encode(data.x, data.train_pos_edge_index)
-    
+
     # Link prediction on validation set
     pos_val_out = model.decode(attract_z, repel_z, data.val_pos_edge_index)
     neg_val_out = model.decode(attract_z, repel_z, data.val_neg_edge_index)
-    
+
     # Link prediction on test set
     pos_test_out = model.decode(attract_z, repel_z, data.test_pos_edge_index)
     neg_test_out = model.decode(attract_z, repel_z, data.test_neg_edge_index)
-    
+
     # Calculate AUC
     from sklearn.metrics import roc_auc_score
-    
-    val_preds = torch.cat([torch.sigmoid(pos_val_out), torch.sigmoid(neg_val_out)])
-    val_labels = torch.cat([torch.ones_like(pos_val_out), torch.zeros_like(neg_val_out)])
+
+    val_preds = torch.cat(
+        [torch.sigmoid(pos_val_out),
+         torch.sigmoid(neg_val_out)])
+    val_labels = torch.cat(
+        [torch.ones_like(pos_val_out),
+         torch.zeros_like(neg_val_out)])
     val_auc = roc_auc_score(val_labels.cpu(), val_preds.cpu())
-    
-    test_preds = torch.cat([torch.sigmoid(pos_test_out), torch.sigmoid(neg_test_out)])
-    test_labels = torch.cat([torch.ones_like(pos_test_out), torch.zeros_like(neg_test_out)])
+
+    test_preds = torch.cat(
+        [torch.sigmoid(pos_test_out),
+         torch.sigmoid(neg_test_out)])
+    test_labels = torch.cat(
+        [torch.ones_like(pos_test_out),
+         torch.zeros_like(neg_test_out)])
     test_auc = roc_auc_score(test_labels.cpu(), test_preds.cpu())
-    
+
     return val_auc, test_auc, model.calculate_r_fraction(attract_z, repel_z)
 
 
 def main():
     parser = argparse.ArgumentParser()
-    parser.add_argument('--dataset', type=str, default='Cora', 
+    parser.add_argument('--dataset', type=str, default='Cora',
                         choices=['Cora', 'CiteSeer', 'PubMed'])
     parser.add_argument('--base_model', type=str, default='GCN',
                         choices=['GCN', 'GAT', 'GraphSAGE'])
@@ -85,51 +94,54 @@ def main():
     parser.add_argument('--epochs', type=int, default=200)
     parser.add_argument('--lr', type=float, default=0.01)
     args = parser.parse_args()
-    
+
     device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
-    
+
     # Load dataset
-    path = osp.join(osp.dirname(osp.realpath(__file__)), '..', 'data', args.dataset)
+    path = osp.join(osp.dirname(osp.realpath(__file__)), '..', 'data',
+                    args.dataset)
     dataset = Planetoid(path, args.dataset, transform=T.NormalizeFeatures())
     data = dataset[0].to(device)
-    
+
     # Process data for link prediction
     data = train_test_split_edges(data)
-    
+
     # Create AttractRepel model with specified base model
-    model = AttractRepel(
-        args.base_model,
-        in_channels=dataset.num_features,
-        hidden_channels=args.hidden_channels,
-        out_channels=args.out_channels,
-        num_layers=args.num_layers,
-        attract_ratio=args.attract_ratio
-    ).to(device)
-    
-    print(f"Testing AttractRepel with {args.base_model} on {args.dataset} dataset")
-    print(f"Attract ratio: {args.attract_ratio}, Dimensions: {model.attract_dim} attract, {model.repel_dim} repel")
-    
+    model = AttractRepel(args.base_model, in_channels=dataset.num_features,
+                         hidden_channels=args.hidden_channels,
+                         out_channels=args.out_channels,
+                         num_layers=args.num_layers,
+                         attract_ratio=args.attract_ratio).to(device)
+
+    print(
+        f"Testing AttractRepel with {args.base_model} on {args.dataset} dataset"
+    )
+    print(
+        f"Attract ratio: {args.attract_ratio}, Dimensions: {model.attract_dim} attract, {model.repel_dim} repel"
+    )
+
     # Optimizer
     optimizer = torch.optim.Adam(model.parameters(), lr=args.lr)
-    
+
     # Training loop
     best_val_auc = 0
     best_test_auc = 0
     best_r_fraction = 0
-    
+
     for epoch in range(1, args.epochs + 1):
         loss = train(model, data, optimizer)
         val_auc, test_auc, r_fraction = test(model, data)
-        
+
         if val_auc > best_val_auc:
             best_val_auc = val_auc
             best_test_auc = test_auc
             best_r_fraction = r_fraction
-        
+
         if epoch % 10 == 0:
-            print(f'Epoch: {epoch:03d}, Loss: {loss:.4f}, Val AUC: {val_auc:.4f}, '
-                  f'Test AUC: {test_auc:.4f}, R-fraction: {r_fraction:.4f}')
-    
+            print(
+                f'Epoch: {epoch:03d}, Loss: {loss:.4f}, Val AUC: {val_auc:.4f}, '
+                f'Test AUC: {test_auc:.4f}, R-fraction: {r_fraction:.4f}')
+
     print(f"Final results for {args.base_model} on {args.dataset}:")
     print(f"Test AUC: {best_test_auc:.4f}, R-fraction: {best_r_fraction:.4f}")
 

--- a/examples/link_pred/README.md
+++ b/examples/link_pred/README.md
@@ -1,0 +1,37 @@
+# Link Prediction Examples
+
+## Attract-Repel Link Prediction
+
+The [`attract_repel.py`](attract_repel.py) example demonstrates how to use the `AttractRepel` wrapper for Graph Neural Networks to improve link prediction performance.
+
+### Usage
+
+```bash
+# Run with GCN on Cora
+python attract_repel.py --dataset=Cora --model=GCN
+
+# Try GraphSAGE on CiteSeer
+python attract_repel.py --dataset=CiteSeer --model=GraphSAGE
+
+# Experiment with different attract/repel ratios
+python attract_repel.py --dataset=PubMed --model=GAT --attract_ratio=0.7
+```
+
+### Performance
+
+The Attract-Repel approach typically shows significant improvements over traditional embeddings:
+
+| Dataset | Traditional (AUC) | Attract-Repel (AUC) | Improvement | R-fraction |
+|---------|-------------------|---------------------|-------------|------------|
+| Cora    | 0.6624            | 0.8945              | +0.2321     | 0.4075     |
+| PubMed  | 0.8977            | 0.9607              | +0.0630     | 0.5062     |
+| CiteSeer| 0.8067            | 0.8206              | +0.0139     | 0.4869     |
+
+### How It Works
+
+The `AttractRepel` wrapper splits node embeddings into two components:
+
+1. **Attract component**: Similar nodes in this space are more likely to connect
+2. **Repel component**: Similar nodes in this space are less likely to connect
+
+This approach is based on the paper "Pseudo-Euclidean Attract-Repel Embeddings for Undirected Graphs" (Peysakhovich et al., 2023).

--- a/examples/link_pred/README.md
+++ b/examples/link_pred/README.md
@@ -21,17 +21,17 @@ python attract_repel.py --dataset=PubMed --model=GAT --attract_ratio=0.7
 
 The Attract-Repel approach typically shows significant improvements over traditional embeddings:
 
-| Dataset | Traditional (AUC) | Attract-Repel (AUC) | Improvement | R-fraction |
-|---------|-------------------|---------------------|-------------|------------|
-| Cora    | 0.6624            | 0.8945              | +0.2321     | 0.4075     |
-| PubMed  | 0.8977            | 0.9607              | +0.0630     | 0.5062     |
-| CiteSeer| 0.8067            | 0.8206              | +0.0139     | 0.4869     |
+| Dataset  | Traditional (AUC) | Attract-Repel (AUC) | Improvement | R-fraction |
+| -------- | ----------------- | ------------------- | ----------- | ---------- |
+| Cora     | 0.6624            | 0.8945              | +0.2321     | 0.4075     |
+| PubMed   | 0.8977            | 0.9607              | +0.0630     | 0.5062     |
+| CiteSeer | 0.8067            | 0.8206              | +0.0139     | 0.4869     |
 
 ### How It Works
 
 The `AttractRepel` wrapper splits node embeddings into two components:
 
 1. **Attract component**: Similar nodes in this space are more likely to connect
-2. **Repel component**: Similar nodes in this space are less likely to connect
+1. **Repel component**: Similar nodes in this space are less likely to connect
 
 This approach is based on the paper "Pseudo-Euclidean Attract-Repel Embeddings for Undirected Graphs" (Peysakhovich et al., 2023).

--- a/examples/link_pred/attract_repel.py
+++ b/examples/link_pred/attract_repel.py
@@ -7,101 +7,80 @@ import torch.nn.functional as F
 import torch_geometric.transforms as T
 from torch_geometric.datasets import Planetoid
 from torch_geometric.nn.models.attract_repel import AttractRepel
-from torch_geometric.utils import (
-    negative_sampling,
-    train_test_split_edges,
-)
+from torch_geometric.utils import negative_sampling, train_test_split_edges
 
 
 def train(model, data, optimizer):
     model.train()
-    
+
     # Forward pass and calculate loss
     optimizer.zero_grad()
-    
+
     # Generate prediction scores for positive edges
-    pos_out = model(
-        data.x, 
-        data.train_pos_edge_index,
-        edge_label_index=data.train_pos_edge_index
-    )
-    
+    pos_out = model(data.x, data.train_pos_edge_index,
+                    edge_label_index=data.train_pos_edge_index)
+
     # Sample and predict on negative edges
     neg_edge_index = negative_sampling(
         edge_index=data.train_pos_edge_index,
         num_nodes=data.num_nodes,
         num_neg_samples=data.train_pos_edge_index.size(1),
     )
-    
-    neg_out = model(
-        data.x, 
-        data.train_pos_edge_index,
-        edge_label_index=neg_edge_index
-    )
+
+    neg_out = model(data.x, data.train_pos_edge_index,
+                    edge_label_index=neg_edge_index)
 
     # Calculate loss
-    pos_loss = F.binary_cross_entropy_with_logits(
-        pos_out, torch.ones_like(pos_out)
-    )
-    neg_loss = F.binary_cross_entropy_with_logits(
-        neg_out, torch.zeros_like(neg_out)
-    )
+    pos_loss = F.binary_cross_entropy_with_logits(pos_out,
+                                                  torch.ones_like(pos_out))
+    neg_loss = F.binary_cross_entropy_with_logits(neg_out,
+                                                  torch.zeros_like(neg_out))
     loss = pos_loss + neg_loss
-    
+
     loss.backward()
     optimizer.step()
-    
+
     return loss.item()
 
 
 @torch.no_grad()
 def test(model, data):
     model.eval()
-    
+
     # Evaluate validation and test edges
-    pos_val_out = model(
-        data.x, 
-        data.train_pos_edge_index,
-        edge_label_index=data.val_pos_edge_index
-    )
-    
-    neg_val_out = model(
-        data.x, 
-        data.train_pos_edge_index,
-        edge_label_index=data.val_neg_edge_index
-    )
-    
-    pos_test_out = model(
-        data.x, 
-        data.train_pos_edge_index,
-        edge_label_index=data.test_pos_edge_index
-    )
-    
-    neg_test_out = model(
-        data.x, 
-        data.train_pos_edge_index,
-        edge_label_index=data.test_neg_edge_index
-    )
-    
+    pos_val_out = model(data.x, data.train_pos_edge_index,
+                        edge_label_index=data.val_pos_edge_index)
+
+    neg_val_out = model(data.x, data.train_pos_edge_index,
+                        edge_label_index=data.val_neg_edge_index)
+
+    pos_test_out = model(data.x, data.train_pos_edge_index,
+                         edge_label_index=data.test_pos_edge_index)
+
+    neg_test_out = model(data.x, data.train_pos_edge_index,
+                         edge_label_index=data.test_neg_edge_index)
+
     # Calculate AUC scores
     from sklearn.metrics import roc_auc_score
-    
+
     val_pred = torch.cat([pos_val_out, neg_val_out]).sigmoid().cpu()
-    val_true = torch.cat([torch.ones(pos_val_out.size(0)), 
-                           torch.zeros(neg_val_out.size(0))])
+    val_true = torch.cat(
+        [torch.ones(pos_val_out.size(0)),
+         torch.zeros(neg_val_out.size(0))])
     val_auc = roc_auc_score(val_true, val_pred)
-    
+
     test_pred = torch.cat([pos_test_out, neg_test_out]).sigmoid().cpu()
-    test_true = torch.cat([torch.ones(pos_test_out.size(0)), 
-                            torch.zeros(neg_test_out.size(0))])
+    test_true = torch.cat(
+        [torch.ones(pos_test_out.size(0)),
+         torch.zeros(neg_test_out.size(0))])
     test_auc = roc_auc_score(test_true, test_pred)
-    
+
     return val_auc, test_auc
 
 
 def main():
     parser = argparse.ArgumentParser()
-    parser.add_argument('--dataset', type=str, default='Cora', 
+    parser.add_argument('--dataset', type=str, default='Cora',
                         choices=['Cora', 'CiteSeer', 'PubMed'])
     parser.add_argument('--model', type=str, default='GCN',
                         choices=['GCN', 'GAT', 'GraphSAGE'])
@@ -115,14 +94,15 @@ def main():
     args = parser.parse_args()
 
     device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
-    
+
     # Load dataset
     transform = T.Compose([
         T.NormalizeFeatures(),
         T.ToDevice(device),
     ])
-    
-    path = osp.join(osp.dirname(osp.realpath(__file__)), '..', '..', 'data', args.dataset)
+
+    path = osp.join(osp.dirname(osp.realpath(__file__)), '..', '..', 'data',
+                    args.dataset)
     dataset = Planetoid(path, args.dataset, transform=transform)
     data = dataset[0]
 
@@ -138,29 +118,36 @@ def main():
         num_layers=args.num_layers,
         attract_ratio=args.attract_ratio,
     ).to(device)
-    
-    print(f"Running {args.model} with Attract-Repel embeddings on {args.dataset}")
-    print(f"Attract dimensions: {model.attract_dim}, Repel dimensions: {model.repel_dim}")
-    
+
+    print(
+        f"Running {args.model} with Attract-Repel embeddings on {args.dataset}"
+    )
+    print(
+        f"Attract dimensions: {model.attract_dim}, Repel dimensions: {model.repel_dim}"
+    )
+
     optimizer = torch.optim.Adam(model.parameters(), lr=args.lr)
 
     best_val_auc = 0
     final_test_auc = 0
-    
+
     for epoch in range(1, args.epochs + 1):
         loss = train(model, data, optimizer)
         val_auc, test_auc = test(model, data)
-        
+
         if val_auc > best_val_auc:
             best_val_auc = val_auc
             final_test_auc = test_auc
-        
+
         if epoch % 10 == 0:
-            print(f'Epoch: {epoch:03d}, Loss: {loss:.4f}, Val AUC: {val_auc:.4f}, '
-                  f'Test AUC: {test_auc:.4f}')
-    
-    print(f'Final results - Val AUC: {best_val_auc:.4f}, Test AUC: {final_test_auc:.4f}')
-    
+            print(
+                f'Epoch: {epoch:03d}, Loss: {loss:.4f}, Val AUC: {val_auc:.4f}, '
+                f'Test AUC: {test_auc:.4f}')
+
+    print(
+        f'Final results - Val AUC: {best_val_auc:.4f}, Test AUC: {final_test_auc:.4f}'
+    )
+
     # Calculate and report R-fraction
     with torch.no_grad():
         attract_z, repel_z = model.encode(data.x, data.train_pos_edge_index)

--- a/examples/link_pred/attract_repel.py
+++ b/examples/link_pred/attract_repel.py
@@ -1,0 +1,172 @@
+import argparse
+import os.path as osp
+
+import torch
+import torch.nn.functional as F
+
+import torch_geometric.transforms as T
+from torch_geometric.datasets import Planetoid
+from torch_geometric.nn.models.attract_repel import AttractRepel
+from torch_geometric.utils import (
+    negative_sampling,
+    train_test_split_edges,
+)
+
+
+def train(model, data, optimizer):
+    model.train()
+    
+    # Forward pass and calculate loss
+    optimizer.zero_grad()
+    
+    # Generate prediction scores for positive edges
+    pos_out = model(
+        data.x, 
+        data.train_pos_edge_index,
+        edge_label_index=data.train_pos_edge_index
+    )
+    
+    # Sample and predict on negative edges
+    neg_edge_index = negative_sampling(
+        edge_index=data.train_pos_edge_index,
+        num_nodes=data.num_nodes,
+        num_neg_samples=data.train_pos_edge_index.size(1),
+    )
+    
+    neg_out = model(
+        data.x, 
+        data.train_pos_edge_index,
+        edge_label_index=neg_edge_index
+    )
+
+    # Calculate loss
+    pos_loss = F.binary_cross_entropy_with_logits(
+        pos_out, torch.ones_like(pos_out)
+    )
+    neg_loss = F.binary_cross_entropy_with_logits(
+        neg_out, torch.zeros_like(neg_out)
+    )
+    loss = pos_loss + neg_loss
+    
+    loss.backward()
+    optimizer.step()
+    
+    return loss.item()
+
+
+@torch.no_grad()
+def test(model, data):
+    model.eval()
+    
+    # Evaluate validation and test edges
+    pos_val_out = model(
+        data.x, 
+        data.train_pos_edge_index,
+        edge_label_index=data.val_pos_edge_index
+    )
+    
+    neg_val_out = model(
+        data.x, 
+        data.train_pos_edge_index,
+        edge_label_index=data.val_neg_edge_index
+    )
+    
+    pos_test_out = model(
+        data.x, 
+        data.train_pos_edge_index,
+        edge_label_index=data.test_pos_edge_index
+    )
+    
+    neg_test_out = model(
+        data.x, 
+        data.train_pos_edge_index,
+        edge_label_index=data.test_neg_edge_index
+    )
+    
+    # Calculate AUC scores
+    from sklearn.metrics import roc_auc_score
+    
+    val_pred = torch.cat([pos_val_out, neg_val_out]).sigmoid().cpu()
+    val_true = torch.cat([torch.ones(pos_val_out.size(0)), 
+                           torch.zeros(neg_val_out.size(0))])
+    val_auc = roc_auc_score(val_true, val_pred)
+    
+    test_pred = torch.cat([pos_test_out, neg_test_out]).sigmoid().cpu()
+    test_true = torch.cat([torch.ones(pos_test_out.size(0)), 
+                            torch.zeros(neg_test_out.size(0))])
+    test_auc = roc_auc_score(test_true, test_pred)
+    
+    return val_auc, test_auc
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--dataset', type=str, default='Cora', 
+                        choices=['Cora', 'CiteSeer', 'PubMed'])
+    parser.add_argument('--model', type=str, default='GCN',
+                        choices=['GCN', 'GAT', 'GraphSAGE'])
+    parser.add_argument('--hidden_channels', type=int, default=128)
+    parser.add_argument('--out_channels', type=int, default=64)
+    parser.add_argument('--num_layers', type=int, default=2)
+    parser.add_argument('--attract_ratio', type=float, default=0.5,
+                        help='Proportion of dimensions for attract component')
+    parser.add_argument('--epochs', type=int, default=200)
+    parser.add_argument('--lr', type=float, default=0.01)
+    args = parser.parse_args()
+
+    device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
+    
+    # Load dataset
+    transform = T.Compose([
+        T.NormalizeFeatures(),
+        T.ToDevice(device),
+    ])
+    
+    path = osp.join(osp.dirname(osp.realpath(__file__)), '..', '..', 'data', args.dataset)
+    dataset = Planetoid(path, args.dataset, transform=transform)
+    data = dataset[0]
+
+    # Process data for link prediction
+    data = train_test_split_edges(data)
+
+    # Initialize model using the wrapper
+    model = AttractRepel(
+        model=args.model,
+        in_channels=dataset.num_features,
+        hidden_channels=args.hidden_channels,
+        out_channels=args.out_channels,
+        num_layers=args.num_layers,
+        attract_ratio=args.attract_ratio,
+    ).to(device)
+    
+    print(f"Running {args.model} with Attract-Repel embeddings on {args.dataset}")
+    print(f"Attract dimensions: {model.attract_dim}, Repel dimensions: {model.repel_dim}")
+    
+    optimizer = torch.optim.Adam(model.parameters(), lr=args.lr)
+
+    best_val_auc = 0
+    final_test_auc = 0
+    
+    for epoch in range(1, args.epochs + 1):
+        loss = train(model, data, optimizer)
+        val_auc, test_auc = test(model, data)
+        
+        if val_auc > best_val_auc:
+            best_val_auc = val_auc
+            final_test_auc = test_auc
+        
+        if epoch % 10 == 0:
+            print(f'Epoch: {epoch:03d}, Loss: {loss:.4f}, Val AUC: {val_auc:.4f}, '
+                  f'Test AUC: {test_auc:.4f}')
+    
+    print(f'Final results - Val AUC: {best_val_auc:.4f}, Test AUC: {final_test_auc:.4f}')
+    
+    # Calculate and report R-fraction
+    with torch.no_grad():
+        attract_z, repel_z = model.encode(data.x, data.train_pos_edge_index)
+        r_fraction = model.calculate_r_fraction(attract_z, repel_z)
+        print(f"R-fraction: {r_fraction.item():.4f}")
+
+
+if __name__ == '__main__':
+    main()

--- a/examples/link_pred/traditional.py
+++ b/examples/link_pred/traditional.py
@@ -6,11 +6,8 @@ import torch.nn.functional as F
 
 import torch_geometric.transforms as T
 from torch_geometric.datasets import Planetoid
-from torch_geometric.nn import GCN, GAT, GraphSAGE
-from torch_geometric.utils import (
-    negative_sampling,
-    train_test_split_edges,
-)
+from torch_geometric.nn import GAT, GCN, GraphSAGE
+from torch_geometric.utils import negative_sampling, train_test_split_edges
 
 
 class LinkPredictor(torch.nn.Module):
@@ -29,16 +26,17 @@ class LinkPredictor(torch.nn.Module):
 def train(encoder, predictor, data, optimizer):
     encoder.train()
     predictor.train()
-    
+
     # Forward pass and calculate loss
     optimizer.zero_grad()
-    
+
     # Get node embeddings
     z = encoder(data.x, data.train_pos_edge_index)
-    
+
     # Positive edges
-    pos_out = predictor(z[data.train_pos_edge_index[0]], z[data.train_pos_edge_index[1]])
-    
+    pos_out = predictor(z[data.train_pos_edge_index[0]],
+                        z[data.train_pos_edge_index[1]])
+
     # Sample and predict on negative edges
     neg_edge_index = negative_sampling(
         edge_index=data.train_pos_edge_index,
@@ -48,17 +46,15 @@ def train(encoder, predictor, data, optimizer):
     neg_out = predictor(z[neg_edge_index[0]], z[neg_edge_index[1]])
 
     # Calculate loss
-    pos_loss = F.binary_cross_entropy_with_logits(
-        pos_out, torch.ones_like(pos_out)
-    )
-    neg_loss = F.binary_cross_entropy_with_logits(
-        neg_out, torch.zeros_like(neg_out)
-    )
+    pos_loss = F.binary_cross_entropy_with_logits(pos_out,
+                                                  torch.ones_like(pos_out))
+    neg_loss = F.binary_cross_entropy_with_logits(neg_out,
+                                                  torch.zeros_like(neg_out))
     loss = pos_loss + neg_loss
-    
+
     loss.backward()
     optimizer.step()
-    
+
     return loss.item()
 
 
@@ -66,33 +62,39 @@ def train(encoder, predictor, data, optimizer):
 def test(encoder, predictor, data):
     encoder.eval()
     predictor.eval()
-    
+
     z = encoder(data.x, data.train_pos_edge_index)
-    
-    pos_val_out = predictor(z[data.val_pos_edge_index[0]], z[data.val_pos_edge_index[1]])
-    neg_val_out = predictor(z[data.val_neg_edge_index[0]], z[data.val_neg_edge_index[1]])
-    
-    pos_test_out = predictor(z[data.test_pos_edge_index[0]], z[data.test_pos_edge_index[1]])
-    neg_test_out = predictor(z[data.test_neg_edge_index[0]], z[data.test_neg_edge_index[1]])
-    
+
+    pos_val_out = predictor(z[data.val_pos_edge_index[0]],
+                            z[data.val_pos_edge_index[1]])
+    neg_val_out = predictor(z[data.val_neg_edge_index[0]],
+                            z[data.val_neg_edge_index[1]])
+
+    pos_test_out = predictor(z[data.test_pos_edge_index[0]],
+                             z[data.test_pos_edge_index[1]])
+    neg_test_out = predictor(z[data.test_neg_edge_index[0]],
+                             z[data.test_neg_edge_index[1]])
+
     from sklearn.metrics import roc_auc_score
-    
+
     val_pred = torch.cat([pos_val_out, neg_val_out]).sigmoid().cpu()
-    val_true = torch.cat([torch.ones(pos_val_out.size(0)), 
-                           torch.zeros(neg_val_out.size(0))])
+    val_true = torch.cat(
+        [torch.ones(pos_val_out.size(0)),
+         torch.zeros(neg_val_out.size(0))])
     val_auc = roc_auc_score(val_true, val_pred)
-    
+
     test_pred = torch.cat([pos_test_out, neg_test_out]).sigmoid().cpu()
-    test_true = torch.cat([torch.ones(pos_test_out.size(0)), 
-                            torch.zeros(neg_test_out.size(0))])
+    test_true = torch.cat(
+        [torch.ones(pos_test_out.size(0)),
+         torch.zeros(neg_test_out.size(0))])
     test_auc = roc_auc_score(test_true, test_pred)
-    
+
     return val_auc, test_auc
 
 
 def main():
     parser = argparse.ArgumentParser()
-    parser.add_argument('--dataset', type=str, default='Cora', 
+    parser.add_argument('--dataset', type=str, default='Cora',
                         choices=['Cora', 'CiteSeer', 'PubMed'])
     parser.add_argument('--model', type=str, default='GCN',
                         choices=['GCN', 'GAT', 'GraphSAGE'])
@@ -104,14 +106,15 @@ def main():
     args = parser.parse_args()
 
     device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
-    
+
     # Load dataset
     transform = T.Compose([
         T.NormalizeFeatures(),
         T.ToDevice(device),
     ])
-    
-    path = osp.join(osp.dirname(osp.realpath(__file__)), '..', '..', 'data', args.dataset)
+
+    path = osp.join(osp.dirname(osp.realpath(__file__)), '..', '..', 'data',
+                    args.dataset)
     dataset = Planetoid(path, args.dataset, transform=transform)
     data = dataset[0]
 
@@ -140,36 +143,35 @@ def main():
             out_channels=args.out_channels,
             num_layers=args.num_layers,
         ).to(device)
-    
+
     # Initialize link predictor
-    predictor = LinkPredictor(
-        in_channels=args.out_channels, 
-        hidden_channels=args.hidden_channels
-    ).to(device)
-    
+    predictor = LinkPredictor(in_channels=args.out_channels,
+                              hidden_channels=args.hidden_channels).to(device)
+
     print(f"Running traditional {args.model} on {args.dataset}")
-    
+
     optimizer = torch.optim.Adam(
-        list(encoder.parameters()) + list(predictor.parameters()),
-        lr=args.lr
-    )
+        list(encoder.parameters()) + list(predictor.parameters()), lr=args.lr)
 
     best_val_auc = 0
     final_test_auc = 0
-    
+
     for epoch in range(1, args.epochs + 1):
         loss = train(encoder, predictor, data, optimizer)
         val_auc, test_auc = test(encoder, predictor, data)
-        
+
         if val_auc > best_val_auc:
             best_val_auc = val_auc
             final_test_auc = test_auc
-        
+
         if epoch % 10 == 0:
-            print(f'Epoch: {epoch:03d}, Loss: {loss:.4f}, Val AUC: {val_auc:.4f}, '
-                  f'Test AUC: {test_auc:.4f}')
-    
-    print(f'Final results - Val AUC: {best_val_auc:.4f}, Test AUC: {final_test_auc:.4f}')
+            print(
+                f'Epoch: {epoch:03d}, Loss: {loss:.4f}, Val AUC: {val_auc:.4f}, '
+                f'Test AUC: {test_auc:.4f}')
+
+    print(
+        f'Final results - Val AUC: {best_val_auc:.4f}, Test AUC: {final_test_auc:.4f}'
+    )
 
 
 if __name__ == '__main__':

--- a/examples/link_pred/traditional.py
+++ b/examples/link_pred/traditional.py
@@ -1,0 +1,176 @@
+import argparse
+import os.path as osp
+
+import torch
+import torch.nn.functional as F
+
+import torch_geometric.transforms as T
+from torch_geometric.datasets import Planetoid
+from torch_geometric.nn import GCN, GAT, GraphSAGE
+from torch_geometric.utils import (
+    negative_sampling,
+    train_test_split_edges,
+)
+
+
+class LinkPredictor(torch.nn.Module):
+    def __init__(self, in_channels, hidden_channels):
+        super().__init__()
+        self.lin1 = torch.nn.Linear(in_channels * 2, hidden_channels)
+        self.lin2 = torch.nn.Linear(hidden_channels, 1)
+
+    def forward(self, z_i, z_j):
+        x = torch.cat([z_i, z_j], dim=1)
+        x = self.lin1(x).relu()
+        x = self.lin2(x)
+        return x.view(-1)
+
+
+def train(encoder, predictor, data, optimizer):
+    encoder.train()
+    predictor.train()
+    
+    # Forward pass and calculate loss
+    optimizer.zero_grad()
+    
+    # Get node embeddings
+    z = encoder(data.x, data.train_pos_edge_index)
+    
+    # Positive edges
+    pos_out = predictor(z[data.train_pos_edge_index[0]], z[data.train_pos_edge_index[1]])
+    
+    # Sample and predict on negative edges
+    neg_edge_index = negative_sampling(
+        edge_index=data.train_pos_edge_index,
+        num_nodes=data.num_nodes,
+        num_neg_samples=data.train_pos_edge_index.size(1),
+    )
+    neg_out = predictor(z[neg_edge_index[0]], z[neg_edge_index[1]])
+
+    # Calculate loss
+    pos_loss = F.binary_cross_entropy_with_logits(
+        pos_out, torch.ones_like(pos_out)
+    )
+    neg_loss = F.binary_cross_entropy_with_logits(
+        neg_out, torch.zeros_like(neg_out)
+    )
+    loss = pos_loss + neg_loss
+    
+    loss.backward()
+    optimizer.step()
+    
+    return loss.item()
+
+
+@torch.no_grad()
+def test(encoder, predictor, data):
+    encoder.eval()
+    predictor.eval()
+    
+    z = encoder(data.x, data.train_pos_edge_index)
+    
+    pos_val_out = predictor(z[data.val_pos_edge_index[0]], z[data.val_pos_edge_index[1]])
+    neg_val_out = predictor(z[data.val_neg_edge_index[0]], z[data.val_neg_edge_index[1]])
+    
+    pos_test_out = predictor(z[data.test_pos_edge_index[0]], z[data.test_pos_edge_index[1]])
+    neg_test_out = predictor(z[data.test_neg_edge_index[0]], z[data.test_neg_edge_index[1]])
+    
+    from sklearn.metrics import roc_auc_score
+    
+    val_pred = torch.cat([pos_val_out, neg_val_out]).sigmoid().cpu()
+    val_true = torch.cat([torch.ones(pos_val_out.size(0)), 
+                           torch.zeros(neg_val_out.size(0))])
+    val_auc = roc_auc_score(val_true, val_pred)
+    
+    test_pred = torch.cat([pos_test_out, neg_test_out]).sigmoid().cpu()
+    test_true = torch.cat([torch.ones(pos_test_out.size(0)), 
+                            torch.zeros(neg_test_out.size(0))])
+    test_auc = roc_auc_score(test_true, test_pred)
+    
+    return val_auc, test_auc
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--dataset', type=str, default='Cora', 
+                        choices=['Cora', 'CiteSeer', 'PubMed'])
+    parser.add_argument('--model', type=str, default='GCN',
+                        choices=['GCN', 'GAT', 'GraphSAGE'])
+    parser.add_argument('--hidden_channels', type=int, default=128)
+    parser.add_argument('--out_channels', type=int, default=64)
+    parser.add_argument('--num_layers', type=int, default=2)
+    parser.add_argument('--epochs', type=int, default=200)
+    parser.add_argument('--lr', type=float, default=0.01)
+    args = parser.parse_args()
+
+    device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
+    
+    # Load dataset
+    transform = T.Compose([
+        T.NormalizeFeatures(),
+        T.ToDevice(device),
+    ])
+    
+    path = osp.join(osp.dirname(osp.realpath(__file__)), '..', '..', 'data', args.dataset)
+    dataset = Planetoid(path, args.dataset, transform=transform)
+    data = dataset[0]
+
+    # Process data for link prediction
+    data = train_test_split_edges(data)
+
+    # Initialize model
+    if args.model == 'GCN':
+        encoder = GCN(
+            in_channels=dataset.num_features,
+            hidden_channels=args.hidden_channels,
+            out_channels=args.out_channels,
+            num_layers=args.num_layers,
+        ).to(device)
+    elif args.model == 'GAT':
+        encoder = GAT(
+            in_channels=dataset.num_features,
+            hidden_channels=args.hidden_channels,
+            out_channels=args.out_channels,
+            num_layers=args.num_layers,
+        ).to(device)
+    elif args.model == 'GraphSAGE':
+        encoder = GraphSAGE(
+            in_channels=dataset.num_features,
+            hidden_channels=args.hidden_channels,
+            out_channels=args.out_channels,
+            num_layers=args.num_layers,
+        ).to(device)
+    
+    # Initialize link predictor
+    predictor = LinkPredictor(
+        in_channels=args.out_channels, 
+        hidden_channels=args.hidden_channels
+    ).to(device)
+    
+    print(f"Running traditional {args.model} on {args.dataset}")
+    
+    optimizer = torch.optim.Adam(
+        list(encoder.parameters()) + list(predictor.parameters()),
+        lr=args.lr
+    )
+
+    best_val_auc = 0
+    final_test_auc = 0
+    
+    for epoch in range(1, args.epochs + 1):
+        loss = train(encoder, predictor, data, optimizer)
+        val_auc, test_auc = test(encoder, predictor, data)
+        
+        if val_auc > best_val_auc:
+            best_val_auc = val_auc
+            final_test_auc = test_auc
+        
+        if epoch % 10 == 0:
+            print(f'Epoch: {epoch:03d}, Loss: {loss:.4f}, Val AUC: {val_auc:.4f}, '
+                  f'Test AUC: {test_auc:.4f}')
+    
+    print(f'Final results - Val AUC: {best_val_auc:.4f}, Test AUC: {final_test_auc:.4f}')
+
+
+if __name__ == '__main__':
+    main()

--- a/test/nn/models/test_attract_repel.py
+++ b/test/nn/models/test_attract_repel.py
@@ -1,108 +1,114 @@
 import torch
-from torch_geometric.nn import GCN, GAT, GraphSAGE
+
+from torch_geometric.nn import GCN
 from torch_geometric.nn.models.attract_repel import AttractRepel
-from torch_geometric.data import Data
 
 
 def test_attract_repel_initialization():
     # Test initialization with string model name
-    model1 = AttractRepel('GCN', in_channels=16, hidden_channels=32, out_channels=8, num_layers=2)
+    model1 = AttractRepel('GCN', in_channels=16, hidden_channels=32,
+                          out_channels=8, num_layers=2)
     assert model1.attract_dim == 4  # Default attract_ratio=0.5
     assert model1.repel_dim == 4
-    
+
     # Test initialization with model instance
-    base_model = GCN(in_channels=16, hidden_channels=32, out_channels=64, num_layers=2)
+    base_model = GCN(in_channels=16, hidden_channels=32, out_channels=64,
+                     num_layers=2)
     model2 = AttractRepel(base_model, out_channels=10, attract_ratio=0.7)
     assert model2.attract_dim == 7  # 70% of 10
     assert model2.repel_dim == 3
-    
+
     # Test with uneven split
-    model3 = AttractRepel('GCN', in_channels=16, hidden_channels=32, out_channels=9, attract_ratio=0.6, num_layers=2)
+    model3 = AttractRepel('GCN', in_channels=16, hidden_channels=32,
+                          out_channels=9, attract_ratio=0.6, num_layers=2)
     assert model3.attract_dim == 5  # int(9 * 0.6) = 5
     assert model3.repel_dim == 4  # 9 - 5 = 4
 
 
 def test_attract_repel_forward():
-    model = AttractRepel('GCN', in_channels=16, hidden_channels=32, out_channels=8, num_layers=2)
-    
+    model = AttractRepel('GCN', in_channels=16, hidden_channels=32,
+                         out_channels=8, num_layers=2)
+
     # Create dummy data
     x = torch.randn(4, 16)  # 4 nodes with 16 features
     edge_index = torch.tensor([[0, 1, 2], [1, 2, 3]])  # 3 edges
-    
+
     # Test encode function
     attract_z, repel_z = model.encode(x, edge_index)
     assert attract_z.size() == (4, 4)
     assert repel_z.size() == (4, 4)
-    
+
     # Test forward pass with edge_label_index
     edge_label_index = torch.tensor([[0, 1], [2, 3]])
     scores = model(x, edge_index, edge_label_index=edge_label_index)
     assert scores.size(0) == edge_label_index.size(1)
-    
+
     # Test forward pass without edge_label_index (return embeddings)
     embeddings = model(x, edge_index)
     assert embeddings.size() == (4, 8)
-    
+
     # Test score calculation
-    manual_scores = model.calculate_scores(
-        attract_z[0:1], attract_z[1:2], 
-        repel_z[0:1], repel_z[1:2]
-    )
+    manual_scores = model.calculate_scores(attract_z[0:1], attract_z[1:2],
+                                           repel_z[0:1], repel_z[1:2])
     assert manual_scores.size(0) == 1
 
 
 def test_attract_repel_with_different_models():
     # Test with GAT
-    gat_model = AttractRepel('GAT', in_channels=16, hidden_channels=32, out_channels=8, num_layers=2)
-    
+    gat_model = AttractRepel('GAT', in_channels=16, hidden_channels=32,
+                             out_channels=8, num_layers=2)
+
     # Test with GraphSAGE
-    sage_model = AttractRepel('GraphSAGE', in_channels=16, hidden_channels=32, out_channels=8, num_layers=2)
-    
+    sage_model = AttractRepel('GraphSAGE', in_channels=16, hidden_channels=32,
+                              out_channels=8, num_layers=2)
+
     # Create dummy data
     x = torch.randn(4, 16)
     edge_index = torch.tensor([[0, 1, 2], [1, 2, 3]])
-    
+
     # Verify both models work
     gat_scores = gat_model(x, edge_index, edge_label_index=edge_index)
     sage_scores = sage_model(x, edge_index, edge_label_index=edge_index)
-    
+
     assert gat_scores.size(0) == edge_index.size(1)
     assert sage_scores.size(0) == edge_index.size(1)
 
 
 def test_r_fraction_calculation():
-    model = AttractRepel('GCN', in_channels=16, hidden_channels=32, out_channels=8, num_layers=2)
-    
+    model = AttractRepel('GCN', in_channels=16, hidden_channels=32,
+                         out_channels=8, num_layers=2)
+
     # Create dummy data
     x = torch.randn(4, 16)
     edge_index = torch.tensor([[0, 1, 2], [1, 2, 3]])
-    
+
     # Get embeddings
     attract_z, repel_z = model.encode(x, edge_index)
-    
+
     # Calculate R-fraction
     r_fraction = model.calculate_r_fraction(attract_z, repel_z)
-    
+
     # Check it's a valid fraction
     assert 0 <= r_fraction <= 1
 
 
 def test_custom_model_adaptation():
     # Create a custom model with different output size
-    base_model = GCN(in_channels=16, hidden_channels=32, out_channels=20, num_layers=2)
-    
+    base_model = GCN(in_channels=16, hidden_channels=32, out_channels=20,
+                     num_layers=2)
+
     # Wrap it with AttractRepel with different out_channels
     model = AttractRepel(base_model, out_channels=10)
-    
+
     # Create dummy data
     x = torch.randn(4, 16)
     edge_index = torch.tensor([[0, 1, 2], [1, 2, 3]])
-    
+
     # Verify the model works and produces correct output sizes
     attract_z, repel_z = model.encode(x, edge_index)
     assert attract_z.size() == (4, 5)  # Half of 10
     assert repel_z.size() == (4, 5)  # Half of 10
-    
+
     # Check embeddings
     embeddings = model(x, edge_index)
     assert embeddings.size() == (4, 10)

--- a/test/nn/models/test_attract_repel.py
+++ b/test/nn/models/test_attract_repel.py
@@ -1,23 +1,29 @@
 import torch
 from torch_geometric.nn import GCN, GAT, GraphSAGE
-from torch_geometric.nn.models import AttractRepel
+from torch_geometric.nn.models.attract_repel import AttractRepel
+from torch_geometric.data import Data
 
 
 def test_attract_repel_initialization():
     # Test initialization with string model name
-    model1 = AttractRepel('GCN', in_channels=16, hidden_channels=32, out_channels=8)
+    model1 = AttractRepel('GCN', in_channels=16, hidden_channels=32, out_channels=8, num_layers=2)
     assert model1.attract_dim == 4  # Default attract_ratio=0.5
     assert model1.repel_dim == 4
     
     # Test initialization with model instance
-    base_model = GCN(in_channels=16, hidden_channels=32, out_channels=64)
+    base_model = GCN(in_channels=16, hidden_channels=32, out_channels=64, num_layers=2)
     model2 = AttractRepel(base_model, out_channels=10, attract_ratio=0.7)
     assert model2.attract_dim == 7  # 70% of 10
     assert model2.repel_dim == 3
+    
+    # Test with uneven split
+    model3 = AttractRepel('GCN', in_channels=16, hidden_channels=32, out_channels=9, attract_ratio=0.6, num_layers=2)
+    assert model3.attract_dim == 5  # int(9 * 0.6) = 5
+    assert model3.repel_dim == 4  # 9 - 5 = 4
 
 
 def test_attract_repel_forward():
-    model = AttractRepel('GCN', in_channels=16, hidden_channels=32, out_channels=8)
+    model = AttractRepel('GCN', in_channels=16, hidden_channels=32, out_channels=8, num_layers=2)
     
     # Create dummy data
     x = torch.randn(4, 16)  # 4 nodes with 16 features
@@ -28,36 +34,44 @@ def test_attract_repel_forward():
     assert attract_z.size() == (4, 4)
     assert repel_z.size() == (4, 4)
     
-    # Test forward pass with edge_index
-    scores = model(x, edge_index, edge_index=edge_index)
-    assert scores.size(0) == edge_index.size(1)
+    # Test forward pass with edge_label_index
+    edge_label_index = torch.tensor([[0, 1], [2, 3]])
+    scores = model(x, edge_index, edge_label_index=edge_label_index)
+    assert scores.size(0) == edge_label_index.size(1)
     
-    # Test forward pass without edge_index
+    # Test forward pass without edge_label_index (return embeddings)
     embeddings = model(x, edge_index)
     assert embeddings.size() == (4, 8)
+    
+    # Test score calculation
+    manual_scores = model.calculate_scores(
+        attract_z[0:1], attract_z[1:2], 
+        repel_z[0:1], repel_z[1:2]
+    )
+    assert manual_scores.size(0) == 1
 
 
 def test_attract_repel_with_different_models():
     # Test with GAT
-    gat_model = AttractRepel('GAT', in_channels=16, hidden_channels=32, out_channels=8)
+    gat_model = AttractRepel('GAT', in_channels=16, hidden_channels=32, out_channels=8, num_layers=2)
     
     # Test with GraphSAGE
-    sage_model = AttractRepel('GraphSAGE', in_channels=16, hidden_channels=32, out_channels=8)
+    sage_model = AttractRepel('GraphSAGE', in_channels=16, hidden_channels=32, out_channels=8, num_layers=2)
     
     # Create dummy data
     x = torch.randn(4, 16)
     edge_index = torch.tensor([[0, 1, 2], [1, 2, 3]])
     
     # Verify both models work
-    gat_scores = gat_model(x, edge_index, edge_index=edge_index)
-    sage_scores = sage_model(x, edge_index, edge_index=edge_index)
+    gat_scores = gat_model(x, edge_index, edge_label_index=edge_index)
+    sage_scores = sage_model(x, edge_index, edge_label_index=edge_index)
     
     assert gat_scores.size(0) == edge_index.size(1)
     assert sage_scores.size(0) == edge_index.size(1)
 
 
 def test_r_fraction_calculation():
-    model = AttractRepel('GCN', in_channels=16, hidden_channels=32, out_channels=8)
+    model = AttractRepel('GCN', in_channels=16, hidden_channels=32, out_channels=8, num_layers=2)
     
     # Create dummy data
     x = torch.randn(4, 16)
@@ -71,3 +85,24 @@ def test_r_fraction_calculation():
     
     # Check it's a valid fraction
     assert 0 <= r_fraction <= 1
+
+
+def test_custom_model_adaptation():
+    # Create a custom model with different output size
+    base_model = GCN(in_channels=16, hidden_channels=32, out_channels=20, num_layers=2)
+    
+    # Wrap it with AttractRepel with different out_channels
+    model = AttractRepel(base_model, out_channels=10)
+    
+    # Create dummy data
+    x = torch.randn(4, 16)
+    edge_index = torch.tensor([[0, 1, 2], [1, 2, 3]])
+    
+    # Verify the model works and produces correct output sizes
+    attract_z, repel_z = model.encode(x, edge_index)
+    assert attract_z.size() == (4, 5)  # Half of 10
+    assert repel_z.size() == (4, 5)  # Half of 10
+    
+    # Check embeddings
+    embeddings = model(x, edge_index)
+    assert embeddings.size() == (4, 10)

--- a/test/nn/models/test_attract_repel.py
+++ b/test/nn/models/test_attract_repel.py
@@ -1,0 +1,73 @@
+import torch
+from torch_geometric.nn import GCN, GAT, GraphSAGE
+from torch_geometric.nn.models import AttractRepel
+
+
+def test_attract_repel_initialization():
+    # Test initialization with string model name
+    model1 = AttractRepel('GCN', in_channels=16, hidden_channels=32, out_channels=8)
+    assert model1.attract_dim == 4  # Default attract_ratio=0.5
+    assert model1.repel_dim == 4
+    
+    # Test initialization with model instance
+    base_model = GCN(in_channels=16, hidden_channels=32, out_channels=64)
+    model2 = AttractRepel(base_model, out_channels=10, attract_ratio=0.7)
+    assert model2.attract_dim == 7  # 70% of 10
+    assert model2.repel_dim == 3
+
+
+def test_attract_repel_forward():
+    model = AttractRepel('GCN', in_channels=16, hidden_channels=32, out_channels=8)
+    
+    # Create dummy data
+    x = torch.randn(4, 16)  # 4 nodes with 16 features
+    edge_index = torch.tensor([[0, 1, 2], [1, 2, 3]])  # 3 edges
+    
+    # Test encode function
+    attract_z, repel_z = model.encode(x, edge_index)
+    assert attract_z.size() == (4, 4)
+    assert repel_z.size() == (4, 4)
+    
+    # Test forward pass with edge_index
+    scores = model(x, edge_index, edge_index=edge_index)
+    assert scores.size(0) == edge_index.size(1)
+    
+    # Test forward pass without edge_index
+    embeddings = model(x, edge_index)
+    assert embeddings.size() == (4, 8)
+
+
+def test_attract_repel_with_different_models():
+    # Test with GAT
+    gat_model = AttractRepel('GAT', in_channels=16, hidden_channels=32, out_channels=8)
+    
+    # Test with GraphSAGE
+    sage_model = AttractRepel('GraphSAGE', in_channels=16, hidden_channels=32, out_channels=8)
+    
+    # Create dummy data
+    x = torch.randn(4, 16)
+    edge_index = torch.tensor([[0, 1, 2], [1, 2, 3]])
+    
+    # Verify both models work
+    gat_scores = gat_model(x, edge_index, edge_index=edge_index)
+    sage_scores = sage_model(x, edge_index, edge_index=edge_index)
+    
+    assert gat_scores.size(0) == edge_index.size(1)
+    assert sage_scores.size(0) == edge_index.size(1)
+
+
+def test_r_fraction_calculation():
+    model = AttractRepel('GCN', in_channels=16, hidden_channels=32, out_channels=8)
+    
+    # Create dummy data
+    x = torch.randn(4, 16)
+    edge_index = torch.tensor([[0, 1, 2], [1, 2, 3]])
+    
+    # Get embeddings
+    attract_z, repel_z = model.encode(x, edge_index)
+    
+    # Calculate R-fraction
+    r_fraction = model.calculate_r_fraction(attract_z, repel_z)
+    
+    # Check it's a valid fraction
+    assert 0 <= r_fraction <= 1

--- a/torch_geometric/nn/models/__init__.py
+++ b/torch_geometric/nn/models/__init__.py
@@ -33,6 +33,7 @@ from .git_mol import GITMol
 from .molecule_gpt import MoleculeGPT
 from .glem import GLEM
 from .sgformer import SGFormer
+from .attract_repel import AttractRepel
 # Deprecated:
 from torch_geometric.explain.algorithm.captum import (to_captum_input,
                                                       captum_output_to_dicts)

--- a/torch_geometric/nn/models/__init__.py
+++ b/torch_geometric/nn/models/__init__.py
@@ -85,4 +85,5 @@ __all__ = classes = [
     'MoleculeGPT',
     'GLEM',
     'SGFormer',
+    'AttractRepel',
 ]

--- a/torch_geometric/nn/models/attract_repel.py
+++ b/torch_geometric/nn/models/attract_repel.py
@@ -1,0 +1,147 @@
+import torch
+import torch.nn as nn
+from torch_geometric.nn.models.basic_gnn import GCN, GAT, GraphSAGE
+
+class AttractRepel(torch.nn.Module):
+    def __init__(self, base_model, in_channels=None, hidden_channels=None, 
+                 out_channels=None, num_layers=2, attract_ratio=0.5, **kwargs):
+        super(AttractRepel, self).__init__()
+        
+        # Store parameters
+        self.attract_ratio = attract_ratio
+        
+        # Initialize base model
+        if isinstance(base_model, str):
+            # Verify required parameters
+            if in_channels is None or hidden_channels is None:
+                raise ValueError("in_channels and hidden_channels must be provided when base_model is a string")
+            
+            # Create model based on string name
+            if base_model == 'GCN':
+                from torch_geometric.nn.models.basic_gnn import GCN
+                self.base_model = GCN(in_channels=in_channels, 
+                                     hidden_channels=hidden_channels,
+                                     num_layers=num_layers,
+                                     out_channels=hidden_channels,  # Set output to hidden_channels
+                                     **kwargs)
+            elif base_model == 'GAT':
+                from torch_geometric.nn.models.basic_gnn import GAT
+                self.base_model = GAT(in_channels=in_channels, 
+                                     hidden_channels=hidden_channels,
+                                     num_layers=num_layers,
+                                     out_channels=hidden_channels,  # Set output to hidden_channels
+                                     **kwargs)
+            elif base_model == 'GraphSAGE':
+                from torch_geometric.nn.models.basic_gnn import GraphSAGE
+                self.base_model = GraphSAGE(in_channels=in_channels, 
+                                           hidden_channels=hidden_channels,
+                                           num_layers=num_layers,
+                                           out_channels=hidden_channels,  # Set output to hidden_channels
+                                           **kwargs)
+            else:
+                raise ValueError(f"Unknown model: {base_model}. "
+                                f"Supported models: 'GCN', 'GAT', 'GraphSAGE'")
+        else:
+            self.base_model = base_model
+        
+        # Set output dimensions
+        base_out_channels = hidden_channels  # Use hidden_channels as safe default
+        self.out_channels = out_channels if out_channels is not None else base_out_channels
+        
+        # Calculate dimensions for attract and repel components
+        self.attract_dim = int(self.out_channels * attract_ratio)
+        self.repel_dim = self.out_channels - self.attract_dim
+        
+        # Create projection layers
+        self.proj_attract = nn.Linear(base_out_channels, self.attract_dim)
+        self.proj_repel = nn.Linear(base_out_channels, self.repel_dim)
+        
+        print(f"Debug: Model initialized with: out_channels={self.out_channels}, "
+              f"attract_dim={self.attract_dim}, repel_dim={self.repel_dim}")
+    def encode(self, *args, **kwargs):
+        """
+        Encode inputs using the base model and project to attract-repel space.
+        
+        Args:
+            *args: Arguments to pass to the base model
+            **kwargs: Keyword arguments to pass to the base model
+            
+        Returns:
+            tuple[torch.Tensor, torch.Tensor]: Attract and repel embeddings
+        """
+        # Get embeddings from base model
+        x = self.base_model(*args, **kwargs)
+        
+        # Project to attract and repel spaces
+        attract_emb = self.proj_attract(x)
+        repel_emb = self.proj_repel(x)
+        
+        return attract_emb, repel_emb
+    
+    def decode(self, attract_z, repel_z, edge_index):
+        """
+        Compute link prediction scores for given edges.
+        
+        Args:
+            attract_z (torch.Tensor): Attract embeddings of shape [num_nodes, attract_dim]
+            repel_z (torch.Tensor): Repel embeddings of shape [num_nodes, repel_dim]
+            edge_index (torch.Tensor): Edge indices of shape [2, num_edges]
+            
+        Returns:
+            torch.Tensor: Link prediction scores for each edge
+        """
+        # Get node pairs
+        row, col = edge_index
+        
+        # Get embeddings for the node pairs
+        attract_z_i, attract_z_j = attract_z[row], attract_z[col]
+        repel_z_i, repel_z_j = repel_z[row], repel_z[col]
+        
+        # Compute the attract-repel dot products
+        attract_score = (attract_z_i * attract_z_j).sum(dim=1)
+        repel_score = (repel_z_i * repel_z_j).sum(dim=1)
+        
+        # Return the final score
+        return attract_score - repel_score
+    
+    def forward(self, *args, edge_index=None, **kwargs):
+        """
+        Forward pass for link prediction.
+        
+        Args:
+            *args: Arguments to pass to the base model
+            edge_index (torch.Tensor, optional): Edge indices to predict.
+                If not provided, returns node embeddings.
+            **kwargs: Keyword arguments to pass to the base model
+            
+        Returns:
+            torch.Tensor or tuple: If edge_index is provided, returns link prediction
+                scores for each edge. Otherwise, returns node embeddings.
+        """
+        # Get node embeddings
+        attract_z, repel_z = self.encode(*args, **kwargs)
+        
+        # If edge_index is provided, decode edges
+        if edge_index is not None:
+            return self.decode(attract_z, repel_z, edge_index)
+        
+        # Otherwise, return embeddings
+        return torch.cat([attract_z, repel_z], dim=1)
+    
+    def calculate_r_fraction(self, attract_z, repel_z):
+        """
+        Calculate the R-fraction of the embeddings.
+        
+        Args:
+            attract_z (torch.Tensor): Attract embeddings
+            repel_z (torch.Tensor): Repel embeddings
+            
+        Returns:
+            float: R-fraction value
+        """
+        attract_norm_squared = torch.sum(attract_z ** 2)
+        repel_norm_squared = torch.sum(repel_z ** 2)
+        
+        r_fraction = repel_norm_squared / (attract_norm_squared + repel_norm_squared + 1e-10)
+        
+        return r_fraction.item()

--- a/torch_geometric/nn/models/attract_repel.py
+++ b/torch_geometric/nn/models/attract_repel.py
@@ -1,6 +1,7 @@
+from typing import Optional, Tuple, Union
+
 import torch
 import torch.nn as nn
-from typing import Callable, Optional, Tuple, Union, List
 
 # Import these at runtime to avoid circular imports
 from torch_geometric.typing import Adj, OptTensor
@@ -8,12 +9,12 @@ from torch_geometric.typing import Adj, OptTensor
 
 class AttractRepel(nn.Module):
     r"""A wrapper for Graph Neural Networks that implements Attract-Repel embeddings.
-    
+
     This wrapper splits the embedding space into "attract" and "repel" components,
     which enables better representation of non-transitive relationships in graphs
-    as described in the paper "Pseudo-Euclidean Attract-Repel Embeddings for 
+    as described in the paper "Pseudo-Euclidean Attract-Repel Embeddings for
     Undirected Graphs" (Peysakhovich et al., 2023).
-    
+
     Args:
         model (Union[str, nn.Module]): The base GNN model to wrap. Can be either a string
             ('GCN', 'GAT', 'GraphSAGE') or an instance of a PyG model.
@@ -24,187 +25,172 @@ class AttractRepel(nn.Module):
             (Default: 0.5)
         **kwargs: Additional arguments for the base model if `model` is a string.
     """
-    def __init__(
-        self, 
-        model: Union[str, nn.Module],
-        in_channels: Optional[int] = None,
-        hidden_channels: Optional[int] = None,
-        out_channels: int = 64,
-        attract_ratio: float = 0.5,
-        **kwargs
-    ):
+    def __init__(self, model: Union[str, nn.Module],
+                 in_channels: Optional[int] = None,
+                 hidden_channels: Optional[int] = None, out_channels: int = 64,
+                 attract_ratio: float = 0.5, **kwargs):
         super().__init__()
-        
+
         # Process dimensions
         self.out_channels = out_channels
         self.attract_ratio = attract_ratio
         self.attract_dim = int(out_channels * attract_ratio)
         self.repel_dim = out_channels - self.attract_dim
-        
+
         # Set up base model
         if isinstance(model, str):
             if in_channels is None or hidden_channels is None:
-                raise ValueError("in_channels and hidden_channels must be provided when model is a string")
-            
+                raise ValueError(
+                    "in_channels and hidden_channels must be provided when model is a string"
+                )
+
             # Handle num_layers parameter
             model_kwargs = kwargs.copy()
             if 'num_layers' not in model_kwargs:
                 model_kwargs['num_layers'] = 2  # Default to 2 layers
-            
+
             # Import specific models here to avoid circular imports
             if model == 'GCN':
                 from torch_geometric.nn import GCN
-                self.base_model = GCN(
-                    in_channels=in_channels,
-                    hidden_channels=hidden_channels,
-                    out_channels=out_channels,
-                    **model_kwargs
-                )
+                self.base_model = GCN(in_channels=in_channels,
+                                      hidden_channels=hidden_channels,
+                                      out_channels=out_channels,
+                                      **model_kwargs)
             elif model == 'GAT':
                 from torch_geometric.nn import GAT
-                self.base_model = GAT(
-                    in_channels=in_channels,
-                    hidden_channels=hidden_channels,
-                    out_channels=out_channels,
-                    **model_kwargs
-                )
+                self.base_model = GAT(in_channels=in_channels,
+                                      hidden_channels=hidden_channels,
+                                      out_channels=out_channels,
+                                      **model_kwargs)
             elif model == 'GraphSAGE':
                 from torch_geometric.nn import GraphSAGE
-                self.base_model = GraphSAGE(
-                    in_channels=in_channels,
-                    hidden_channels=hidden_channels,
-                    out_channels=out_channels,
-                    **model_kwargs
-                )
+                self.base_model = GraphSAGE(in_channels=in_channels,
+                                            hidden_channels=hidden_channels,
+                                            out_channels=out_channels,
+                                            **model_kwargs)
             else:
                 raise ValueError(f"Unknown model type: {model}")
         else:
             # User provided a model instance
             self.base_model = model
-            
+
             # Check if we need to modify the output dimension
-            if hasattr(self.base_model, 'out_channels') and self.base_model.out_channels != out_channels:
+            if hasattr(self.base_model, 'out_channels'
+                       ) and self.base_model.out_channels != out_channels:
                 # Replace last layer
-                if hasattr(self.base_model, 'lin') and isinstance(self.base_model.lin, nn.Linear):
+                if hasattr(self.base_model, 'lin') and isinstance(
+                        self.base_model.lin, nn.Linear):
                     in_features = self.base_model.lin.in_features
                     self.base_model.lin = nn.Linear(in_features, out_channels)
                     self.base_model.out_channels = out_channels
-                elif hasattr(self.base_model, 'convs') and isinstance(self.base_model.convs, nn.ModuleList):
+                elif hasattr(self.base_model, 'convs') and isinstance(
+                        self.base_model.convs, nn.ModuleList):
                     # Assume the last layer in convs is the output layer
-                    self._replace_last_layer(self.base_model.convs, out_channels)
+                    self._replace_last_layer(self.base_model.convs,
+                                             out_channels)
                     self.base_model.out_channels = out_channels
-    
-    def _replace_last_layer(self, module_list: nn.ModuleList, out_channels: int):
+
+    def _replace_last_layer(self, module_list: nn.ModuleList,
+                            out_channels: int):
         """Helper to replace the last layer in a module list."""
         if len(module_list) == 0:
             return
-            
+
         last_module = module_list[-1]
-        if hasattr(last_module, 'lin_rel') and isinstance(last_module.lin_rel, nn.Linear):
+        if hasattr(last_module, 'lin_rel') and isinstance(
+                last_module.lin_rel, nn.Linear):
             # For GAT-like models
             in_features = last_module.lin_rel.in_features
             last_module.lin_rel = nn.Linear(in_features, out_channels)
-        elif hasattr(last_module, 'lin') and isinstance(last_module.lin, nn.Linear):
+        elif hasattr(last_module, 'lin') and isinstance(
+                last_module.lin, nn.Linear):
             # For GCN-like models
             in_features = last_module.lin.in_features
             last_module.lin = nn.Linear(in_features, out_channels)
         elif hasattr(last_module, 'out_channels'):
             # Direct attribute
             last_module.out_channels = out_channels
-    
-    def encode(
-        self, 
-        x: torch.Tensor, 
-        edge_index: Adj, 
-        edge_weight: OptTensor = None,
-        **kwargs
-    ) -> Tuple[torch.Tensor, torch.Tensor]:
+
+    def encode(self, x: torch.Tensor, edge_index: Adj,
+               edge_weight: OptTensor = None,
+               **kwargs) -> Tuple[torch.Tensor, torch.Tensor]:
         """Encode input data into attract and repel embeddings.
-        
+
         Args:
             x: The node features.
             edge_index: The edge indices.
             edge_weight: One-dimensional edge weights.
             **kwargs: Additional arguments forwarded to the base model.
-            
+
         Returns:
             Tuple[torch.Tensor, torch.Tensor]: Attract and repel embeddings.
         """
         # Get node embeddings from base model
         z = self.base_model(x, edge_index, edge_weight, **kwargs)
-        
+
         # Split into attract and repel components
         attract_z = z[:, :self.attract_dim]
         repel_z = z[:, self.attract_dim:]
-        
+
         return attract_z, repel_z
-    
-    def calculate_scores(
-        self, 
-        attract_z_src: torch.Tensor, 
-        attract_z_dst: torch.Tensor,
-        repel_z_src: torch.Tensor, 
-        repel_z_dst: torch.Tensor
-    ) -> torch.Tensor:
+
+    def calculate_scores(self, attract_z_src: torch.Tensor,
+                         attract_z_dst: torch.Tensor,
+                         repel_z_src: torch.Tensor,
+                         repel_z_dst: torch.Tensor) -> torch.Tensor:
         """Calculate the attract-repel scores for pairs of nodes.
-        
+
         Args:
             attract_z_src: Attract embeddings for source nodes.
             attract_z_dst: Attract embeddings for destination nodes.
             repel_z_src: Repel embeddings for source nodes.
             repel_z_dst: Repel embeddings for destination nodes.
-            
+
         Returns:
             torch.Tensor: Attract-repel scores.
         """
         # Calculate attract score (dot product of attract components)
         attract_score = (attract_z_src * attract_z_dst).sum(dim=1)
-        
+
         # Calculate repel score (dot product of repel components)
         repel_score = (repel_z_src * repel_z_dst).sum(dim=1)
-        
+
         # AR score = attract score - repel score
         return attract_score - repel_score
-    
-    def calculate_r_fraction(
-        self, 
-        attract_z: torch.Tensor, 
-        repel_z: torch.Tensor
-    ) -> torch.Tensor:
+
+    def calculate_r_fraction(self, attract_z: torch.Tensor,
+                             repel_z: torch.Tensor) -> torch.Tensor:
         """Calculate the R-fraction of the embeddings.
-        
+
         The R-fraction measures how much of the embedding is explained by the repel component.
         Higher values indicate more heterophily in the network.
-        
+
         Args:
             attract_z: Attract embeddings.
             repel_z: Repel embeddings.
-            
+
         Returns:
             torch.Tensor: R-fraction value.
         """
-        attract_norm_squared = torch.sum(attract_z ** 2)
-        repel_norm_squared = torch.sum(repel_z ** 2)
-        
+        attract_norm_squared = torch.sum(attract_z**2)
+        repel_norm_squared = torch.sum(repel_z**2)
+
         return repel_norm_squared / (attract_norm_squared + repel_norm_squared)
-    
+
     def forward(
-        self, 
-        x: torch.Tensor, 
-        edge_index: Adj,
-        edge_weight: OptTensor = None,
-        edge_label_index: OptTensor = None,
-        **kwargs
+            self, x: torch.Tensor, edge_index: Adj,
+            edge_weight: OptTensor = None, edge_label_index: OptTensor = None,
+            **kwargs
     ) -> Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]:
         """Forward pass.
-        
+
         Args:
             x: The node features.
             edge_index: The edge indices.
             edge_weight: One-dimensional edge weights.
             edge_label_index: Indices of edges for which to compute scores.
             **kwargs: Additional arguments forwarded to the base model.
-            
+
         Returns:
             If edge_label_index or edge_index is provided as the target for prediction:
                 Attract-repel scores for the provided edges.
@@ -213,23 +199,19 @@ class AttractRepel(nn.Module):
         """
         # Get attract and repel embeddings
         attract_z, repel_z = self.encode(x, edge_index, edge_weight, **kwargs)
-        
+
         # If edge_label_index is provided, compute scores for those edges
         if edge_label_index is not None:
             src, dst = edge_label_index
-            return self.calculate_scores(
-                attract_z[src], attract_z[dst], 
-                repel_z[src], repel_z[dst]
-            )
-        
+            return self.calculate_scores(attract_z[src], attract_z[dst],
+                                         repel_z[src], repel_z[dst])
+
         # If edge_index is specified again specifically for prediction
         elif 'edge_index' in kwargs:
             src, dst = kwargs['edge_index']
-            return self.calculate_scores(
-                attract_z[src], attract_z[dst], 
-                repel_z[src], repel_z[dst]
-            )
-        
+            return self.calculate_scores(attract_z[src], attract_z[dst],
+                                         repel_z[src], repel_z[dst])
+
         # Otherwise return full node embeddings (concatenated)
         else:
             return torch.cat([attract_z, repel_z], dim=1)

--- a/torch_geometric/nn/models/attract_repel.py
+++ b/torch_geometric/nn/models/attract_repel.py
@@ -1,147 +1,235 @@
 import torch
 import torch.nn as nn
-from torch_geometric.nn.models.basic_gnn import GCN, GAT, GraphSAGE
+from typing import Callable, Optional, Tuple, Union, List
 
-class AttractRepel(torch.nn.Module):
-    def __init__(self, base_model, in_channels=None, hidden_channels=None, 
-                 out_channels=None, num_layers=2, attract_ratio=0.5, **kwargs):
-        super(AttractRepel, self).__init__()
-        
-        # Store parameters
-        self.attract_ratio = attract_ratio
-        
-        # Initialize base model
-        if isinstance(base_model, str):
-            # Verify required parameters
-            if in_channels is None or hidden_channels is None:
-                raise ValueError("in_channels and hidden_channels must be provided when base_model is a string")
-            
-            # Create model based on string name
-            if base_model == 'GCN':
-                from torch_geometric.nn.models.basic_gnn import GCN
-                self.base_model = GCN(in_channels=in_channels, 
-                                     hidden_channels=hidden_channels,
-                                     num_layers=num_layers,
-                                     out_channels=hidden_channels,  # Set output to hidden_channels
-                                     **kwargs)
-            elif base_model == 'GAT':
-                from torch_geometric.nn.models.basic_gnn import GAT
-                self.base_model = GAT(in_channels=in_channels, 
-                                     hidden_channels=hidden_channels,
-                                     num_layers=num_layers,
-                                     out_channels=hidden_channels,  # Set output to hidden_channels
-                                     **kwargs)
-            elif base_model == 'GraphSAGE':
-                from torch_geometric.nn.models.basic_gnn import GraphSAGE
-                self.base_model = GraphSAGE(in_channels=in_channels, 
-                                           hidden_channels=hidden_channels,
-                                           num_layers=num_layers,
-                                           out_channels=hidden_channels,  # Set output to hidden_channels
-                                           **kwargs)
-            else:
-                raise ValueError(f"Unknown model: {base_model}. "
-                                f"Supported models: 'GCN', 'GAT', 'GraphSAGE'")
-        else:
-            self.base_model = base_model
-        
-        # Set output dimensions
-        base_out_channels = hidden_channels  # Use hidden_channels as safe default
-        self.out_channels = out_channels if out_channels is not None else base_out_channels
-        
-        # Calculate dimensions for attract and repel components
-        self.attract_dim = int(self.out_channels * attract_ratio)
-        self.repel_dim = self.out_channels - self.attract_dim
-        
-        # Create projection layers
-        self.proj_attract = nn.Linear(base_out_channels, self.attract_dim)
-        self.proj_repel = nn.Linear(base_out_channels, self.repel_dim)
-        
-        print(f"Debug: Model initialized with: out_channels={self.out_channels}, "
-              f"attract_dim={self.attract_dim}, repel_dim={self.repel_dim}")
-    def encode(self, *args, **kwargs):
-        """
-        Encode inputs using the base model and project to attract-repel space.
-        
-        Args:
-            *args: Arguments to pass to the base model
-            **kwargs: Keyword arguments to pass to the base model
-            
-        Returns:
-            tuple[torch.Tensor, torch.Tensor]: Attract and repel embeddings
-        """
-        # Get embeddings from base model
-        x = self.base_model(*args, **kwargs)
-        
-        # Project to attract and repel spaces
-        attract_emb = self.proj_attract(x)
-        repel_emb = self.proj_repel(x)
-        
-        return attract_emb, repel_emb
+# Import these at runtime to avoid circular imports
+from torch_geometric.typing import Adj, OptTensor
+
+
+class AttractRepel(nn.Module):
+    r"""A wrapper for Graph Neural Networks that implements Attract-Repel embeddings.
     
-    def decode(self, attract_z, repel_z, edge_index):
-        """
-        Compute link prediction scores for given edges.
+    This wrapper splits the embedding space into "attract" and "repel" components,
+    which enables better representation of non-transitive relationships in graphs
+    as described in the paper "Pseudo-Euclidean Attract-Repel Embeddings for 
+    Undirected Graphs" (Peysakhovich et al., 2023).
+    
+    Args:
+        model (Union[str, nn.Module]): The base GNN model to wrap. Can be either a string
+            ('GCN', 'GAT', 'GraphSAGE') or an instance of a PyG model.
+        in_channels (Optional[int]): Size of each input sample. Required if `model` is a string.
+        hidden_channels (Optional[int]): Size of hidden layers. Required if `model` is a string.
+        out_channels (int): Size of each output sample.
+        attract_ratio (float, optional): Ratio of dimensions to allocate to the attract component.
+            (Default: 0.5)
+        **kwargs: Additional arguments for the base model if `model` is a string.
+    """
+    def __init__(
+        self, 
+        model: Union[str, nn.Module],
+        in_channels: Optional[int] = None,
+        hidden_channels: Optional[int] = None,
+        out_channels: int = 64,
+        attract_ratio: float = 0.5,
+        **kwargs
+    ):
+        super().__init__()
+        
+        # Process dimensions
+        self.out_channels = out_channels
+        self.attract_ratio = attract_ratio
+        self.attract_dim = int(out_channels * attract_ratio)
+        self.repel_dim = out_channels - self.attract_dim
+        
+        # Set up base model
+        if isinstance(model, str):
+            if in_channels is None or hidden_channels is None:
+                raise ValueError("in_channels and hidden_channels must be provided when model is a string")
+            
+            # Handle num_layers parameter
+            model_kwargs = kwargs.copy()
+            if 'num_layers' not in model_kwargs:
+                model_kwargs['num_layers'] = 2  # Default to 2 layers
+            
+            # Import specific models here to avoid circular imports
+            if model == 'GCN':
+                from torch_geometric.nn import GCN
+                self.base_model = GCN(
+                    in_channels=in_channels,
+                    hidden_channels=hidden_channels,
+                    out_channels=out_channels,
+                    **model_kwargs
+                )
+            elif model == 'GAT':
+                from torch_geometric.nn import GAT
+                self.base_model = GAT(
+                    in_channels=in_channels,
+                    hidden_channels=hidden_channels,
+                    out_channels=out_channels,
+                    **model_kwargs
+                )
+            elif model == 'GraphSAGE':
+                from torch_geometric.nn import GraphSAGE
+                self.base_model = GraphSAGE(
+                    in_channels=in_channels,
+                    hidden_channels=hidden_channels,
+                    out_channels=out_channels,
+                    **model_kwargs
+                )
+            else:
+                raise ValueError(f"Unknown model type: {model}")
+        else:
+            # User provided a model instance
+            self.base_model = model
+            
+            # Check if we need to modify the output dimension
+            if hasattr(self.base_model, 'out_channels') and self.base_model.out_channels != out_channels:
+                # Replace last layer
+                if hasattr(self.base_model, 'lin') and isinstance(self.base_model.lin, nn.Linear):
+                    in_features = self.base_model.lin.in_features
+                    self.base_model.lin = nn.Linear(in_features, out_channels)
+                    self.base_model.out_channels = out_channels
+                elif hasattr(self.base_model, 'convs') and isinstance(self.base_model.convs, nn.ModuleList):
+                    # Assume the last layer in convs is the output layer
+                    self._replace_last_layer(self.base_model.convs, out_channels)
+                    self.base_model.out_channels = out_channels
+    
+    def _replace_last_layer(self, module_list: nn.ModuleList, out_channels: int):
+        """Helper to replace the last layer in a module list."""
+        if len(module_list) == 0:
+            return
+            
+        last_module = module_list[-1]
+        if hasattr(last_module, 'lin_rel') and isinstance(last_module.lin_rel, nn.Linear):
+            # For GAT-like models
+            in_features = last_module.lin_rel.in_features
+            last_module.lin_rel = nn.Linear(in_features, out_channels)
+        elif hasattr(last_module, 'lin') and isinstance(last_module.lin, nn.Linear):
+            # For GCN-like models
+            in_features = last_module.lin.in_features
+            last_module.lin = nn.Linear(in_features, out_channels)
+        elif hasattr(last_module, 'out_channels'):
+            # Direct attribute
+            last_module.out_channels = out_channels
+    
+    def encode(
+        self, 
+        x: torch.Tensor, 
+        edge_index: Adj, 
+        edge_weight: OptTensor = None,
+        **kwargs
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        """Encode input data into attract and repel embeddings.
         
         Args:
-            attract_z (torch.Tensor): Attract embeddings of shape [num_nodes, attract_dim]
-            repel_z (torch.Tensor): Repel embeddings of shape [num_nodes, repel_dim]
-            edge_index (torch.Tensor): Edge indices of shape [2, num_edges]
+            x: The node features.
+            edge_index: The edge indices.
+            edge_weight: One-dimensional edge weights.
+            **kwargs: Additional arguments forwarded to the base model.
             
         Returns:
-            torch.Tensor: Link prediction scores for each edge
+            Tuple[torch.Tensor, torch.Tensor]: Attract and repel embeddings.
         """
-        # Get node pairs
-        row, col = edge_index
+        # Get node embeddings from base model
+        z = self.base_model(x, edge_index, edge_weight, **kwargs)
         
-        # Get embeddings for the node pairs
-        attract_z_i, attract_z_j = attract_z[row], attract_z[col]
-        repel_z_i, repel_z_j = repel_z[row], repel_z[col]
+        # Split into attract and repel components
+        attract_z = z[:, :self.attract_dim]
+        repel_z = z[:, self.attract_dim:]
         
-        # Compute the attract-repel dot products
-        attract_score = (attract_z_i * attract_z_j).sum(dim=1)
-        repel_score = (repel_z_i * repel_z_j).sum(dim=1)
+        return attract_z, repel_z
+    
+    def calculate_scores(
+        self, 
+        attract_z_src: torch.Tensor, 
+        attract_z_dst: torch.Tensor,
+        repel_z_src: torch.Tensor, 
+        repel_z_dst: torch.Tensor
+    ) -> torch.Tensor:
+        """Calculate the attract-repel scores for pairs of nodes.
         
-        # Return the final score
+        Args:
+            attract_z_src: Attract embeddings for source nodes.
+            attract_z_dst: Attract embeddings for destination nodes.
+            repel_z_src: Repel embeddings for source nodes.
+            repel_z_dst: Repel embeddings for destination nodes.
+            
+        Returns:
+            torch.Tensor: Attract-repel scores.
+        """
+        # Calculate attract score (dot product of attract components)
+        attract_score = (attract_z_src * attract_z_dst).sum(dim=1)
+        
+        # Calculate repel score (dot product of repel components)
+        repel_score = (repel_z_src * repel_z_dst).sum(dim=1)
+        
+        # AR score = attract score - repel score
         return attract_score - repel_score
     
-    def forward(self, *args, edge_index=None, **kwargs):
-        """
-        Forward pass for link prediction.
+    def calculate_r_fraction(
+        self, 
+        attract_z: torch.Tensor, 
+        repel_z: torch.Tensor
+    ) -> torch.Tensor:
+        """Calculate the R-fraction of the embeddings.
+        
+        The R-fraction measures how much of the embedding is explained by the repel component.
+        Higher values indicate more heterophily in the network.
         
         Args:
-            *args: Arguments to pass to the base model
-            edge_index (torch.Tensor, optional): Edge indices to predict.
-                If not provided, returns node embeddings.
-            **kwargs: Keyword arguments to pass to the base model
+            attract_z: Attract embeddings.
+            repel_z: Repel embeddings.
             
         Returns:
-            torch.Tensor or tuple: If edge_index is provided, returns link prediction
-                scores for each edge. Otherwise, returns node embeddings.
-        """
-        # Get node embeddings
-        attract_z, repel_z = self.encode(*args, **kwargs)
-        
-        # If edge_index is provided, decode edges
-        if edge_index is not None:
-            return self.decode(attract_z, repel_z, edge_index)
-        
-        # Otherwise, return embeddings
-        return torch.cat([attract_z, repel_z], dim=1)
-    
-    def calculate_r_fraction(self, attract_z, repel_z):
-        """
-        Calculate the R-fraction of the embeddings.
-        
-        Args:
-            attract_z (torch.Tensor): Attract embeddings
-            repel_z (torch.Tensor): Repel embeddings
-            
-        Returns:
-            float: R-fraction value
+            torch.Tensor: R-fraction value.
         """
         attract_norm_squared = torch.sum(attract_z ** 2)
         repel_norm_squared = torch.sum(repel_z ** 2)
         
-        r_fraction = repel_norm_squared / (attract_norm_squared + repel_norm_squared + 1e-10)
+        return repel_norm_squared / (attract_norm_squared + repel_norm_squared)
+    
+    def forward(
+        self, 
+        x: torch.Tensor, 
+        edge_index: Adj,
+        edge_weight: OptTensor = None,
+        edge_label_index: OptTensor = None,
+        **kwargs
+    ) -> Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]:
+        """Forward pass.
         
-        return r_fraction.item()
+        Args:
+            x: The node features.
+            edge_index: The edge indices.
+            edge_weight: One-dimensional edge weights.
+            edge_label_index: Indices of edges for which to compute scores.
+            **kwargs: Additional arguments forwarded to the base model.
+            
+        Returns:
+            If edge_label_index or edge_index is provided as the target for prediction:
+                Attract-repel scores for the provided edges.
+            Otherwise:
+                The concatenated attract-repel node embeddings.
+        """
+        # Get attract and repel embeddings
+        attract_z, repel_z = self.encode(x, edge_index, edge_weight, **kwargs)
+        
+        # If edge_label_index is provided, compute scores for those edges
+        if edge_label_index is not None:
+            src, dst = edge_label_index
+            return self.calculate_scores(
+                attract_z[src], attract_z[dst], 
+                repel_z[src], repel_z[dst]
+            )
+        
+        # If edge_index is specified again specifically for prediction
+        elif 'edge_index' in kwargs:
+            src, dst = kwargs['edge_index']
+            return self.calculate_scores(
+                attract_z[src], attract_z[dst], 
+                repel_z[src], repel_z[dst]
+            )
+        
+        # Otherwise return full node embeddings (concatenated)
+        else:
+            return torch.cat([attract_z, repel_z], dim=1)


### PR DESCRIPTION
## Overview

This PR adds an implementation of the Attract-Repel embedding wrapper as discussed in the paper [["Pseudo-Euclidean Attract-Repel Embeddings for Undirected Graphs"](https://arxiv.org/abs/2106.09671)](https://arxiv.org/abs/2106.09671) (Peysakhovich et al., 2023). The wrapper allows any GNN model to incorporate attract-repel embeddings for improved link prediction performance, especially on graphs with non-transitive relationships.

## Implementation Details

The implementation includes:

1. A general-purpose `AttractRepel` wrapper class that can wrap any GNN model
2. Examples showing how to use the wrapper for link prediction
3. Comprehensive tests for the implementation

## Performance Improvements

I've evaluated the approach across different GNN architectures and datasets. The results consistently show significant improvements:

| Dataset | Model | Traditional AUC | Attract-Repel AUC | Improvement | R-fraction |
|---------|-------|-----------------|-------------------|-------------|------------|
| Cora | GCN | 0.8087 | 0.8818 | +0.0731 | 0.4641 |
| Cora | GAT | 0.8457 | 0.9054 | +0.0597 | 0.4132 |
| Cora | GraphSAGE | 0.8299 | 0.8648 | +0.0349 | 0.5326 |
| CiteSeer | GCN | 0.7697 | 0.8596 | +0.0899 | 0.4873 |
| CiteSeer | GAT | 0.7939 | 0.8571 | +0.0632 | 0.4830 |
| CiteSeer | GraphSAGE | 0.7944 | 0.8039 | +0.0095 | 0.6176 |
| PubMed | GCN | 0.8929 | 0.9589 | +0.0660 | 0.5135 |
| PubMed | GAT | 0.8790 | 0.9055 | +0.0265 | 0.4663 |
| PubMed | GraphSAGE | 0.8638 | 0.9115 | +0.0477 | 0.5672 |

The R-fraction measures the proportion of the embedding explained by the repel component. Higher values indicate more heterophily in the network.

## How It Works

Traditional GNN embeddings rely on dot product similarity, which struggles with non-transitive relationships in graphs. The Attract-Repel approach addresses this by splitting embeddings into two components:

1. **Attract component**: Similar nodes in this space are more likely to connect
2. **Repel component**: Similar nodes in this space are less likely to connect

The link prediction score is calculated as: `attract_score - repel_score`

## Experimental Results

We conducted extensive experiments on both homophilic and heterophilic networks to validate the effectiveness of the Attract-Repel approach and provide guidance on selecting the optimal attract_ratio parameter.

CiteSeer Dataset
![attract_ratio_tuning_CiteSeer_GCN](https://github.com/user-attachments/assets/6aef7810-024a-420e-8950-d38f7f859936)

Actor Dataset
![attract_ratio_tuning_Actor_GCN](https://github.com/user-attachments/assets/4fc83e02-8625-47e5-9e80-c1c994145397)


### Key Findings:

1. **Network structure dictates optimal ratio**: We found a clear relationship between a network's homophily characteristics and its optimal attract_ratio value.

2. **Homophilic networks**: For citation networks like Cora, higher attract ratios (0.8-1.0) consistently perform best, with attract_ratio=1.0 typically yielding the highest AUC scores.

3. **Heterophilic networks**: For networks with heterophilic properties (Cornell, Texas, etc.), lower attract ratios around 0.2 consistently perform best, indicating the importance of repel dimensions.

4. **Consistent pattern**: This pattern was observed across multiple datasets, suggesting a general principle for parameter selection based on network characteristics.

## Implementation Guidance

Based on our experimental results, we recommend the following approach to selecting the attract_ratio parameter:

1. **For highly homophilic networks** (homophily score > 0.7):
   - Use attract_ratio=0.8 often performs best with high AUC but low loss

2. **For heterophilic networks** (homophily score < 0.3):
   - Use attract_ratio=0.2 as a default setting with nice tradeoff between AUC and loss
   - Consider testing values in the range [0.1, 0.3] for fine-tuning

3. **For mixed networks** (homophily score between 0.3-0.7):
   - Start with attract_ratio=0.5
   - Tune based on validation performance, moving toward 0.2 for more heterophilic behavior or toward 0.8 for more homophilic behavior

The attract_ratio parameter effectively controls the balance between modeling similarity vs. difference in connected nodes, allowing the model to adapt to different network structures.



## Usage Example

```python
# Wrap any GNN model with AttractRepel
model = AttractRepel(
    model='GCN',  # Or pass your own model instance
    in_channels=dataset.num_features,
    hidden_channels=128,
    out_channels=64,
    num_layers=2,
    attract_ratio=0.5,  # Control the split between attract/repel dimensions
)

# Use it for link prediction
scores = model(
    x=data.x, 
    edge_index=data.train_pos_edge_index,
    edge_label_index=data.val_pos_edge_index
)

# Access attract and repel embeddings separately
attract_z, repel_z = model.encode(data.x, data.edge_index)
```

## Running the Examples

The PR includes complete examples demonstrating traditional vs. attract-repel approaches:

```bash
# Run with GCN on Cora
python examples/link_pred/attract_repel.py --dataset=Cora --model=GCN

# Try GraphSAGE on CiteSeer
python examples/link_pred/attract_repel.py --dataset=CiteSeer --model=GraphSAGE

# Experiment with different attract/repel ratios
python examples/link_pred/attract_repel.py --dataset=PubMed --model=GAT --attract_ratio=0.7

# Compare with traditional approaches
python examples/link_pred/traditional.py --dataset=Cora --model=GCN
```

## Additional Features

- Calculate R-fraction to measure heterophily: `model.calculate_r_fraction(attract_z, repel_z)`
- Efficient implementation with no additional parameters compared to traditional link predictors
- Compatible with any GNN architecture in PyTorch Geometric

## References

- Paper: [[Pseudo-Euclidean Attract-Repel Embeddings for Undirected Graphs](https://arxiv.org/abs/2106.09671)](https://arxiv.org/abs/2106.09671)
- This PR builds on the basic link prediction example added in PR #10105 and PR #10085 

## Notes

I notice there are one redundant file in this PR that should be removed:

1. `examples/attract_repel_wrapper.py` - This was an early version of the implementation that's been properly replaced by `examples/link_pred/attract_repel.py`

The proper implementation files are:
- `examples/link_pred/attract_repel.py` - The main example using the AttractRepel wrapper
- `examples/link_pred/traditional.py` - The baseline for comparison
- `examples/link_pred/README.md` - Documentation for the examples
- `test/nn/models/test_attract_repel.py` - Tests for the implementation
- `torch_geometric/nn/models/attract_repel.py` - The core implementation

If possible, please exclude the two redundant files when merging this PR.