### PR TITLE
Bi-directional Sampling for NeighborSampler

### DIFF
--- a/test/sampler/test_sampler_neighbor_sampler.py
+++ b/test/sampler/test_sampler_neighbor_sampler.py
@@ -1,46 +1,46 @@
 import pytest
 import torch
-
+from torch_geometric.testing import onlyNeighborSampler, MyGraphStore, MyFeatureStore
 from torch_geometric.data import Data, HeteroData
 from torch_geometric.sampler.base import NodeSamplerInput, SamplerOutput
 from torch_geometric.sampler.neighbor_sampler import NeighborSampler
-from torch_geometric.testing import (
-    MyFeatureStore,
-    MyGraphStore,
-    onlyNeighborSampler,
-)
 
 
 def _init_sample_graph(hetero=False):
-    """Initializes the following graph.
+    """ Initializes the following graph.
 
     #############                    ###########
     # Alice (0) # -> "works with" -> # Bob (1) #
     #############                    ###########
          |
          v
-      "leads"
+      "leads" 
          |
          v
     #############                    ############
     # Carol (2) # -> "works with" -> # Dave (3) #
     #############                    ############
     """
-    sample_x = torch.tensor([[0], [1], [2], [3]])
+
+    sample_x = torch.tensor([[0],[1],[2],[3]])
 
     if not hetero:
-        sample_edge_indices = torch.tensor([[0, 0, 2], [1, 2, 3]])
+        sample_edge_indices = torch.tensor([
+            [0,0,2],
+            [1,2,3]
+        ])
     else:
         sample_edge_indices = {
-            ('person', 'works_with', 'person'): {
-                "edge_index": torch.tensor([[0, 2], [1, 3]])
-            },
-            ('person', 'leads', 'person'): {
-                "edge_index": torch.tensor([[0], [2]])
-            }
+            ('person', 'works_with', 'person'): {"edge_index": torch.tensor([
+                [0,2],
+                [1,3]
+            ])},
+            ('person', 'leads', 'person'): {"edge_index": torch.tensor([
+                [0],
+                [2]
+            ])}
         }
     return sample_x, sample_edge_indices
-
 
 def _init_graph_to_sample(graph_dtype, hetero=False):
     sample_x, sample_edge_indices = _init_sample_graph(hetero)
@@ -49,11 +49,9 @@ def _init_graph_to_sample(graph_dtype, hetero=False):
         graph_to_sample = Data(edge_index=sample_edge_indices, x=sample_x)
     elif graph_dtype == 'remote' and not hetero:
         graph_store = MyGraphStore()
-        graph_store.put_edge_index(sample_edge_indices, edge_type=None,
-                                   layout='coo', size=(4, 4))
+        graph_store.put_edge_index(sample_edge_indices, edge_type=None, layout='coo', size=(4, 4))
         feature_store = MyFeatureStore()
-        feature_store.put_tensor(sample_x, group_name='person', attr_name='x',
-                                 index=None)
+        feature_store.put_tensor(sample_x, group_name='person', attr_name='x', index=None)
         graph_to_sample = (feature_store, graph_store)
     elif graph_dtype == 'data' and hetero:
         graph_to_sample = HeteroData(sample_edge_indices)
@@ -62,15 +60,11 @@ def _init_graph_to_sample(graph_dtype, hetero=False):
         graph_store = MyGraphStore()
         for edge_type, edge_index in sample_edge_indices.items():
             edge_index = edge_index["edge_index"]
-            graph_store.put_edge_index(
-                edge_index, edge_type=edge_type, layout='coo',
-                size=(1 + torch.max(edge_index, dim=1).values))
+            graph_store.put_edge_index(edge_index, edge_type=edge_type, layout='coo', size=(1+torch.max(edge_index, dim=1).values))
         feature_store = MyFeatureStore()
-        feature_store.put_tensor(sample_x, group_name='person', attr_name='x',
-                                 index=None)
+        feature_store.put_tensor(sample_x, group_name='person', attr_name='x', index=None)
         graph_to_sample = (feature_store, graph_store)
     return graph_to_sample
-
 
 @onlyNeighborSampler
 @pytest.mark.parametrize('input_type', ['data', 'remote'])
@@ -86,30 +80,41 @@ def test_homogeneous_neighbor_sampler_basic(input_type):
     }
 
     # Sampling from Bob should yield only Alice
-    node_sampler_input = NodeSamplerInput(input_id=None,
-                                          node=torch.tensor([1]))
+    node_sampler_input = NodeSamplerInput(input_id=None, node=torch.tensor([1]))
     expected_output = SamplerOutput(
-        node=torch.tensor([1, 0]), row=torch.tensor([1]),
-        col=torch.tensor([0]), edge=torch.tensor([0]), batch=None,
-        num_sampled_nodes=[1, 1], num_sampled_edges=[1], orig_row=None,
-        orig_col=None, metadata=(None, None))
+        node=torch.tensor([1, 0]),
+        row=torch.tensor([1]),
+        col=torch.tensor([0]),
+        edge=torch.tensor([0]),
+        batch=None,
+        num_sampled_nodes=[1, 1],
+        num_sampled_edges=[1],
+        orig_row=None,
+        orig_col=None,
+        metadata=(None, None)
+    )
     sampler = NeighborSampler(**sampler_kwargs)
     sampler_output = sampler.sample_from_nodes(node_sampler_input)
     assert str(sampler_output) == str(expected_output)
+
 
     # Sampling Alice should yield no edges
-    node_sampler_input = NodeSamplerInput(input_id=None,
-                                          node=torch.tensor([0]))
-    expected_output = SamplerOutput(node=torch.tensor([0]), row=torch.empty(
-        0, dtype=torch.int64), col=torch.empty(0, dtype=torch.int64),
-                                    edge=torch.empty(0, dtype=torch.int64),
-                                    batch=None, num_sampled_nodes=[1, 0],
-                                    num_sampled_edges=[0], orig_row=None,
-                                    orig_col=None, metadata=(None, None))
+    node_sampler_input = NodeSamplerInput(input_id=None, node=torch.tensor([0]))
+    expected_output = SamplerOutput(
+        node=torch.tensor([0]),
+        row=torch.empty(0, dtype=torch.int64),
+        col=torch.empty(0, dtype=torch.int64),
+        edge=torch.empty(0, dtype=torch.int64),
+        batch=None,
+        num_sampled_nodes=[1, 0],
+        num_sampled_edges=[0],
+        orig_row=None,
+        orig_col=None,
+        metadata=(None, None)
+    )
     sampler = NeighborSampler(**sampler_kwargs)
     sampler_output = sampler.sample_from_nodes(node_sampler_input)
     assert str(sampler_output) == str(expected_output)
-
 
 @onlyNeighborSampler
 @pytest.mark.parametrize('input_type', ['data', 'remote'])
@@ -125,28 +130,21 @@ def test_heterogeneous_neighbor_sampler_basic(input_type):
     }
 
     # Sampling from Bob should yield only Alice
-    node_sampler_input = NodeSamplerInput(input_id=None,
-                                          node=torch.tensor([1]),
-                                          input_type="person")
+    node_sampler_input = NodeSamplerInput(input_id=None, node=torch.tensor([1]), input_type="person")
     sampler = NeighborSampler(**sampler_kwargs)
     sampler_output = sampler.sample_from_nodes(node_sampler_input)
-    assert set(sampler_output.node['person'].tolist()) == {1, 0}
-    assert sampler_output.row[('person', 'works_with',
-                               'person')] == torch.tensor([1])
+    assert set(sampler_output.node['person'].tolist()) == set([1, 0])
+    assert sampler_output.row[('person', 'works_with', 'person')] == torch.tensor([1])
     assert sampler_output.row[('person', 'leads', 'person')].numel() == 0
-    assert sampler_output.col[('person', 'works_with',
-                               'person')] == torch.tensor([0])
+    assert sampler_output.col[('person', 'works_with', 'person')] == torch.tensor([0])
     assert sampler_output.col[('person', 'leads', 'person')].numel() == 0
-    assert sampler_output.edge[('person', 'works_with',
-                                'person')] == torch.tensor([0])
+    assert sampler_output.edge[('person', 'works_with', 'person')] == torch.tensor([0])
     assert sampler_output.edge[('person', 'leads', 'person')].numel() == 0
 
     # Sampling Alice should yield no edges
-    node_sampler_input = NodeSamplerInput(input_id=None,
-                                          node=torch.tensor([0]),
-                                          input_type="person")
+    node_sampler_input = NodeSamplerInput(input_id=None, node=torch.tensor([0]), input_type="person")
     sampler_output = sampler.sample_from_nodes(node_sampler_input)
-    assert set(sampler_output.node['person'].tolist()) == {0}
+    assert set(sampler_output.node['person'].tolist()) == set([0])
     assert sampler_output.row[('person', 'works_with', 'person')].numel() == 0
     assert sampler_output.row[('person', 'leads', 'person')].numel() == 0
     assert sampler_output.col[('person', 'works_with', 'person')].numel() == 0

--- a/test/sampler/test_sampler_neighbor_sampler.py
+++ b/test/sampler/test_sampler_neighbor_sampler.py
@@ -1,51 +1,48 @@
 import pytest
 import torch
-from torch_geometric.testing import onlyNeighborSampler, MyGraphStore, MyFeatureStore
+
 from torch_geometric.data import Data, HeteroData
 from torch_geometric.sampler.base import NodeSamplerInput, SamplerOutput
-from torch_geometric.sampler.neighbor_sampler import NeighborSampler, BidirectionalNeighborSampler
+from torch_geometric.sampler.neighbor_sampler import (
+    BidirectionalNeighborSampler,
+    NeighborSampler,
+)
+from torch_geometric.testing import (
+    MyFeatureStore,
+    MyGraphStore,
+    onlyNeighborSampler,
+)
 
 
 def _init_sample_graph(hetero=False):
-    """ Initializes the following graph.
+    """Initializes the following graph.
 
     #############                    ###########
     # Alice (0) # -> "works with" -> # Bob (1) #
     #############                    ###########
          |
          v
-      "leads" 
+      "leads"
          |
          v
     #############                    ############
     # Carol (2) # -> "works with" -> # Dave (3) #
     #############                    ############
     """
-
     # node attributes dont matter much, they are just necessary for heterogeneous graphs to work
-    sample_x = torch.tensor([[0],[1],[2],[3]])
+    sample_x = torch.tensor([[0], [1], [2], [3]])
 
     if not hetero:
-        sample_edge_indices = torch.tensor([
-            [0,0,2],
-            [1,2,3]
-        ])
+        sample_edge_indices = torch.tensor([[0, 0, 2], [1, 2, 3]])
     else:
         sample_edge_indices = dict({
-            ('person', 'works_with', 'person'): dict({
-                "edge_index": torch.tensor([
-                    [0,2],
-                    [1,3]
-                ])
-            }),
-            ('person', 'leads', 'person'): dict({
-                "edge_index": torch.tensor([
-                    [0],
-                    [2]
-                ])
-            })
+            ('person', 'works_with', 'person'):
+            dict({"edge_index": torch.tensor([[0, 2], [1, 3]])}),
+            ('person', 'leads', 'person'):
+            dict({"edge_index": torch.tensor([[0], [2]])})
         })
     return sample_x, sample_edge_indices
+
 
 def _init_graph_to_sample(graph_dtype, hetero=False, reverse=False):
     sample_x, sample_edge_indices = _init_sample_graph(hetero)
@@ -56,15 +53,18 @@ def _init_graph_to_sample(graph_dtype, hetero=False, reverse=False):
             for edge_type, edge_index in sample_edge_indices.items():
                 edge_index = edge_index["edge_index"]
                 flipped_edge_index = edge_index.flip(0)
-                sample_edge_indices[edge_type] = dict({"edge_index": flipped_edge_index})
+                sample_edge_indices[edge_type] = dict(
+                    {"edge_index": flipped_edge_index})
     graph_to_sample = None
     if graph_dtype == 'data' and not hetero:
         graph_to_sample = Data(edge_index=sample_edge_indices, x=sample_x)
     elif graph_dtype == 'remote' and not hetero:
         graph_store = MyGraphStore()
-        graph_store.put_edge_index(sample_edge_indices, edge_type=None, layout='coo', size=(4, 4))
+        graph_store.put_edge_index(sample_edge_indices, edge_type=None,
+                                   layout='coo', size=(4, 4))
         feature_store = MyFeatureStore()
-        feature_store.put_tensor(sample_x, group_name='person', attr_name='x', index=None)
+        feature_store.put_tensor(sample_x, group_name='person', attr_name='x',
+                                 index=None)
         graph_to_sample = (feature_store, graph_store)
     elif graph_dtype == 'data' and hetero:
         graph_to_sample = HeteroData(sample_edge_indices)
@@ -73,11 +73,15 @@ def _init_graph_to_sample(graph_dtype, hetero=False, reverse=False):
         graph_store = MyGraphStore()
         for edge_type, edge_index in sample_edge_indices.items():
             edge_index = edge_index["edge_index"]
-            graph_store.put_edge_index(edge_index, edge_type=edge_type, layout='coo', size=(len(sample_x), len(sample_x)))
+            graph_store.put_edge_index(edge_index, edge_type=edge_type,
+                                       layout='coo',
+                                       size=(len(sample_x), len(sample_x)))
         feature_store = MyFeatureStore()
-        feature_store.put_tensor(sample_x, group_name='person', attr_name='x', index=None)
+        feature_store.put_tensor(sample_x, group_name='person', attr_name='x',
+                                 index=None)
         graph_to_sample = (feature_store, graph_store)
     return graph_to_sample
+
 
 @onlyNeighborSampler
 @pytest.mark.parametrize('input_type', ['data', 'remote'])
@@ -93,41 +97,30 @@ def test_homogeneous_neighbor_sampler_basic(input_type):
     }
 
     # Sampling from Bob should yield only Alice
-    node_sampler_input = NodeSamplerInput(input_id=None, node=torch.tensor([1]))
+    node_sampler_input = NodeSamplerInput(input_id=None,
+                                          node=torch.tensor([1]))
     expected_output = SamplerOutput(
-        node=torch.tensor([1, 0]),
-        row=torch.tensor([1]),
-        col=torch.tensor([0]),
-        edge=torch.tensor([0]),
-        batch=None,
-        num_sampled_nodes=[1, 1],
-        num_sampled_edges=[1],
-        orig_row=None,
-        orig_col=None,
-        metadata=(None, None)
-    )
+        node=torch.tensor([1, 0]), row=torch.tensor([1]),
+        col=torch.tensor([0]), edge=torch.tensor([0]), batch=None,
+        num_sampled_nodes=[1, 1], num_sampled_edges=[1], orig_row=None,
+        orig_col=None, metadata=(None, None))
     sampler = NeighborSampler(**sampler_kwargs)
     sampler_output = sampler.sample_from_nodes(node_sampler_input)
     assert str(sampler_output) == str(expected_output)
-
 
     # Sampling Alice should yield no edges
-    node_sampler_input = NodeSamplerInput(input_id=None, node=torch.tensor([0]))
-    expected_output = SamplerOutput(
-        node=torch.tensor([0]),
-        row=torch.empty(0, dtype=torch.int64),
-        col=torch.empty(0, dtype=torch.int64),
-        edge=torch.empty(0, dtype=torch.int64),
-        batch=None,
-        num_sampled_nodes=[1, 0],
-        num_sampled_edges=[0],
-        orig_row=None,
-        orig_col=None,
-        metadata=(None, None)
-    )
+    node_sampler_input = NodeSamplerInput(input_id=None,
+                                          node=torch.tensor([0]))
+    expected_output = SamplerOutput(node=torch.tensor([0]), row=torch.empty(
+        0, dtype=torch.int64), col=torch.empty(0, dtype=torch.int64),
+                                    edge=torch.empty(0, dtype=torch.int64),
+                                    batch=None, num_sampled_nodes=[1, 0],
+                                    num_sampled_edges=[0], orig_row=None,
+                                    orig_col=None, metadata=(None, None))
     sampler = NeighborSampler(**sampler_kwargs)
     sampler_output = sampler.sample_from_nodes(node_sampler_input)
     assert str(sampler_output) == str(expected_output)
+
 
 @onlyNeighborSampler
 @pytest.mark.parametrize('input_type', ['data', 'remote'])
@@ -143,21 +136,28 @@ def test_heterogeneous_neighbor_sampler_basic(input_type):
     }
 
     # Sampling from Bob should yield only Alice
-    node_sampler_input = NodeSamplerInput(input_id=None, node=torch.tensor([1]), input_type="person")
+    node_sampler_input = NodeSamplerInput(input_id=None,
+                                          node=torch.tensor([1]),
+                                          input_type="person")
     sampler = NeighborSampler(**sampler_kwargs)
     sampler_output = sampler.sample_from_nodes(node_sampler_input)
-    assert set(sampler_output.node['person'].tolist()) == set([1, 0])
-    assert sampler_output.row[('person', 'works_with', 'person')] == torch.tensor([1])
+    assert set(sampler_output.node['person'].tolist()) == {1, 0}
+    assert sampler_output.row[('person', 'works_with',
+                               'person')] == torch.tensor([1])
     assert sampler_output.row[('person', 'leads', 'person')].numel() == 0
-    assert sampler_output.col[('person', 'works_with', 'person')] == torch.tensor([0])
+    assert sampler_output.col[('person', 'works_with',
+                               'person')] == torch.tensor([0])
     assert sampler_output.col[('person', 'leads', 'person')].numel() == 0
-    assert sampler_output.edge[('person', 'works_with', 'person')] == torch.tensor([0])
+    assert sampler_output.edge[('person', 'works_with',
+                                'person')] == torch.tensor([0])
     assert sampler_output.edge[('person', 'leads', 'person')].numel() == 0
 
     # Sampling Alice should yield no edges
-    node_sampler_input = NodeSamplerInput(input_id=None, node=torch.tensor([0]), input_type="person")
+    node_sampler_input = NodeSamplerInput(input_id=None,
+                                          node=torch.tensor([0]),
+                                          input_type="person")
     sampler_output = sampler.sample_from_nodes(node_sampler_input)
-    assert set(sampler_output.node['person'].tolist()) == set([0])
+    assert set(sampler_output.node['person'].tolist()) == {0}
     assert sampler_output.row[('person', 'works_with', 'person')].numel() == 0
     assert sampler_output.row[('person', 'leads', 'person')].numel() == 0
     assert sampler_output.col[('person', 'works_with', 'person')].numel() == 0
@@ -165,10 +165,11 @@ def test_heterogeneous_neighbor_sampler_basic(input_type):
     assert sampler_output.edge[('person', 'works_with', 'person')].numel() == 0
     assert sampler_output.edge[('person', 'leads', 'person')].numel() == 0
 
+
 @onlyNeighborSampler
 @pytest.mark.parametrize('input_type', ['data', 'remote'])
 def test_homogeneous_neighbor_sampler_backwards(input_type):
-    
+
     graph_to_sample = _init_graph_to_sample(input_type, hetero=False)
 
     sampler_kwargs = {
@@ -176,12 +177,12 @@ def test_homogeneous_neighbor_sampler_backwards(input_type):
         'num_neighbors': [1],
     }
 
-    node_sampler_input = NodeSamplerInput(input_id=None, node=torch.tensor([2]))
+    node_sampler_input = NodeSamplerInput(input_id=None,
+                                          node=torch.tensor([2]))
 
     sampler = NeighborSampler(**sampler_kwargs)
     # This output should have Carol and Alice
     sampler_output = sampler.sample_from_nodes(node_sampler_input)
-
 
     backward_sampler_kwargs = {
         'data': graph_to_sample,
@@ -190,9 +191,11 @@ def test_homogeneous_neighbor_sampler_backwards(input_type):
     }
     backward_sampler = NeighborSampler(**backward_sampler_kwargs)
     # This output should have Carol and Dave
-    backward_sampler_output = backward_sampler.sample_from_nodes(node_sampler_input)
+    backward_sampler_output = backward_sampler.sample_from_nodes(
+        node_sampler_input)
 
-    reverse_graph_to_sample = _init_graph_to_sample(input_type, hetero=False, reverse=True)
+    reverse_graph_to_sample = _init_graph_to_sample(input_type, hetero=False,
+                                                    reverse=True)
 
     reverse_sampler_kwargs = {
         'data': reverse_graph_to_sample,
@@ -201,7 +204,8 @@ def test_homogeneous_neighbor_sampler_backwards(input_type):
 
     reverse_sampler = NeighborSampler(**reverse_sampler_kwargs)
     # This output should have Carol and Dave
-    reverse_sampler_output = reverse_sampler.sample_from_nodes(node_sampler_input)
+    reverse_sampler_output = reverse_sampler.sample_from_nodes(
+        node_sampler_input)
 
     reverse_backward_sampler_kwargs = {
         'data': reverse_graph_to_sample,
@@ -209,19 +213,25 @@ def test_homogeneous_neighbor_sampler_backwards(input_type):
         'sample_direction': 'backward',
     }
 
-    reverse_backward_sampler = NeighborSampler(**reverse_backward_sampler_kwargs)
+    reverse_backward_sampler = NeighborSampler(
+        **reverse_backward_sampler_kwargs)
     # This output should have Carol and Alice
-    reverse_backward_sampler_output = reverse_backward_sampler.sample_from_nodes(node_sampler_input)
+    reverse_backward_sampler_output = reverse_backward_sampler.sample_from_nodes(
+        node_sampler_input)
 
-    assert torch.equal(sampler_output.node, reverse_backward_sampler_output.node)
+    assert torch.equal(sampler_output.node,
+                       reverse_backward_sampler_output.node)
     assert torch.equal(sampler_output.row, reverse_backward_sampler_output.col)
     assert torch.equal(sampler_output.col, reverse_backward_sampler_output.row)
-    assert torch.equal(sampler_output.edge, reverse_backward_sampler_output.edge)
+    assert torch.equal(sampler_output.edge,
+                       reverse_backward_sampler_output.edge)
 
-    assert torch.equal(backward_sampler_output.node, reverse_sampler_output.node)
+    assert torch.equal(backward_sampler_output.node,
+                       reverse_sampler_output.node)
     assert torch.equal(backward_sampler_output.row, reverse_sampler_output.col)
     assert torch.equal(backward_sampler_output.col, reverse_sampler_output.row)
-    assert torch.equal(backward_sampler_output.edge, reverse_sampler_output.edge)
+    assert torch.equal(backward_sampler_output.edge,
+                       reverse_sampler_output.edge)
 
 
 @onlyNeighborSampler
@@ -234,12 +244,13 @@ def test_heterogeneous_neighbor_sampler_backwards(input_type):
         'num_neighbors': [1],
     }
 
-    node_sampler_input = NodeSamplerInput(input_id=None, node=torch.tensor([2]), input_type="person")
+    node_sampler_input = NodeSamplerInput(input_id=None,
+                                          node=torch.tensor([2]),
+                                          input_type="person")
 
     sampler = NeighborSampler(**sampler_kwargs)
     # This output should have Carol and Alice
     sampler_output = sampler.sample_from_nodes(node_sampler_input)
-
 
     backward_sampler_kwargs = {
         'data': graph_to_sample,
@@ -248,9 +259,11 @@ def test_heterogeneous_neighbor_sampler_backwards(input_type):
     }
     backward_sampler = NeighborSampler(**backward_sampler_kwargs)
     # This output should have Carol and Dave
-    backward_sampler_output = backward_sampler.sample_from_nodes(node_sampler_input)
+    backward_sampler_output = backward_sampler.sample_from_nodes(
+        node_sampler_input)
 
-    reverse_graph_to_sample = _init_graph_to_sample(input_type, hetero=True, reverse=True)
+    reverse_graph_to_sample = _init_graph_to_sample(input_type, hetero=True,
+                                                    reverse=True)
 
     reverse_sampler_kwargs = {
         'data': reverse_graph_to_sample,
@@ -259,7 +272,8 @@ def test_heterogeneous_neighbor_sampler_backwards(input_type):
 
     reverse_sampler = NeighborSampler(**reverse_sampler_kwargs)
     # This output should have Carol and Dave
-    reverse_sampler_output = reverse_sampler.sample_from_nodes(node_sampler_input)
+    reverse_sampler_output = reverse_sampler.sample_from_nodes(
+        node_sampler_input)
 
     reverse_backward_sampler_kwargs = {
         'data': reverse_graph_to_sample,
@@ -267,28 +281,43 @@ def test_heterogeneous_neighbor_sampler_backwards(input_type):
         'sample_direction': 'backward',
     }
 
-    reverse_backward_sampler = NeighborSampler(**reverse_backward_sampler_kwargs)
+    reverse_backward_sampler = NeighborSampler(
+        **reverse_backward_sampler_kwargs)
     # This output should have Carol and Alice
-    reverse_backward_sampler_output = reverse_backward_sampler.sample_from_nodes(node_sampler_input)
+    reverse_backward_sampler_output = reverse_backward_sampler.sample_from_nodes(
+        node_sampler_input)
 
-    assert sampler_output.node.keys() == reverse_backward_sampler_output.node.keys()
-    assert reverse_sampler_output.node.keys() == backward_sampler_output.node.keys()
+    assert sampler_output.node.keys(
+    ) == reverse_backward_sampler_output.node.keys()
+    assert reverse_sampler_output.node.keys(
+    ) == backward_sampler_output.node.keys()
     for key in sampler_output.node.keys():
-        assert torch.equal(sampler_output.node[key], reverse_backward_sampler_output.node[key])
+        assert torch.equal(sampler_output.node[key],
+                           reverse_backward_sampler_output.node[key])
     for key in reverse_sampler_output.node.keys():
-        assert torch.equal(reverse_sampler_output.node[key], backward_sampler_output.node[key])
-    
-    assert sampler_output.row.keys() == reverse_backward_sampler_output.row.keys()
-    assert reverse_sampler_output.row.keys() == backward_sampler_output.row.keys()
+        assert torch.equal(reverse_sampler_output.node[key],
+                           backward_sampler_output.node[key])
+
+    assert sampler_output.row.keys(
+    ) == reverse_backward_sampler_output.row.keys()
+    assert reverse_sampler_output.row.keys(
+    ) == backward_sampler_output.row.keys()
     for key in sampler_output.row.keys():
-        assert torch.equal(sampler_output.row[key], reverse_backward_sampler_output.col[key])
-        assert torch.equal(sampler_output.col[key], reverse_backward_sampler_output.row[key])
-        assert torch.equal(sampler_output.edge[key], reverse_backward_sampler_output.edge[key])
+        assert torch.equal(sampler_output.row[key],
+                           reverse_backward_sampler_output.col[key])
+        assert torch.equal(sampler_output.col[key],
+                           reverse_backward_sampler_output.row[key])
+        assert torch.equal(sampler_output.edge[key],
+                           reverse_backward_sampler_output.edge[key])
     for key in reverse_sampler_output.row.keys():
-        assert torch.equal(reverse_sampler_output.row[key], backward_sampler_output.col[key])
-        assert torch.equal(reverse_sampler_output.col[key], backward_sampler_output.row[key])
-        assert torch.equal(reverse_sampler_output.edge[key], backward_sampler_output.edge[key])
-    
+        assert torch.equal(reverse_sampler_output.row[key],
+                           backward_sampler_output.col[key])
+        assert torch.equal(reverse_sampler_output.col[key],
+                           backward_sampler_output.row[key])
+        assert torch.equal(reverse_sampler_output.edge[key],
+                           backward_sampler_output.edge[key])
+
+
 @onlyNeighborSampler
 @pytest.mark.parametrize('input_type', ['data', 'remote'])
 def test_bidirectional_neighbor_sampler(input_type):
@@ -299,35 +328,38 @@ def test_bidirectional_neighbor_sampler(input_type):
         'num_neighbors': [1],
     }
 
-    node_sampler_input = NodeSamplerInput(input_id=None, node=torch.tensor([2]))
+    node_sampler_input = NodeSamplerInput(input_id=None,
+                                          node=torch.tensor([2]))
     sampler = BidirectionalNeighborSampler(**sampler_kwargs)
     sampler_output = sampler.sample_from_nodes(node_sampler_input)
 
     expected_output = SamplerOutput(
         # Union between forward and backward nodes
-        node=torch.tensor([0, 2, 3]),           
+        node=torch.tensor([0, 2, 3]),
         # Reindexed to be relative to new nodes field
-        row=torch.tensor([0, 1]),               
+        row=torch.tensor([0, 1]),
         # Reindexed to be relative to new nodes field
-        col=torch.tensor([1, 2]),               
+        col=torch.tensor([1, 2]),
         # Union between forward and backward edges
-        edge=torch.tensor([1, 2]),              
+        edge=torch.tensor([1, 2]),
         # Will be part of node uid if disjoint=True
-        batch=None,                             
+        batch=None,
         # nodes are only counted on their first sample
-        num_sampled_nodes=[1,1,0,1],            
+        num_sampled_nodes=[1, 1, 0, 1],
         # edges are only counted on their first sample
-        num_sampled_edges=[1,1],                
+        num_sampled_edges=[1, 1],
         # Will be used as edge uid if bidirectional=True with keep_orig_edges=True
-        orig_row=None,                          
+        orig_row=None,
         # Will be used as edge uid if bidirectional=True with keep_orig_edges=True
-        orig_col=None,                          
+        orig_col=None,
         # simple concat of forward and backward metadata
-        metadata=[(None, None), (None, None)]   
-    )
+        metadata=[(None, None), (None, None)])
     assert str(sampler_output) == str(expected_output)
 
-@pytest.mark.skip(reason="BidirectionalSampler is not implemented yet for heterogeneous graphs.")
+
+@pytest.mark.skip(
+    reason=
+    "BidirectionalSampler is not implemented yet for heterogeneous graphs.")
 @onlyNeighborSampler
 @pytest.mark.parametrize('input_type', ['data', 'remote'])
 def test_bidirectional_neighbor_sampler_hetero(input_type):

--- a/test/sampler/test_sampler_neighbor_sampler.py
+++ b/test/sampler/test_sampler_neighbor_sampler.py
@@ -96,8 +96,8 @@ def test_homogeneous_neighbor_sampler_basic(input_type):
     node_sampler_input = NodeSamplerInput(input_id=None, node=torch.tensor([1]))
     expected_output = SamplerOutput(
         node=torch.tensor([1, 0]),
-        row=torch.tensor([0]),
-        col=torch.tensor([1]),
+        row=torch.tensor([1]),
+        col=torch.tensor([0]),
         edge=torch.tensor([0]),
         batch=None,
         num_sampled_nodes=[1, 1],
@@ -147,9 +147,9 @@ def test_heterogeneous_neighbor_sampler_basic(input_type):
     sampler = NeighborSampler(**sampler_kwargs)
     sampler_output = sampler.sample_from_nodes(node_sampler_input)
     assert set(sampler_output.node['person'].tolist()) == set([1, 0])
-    assert sampler_output.row[('person', 'works_with', 'person')] == torch.tensor([0])
+    assert sampler_output.row[('person', 'works_with', 'person')] == torch.tensor([1])
     assert sampler_output.row[('person', 'leads', 'person')].numel() == 0
-    assert sampler_output.col[('person', 'works_with', 'person')] == torch.tensor([1])
+    assert sampler_output.col[('person', 'works_with', 'person')] == torch.tensor([0])
     assert sampler_output.col[('person', 'leads', 'person')].numel() == 0
     assert sampler_output.edge[('person', 'works_with', 'person')] == torch.tensor([0])
     assert sampler_output.edge[('person', 'leads', 'person')].numel() == 0
@@ -304,16 +304,26 @@ def test_bidirectional_neighbor_sampler(input_type):
     sampler_output = sampler.sample_from_nodes(node_sampler_input)
 
     expected_output = SamplerOutput(
-        node=torch.tensor([0, 2, 3]),           # Union between forward and backward nodes
-        row=torch.tensor([0, 2]),               # Union between forward and backward edges
-        col=torch.tensor([2, 3]),               # Union between forward and backward edges
-        edge=torch.tensor([1, 2]),              # Union between forward and backward edges
-        batch=None,                             # Will be part of node uid if disjoint=True
-        num_sampled_nodes=[1,1,0,1],            # nodes are only counted on their first sample
-        num_sampled_edges=[1,1],                # edges are only counted on their first sample
-        orig_row=None,                          # Will be used as edge uid if bidirectional=True with keep_orig_edges=True
-        orig_col=None,                          # Will be used as edge uid if bidirectional=True with keep_orig_edges=True
-        metadata=[(None, None), (None, None)]   # simple concat of forward and backward metadata
+        # Union between forward and backward nodes
+        node=torch.tensor([0, 2, 3]),           
+        # Reindexed to be relative to new nodes field
+        row=torch.tensor([0, 1]),               
+        # Reindexed to be relative to new nodes field
+        col=torch.tensor([1, 2]),               
+        # Union between forward and backward edges
+        edge=torch.tensor([1, 2]),              
+        # Will be part of node uid if disjoint=True
+        batch=None,                             
+        # nodes are only counted on their first sample
+        num_sampled_nodes=[1,1,0,1],            
+        # edges are only counted on their first sample
+        num_sampled_edges=[1,1],                
+        # Will be used as edge uid if bidirectional=True with keep_orig_edges=True
+        orig_row=None,                          
+        # Will be used as edge uid if bidirectional=True with keep_orig_edges=True
+        orig_col=None,                          
+        # simple concat of forward and backward metadata
+        metadata=[(None, None), (None, None)]   
     )
     assert str(sampler_output) == str(expected_output)
 

--- a/test/sampler/test_sampler_neighbor_sampler.py
+++ b/test/sampler/test_sampler_neighbor_sampler.py
@@ -224,6 +224,7 @@ def test_homogeneous_neighbor_sampler_backwards(input_type):
     assert torch.equal(backward_sampler_output.edge, reverse_sampler_output.edge)
 
 
+@onlyNeighborSampler
 @pytest.mark.parametrize('input_type', ['data', 'remote'])
 def test_heterogeneous_neighbor_sampler_backwards(input_type):
     graph_to_sample = _init_graph_to_sample(input_type, hetero=True)

--- a/test/sampler/test_sampler_neighbor_sampler.py
+++ b/test/sampler/test_sampler_neighbor_sampler.py
@@ -305,8 +305,8 @@ def test_bidirectional_neighbor_sampler(input_type):
 
     expected_output = SamplerOutput(
         node=torch.tensor([0, 2, 3]),           # Union between forward and backward nodes
-        row=torch.tensor([1, 1]),               # Union between forward and backward edges
-        col=torch.tensor([0, 0]),               # Union between forward and backward edges
+        row=torch.tensor([0, 2]),               # Union between forward and backward edges
+        col=torch.tensor([2, 3]),               # Union between forward and backward edges
         edge=torch.tensor([1, 2]),              # Union between forward and backward edges
         batch=None,                             # Will be part of node uid if disjoint=True
         num_sampled_nodes=[1,1,0,1],            # nodes are only counted on their first sample

--- a/test/sampler/test_sampler_neighbor_sampler.py
+++ b/test/sampler/test_sampler_neighbor_sampler.py
@@ -151,3 +151,22 @@ def test_heterogeneous_neighbor_sampler_basic(input_type):
     assert sampler_output.col[('person', 'leads', 'person')].numel() == 0
     assert sampler_output.edge[('person', 'works_with', 'person')].numel() == 0
     assert sampler_output.edge[('person', 'leads', 'person')].numel() == 0
+
+@onlyNeighborSampler
+@pytest.mark.parametrize('input_type', ['data', 'remote'])
+def test_homogeneous_neighbor_sampler_backwards(input_type):
+    
+    # 1) old graph: Sample forward from Carol
+    # 2) old graph: Sample backwards from Carol
+    # 3) Reinitialize with reverse edge indices
+    # 4) new graph: Sample forward from Carol
+    # 5) new graph: Sample backwards from Carol
+    # 6) assert that old_graph forward == new_graph backward
+    # 7) assert that old_graph backward == new_graph forward
+    pass
+ 
+
+@onlyNeighborSampler
+@pytest.mark.parametrize('input_type', ['data', 'remote'])
+def test_heterogeneous_neighbor_sampler_backwards(input_type):
+    pass

--- a/test/sampler/test_sampler_neighbor_sampler.py
+++ b/test/sampler/test_sampler_neighbor_sampler.py
@@ -22,6 +22,7 @@ def _init_sample_graph(hetero=False):
     #############                    ############
     """
 
+    # node attributes dont matter much, they are just necessary for heterogeneous graphs to work
     sample_x = torch.tensor([[0],[1],[2],[3]])
 
     if not hetero:
@@ -30,20 +31,32 @@ def _init_sample_graph(hetero=False):
             [1,2,3]
         ])
     else:
-        sample_edge_indices = {
-            ('person', 'works_with', 'person'): {"edge_index": torch.tensor([
-                [0,2],
-                [1,3]
-            ])},
-            ('person', 'leads', 'person'): {"edge_index": torch.tensor([
-                [0],
-                [2]
-            ])}
-        }
+        sample_edge_indices = dict({
+            ('person', 'works_with', 'person'): dict({
+                "edge_index": torch.tensor([
+                    [0,2],
+                    [1,3]
+                ])
+            }),
+            ('person', 'leads', 'person'): dict({
+                "edge_index": torch.tensor([
+                    [0],
+                    [2]
+                ])
+            })
+        })
     return sample_x, sample_edge_indices
 
-def _init_graph_to_sample(graph_dtype, hetero=False):
+def _init_graph_to_sample(graph_dtype, hetero=False, reverse=False):
     sample_x, sample_edge_indices = _init_sample_graph(hetero)
+    if reverse:
+        if not hetero:
+            sample_edge_indices = sample_edge_indices.flip(0)
+        else:
+            for edge_type, edge_index in sample_edge_indices.items():
+                edge_index = edge_index["edge_index"]
+                flipped_edge_index = edge_index.flip(0)
+                sample_edge_indices[edge_type] = dict({"edge_index": flipped_edge_index})
     graph_to_sample = None
     if graph_dtype == 'data' and not hetero:
         graph_to_sample = Data(edge_index=sample_edge_indices, x=sample_x)
@@ -60,7 +73,7 @@ def _init_graph_to_sample(graph_dtype, hetero=False):
         graph_store = MyGraphStore()
         for edge_type, edge_index in sample_edge_indices.items():
             edge_index = edge_index["edge_index"]
-            graph_store.put_edge_index(edge_index, edge_type=edge_type, layout='coo', size=(1+torch.max(edge_index, dim=1).values))
+            graph_store.put_edge_index(edge_index, edge_type=edge_type, layout='coo', size=(len(sample_x), len(sample_x)))
         feature_store = MyFeatureStore()
         feature_store.put_tensor(sample_x, group_name='person', attr_name='x', index=None)
         graph_to_sample = (feature_store, graph_store)
@@ -156,17 +169,122 @@ def test_heterogeneous_neighbor_sampler_basic(input_type):
 @pytest.mark.parametrize('input_type', ['data', 'remote'])
 def test_homogeneous_neighbor_sampler_backwards(input_type):
     
-    # 1) old graph: Sample forward from Carol
-    # 2) old graph: Sample backwards from Carol
-    # 3) Reinitialize with reverse edge indices
-    # 4) new graph: Sample forward from Carol
-    # 5) new graph: Sample backwards from Carol
-    # 6) assert that old_graph forward == new_graph backward
-    # 7) assert that old_graph backward == new_graph forward
-    pass
- 
+    graph_to_sample = _init_graph_to_sample(input_type, hetero=False)
 
-@onlyNeighborSampler
+    sampler_kwargs = {
+        'data': graph_to_sample,
+        'num_neighbors': [1],
+    }
+
+    node_sampler_input = NodeSamplerInput(input_id=None, node=torch.tensor([2]))
+
+    sampler = NeighborSampler(**sampler_kwargs)
+    # This output should have Carol and Alice
+    sampler_output = sampler.sample_from_nodes(node_sampler_input)
+
+
+    backward_sampler_kwargs = {
+        'data': graph_to_sample,
+        'num_neighbors': [1],
+        'sample_direction': 'backward',
+    }
+    backward_sampler = NeighborSampler(**backward_sampler_kwargs)
+    # This output should have Carol and Dave
+    backward_sampler_output = backward_sampler.sample_from_nodes(node_sampler_input)
+
+    reverse_graph_to_sample = _init_graph_to_sample(input_type, hetero=False, reverse=True)
+
+    reverse_sampler_kwargs = {
+        'data': reverse_graph_to_sample,
+        'num_neighbors': [1],
+    }
+
+    reverse_sampler = NeighborSampler(**reverse_sampler_kwargs)
+    # This output should have Carol and Dave
+    reverse_sampler_output = reverse_sampler.sample_from_nodes(node_sampler_input)
+
+    reverse_backward_sampler_kwargs = {
+        'data': reverse_graph_to_sample,
+        'num_neighbors': [1],
+        'sample_direction': 'backward',
+    }
+
+    reverse_backward_sampler = NeighborSampler(**reverse_backward_sampler_kwargs)
+    # This output should have Carol and Alice
+    reverse_backward_sampler_output = reverse_backward_sampler.sample_from_nodes(node_sampler_input)
+
+    assert torch.equal(sampler_output.node, reverse_backward_sampler_output.node)
+    assert torch.equal(sampler_output.row, reverse_backward_sampler_output.row)
+    assert torch.equal(sampler_output.col, reverse_backward_sampler_output.col)
+    assert torch.equal(sampler_output.edge, reverse_backward_sampler_output.edge)
+
+    assert torch.equal(backward_sampler_output.node, reverse_sampler_output.node)
+    assert torch.equal(backward_sampler_output.row, reverse_sampler_output.row)
+    assert torch.equal(backward_sampler_output.col, reverse_sampler_output.col)
+    assert torch.equal(backward_sampler_output.edge, reverse_sampler_output.edge)
+
+
 @pytest.mark.parametrize('input_type', ['data', 'remote'])
 def test_heterogeneous_neighbor_sampler_backwards(input_type):
-    pass
+    graph_to_sample = _init_graph_to_sample(input_type, hetero=True)
+
+    sampler_kwargs = {
+        'data': graph_to_sample,
+        'num_neighbors': [1],
+    }
+
+    node_sampler_input = NodeSamplerInput(input_id=None, node=torch.tensor([2]), input_type="person")
+
+    sampler = NeighborSampler(**sampler_kwargs)
+    # This output should have Carol and Alice
+    sampler_output = sampler.sample_from_nodes(node_sampler_input)
+
+
+    backward_sampler_kwargs = {
+        'data': graph_to_sample,
+        'num_neighbors': [1],
+        'sample_direction': 'backward',
+    }
+    backward_sampler = NeighborSampler(**backward_sampler_kwargs)
+    # This output should have Carol and Dave
+    backward_sampler_output = backward_sampler.sample_from_nodes(node_sampler_input)
+
+    reverse_graph_to_sample = _init_graph_to_sample(input_type, hetero=True, reverse=True)
+
+    reverse_sampler_kwargs = {
+        'data': reverse_graph_to_sample,
+        'num_neighbors': [1],
+    }
+
+    reverse_sampler = NeighborSampler(**reverse_sampler_kwargs)
+    # This output should have Carol and Dave
+    reverse_sampler_output = reverse_sampler.sample_from_nodes(node_sampler_input)
+
+    reverse_backward_sampler_kwargs = {
+        'data': reverse_graph_to_sample,
+        'num_neighbors': [1],
+        'sample_direction': 'backward',
+    }
+
+    reverse_backward_sampler = NeighborSampler(**reverse_backward_sampler_kwargs)
+    # This output should have Carol and Alice
+    reverse_backward_sampler_output = reverse_backward_sampler.sample_from_nodes(node_sampler_input)
+
+    assert sampler_output.node.keys() == reverse_backward_sampler_output.node.keys()
+    assert reverse_sampler_output.node.keys() == backward_sampler_output.node.keys()
+    for key in sampler_output.node.keys():
+        assert torch.equal(sampler_output.node[key], reverse_backward_sampler_output.node[key])
+    for key in reverse_sampler_output.node.keys():
+        assert torch.equal(reverse_sampler_output.node[key], backward_sampler_output.node[key])
+    
+    assert sampler_output.row.keys() == reverse_backward_sampler_output.row.keys()
+    assert reverse_sampler_output.row.keys() == backward_sampler_output.row.keys()
+    for key in sampler_output.row.keys():
+        assert torch.equal(sampler_output.row[key], reverse_backward_sampler_output.row[key])
+        assert torch.equal(sampler_output.col[key], reverse_backward_sampler_output.col[key])
+        assert torch.equal(sampler_output.edge[key], reverse_backward_sampler_output.edge[key])
+    for key in reverse_sampler_output.row.keys():
+        assert torch.equal(reverse_sampler_output.row[key], backward_sampler_output.row[key])
+        assert torch.equal(reverse_sampler_output.col[key], backward_sampler_output.col[key])
+        assert torch.equal(reverse_sampler_output.edge[key], backward_sampler_output.edge[key])
+    

--- a/test/sampler/test_sampler_neighbor_sampler.py
+++ b/test/sampler/test_sampler_neighbor_sampler.py
@@ -96,8 +96,8 @@ def test_homogeneous_neighbor_sampler_basic(input_type):
     node_sampler_input = NodeSamplerInput(input_id=None, node=torch.tensor([1]))
     expected_output = SamplerOutput(
         node=torch.tensor([1, 0]),
-        row=torch.tensor([1]),
-        col=torch.tensor([0]),
+        row=torch.tensor([0]),
+        col=torch.tensor([1]),
         edge=torch.tensor([0]),
         batch=None,
         num_sampled_nodes=[1, 1],
@@ -147,9 +147,9 @@ def test_heterogeneous_neighbor_sampler_basic(input_type):
     sampler = NeighborSampler(**sampler_kwargs)
     sampler_output = sampler.sample_from_nodes(node_sampler_input)
     assert set(sampler_output.node['person'].tolist()) == set([1, 0])
-    assert sampler_output.row[('person', 'works_with', 'person')] == torch.tensor([1])
+    assert sampler_output.row[('person', 'works_with', 'person')] == torch.tensor([0])
     assert sampler_output.row[('person', 'leads', 'person')].numel() == 0
-    assert sampler_output.col[('person', 'works_with', 'person')] == torch.tensor([0])
+    assert sampler_output.col[('person', 'works_with', 'person')] == torch.tensor([1])
     assert sampler_output.col[('person', 'leads', 'person')].numel() == 0
     assert sampler_output.edge[('person', 'works_with', 'person')] == torch.tensor([0])
     assert sampler_output.edge[('person', 'leads', 'person')].numel() == 0
@@ -214,13 +214,13 @@ def test_homogeneous_neighbor_sampler_backwards(input_type):
     reverse_backward_sampler_output = reverse_backward_sampler.sample_from_nodes(node_sampler_input)
 
     assert torch.equal(sampler_output.node, reverse_backward_sampler_output.node)
-    assert torch.equal(sampler_output.row, reverse_backward_sampler_output.row)
-    assert torch.equal(sampler_output.col, reverse_backward_sampler_output.col)
+    assert torch.equal(sampler_output.row, reverse_backward_sampler_output.col)
+    assert torch.equal(sampler_output.col, reverse_backward_sampler_output.row)
     assert torch.equal(sampler_output.edge, reverse_backward_sampler_output.edge)
 
     assert torch.equal(backward_sampler_output.node, reverse_sampler_output.node)
-    assert torch.equal(backward_sampler_output.row, reverse_sampler_output.row)
-    assert torch.equal(backward_sampler_output.col, reverse_sampler_output.col)
+    assert torch.equal(backward_sampler_output.row, reverse_sampler_output.col)
+    assert torch.equal(backward_sampler_output.col, reverse_sampler_output.row)
     assert torch.equal(backward_sampler_output.edge, reverse_sampler_output.edge)
 
 
@@ -281,12 +281,12 @@ def test_heterogeneous_neighbor_sampler_backwards(input_type):
     assert sampler_output.row.keys() == reverse_backward_sampler_output.row.keys()
     assert reverse_sampler_output.row.keys() == backward_sampler_output.row.keys()
     for key in sampler_output.row.keys():
-        assert torch.equal(sampler_output.row[key], reverse_backward_sampler_output.row[key])
-        assert torch.equal(sampler_output.col[key], reverse_backward_sampler_output.col[key])
+        assert torch.equal(sampler_output.row[key], reverse_backward_sampler_output.col[key])
+        assert torch.equal(sampler_output.col[key], reverse_backward_sampler_output.row[key])
         assert torch.equal(sampler_output.edge[key], reverse_backward_sampler_output.edge[key])
     for key in reverse_sampler_output.row.keys():
-        assert torch.equal(reverse_sampler_output.row[key], backward_sampler_output.row[key])
-        assert torch.equal(reverse_sampler_output.col[key], backward_sampler_output.col[key])
+        assert torch.equal(reverse_sampler_output.row[key], backward_sampler_output.col[key])
+        assert torch.equal(reverse_sampler_output.col[key], backward_sampler_output.row[key])
         assert torch.equal(reverse_sampler_output.edge[key], backward_sampler_output.edge[key])
     
 @onlyNeighborSampler

--- a/test/sampler/test_sampler_neighbor_sampler.py
+++ b/test/sampler/test_sampler_neighbor_sampler.py
@@ -29,7 +29,8 @@ def _init_sample_graph(hetero=False):
     # Carol (2) # -> "works with" -> # Dave (3) #
     #############                    ############
     """
-    # node attributes dont matter much, they are just necessary for heterogeneous graphs to work
+    # node attributes dont matter much, they are just necessary for
+    # heterogeneous graphs to work
     sample_x = torch.tensor([[0], [1], [2], [3]])
 
     if not hetero:
@@ -216,8 +217,8 @@ def test_homogeneous_neighbor_sampler_backwards(input_type):
     reverse_backward_sampler = NeighborSampler(
         **reverse_backward_sampler_kwargs)
     # This output should have Carol and Alice
-    reverse_backward_sampler_output = reverse_backward_sampler.sample_from_nodes(
-        node_sampler_input)
+    reverse_backward_sampler_output = \
+        reverse_backward_sampler.sample_from_nodes(node_sampler_input)
 
     assert torch.equal(sampler_output.node,
                        reverse_backward_sampler_output.node)
@@ -284,8 +285,8 @@ def test_heterogeneous_neighbor_sampler_backwards(input_type):
     reverse_backward_sampler = NeighborSampler(
         **reverse_backward_sampler_kwargs)
     # This output should have Carol and Alice
-    reverse_backward_sampler_output = reverse_backward_sampler.sample_from_nodes(
-        node_sampler_input)
+    reverse_backward_sampler_output = \
+        reverse_backward_sampler.sample_from_nodes(node_sampler_input)
 
     assert sampler_output.node.keys(
     ) == reverse_backward_sampler_output.node.keys()
@@ -348,9 +349,11 @@ def test_bidirectional_neighbor_sampler(input_type):
         num_sampled_nodes=[1, 1, 0, 1],
         # edges are only counted on their first sample
         num_sampled_edges=[1, 1],
-        # Will be used as edge uid if bidirectional=True with keep_orig_edges=True
+        # Will be used as edge uid if bidirectional=True with
+        # keep_orig_edges=True
         orig_row=None,
-        # Will be used as edge uid if bidirectional=True with keep_orig_edges=True
+        # Will be used as edge uid if bidirectional=True with
+        # keep_orig_edges=True
         orig_col=None,
         # simple concat of forward and backward metadata
         metadata=[(None, None), (None, None)])
@@ -358,8 +361,8 @@ def test_bidirectional_neighbor_sampler(input_type):
 
 
 @pytest.mark.skip(
-    reason=
-    "BidirectionalSampler is not implemented yet for heterogeneous graphs.")
+    reason="BidirectionalSampler not implemented yet for heterogeneous graphs."
+)
 @onlyNeighborSampler
 @pytest.mark.parametrize('input_type', ['data', 'remote'])
 def test_bidirectional_neighbor_sampler_hetero(input_type):

--- a/torch_geometric/sampler/__init__.py
+++ b/torch_geometric/sampler/__init__.py
@@ -3,7 +3,7 @@ r"""Graph sampler package."""
 from .base import (BaseSampler, NodeSamplerInput, EdgeSamplerInput,
                    SamplerOutput, HeteroSamplerOutput, NegativeSampling,
                    NumNeighbors)
-from .neighbor_sampler import NeighborSampler
+from .neighbor_sampler import NeighborSampler, BidirectionalNeighborSampler
 from .hgt_sampler import HGTSampler
 
 __all__ = classes = [
@@ -15,5 +15,6 @@ __all__ = classes = [
     'NumNeighbors',
     'NegativeSampling',
     'NeighborSampler',
+    'BidirectionalNeighborSampler',
     'HGTSampler',
 ]

--- a/torch_geometric/sampler/base.py
+++ b/torch_geometric/sampler/base.py
@@ -236,7 +236,7 @@ class SamplerOutput(CastMixin):
         )
 
         return out
-    
+
     @classmethod
     def collate(cls, outputs: List['SamplerOutput']) -> 'SamplerOutput':
         r"""Collate a list of :class:`~torch_geometric.sampler.SamplerOutput`
@@ -260,13 +260,15 @@ class SamplerOutput(CastMixin):
                 assert out.num_sampled_nodes is not None == has_num_sampled_nodes
                 assert out.num_sampled_edges is not None == has_num_sampled_edges
         except AssertionError:
-            raise ValueError(f"Output {i} has a different field than the first output")
-        
+            raise ValueError(
+                f"Output {i} has a different field than the first output")
+
         for other in outputs[1:]:
-            out = out.merge_with(other) 
-        return out 
-    
-    def merge_with(self, other: 'SamplerOutput', replace: bool = False) -> 'SamplerOutput':
+            out = out.merge_with(other)
+        return out
+
+    def merge_with(self, other: 'SamplerOutput',
+                   replace: bool = False) -> 'SamplerOutput':
         """Merges two SamplerOutputs. If replace is False, self's nodes and edges take precedence.
         """
         if replace:
@@ -274,16 +276,30 @@ class SamplerOutput(CastMixin):
                 node=torch.cat([self.node, other.node], dim=0),
                 row=torch.cat([self.row, len(self.node) + other.row], dim=0),
                 col=torch.cat([self.col, len(self.node) + other.col], dim=0),
-                edge=torch.cat([self.edge, other.edge], dim=0) if self.edge is not None and other.edge is not None else None,
-                batch=torch.cat([self.batch, other.batch], dim=0) if self.batch is not None and other.batch is not None else None,
-                num_sampled_nodes=self.num_sampled_nodes + other.num_sampled_nodes if self.num_sampled_nodes is not None and other.num_sampled_nodes is not None else None,
-                num_sampled_edges=self.num_sampled_edges + other.num_sampled_edges if self.num_sampled_edges is not None and other.num_sampled_edges is not None else None,
-                orig_row=torch.cat([self.orig_row, len(self.node) + other.orig_row], dim=0) if self.orig_row is not None and other.orig_row is not None else None,
-                orig_col=torch.cat([self.orig_col, len(self.node) + other.orig_col], dim=0) if self.orig_col is not None and other.orig_col is not None else None,
+                edge=torch.cat([self.edge, other.edge], dim=0)
+                if self.edge is not None and other.edge is not None else None,
+                batch=torch.cat([self.batch, other.batch], dim=0) if
+                self.batch is not None and other.batch is not None else None,
+                num_sampled_nodes=self.num_sampled_nodes +
+                other.num_sampled_nodes if self.num_sampled_nodes is not None
+                and other.num_sampled_nodes is not None else None,
+                num_sampled_edges=self.num_sampled_edges +
+                other.num_sampled_edges if self.num_sampled_edges is not None
+                and other.num_sampled_edges is not None else None,
+                orig_row=torch.cat(
+                    [self.orig_row,
+                     len(self.node) +
+                     other.orig_row], dim=0) if self.orig_row is not None
+                and other.orig_row is not None else None,
+                orig_col=torch.cat(
+                    [self.orig_col,
+                     len(self.node) +
+                     other.orig_col], dim=0) if self.orig_col is not None
+                and other.orig_col is not None else None,
                 metadata=[self.metadata, other.metadata],
             )
         else:
-            
+
             # NODES
             old_nodes, new_nodes = self.node, other.node
             old_node_uid, new_node_uid = [old_nodes], [new_nodes]
@@ -292,28 +308,34 @@ class SamplerOutput(CastMixin):
             if self.batch is not None and other.batch is not None:
                 old_node_uid.append(self.batch)
                 new_node_uid.append(other.batch)
-            
+
             # NOTE: if any new node fields are added, they need to be merged here
 
             old_node_uid = torch.stack(old_node_uid, dim=1)
             new_node_uid = torch.stack(new_node_uid, dim=1)
 
-            merged_node_uid = torch.cat([old_node_uid, new_node_uid], dim=0).unique(dim=0)
+            merged_node_uid = torch.cat([old_node_uid, new_node_uid],
+                                        dim=0).unique(dim=0)
             num_old_nodes = old_node_uid.shape[0]
 
             # Recompute num sampled nodes for second output, subtracting out nodes already seen in first output
             merged_node_num_sampled_nodes = None
             if self.num_sampled_nodes is not None and other.num_sampled_nodes is not None:
-                merged_node_num_sampled_nodes = copy.copy(self.num_sampled_nodes)
+                merged_node_num_sampled_nodes = copy.copy(
+                    self.num_sampled_nodes)
                 curr_index = 0
                 # NOTE: There's an assumption here that no two nodes will be sampled twice in the same SampleOutput object
                 for minibatch in other.num_sampled_nodes:
-                    size_of_intersect = torch.cat([old_node_uid, new_node_uid[curr_index:curr_index + minibatch]]).unique(dim=0).shape[0] - num_old_nodes
+                    size_of_intersect = torch.cat([
+                        old_node_uid,
+                        new_node_uid[curr_index:curr_index + minibatch]
+                    ]).unique(dim=0).shape[0] - num_old_nodes
                     merged_node_num_sampled_nodes.append(size_of_intersect)
                     curr_index += minibatch
-            
-            merged_nodes = merged_node_uid[:,0]
-            merged_batch = merged_node_uid[:,1] if self.batch is not None and other.batch is not None else None
+
+            merged_nodes = merged_node_uid[:, 0]
+            merged_batch = merged_node_uid[:,
+                                           1] if self.batch is not None and other.batch is not None else None
 
             # EDGES
             is_bidirectional = self.orig_row is not None and self.orig_col is not None and other.orig_row is not None and other.orig_col is not None
@@ -323,48 +345,63 @@ class SamplerOutput(CastMixin):
             else:
                 old_row, old_col = self.row, self.col
                 new_row, new_col = other.row, other.col
-            
+
             # Transform the row and col indices to be global node ids instead of relative indices to nodes field
-            old_row, old_col = torch.index_select(old_nodes, 0, old_row), torch.index_select(old_nodes, 0, old_col)
-            new_row, new_col = torch.index_select(new_nodes, 0, new_row), torch.index_select(new_nodes, 0, new_col)
-            
+            old_row, old_col = torch.index_select(old_nodes, 0,
+                                                  old_row), torch.index_select(
+                                                      old_nodes, 0, old_col)
+            new_row, new_col = torch.index_select(new_nodes, 0,
+                                                  new_row), torch.index_select(
+                                                      new_nodes, 0, new_col)
+
             old_edge_uid, new_edge_uid = [old_row, old_col], [new_row, new_col]
 
             if self.edge is not None and other.edge is not None:
                 old_edge_uid.append(self.edge)
                 new_edge_uid.append(other.edge)
-            
+
             old_edge_uid = torch.stack(old_edge_uid, dim=1)
             new_edge_uid = torch.stack(new_edge_uid, dim=1)
-             
-            merged_edge_uid = torch.cat([old_edge_uid, new_edge_uid], dim=0).unique(dim=0)
+
+            merged_edge_uid = torch.cat([old_edge_uid, new_edge_uid],
+                                        dim=0).unique(dim=0)
             num_old_edges = old_edge_uid.shape[0]
 
             merged_edge_num_sampled_edges = None
             if self.num_sampled_edges is not None and other.num_sampled_edges is not None:
-                merged_edge_num_sampled_edges = copy.copy(self.num_sampled_edges)
+                merged_edge_num_sampled_edges = copy.copy(
+                    self.num_sampled_edges)
                 curr_index = 0
                 # NOTE: There's an assumption here that no two edges will be sampled twice in the same SampleOutput object
                 for minibatch in other.num_sampled_edges:
-                    size_of_intersect = torch.cat([old_edge_uid, new_edge_uid[curr_index:curr_index + minibatch]]).unique(dim=0).shape[0] - num_old_edges
+                    size_of_intersect = torch.cat([
+                        old_edge_uid,
+                        new_edge_uid[curr_index:curr_index + minibatch]
+                    ]).unique(dim=0).shape[0] - num_old_edges
                     merged_edge_num_sampled_edges.append(size_of_intersect)
                     curr_index += minibatch
-            
-            merged_row = merged_edge_uid[:,0]
-            merged_col = merged_edge_uid[:,1]
-            merged_edge = merged_edge_uid[:,2] if self.edge is not None and other.edge is not None else None
+
+            merged_row = merged_edge_uid[:, 0]
+            merged_col = merged_edge_uid[:, 1]
+            merged_edge = merged_edge_uid[:,
+                                          2] if self.edge is not None and other.edge is not None else None
 
             # restore to row and col indices relative to nodes field
             merged_node_size = merged_nodes.numel()
             merged_edge_size = merged_row.numel()
 
-            merged_node_expand = merged_nodes.unsqueeze(1).expand(merged_node_size, merged_edge_size)
+            merged_node_expand = merged_nodes.unsqueeze(1).expand(
+                merged_node_size, merged_edge_size)
 
-            merged_row_expand = merged_row.unsqueeze(0).expand(merged_node_size, merged_edge_size)
-            merged_row = (merged_row_expand == merged_node_expand).nonzero()[:,0]
+            merged_row_expand = merged_row.unsqueeze(0).expand(
+                merged_node_size, merged_edge_size)
+            merged_row = (merged_row_expand == merged_node_expand).nonzero()[:,
+                                                                             0]
 
-            merged_col_expand = merged_col.unsqueeze(0).expand(merged_node_size, merged_edge_size)
-            merged_col = (merged_col_expand == merged_node_expand).nonzero()[:,0]
+            merged_col_expand = merged_col.unsqueeze(0).expand(
+                merged_node_size, merged_edge_size)
+            merged_col = (merged_col_expand == merged_node_expand).nonzero()[:,
+                                                                             0]
 
             out = SamplerOutput(
                 node=merged_nodes,
@@ -380,6 +417,8 @@ class SamplerOutput(CastMixin):
             if is_bidirectional:
                 out = out.to_bidirectional(keep_orig_edges=True)
             return out
+
+
 @dataclass
 class HeteroSamplerOutput(CastMixin):
     r"""The sampling output of a :class:`~torch_geometric.sampler.BaseSampler`
@@ -518,19 +557,22 @@ class HeteroSamplerOutput(CastMixin):
         return out
 
     @classmethod
-    def collate(cls, outputs: List['HeteroSamplerOutput']) -> 'HeteroSamplerOutput':
+    def collate(cls,
+                outputs: List['HeteroSamplerOutput']) -> 'HeteroSamplerOutput':
         r"""Collate a list of :class:`~torch_geometric.sampler.HeteroSamplerOutput`
         objects into a single :class:`~torch_geometric.sampler.HeteroSamplerOutput`
         object. Requires that they all have the same fields.
         """
         # TODO(zaristei)
         raise NotImplementedError
-    
-    def merge_with(self, other: 'HeteroSamplerOutput', replace: bool = False) -> 'HeteroSamplerOutput':
+
+    def merge_with(self, other: 'HeteroSamplerOutput',
+                   replace: bool = False) -> 'HeteroSamplerOutput':
         """Merges two HeteroSamplerOutputs. If replace is False, self's nodes and edges take precedence.
         """
         # TODO(zaristei)
         raise NotImplementedError
+
 
 @dataclass(frozen=True)
 class NumNeighbors:

--- a/torch_geometric/sampler/base.py
+++ b/torch_geometric/sampler/base.py
@@ -238,8 +238,7 @@ class SamplerOutput(CastMixin):
         return out
 
     @classmethod
-    def collate(cls,
-                outputs: List['SamplerOutput'],
+    def collate(cls, outputs: List['SamplerOutput'],
                 replace: bool = False) -> 'SamplerOutput':
         r"""Collate a list of :class:`~torch_geometric.sampler.SamplerOutput`
         objects into a single :class:`~torch_geometric.sampler.SamplerOutput`

--- a/torch_geometric/sampler/neighbor_sampler.py
+++ b/torch_geometric/sampler/neighbor_sampler.py
@@ -555,7 +555,8 @@ class BidirectionalNeighborSampler(BaseSampler):
         # Deprecated:
         directed: bool = True,
     ):
-        self.backward_neighbors_explicitly_set = num_backward_neighbors is not None
+        self.backward_neighbors_explicitly_set = (num_backward_neighbors
+                                                  is not None)
         if num_backward_neighbors is None:
             num_backward_neighbors = num_neighbors
 

--- a/torch_geometric/sampler/neighbor_sampler.py
+++ b/torch_geometric/sampler/neighbor_sampler.py
@@ -223,11 +223,7 @@ class NeighborSampler(BaseSampler):
                 if sample_direction == 'forward':
                     self.row, self.colptr, self.perm = graph_store.csc()
                 elif sample_direction == 'backward':
-                    # HACK
-                    row, col, _ = graph_store.coo()
-                    transpose_edge_index = torch.stack([col, row], dim=0)
-                    temp_data = Data(edge_index=transpose_edge_index, num_nodes=self.num_nodes)
-                    self.row, self.colptr, self.perm = to_csc(temp_data, device='cpu', share_memory=share_memory, is_sorted=is_sorted, src_node_time=self.node_time, edge_time=self.edge_time, to_transpose=sample_direction == 'forward')
+                    self.colptr, self.row, self.perm = graph_store.csr()
 
             else:
                 node_types = [
@@ -270,8 +266,7 @@ class NeighborSampler(BaseSampler):
                 if sample_direction == 'forward':
                     row_dict, colptr_dict, self.perm = graph_store.csc()
                 elif sample_direction == 'backward':
-                    # TODO(zaristei): Fix for Heterogeneous graph stores
-                    raise NotImplementedError
+                    colptr_dict, row_dict, self.perm = graph_store.csr()
                 self.row_dict = remap_keys(row_dict, self.to_rel_type)
                 self.colptr_dict = remap_keys(colptr_dict, self.to_rel_type)
 
@@ -597,14 +592,7 @@ class BidirectionalNeighborSampler(BaseSampler):
         forward_out = self.forward_sampler.sample_from_nodes(inputs)
         backward_out = self.backward_sampler.sample_from_nodes(inputs)
 
-        if self.is_hetero:
-            # TODO(zaristei): Implement heterogeneous bidirectional sampling
-            raise NotImplementedError
-        else:
-            # Homogeneous bidirectional sampling
-            pass
-        
-        return forward_out
+        return self._merge_outputs(forward_out, backward_out)
     
     def sample_from_edges(
         self,
@@ -614,14 +602,42 @@ class BidirectionalNeighborSampler(BaseSampler):
         forward_out = self.forward_sampler.sample_from_edges(inputs, neg_sampling)
         backward_out = self.backward_sampler.sample_from_edges(inputs, neg_sampling)
 
+        return self._merge_outputs(forward_out, backward_out)
+
+    def _merge_outputs(self, forward_out, backward_out):
+        """Merges the outputs of the forward and backward samplers.
+        """
+        # TODO(zaristei): Write generalized collate function for arbitrary
+        # sampler outputs
+
         if self.is_hetero:
             # TODO(zaristei): Implement heterogeneous bidirectional sampling
             raise NotImplementedError
         else:
             # Homogeneous bidirectional sampling
-            pass
-        
-        return forward_out
+
+            # Note backward sampler's row and col are reversed so they need to flipped back
+            backward_row, backward_col, backward_orig_row, backward_orig_col = backward_out.col, backward_out.row, backward_out.orig_col, backward_out.orig_row
+            backward_out.row, backward_out.col = backward_row, backward_col
+            backward_out.orig_row, backward_out.orig_col = backward_orig_row, backward_orig_col
+
+            if self.forward_sampler.replace:
+
+                node = torch.cat([forward_out.node, backward_out.node], dim=0)
+                row = torch.cat([forward_out.row, backward_out.row], dim=0)
+                col = torch.cat([forward_out.col, backward_out.col], dim=0)
+                edge = torch.cat([forward_out.edge, backward_out.edge], dim=0)
+                batch = torch.cat([forward_out.batch, backward_out.batch], dim=0) if forward_out.batch is not None and backward_out.batch is not None else None
+                num_sampled_nodes = forward_out.num_sampled_nodes + backward_out.num_sampled_nodes if forward_out.num_sampled_nodes is not None and backward_out.num_sampled_nodes is not None else None
+                num_sampled_edges = forward_out.num_sampled_edges + backward_out.num_sampled_edges if forward_out.num_sampled_edges is not None and backward_out.num_sampled_edges is not None else None
+                orig_row = torch.cat([forward_out.orig_row, backward_out.orig_row], dim=0) if forward_out.orig_row is not None and backward_out.orig_row is not None else None
+                orig_col = torch.cat([forward_out.orig_col, backward_out.orig_col], dim=0) if forward_out.orig_col is not None and backward_out.orig_col is not None else None
+                metadata = [forward_out.metadata, backward_out.metadata]
+
+                return SamplerOutput(node, row, col, edge, batch, num_sampled_nodes, num_sampled_edges, orig_row, orig_col, metadata)
+            else:
+                # TODO(zaristei): Implement generic sampling without replacement
+                raise NotImplementedError
 
         
     @property

--- a/torch_geometric/sampler/neighbor_sampler.py
+++ b/torch_geometric/sampler/neighbor_sampler.py
@@ -47,8 +47,7 @@ class NeighborSampler(BaseSampler):
         weight_attr: Optional[str] = None,
         is_sorted: bool = False,
         share_memory: bool = False,
-        # Deprecated:
-        directed: bool = True,
+        directed: bool = True,  # Deprecated
         sample_direction: Literal['forward', 'backward'] = 'forward',
     ):
         if not directed:

--- a/torch_geometric/sampler/utils.py
+++ b/torch_geometric/sampler/utils.py
@@ -6,8 +6,9 @@ from torch import Tensor
 from torch_geometric.data import Data, HeteroData
 from torch_geometric.data.storage import EdgeStorage
 from torch_geometric.index import index2ptr
-from torch_geometric.typing import EdgeType, NodeType, OptTensor, SparseTensor
+from torch_geometric.typing import EdgeType, NodeType, OptTensor
 from torch_geometric.utils import coalesce, index_sort, lexsort
+from torch_geometric.sampler import SamplerOutput
 
 # Edge Layout Conversion ######################################################
 
@@ -55,7 +56,7 @@ def to_csc(
             raise NotImplementedError("Temporal sampling via 'SparseTensor' "
                                       "format not yet supported")
         if to_transpose:
-            colptr, row, _ = data.adj.csr()
+            row, colptr, _ = data.adj.csr()
         else:
             colptr, row, _ = data.adj.csc()
 
@@ -70,7 +71,7 @@ def to_csc(
             #                           "format not yet supported")
             pass
         if to_transpose:
-            colptr, row, _ = data.adj_t.csc()
+            row, colptr, _ = data.adj_t.csc()
         else:
             colptr, row, _ = data.adj_t.csr()
 

--- a/torch_geometric/sampler/utils.py
+++ b/torch_geometric/sampler/utils.py
@@ -6,7 +6,7 @@ from torch import Tensor
 from torch_geometric.data import Data, HeteroData
 from torch_geometric.data.storage import EdgeStorage
 from torch_geometric.index import index2ptr
-from torch_geometric.typing import EdgeType, NodeType, OptTensor
+from torch_geometric.typing import EdgeType, NodeType, OptTensor, SparseTensor
 from torch_geometric.utils import coalesce, index_sort, lexsort
 
 # Edge Layout Conversion ######################################################
@@ -41,6 +41,7 @@ def to_csc(
     is_sorted: bool = False,
     src_node_time: Optional[Tensor] = None,
     edge_time: Optional[Tensor] = None,
+    to_transpose: bool = False,
 ) -> Tuple[Tensor, Tensor, OptTensor]:
     # Convert the graph data into a suitable format for sampling (CSC format).
     # Returns the `colptr` and `row` indices of the graph, as well as an
@@ -53,7 +54,10 @@ def to_csc(
         if src_node_time is not None:
             raise NotImplementedError("Temporal sampling via 'SparseTensor' "
                                       "format not yet supported")
-        colptr, row, _ = data.adj.csc()
+        if to_transpose:
+            colptr, row, _ = data.adj.csr()
+        else:
+            colptr, row, _ = data.adj.csc()
 
     elif hasattr(data, 'adj_t'):
         if src_node_time is not None:
@@ -65,10 +69,17 @@ def to_csc(
             # raise NotImplementedError("Temporal sampling via 'SparseTensor' "
             #                           "format not yet supported")
             pass
-        colptr, row, _ = data.adj_t.csr()
+        if to_transpose:
+            colptr, row, _ = data.adj_t.csc()
+        else:
+            colptr, row, _ = data.adj_t.csr()
 
     elif data.edge_index is not None:
-        row, col = data.edge_index
+        if to_transpose:
+            col, row = data.edge_index
+        else:
+            row, col = data.edge_index
+
         if not is_sorted:
             row, col, perm = sort_csc(row, col, src_node_time, edge_time)
         colptr = index2ptr(col, data.size(1))
@@ -89,7 +100,6 @@ def to_csc(
 
     return colptr, row, perm
 
-
 def to_hetero_csc(
     data: HeteroData,
     device: Optional[torch.device] = None,
@@ -97,6 +107,7 @@ def to_hetero_csc(
     is_sorted: bool = False,
     node_time_dict: Optional[Dict[NodeType, Tensor]] = None,
     edge_time_dict: Optional[Dict[EdgeType, Tensor]] = None,
+    to_transpose: bool = False,
 ) -> Tuple[Dict[str, Tensor], Dict[str, Tensor], Dict[str, OptTensor]]:
     # Convert the heterogeneous graph data into a suitable format for sampling
     # (CSC format).
@@ -108,7 +119,7 @@ def to_hetero_csc(
         src_node_time = (node_time_dict or {}).get(edge_type[0], None)
         edge_time = (edge_time_dict or {}).get(edge_type, None)
         out = to_csc(store, device, share_memory, is_sorted, src_node_time,
-                     edge_time)
+                     edge_time, to_transpose)
         colptr_dict[edge_type], row_dict[edge_type], perm_dict[edge_type] = out
 
     return colptr_dict, row_dict, perm_dict

--- a/torch_geometric/sampler/utils.py
+++ b/torch_geometric/sampler/utils.py
@@ -8,7 +8,6 @@ from torch_geometric.data.storage import EdgeStorage
 from torch_geometric.index import index2ptr
 from torch_geometric.typing import EdgeType, NodeType, OptTensor
 from torch_geometric.utils import coalesce, index_sort, lexsort
-from torch_geometric.sampler import SamplerOutput
 
 # Edge Layout Conversion ######################################################
 

--- a/torch_geometric/sampler/utils.py
+++ b/torch_geometric/sampler/utils.py
@@ -100,6 +100,7 @@ def to_csc(
 
     return colptr, row, perm
 
+
 def to_hetero_csc(
     data: HeteroData,
     device: Optional[torch.device] = None,


### PR DESCRIPTION
This PR makes the following changes:

- Modifies NeighborSampler so that sampling can occur from `src` to `dst` node, and not just from `dst` to `src` node, which is the current default behavior.
- Adds a new sampler called `BidirectionalNeighborSampler`, which samples nodes/edges in both upstream and downstream directions for a directed graph, as if it were an undirected graph.
- Add `merge_with` and `collate` methods to the SamplerOutput dataclass, allowing for different SamplerOutputs to be merged together. This also becomes useful in scenarios where the user may want to sample using multiple different unique sampling methods.

This PR will remain in draft until methods are also implemented on the corresponding Hetero graph classes, and unittests have been written to cover new behaviors.