### PR TITLE
Fix Edge Case for Remote Graph Store

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- Fixed `_recursive_config()` for `torch.nn.ModuleList`([#10124](https://github.com/pyg-team/pytorch_geometric/pull/10124))
 - Fixed the `k_hop_subgraph()` method for directed graphs ([#9756](https://github.com/pyg-team/pytorch_geometric/pull/9756))
 - Fixed `utils.group_cat` concatenating dimension ([#9766](https://github.com/pyg-team/pytorch_geometric/pull/9766))
 - Fixed `WebQSDataset.process` raising exceptions ([#9665](https://github.com/pyg-team/pytorch_geometric/pull/9665))

--- a/test/sampler/test_sampler_neighbor_sampler.py
+++ b/test/sampler/test_sampler_neighbor_sampler.py
@@ -1,46 +1,46 @@
 import pytest
 import torch
-from torch_geometric.testing import onlyNeighborSampler, MyGraphStore, MyFeatureStore
+
 from torch_geometric.data import Data, HeteroData
 from torch_geometric.sampler.base import NodeSamplerInput, SamplerOutput
 from torch_geometric.sampler.neighbor_sampler import NeighborSampler
+from torch_geometric.testing import (
+    MyFeatureStore,
+    MyGraphStore,
+    onlyNeighborSampler,
+)
 
 
 def _init_sample_graph(hetero=False):
-    """ Initializes the following graph.
+    """Initializes the following graph.
 
     #############                    ###########
     # Alice (0) # -> "works with" -> # Bob (1) #
     #############                    ###########
          |
          v
-      "leads" 
+      "leads"
          |
          v
     #############                    ############
     # Carol (2) # -> "works with" -> # Dave (3) #
     #############                    ############
     """
-
-    sample_x = torch.tensor([[0],[1],[2],[3]])
+    sample_x = torch.tensor([[0], [1], [2], [3]])
 
     if not hetero:
-        sample_edge_indices = torch.tensor([
-            [0,0,2],
-            [1,2,3]
-        ])
+        sample_edge_indices = torch.tensor([[0, 0, 2], [1, 2, 3]])
     else:
         sample_edge_indices = {
-            ('person', 'works_with', 'person'): {"edge_index": torch.tensor([
-                [0,2],
-                [1,3]
-            ])},
-            ('person', 'leads', 'person'): {"edge_index": torch.tensor([
-                [0],
-                [2]
-            ])}
+            ('person', 'works_with', 'person'): {
+                "edge_index": torch.tensor([[0, 2], [1, 3]])
+            },
+            ('person', 'leads', 'person'): {
+                "edge_index": torch.tensor([[0], [2]])
+            }
         }
     return sample_x, sample_edge_indices
+
 
 def _init_graph_to_sample(graph_dtype, hetero=False):
     sample_x, sample_edge_indices = _init_sample_graph(hetero)
@@ -49,9 +49,11 @@ def _init_graph_to_sample(graph_dtype, hetero=False):
         graph_to_sample = Data(edge_index=sample_edge_indices, x=sample_x)
     elif graph_dtype == 'remote' and not hetero:
         graph_store = MyGraphStore()
-        graph_store.put_edge_index(sample_edge_indices, edge_type=None, layout='coo', size=(4, 4))
+        graph_store.put_edge_index(sample_edge_indices, edge_type=None,
+                                   layout='coo', size=(4, 4))
         feature_store = MyFeatureStore()
-        feature_store.put_tensor(sample_x, group_name='person', attr_name='x', index=None)
+        feature_store.put_tensor(sample_x, group_name='person', attr_name='x',
+                                 index=None)
         graph_to_sample = (feature_store, graph_store)
     elif graph_dtype == 'data' and hetero:
         graph_to_sample = HeteroData(sample_edge_indices)
@@ -60,11 +62,15 @@ def _init_graph_to_sample(graph_dtype, hetero=False):
         graph_store = MyGraphStore()
         for edge_type, edge_index in sample_edge_indices.items():
             edge_index = edge_index["edge_index"]
-            graph_store.put_edge_index(edge_index, edge_type=edge_type, layout='coo', size=(1+torch.max(edge_index, dim=1).values))
+            graph_store.put_edge_index(
+                edge_index, edge_type=edge_type, layout='coo',
+                size=(1 + torch.max(edge_index, dim=1).values))
         feature_store = MyFeatureStore()
-        feature_store.put_tensor(sample_x, group_name='person', attr_name='x', index=None)
+        feature_store.put_tensor(sample_x, group_name='person', attr_name='x',
+                                 index=None)
         graph_to_sample = (feature_store, graph_store)
     return graph_to_sample
+
 
 @onlyNeighborSampler
 @pytest.mark.parametrize('input_type', ['data', 'remote'])
@@ -80,41 +86,30 @@ def test_homogeneous_neighbor_sampler_basic(input_type):
     }
 
     # Sampling from Bob should yield only Alice
-    node_sampler_input = NodeSamplerInput(input_id=None, node=torch.tensor([1]))
+    node_sampler_input = NodeSamplerInput(input_id=None,
+                                          node=torch.tensor([1]))
     expected_output = SamplerOutput(
-        node=torch.tensor([1, 0]),
-        row=torch.tensor([1]),
-        col=torch.tensor([0]),
-        edge=torch.tensor([0]),
-        batch=None,
-        num_sampled_nodes=[1, 1],
-        num_sampled_edges=[1],
-        orig_row=None,
-        orig_col=None,
-        metadata=(None, None)
-    )
+        node=torch.tensor([1, 0]), row=torch.tensor([1]),
+        col=torch.tensor([0]), edge=torch.tensor([0]), batch=None,
+        num_sampled_nodes=[1, 1], num_sampled_edges=[1], orig_row=None,
+        orig_col=None, metadata=(None, None))
     sampler = NeighborSampler(**sampler_kwargs)
     sampler_output = sampler.sample_from_nodes(node_sampler_input)
     assert str(sampler_output) == str(expected_output)
-
 
     # Sampling Alice should yield no edges
-    node_sampler_input = NodeSamplerInput(input_id=None, node=torch.tensor([0]))
-    expected_output = SamplerOutput(
-        node=torch.tensor([0]),
-        row=torch.empty(0, dtype=torch.int64),
-        col=torch.empty(0, dtype=torch.int64),
-        edge=torch.empty(0, dtype=torch.int64),
-        batch=None,
-        num_sampled_nodes=[1, 0],
-        num_sampled_edges=[0],
-        orig_row=None,
-        orig_col=None,
-        metadata=(None, None)
-    )
+    node_sampler_input = NodeSamplerInput(input_id=None,
+                                          node=torch.tensor([0]))
+    expected_output = SamplerOutput(node=torch.tensor([0]), row=torch.empty(
+        0, dtype=torch.int64), col=torch.empty(0, dtype=torch.int64),
+                                    edge=torch.empty(0, dtype=torch.int64),
+                                    batch=None, num_sampled_nodes=[1, 0],
+                                    num_sampled_edges=[0], orig_row=None,
+                                    orig_col=None, metadata=(None, None))
     sampler = NeighborSampler(**sampler_kwargs)
     sampler_output = sampler.sample_from_nodes(node_sampler_input)
     assert str(sampler_output) == str(expected_output)
+
 
 @onlyNeighborSampler
 @pytest.mark.parametrize('input_type', ['data', 'remote'])
@@ -130,21 +125,28 @@ def test_heterogeneous_neighbor_sampler_basic(input_type):
     }
 
     # Sampling from Bob should yield only Alice
-    node_sampler_input = NodeSamplerInput(input_id=None, node=torch.tensor([1]), input_type="person")
+    node_sampler_input = NodeSamplerInput(input_id=None,
+                                          node=torch.tensor([1]),
+                                          input_type="person")
     sampler = NeighborSampler(**sampler_kwargs)
     sampler_output = sampler.sample_from_nodes(node_sampler_input)
-    assert set(sampler_output.node['person'].tolist()) == set([1, 0])
-    assert sampler_output.row[('person', 'works_with', 'person')] == torch.tensor([1])
+    assert set(sampler_output.node['person'].tolist()) == {1, 0}
+    assert sampler_output.row[('person', 'works_with',
+                               'person')] == torch.tensor([1])
     assert sampler_output.row[('person', 'leads', 'person')].numel() == 0
-    assert sampler_output.col[('person', 'works_with', 'person')] == torch.tensor([0])
+    assert sampler_output.col[('person', 'works_with',
+                               'person')] == torch.tensor([0])
     assert sampler_output.col[('person', 'leads', 'person')].numel() == 0
-    assert sampler_output.edge[('person', 'works_with', 'person')] == torch.tensor([0])
+    assert sampler_output.edge[('person', 'works_with',
+                                'person')] == torch.tensor([0])
     assert sampler_output.edge[('person', 'leads', 'person')].numel() == 0
 
     # Sampling Alice should yield no edges
-    node_sampler_input = NodeSamplerInput(input_id=None, node=torch.tensor([0]), input_type="person")
+    node_sampler_input = NodeSamplerInput(input_id=None,
+                                          node=torch.tensor([0]),
+                                          input_type="person")
     sampler_output = sampler.sample_from_nodes(node_sampler_input)
-    assert set(sampler_output.node['person'].tolist()) == set([0])
+    assert set(sampler_output.node['person'].tolist()) == {0}
     assert sampler_output.row[('person', 'works_with', 'person')].numel() == 0
     assert sampler_output.row[('person', 'leads', 'person')].numel() == 0
     assert sampler_output.col[('person', 'works_with', 'person')].numel() == 0

--- a/test/sampler/test_sampler_neighbor_sampler.py
+++ b/test/sampler/test_sampler_neighbor_sampler.py
@@ -1,0 +1,153 @@
+import pytest
+import torch
+from torch_geometric.testing import onlyNeighborSampler, MyGraphStore, MyFeatureStore
+from torch_geometric.data import Data, HeteroData
+from torch_geometric.sampler.base import NodeSamplerInput, SamplerOutput
+from torch_geometric.sampler.neighbor_sampler import NeighborSampler
+
+
+def _init_sample_graph(hetero=False):
+    """ Initializes the following graph.
+
+    #############                    ###########
+    # Alice (0) # -> "works with" -> # Bob (1) #
+    #############                    ###########
+         |
+         v
+      "leads" 
+         |
+         v
+    #############                    ############
+    # Carol (2) # -> "works with" -> # Dave (3) #
+    #############                    ############
+    """
+
+    sample_x = torch.tensor([[0],[1],[2],[3]])
+
+    if not hetero:
+        sample_edge_indices = torch.tensor([
+            [0,0,2],
+            [1,2,3]
+        ])
+    else:
+        sample_edge_indices = {
+            ('person', 'works_with', 'person'): {"edge_index": torch.tensor([
+                [0,2],
+                [1,3]
+            ])},
+            ('person', 'leads', 'person'): {"edge_index": torch.tensor([
+                [0],
+                [2]
+            ])}
+        }
+    return sample_x, sample_edge_indices
+
+def _init_graph_to_sample(graph_dtype, hetero=False):
+    sample_x, sample_edge_indices = _init_sample_graph(hetero)
+    graph_to_sample = None
+    if graph_dtype == 'data' and not hetero:
+        graph_to_sample = Data(edge_index=sample_edge_indices, x=sample_x)
+    elif graph_dtype == 'remote' and not hetero:
+        graph_store = MyGraphStore()
+        graph_store.put_edge_index(sample_edge_indices, edge_type=None, layout='coo', size=(4, 4))
+        feature_store = MyFeatureStore()
+        feature_store.put_tensor(sample_x, group_name='person', attr_name='x', index=None)
+        graph_to_sample = (feature_store, graph_store)
+    elif graph_dtype == 'data' and hetero:
+        graph_to_sample = HeteroData(sample_edge_indices)
+        graph_to_sample['person'].x = sample_x
+    elif graph_dtype == 'remote' and hetero:
+        graph_store = MyGraphStore()
+        for edge_type, edge_index in sample_edge_indices.items():
+            edge_index = edge_index["edge_index"]
+            graph_store.put_edge_index(edge_index, edge_type=edge_type, layout='coo', size=(1+torch.max(edge_index, dim=1).values))
+        feature_store = MyFeatureStore()
+        feature_store.put_tensor(sample_x, group_name='person', attr_name='x', index=None)
+        graph_to_sample = (feature_store, graph_store)
+    return graph_to_sample
+
+@onlyNeighborSampler
+@pytest.mark.parametrize('input_type', ['data', 'remote'])
+def test_homogeneous_neighbor_sampler_basic(input_type):
+    graph_to_sample = _init_graph_to_sample(input_type, hetero=False)
+
+    # NeighborSampler default parameters 1 node
+    # disjoint = False
+    # replace = False
+    sampler_kwargs = {
+        'data': graph_to_sample,
+        'num_neighbors': [1],
+    }
+
+    # Sampling from Bob should yield only Alice
+    node_sampler_input = NodeSamplerInput(input_id=None, node=torch.tensor([1]))
+    expected_output = SamplerOutput(
+        node=torch.tensor([1, 0]),
+        row=torch.tensor([1]),
+        col=torch.tensor([0]),
+        edge=torch.tensor([0]),
+        batch=None,
+        num_sampled_nodes=[1, 1],
+        num_sampled_edges=[1],
+        orig_row=None,
+        orig_col=None,
+        metadata=(None, None)
+    )
+    sampler = NeighborSampler(**sampler_kwargs)
+    sampler_output = sampler.sample_from_nodes(node_sampler_input)
+    assert str(sampler_output) == str(expected_output)
+
+
+    # Sampling Alice should yield no edges
+    node_sampler_input = NodeSamplerInput(input_id=None, node=torch.tensor([0]))
+    expected_output = SamplerOutput(
+        node=torch.tensor([0]),
+        row=torch.empty(0, dtype=torch.int64),
+        col=torch.empty(0, dtype=torch.int64),
+        edge=torch.empty(0, dtype=torch.int64),
+        batch=None,
+        num_sampled_nodes=[1, 0],
+        num_sampled_edges=[0],
+        orig_row=None,
+        orig_col=None,
+        metadata=(None, None)
+    )
+    sampler = NeighborSampler(**sampler_kwargs)
+    sampler_output = sampler.sample_from_nodes(node_sampler_input)
+    assert str(sampler_output) == str(expected_output)
+
+@onlyNeighborSampler
+@pytest.mark.parametrize('input_type', ['data', 'remote'])
+def test_heterogeneous_neighbor_sampler_basic(input_type):
+    graph_to_sample = _init_graph_to_sample(input_type, hetero=True)
+
+    # NeighborSampler default parameters 1 node
+    # disjoint = False
+    # replace = False
+    sampler_kwargs = {
+        'data': graph_to_sample,
+        'num_neighbors': [1],
+    }
+
+    # Sampling from Bob should yield only Alice
+    node_sampler_input = NodeSamplerInput(input_id=None, node=torch.tensor([1]), input_type="person")
+    sampler = NeighborSampler(**sampler_kwargs)
+    sampler_output = sampler.sample_from_nodes(node_sampler_input)
+    assert set(sampler_output.node['person'].tolist()) == set([1, 0])
+    assert sampler_output.row[('person', 'works_with', 'person')] == torch.tensor([1])
+    assert sampler_output.row[('person', 'leads', 'person')].numel() == 0
+    assert sampler_output.col[('person', 'works_with', 'person')] == torch.tensor([0])
+    assert sampler_output.col[('person', 'leads', 'person')].numel() == 0
+    assert sampler_output.edge[('person', 'works_with', 'person')] == torch.tensor([0])
+    assert sampler_output.edge[('person', 'leads', 'person')].numel() == 0
+
+    # Sampling Alice should yield no edges
+    node_sampler_input = NodeSamplerInput(input_id=None, node=torch.tensor([0]), input_type="person")
+    sampler_output = sampler.sample_from_nodes(node_sampler_input)
+    assert set(sampler_output.node['person'].tolist()) == set([0])
+    assert sampler_output.row[('person', 'works_with', 'person')].numel() == 0
+    assert sampler_output.row[('person', 'leads', 'person')].numel() == 0
+    assert sampler_output.col[('person', 'works_with', 'person')].numel() == 0
+    assert sampler_output.col[('person', 'leads', 'person')].numel() == 0
+    assert sampler_output.edge[('person', 'works_with', 'person')].numel() == 0
+    assert sampler_output.edge[('person', 'leads', 'person')].numel() == 0

--- a/test/test_config_mixin.py
+++ b/test/test_config_mixin.py
@@ -1,12 +1,16 @@
 from dataclasses import asdict, dataclass, is_dataclass
+from typing import Sequence
 
+import pytest
 import torch
 
 from torch_geometric.config_mixin import ConfigMixin
 from torch_geometric.config_store import clear_config_store, register
 
 
-def teardown_function() -> None:
+@pytest.fixture(scope="session", autouse=True)
+def teardown_once():
+    yield  # This allows tests to run before teardown is executed
     clear_config_store()
 
 
@@ -26,6 +30,22 @@ class Module(Base):
         super().__init__()
         self.x = x
         self.data = data
+
+
+@register(with_target=True)
+class SubModule(Base):
+    def __init__(self, p: float):
+        super().__init__()
+        self.p = p
+
+
+@register(with_target=True)
+class CompoundModule(torch.nn.Module, ConfigMixin):
+    def __init__(self, z: int, module: Module, submodules: list[SubModule]):
+        super().__init__()
+        self.z = z
+        self.module = module
+        self.submodules = torch.nn.ModuleList(submodules)
 
 
 def test_config_mixin() -> None:
@@ -84,3 +104,39 @@ def test_config_mixin() -> None:
     assert isinstance(model.data, dict)
     assert model.data['x'] == 1
     assert model.data['y'] == 2
+
+
+def test_config_mixin_compound() -> None:
+    submodules = [SubModule(1.41), SubModule(3.14)]
+    module = Module(x=0, data=Dataclass(x=1, y=2))
+    model = CompoundModule(z=3, module=module, submodules=submodules)
+    cfg = model.config()
+    assert is_dataclass(cfg)
+    assert cfg._target_ == 'test_config_mixin.CompoundModule'
+    assert cfg.z == 3
+    assert cfg.module._target_ == 'test_config_mixin.Module'
+    assert cfg.module.x == 0
+    assert isinstance(cfg.module.data, Dataclass)
+    assert cfg.module.data.x == 1
+    assert cfg.module.data.y == 2
+    assert len(cfg.submodules) == 2
+    assert isinstance(cfg.submodules, Sequence)
+    assert cfg.submodules[0]._target_ == 'test_config_mixin.SubModule'
+    assert cfg.submodules[0].p == 1.41
+    assert cfg.submodules[1]._target_ == 'test_config_mixin.SubModule'
+    assert cfg.submodules[1].p == 3.14
+
+    model = CompoundModule.from_config(cfg)
+    assert isinstance(model, CompoundModule)
+    assert model.z == 3
+    assert isinstance(model.module, Module)
+    assert model.module.x == 0
+    assert isinstance(model.module.data, Dataclass)
+    assert model.module.data.x == 1
+    assert model.module.data.y == 2
+    assert isinstance(model.submodules, torch.nn.ModuleList)
+    assert len(model.submodules) == 2
+    assert isinstance(model.submodules[0], SubModule)
+    assert model.submodules[0].p == 1.41
+    assert isinstance(model.submodules[1], SubModule)
+    assert model.submodules[1].p == 3.14

--- a/torch_geometric/config_mixin.py
+++ b/torch_geometric/config_mixin.py
@@ -1,7 +1,7 @@
 import inspect
 from dataclasses import fields, is_dataclass
 from importlib import import_module
-from typing import Any, Dict
+from typing import Any, Dict, Iterable
 
 from torch_geometric.config_store import (
     class_from_dataclass,
@@ -71,7 +71,7 @@ def _recursive_config(value: Any) -> Any:
         return value.config()
     if is_torch_instance(value, ConfigMixin):
         return value.config()
-    if isinstance(value, (tuple, list)):
+    if isinstance(value, (tuple, list, Iterable)):
         return [_recursive_config(v) for v in value]
     if isinstance(value, dict):
         return {k: _recursive_config(v) for k, v in value.items()}

--- a/torch_geometric/sampler/__init__.py
+++ b/torch_geometric/sampler/__init__.py
@@ -3,7 +3,7 @@ r"""Graph sampler package."""
 from .base import (BaseSampler, NodeSamplerInput, EdgeSamplerInput,
                    SamplerOutput, HeteroSamplerOutput, NegativeSampling,
                    NumNeighbors)
-from .neighbor_sampler import NeighborSampler
+from .neighbor_sampler import NeighborSampler, BidirectionalNeighborSampler
 from .hgt_sampler import HGTSampler
 
 __all__ = classes = [
@@ -15,5 +15,6 @@ __all__ = classes = [
     'NumNeighbors',
     'NegativeSampling',
     'NeighborSampler',
+    'BidirectionalNeighborSampler',
     'HGTSampler',
 ]

--- a/torch_geometric/sampler/base.py
+++ b/torch_geometric/sampler/base.py
@@ -236,7 +236,7 @@ class SamplerOutput(CastMixin):
         )
 
         return out
-    
+
     @classmethod
     def collate(cls, outputs: List['SamplerOutput']) -> 'SamplerOutput':
         r"""Collate a list of :class:`~torch_geometric.sampler.SamplerOutput`
@@ -260,13 +260,15 @@ class SamplerOutput(CastMixin):
                 assert out.num_sampled_nodes is not None == has_num_sampled_nodes
                 assert out.num_sampled_edges is not None == has_num_sampled_edges
         except AssertionError:
-            raise ValueError(f"Output {i} has a different field than the first output")
-        
+            raise ValueError(
+                f"Output {i} has a different field than the first output")
+
         for other in outputs[1:]:
-            out = out.merge_with(other) 
-        return out 
-    
-    def merge_with(self, other: 'SamplerOutput', replace: bool = False) -> 'SamplerOutput':
+            out = out.merge_with(other)
+        return out
+
+    def merge_with(self, other: 'SamplerOutput',
+                   replace: bool = False) -> 'SamplerOutput':
         """Merges two SamplerOutputs. If replace is False, self's nodes and edges take precedence.
         """
         if replace:
@@ -274,16 +276,26 @@ class SamplerOutput(CastMixin):
                 node=torch.cat([self.node, other.node], dim=0),
                 row=torch.cat([self.row, other.row], dim=0),
                 col=torch.cat([self.col, other.col], dim=0),
-                edge=torch.cat([self.edge, other.edge], dim=0) if self.edge is not None and other.edge is not None else None,
-                batch=torch.cat([self.batch, other.batch], dim=0) if self.batch is not None and other.batch is not None else None,
-                num_sampled_nodes=self.num_sampled_nodes + other.num_sampled_nodes if self.num_sampled_nodes is not None and other.num_sampled_nodes is not None else None,
-                num_sampled_edges=self.num_sampled_edges + other.num_sampled_edges if self.num_sampled_edges is not None and other.num_sampled_edges is not None else None,
-                orig_row=torch.cat([self.orig_row, other.orig_row], dim=0) if self.orig_row is not None and other.orig_row is not None else None,
-                orig_col=torch.cat([self.orig_col, other.orig_col], dim=0) if self.orig_col is not None and other.orig_col is not None else None,
+                edge=torch.cat([self.edge, other.edge], dim=0)
+                if self.edge is not None and other.edge is not None else None,
+                batch=torch.cat([self.batch, other.batch], dim=0) if
+                self.batch is not None and other.batch is not None else None,
+                num_sampled_nodes=self.num_sampled_nodes +
+                other.num_sampled_nodes if self.num_sampled_nodes is not None
+                and other.num_sampled_nodes is not None else None,
+                num_sampled_edges=self.num_sampled_edges +
+                other.num_sampled_edges if self.num_sampled_edges is not None
+                and other.num_sampled_edges is not None else None,
+                orig_row=torch.cat([self.orig_row, other.orig_row], dim=0)
+                if self.orig_row is not None and other.orig_row is not None
+                else None,
+                orig_col=torch.cat([self.orig_col, other.orig_col], dim=0)
+                if self.orig_col is not None and other.orig_col is not None
+                else None,
                 metadata=[self.metadata, other.metadata],
             )
         else:
-            
+
             # NODES
             old_node_uid, new_node_uid = [self.node], [other.node]
 
@@ -291,28 +303,34 @@ class SamplerOutput(CastMixin):
             if self.batch is not None and other.batch is not None:
                 old_node_uid.append(self.batch)
                 new_node_uid.append(other.batch)
-            
+
             # NOTE: if any new node fields are added, they need to be merged here
 
             old_node_uid = torch.stack(old_node_uid, dim=1)
             new_node_uid = torch.stack(new_node_uid, dim=1)
 
-            merged_node_uid = torch.cat([old_node_uid, new_node_uid], dim=0).unique(dim=0)
+            merged_node_uid = torch.cat([old_node_uid, new_node_uid],
+                                        dim=0).unique(dim=0)
             num_old_nodes = old_node_uid.shape[0]
 
             # Recompute num sampled nodes for second output, subtracting out nodes already seen in first output
             merged_node_num_sampled_nodes = None
             if self.num_sampled_nodes is not None and other.num_sampled_nodes is not None:
-                merged_node_num_sampled_nodes = copy.copy(self.num_sampled_nodes)
+                merged_node_num_sampled_nodes = copy.copy(
+                    self.num_sampled_nodes)
                 curr_index = 0
                 # NOTE: There's an assumption here that no two nodes will be sampled twice in the same SampleOutput object
                 for minibatch in other.num_sampled_nodes:
-                    size_of_intersect = torch.cat([old_node_uid, new_node_uid[curr_index:curr_index + minibatch]]).unique(dim=0).shape[0] - num_old_nodes
+                    size_of_intersect = torch.cat([
+                        old_node_uid,
+                        new_node_uid[curr_index:curr_index + minibatch]
+                    ]).unique(dim=0).shape[0] - num_old_nodes
                     merged_node_num_sampled_nodes.append(size_of_intersect)
                     curr_index += minibatch
-            
-            merged_nodes = merged_node_uid[:,0]
-            merged_batch = merged_node_uid[:,1] if self.batch is not None and other.batch is not None else None
+
+            merged_nodes = merged_node_uid[:, 0]
+            merged_batch = merged_node_uid[:,
+                                           1] if self.batch is not None and other.batch is not None else None
 
             # EDGES
             is_bidirectional = self.orig_row is not None and self.orig_col is not None and other.orig_row is not None and other.orig_col is not None
@@ -322,32 +340,38 @@ class SamplerOutput(CastMixin):
             else:
                 old_row, old_col = self.row, self.col
                 new_row, new_col = other.row, other.col
-            
+
             old_edge_uid, new_edge_uid = [old_row, old_col], [new_row, new_col]
 
             if self.edge is not None and other.edge is not None:
                 old_edge_uid.append(self.edge)
                 new_edge_uid.append(other.edge)
-            
+
             old_edge_uid = torch.stack(old_edge_uid, dim=1)
             new_edge_uid = torch.stack(new_edge_uid, dim=1)
-             
-            merged_edge_uid = torch.cat([old_edge_uid, new_edge_uid], dim=0).unique(dim=0)
+
+            merged_edge_uid = torch.cat([old_edge_uid, new_edge_uid],
+                                        dim=0).unique(dim=0)
             num_old_edges = old_edge_uid.shape[0]
 
             merged_edge_num_sampled_edges = None
             if self.num_sampled_edges is not None and other.num_sampled_edges is not None:
-                merged_edge_num_sampled_edges = copy.copy(self.num_sampled_edges)
+                merged_edge_num_sampled_edges = copy.copy(
+                    self.num_sampled_edges)
                 curr_index = 0
                 # NOTE: There's an assumption here that no two edges will be sampled twice in the same SampleOutput object
                 for minibatch in other.num_sampled_edges:
-                    size_of_intersect = torch.cat([old_edge_uid, new_edge_uid[curr_index:curr_index + minibatch]]).unique(dim=0).shape[0] - num_old_edges
+                    size_of_intersect = torch.cat([
+                        old_edge_uid,
+                        new_edge_uid[curr_index:curr_index + minibatch]
+                    ]).unique(dim=0).shape[0] - num_old_edges
                     merged_edge_num_sampled_edges.append(size_of_intersect)
                     curr_index += minibatch
-            
-            merged_row = merged_edge_uid[:,0]
-            merged_col = merged_edge_uid[:,1]
-            merged_edge = merged_edge_uid[:,2] if self.edge is not None and other.edge is not None else None
+
+            merged_row = merged_edge_uid[:, 0]
+            merged_col = merged_edge_uid[:, 1]
+            merged_edge = merged_edge_uid[:,
+                                          2] if self.edge is not None and other.edge is not None else None
 
             out = SamplerOutput(
                 node=merged_nodes,
@@ -363,6 +387,8 @@ class SamplerOutput(CastMixin):
             if is_bidirectional:
                 out = out.to_bidirectional(keep_orig_edges=True)
             return out
+
+
 @dataclass
 class HeteroSamplerOutput(CastMixin):
     r"""The sampling output of a :class:`~torch_geometric.sampler.BaseSampler`
@@ -501,19 +527,22 @@ class HeteroSamplerOutput(CastMixin):
         return out
 
     @classmethod
-    def collate(cls, outputs: List['HeteroSamplerOutput']) -> 'HeteroSamplerOutput':
+    def collate(cls,
+                outputs: List['HeteroSamplerOutput']) -> 'HeteroSamplerOutput':
         r"""Collate a list of :class:`~torch_geometric.sampler.HeteroSamplerOutput`
         objects into a single :class:`~torch_geometric.sampler.HeteroSamplerOutput`
         object. Requires that they all have the same fields.
         """
         # TODO(zaristei)
         raise NotImplementedError
-    
-    def merge_with(self, other: 'HeteroSamplerOutput', replace: bool = False) -> 'HeteroSamplerOutput':
+
+    def merge_with(self, other: 'HeteroSamplerOutput',
+                   replace: bool = False) -> 'HeteroSamplerOutput':
         """Merges two HeteroSamplerOutputs. If replace is False, self's nodes and edges take precedence.
         """
         # TODO(zaristei)
         raise NotImplementedError
+
 
 @dataclass(frozen=True)
 class NumNeighbors:

--- a/torch_geometric/sampler/neighbor_sampler.py
+++ b/torch_geometric/sampler/neighbor_sampler.py
@@ -86,7 +86,8 @@ class NeighborSampler(BaseSampler):
             self.colptr, self.row, self.perm = to_csc(
                 data, device='cpu', share_memory=share_memory,
                 is_sorted=is_sorted, src_node_time=self.node_time,
-                edge_time=self.edge_time, to_transpose=sample_direction == 'backward')
+                edge_time=self.edge_time,
+                to_transpose=sample_direction == 'backward')
 
             if self.edge_time is not None and self.perm is not None:
                 self.edge_time = self.edge_time[self.perm]
@@ -140,7 +141,8 @@ class NeighborSampler(BaseSampler):
             colptr_dict, row_dict, self.perm = to_hetero_csc(
                 data, device='cpu', share_memory=share_memory,
                 is_sorted=is_sorted, node_time_dict=self.node_time,
-                edge_time_dict=self.edge_time, to_transpose=sample_direction == 'backward')
+                edge_time_dict=self.edge_time,
+                to_transpose=sample_direction == 'backward')
 
             self.row_dict = remap_keys(row_dict, self.to_rel_type)
             self.colptr_dict = remap_keys(colptr_dict, self.to_rel_type)
@@ -524,8 +526,10 @@ class NeighborSampler(BaseSampler):
                 num_sampled_edges=num_sampled_edges,
             )
 
+
 class BidirectionalNeighborSampler(BaseSampler):
     """A sampler that allows for both upstream and downstream sampling."""
+
     # NOTE: Designed to have the same interface as `NeighborSampler`
     def __init__(
         self,
@@ -547,19 +551,25 @@ class BidirectionalNeighborSampler(BaseSampler):
         if num_backward_neighbors is None:
             num_backward_neighbors = num_neighbors
 
-        self.forward_sampler = NeighborSampler(data, num_neighbors, subgraph_type, replace, disjoint, temporal_strategy, time_attr, weight_attr, is_sorted, share_memory, sample_direction='forward', directed=directed)
-        self.backward_sampler = NeighborSampler(data, num_backward_neighbors, subgraph_type, replace, disjoint, temporal_strategy, time_attr, weight_attr, is_sorted, share_memory, sample_direction='backward', directed=directed)
-    
+        self.forward_sampler = NeighborSampler(
+            data, num_neighbors, subgraph_type, replace, disjoint,
+            temporal_strategy, time_attr, weight_attr, is_sorted, share_memory,
+            sample_direction='forward', directed=directed)
+        self.backward_sampler = NeighborSampler(
+            data, num_backward_neighbors, subgraph_type, replace, disjoint,
+            temporal_strategy, time_attr, weight_attr, is_sorted, share_memory,
+            sample_direction='backward', directed=directed)
+
     @property
     def num_neighbors(self) -> NumNeighbors:
         return self.forward_sampler.num_neighbors
-    
+
     @num_neighbors.setter
     def num_neighbors(self, num_neighbors: NumNeighborsType):
         self.forward_sampler.num_neighbors = num_neighbors
         if not self.backward_neighbors_explicitly_set:
             self.backward_sampler.num_neighbors = num_neighbors
-    
+
     @property
     def num_backward_neighbors(self) -> NumNeighbors:
         return self.backward_sampler.num_neighbors
@@ -568,23 +578,24 @@ class BidirectionalNeighborSampler(BaseSampler):
     def num_backward_neighbors(self, num_neighbors: NumNeighborsType):
         self.backward_sampler.num_neighbors = num_neighbors
         self.backward_neighbors_explicitly_set = True
+
     @property
     def is_hetero(self) -> bool:
         return self.forward_sampler.is_hetero
-    
+
     @property
     def is_temporal(self) -> bool:
         return self.forward_sampler.is_temporal
-    
+
     @property
     def disjoint(self) -> bool:
         return self.forward_sampler.disjoint
-        
+
     @disjoint.setter
     def disjoint(self, disjoint: bool):
         self.forward_sampler.disjoint = disjoint
         self.backward_sampler.disjoint = disjoint
-        
+
     def sample_from_nodes(
         self,
         inputs: NodeSamplerInput,
@@ -593,25 +604,24 @@ class BidirectionalNeighborSampler(BaseSampler):
         backward_out = self.backward_sampler.sample_from_nodes(inputs)
         out = forward_out.merge_with(backward_out)
         return out
-    
+
     def sample_from_edges(
         self,
         inputs: EdgeSamplerInput,
         neg_sampling: Optional[NegativeSampling] = None,
     ) -> Union[SamplerOutput, HeteroSamplerOutput]:
-        forward_out = self.forward_sampler.sample_from_edges(inputs, neg_sampling)
-        backward_out = self.backward_sampler.sample_from_edges(inputs, neg_sampling)
+        forward_out = self.forward_sampler.sample_from_edges(
+            inputs, neg_sampling)
+        backward_out = self.backward_sampler.sample_from_edges(
+            inputs, neg_sampling)
 
         return forward_out.merge_with(backward_out)
- 
+
     @property
     def edge_permutation(self) -> Union[OptTensor, Dict[EdgeType, OptTensor]]:
         return self.forward_sampler.edge_permutation
-        
-        
-        
-        
-        
+
+
 # Sampling Utilities ##########################################################
 
 

--- a/torch_geometric/sampler/neighbor_sampler.py
+++ b/torch_geometric/sampler/neighbor_sampler.py
@@ -47,6 +47,7 @@ class NeighborSampler(BaseSampler):
         weight_attr: Optional[str] = None,
         is_sorted: bool = False,
         share_memory: bool = False,
+        sample_direction: Literal['forward', 'backward'] = 'forward',
         # Deprecated:
         directed: bool = True,
     ):
@@ -85,7 +86,7 @@ class NeighborSampler(BaseSampler):
             self.colptr, self.row, self.perm = to_csc(
                 data, device='cpu', share_memory=share_memory,
                 is_sorted=is_sorted, src_node_time=self.node_time,
-                edge_time=self.edge_time)
+                edge_time=self.edge_time, to_transpose=sample_direction == 'backward')
 
             if self.edge_time is not None and self.perm is not None:
                 self.edge_time = self.edge_time[self.perm]
@@ -139,7 +140,7 @@ class NeighborSampler(BaseSampler):
             colptr_dict, row_dict, self.perm = to_hetero_csc(
                 data, device='cpu', share_memory=share_memory,
                 is_sorted=is_sorted, node_time_dict=self.node_time,
-                edge_time_dict=self.edge_time)
+                edge_time_dict=self.edge_time, to_transpose=sample_direction == 'backward')
 
             self.row_dict = remap_keys(row_dict, self.to_rel_type)
             self.colptr_dict = remap_keys(colptr_dict, self.to_rel_type)
@@ -219,7 +220,10 @@ class NeighborSampler(BaseSampler):
                     else:
                         self.edge_time = time_tensor
 
-                self.row, self.colptr, self.perm = graph_store.csc()
+                if sample_direction == 'forward':
+                    self.row, self.colptr, self.perm = graph_store.csc()
+                elif sample_direction == 'backward':
+                    self.colptr, self.row, self.perm = graph_store.csr()
 
             else:
                 node_types = [
@@ -259,8 +263,10 @@ class NeighborSampler(BaseSampler):
                 # Conversion to/from C++ string type (see above):
                 self.to_rel_type = {k: '__'.join(k) for k in self.edge_types}
                 self.to_edge_type = {v: k for k, v in self.to_rel_type.items()}
-                # Convert the graph data into CSC format for sampling:
-                row_dict, colptr_dict, self.perm = graph_store.csc()
+                if sample_direction == 'forward':
+                    row_dict, colptr_dict, self.perm = graph_store.csc()
+                elif sample_direction == 'backward':
+                    colptr_dict, row_dict, self.perm = graph_store.csr()
                 self.row_dict = remap_keys(row_dict, self.to_rel_type)
                 self.colptr_dict = remap_keys(colptr_dict, self.to_rel_type)
 
@@ -518,7 +524,94 @@ class NeighborSampler(BaseSampler):
                 num_sampled_edges=num_sampled_edges,
             )
 
+class BidirectionalNeighborSampler(BaseSampler):
+    """A sampler that allows for both upstream and downstream sampling."""
+    # NOTE: Designed to have the same interface as `NeighborSampler`
+    def __init__(
+        self,
+        data: Union[Data, HeteroData, Tuple[FeatureStore, GraphStore]],
+        num_neighbors: NumNeighborsType,
+        num_backward_neighbors: Optional[NumNeighborsType] = None,
+        subgraph_type: Union[SubgraphType, str] = 'directional',
+        replace: bool = False,
+        disjoint: bool = False,
+        temporal_strategy: str = 'uniform',
+        time_attr: Optional[str] = None,
+        weight_attr: Optional[str] = None,
+        is_sorted: bool = False,
+        share_memory: bool = False,
+        # Deprecated:
+        directed: bool = True,
+    ):
+        self.backward_neighbors_explicitly_set = num_backward_neighbors is not None
+        if num_backward_neighbors is None:
+            num_backward_neighbors = num_neighbors
 
+        self.forward_sampler = NeighborSampler(data, num_neighbors, subgraph_type, replace, disjoint, temporal_strategy, time_attr, weight_attr, is_sorted, share_memory, sample_direction='forward', directed=directed)
+        self.backward_sampler = NeighborSampler(data, num_backward_neighbors, subgraph_type, replace, disjoint, temporal_strategy, time_attr, weight_attr, is_sorted, share_memory, sample_direction='backward', directed=directed)
+    
+    @property
+    def num_neighbors(self) -> NumNeighbors:
+        return self.forward_sampler.num_neighbors
+    
+    @num_neighbors.setter
+    def num_neighbors(self, num_neighbors: NumNeighborsType):
+        self.forward_sampler.num_neighbors = num_neighbors
+        if not self.backward_neighbors_explicitly_set:
+            self.backward_sampler.num_neighbors = num_neighbors
+    
+    @property
+    def num_backward_neighbors(self) -> NumNeighbors:
+        return self.backward_sampler.num_neighbors
+
+    @num_backward_neighbors.setter
+    def num_backward_neighbors(self, num_neighbors: NumNeighborsType):
+        self.backward_sampler.num_neighbors = num_neighbors
+        self.backward_neighbors_explicitly_set = True
+    @property
+    def is_hetero(self) -> bool:
+        return self.forward_sampler.is_hetero
+    
+    @property
+    def is_temporal(self) -> bool:
+        return self.forward_sampler.is_temporal
+    
+    @property
+    def disjoint(self) -> bool:
+        return self.forward_sampler.disjoint
+        
+    @disjoint.setter
+    def disjoint(self, disjoint: bool):
+        self.forward_sampler.disjoint = disjoint
+        self.backward_sampler.disjoint = disjoint
+        
+    def sample_from_nodes(
+        self,
+        inputs: NodeSamplerInput,
+    ) -> Union[SamplerOutput, HeteroSamplerOutput]:
+        forward_out = self.forward_sampler.sample_from_nodes(inputs)
+        backward_out = self.backward_sampler.sample_from_nodes(inputs)
+        out = forward_out.merge_with(backward_out)
+        return out
+    
+    def sample_from_edges(
+        self,
+        inputs: EdgeSamplerInput,
+        neg_sampling: Optional[NegativeSampling] = None,
+    ) -> Union[SamplerOutput, HeteroSamplerOutput]:
+        forward_out = self.forward_sampler.sample_from_edges(inputs, neg_sampling)
+        backward_out = self.backward_sampler.sample_from_edges(inputs, neg_sampling)
+
+        return forward_out.merge_with(backward_out)
+ 
+    @property
+    def edge_permutation(self) -> Union[OptTensor, Dict[EdgeType, OptTensor]]:
+        return self.forward_sampler.edge_permutation
+        
+        
+        
+        
+        
 # Sampling Utilities ##########################################################
 
 

--- a/torch_geometric/sampler/utils.py
+++ b/torch_geometric/sampler/utils.py
@@ -100,6 +100,7 @@ def to_csc(
 
     return colptr, row, perm
 
+
 def to_hetero_csc(
     data: HeteroData,
     device: Optional[torch.device] = None,

--- a/torch_geometric/sampler/utils.py
+++ b/torch_geometric/sampler/utils.py
@@ -41,6 +41,7 @@ def to_csc(
     is_sorted: bool = False,
     src_node_time: Optional[Tensor] = None,
     edge_time: Optional[Tensor] = None,
+    to_transpose: bool = False,
 ) -> Tuple[Tensor, Tensor, OptTensor]:
     # Convert the graph data into a suitable format for sampling (CSC format).
     # Returns the `colptr` and `row` indices of the graph, as well as an
@@ -53,7 +54,10 @@ def to_csc(
         if src_node_time is not None:
             raise NotImplementedError("Temporal sampling via 'SparseTensor' "
                                       "format not yet supported")
-        colptr, row, _ = data.adj.csc()
+        if to_transpose:
+            row, colptr, _ = data.adj.csr()
+        else:
+            colptr, row, _ = data.adj.csc()
 
     elif hasattr(data, 'adj_t'):
         if src_node_time is not None:
@@ -65,10 +69,17 @@ def to_csc(
             # raise NotImplementedError("Temporal sampling via 'SparseTensor' "
             #                           "format not yet supported")
             pass
-        colptr, row, _ = data.adj_t.csr()
+        if to_transpose:
+            row, colptr, _ = data.adj_t.csc()
+        else:
+            colptr, row, _ = data.adj_t.csr()
 
     elif data.edge_index is not None:
-        row, col = data.edge_index
+        if to_transpose:
+            col, row = data.edge_index
+        else:
+            row, col = data.edge_index
+
         if not is_sorted:
             row, col, perm = sort_csc(row, col, src_node_time, edge_time)
         colptr = index2ptr(col, data.size(1))
@@ -89,7 +100,6 @@ def to_csc(
 
     return colptr, row, perm
 
-
 def to_hetero_csc(
     data: HeteroData,
     device: Optional[torch.device] = None,
@@ -97,6 +107,7 @@ def to_hetero_csc(
     is_sorted: bool = False,
     node_time_dict: Optional[Dict[NodeType, Tensor]] = None,
     edge_time_dict: Optional[Dict[EdgeType, Tensor]] = None,
+    to_transpose: bool = False,
 ) -> Tuple[Dict[str, Tensor], Dict[str, Tensor], Dict[str, OptTensor]]:
     # Convert the heterogeneous graph data into a suitable format for sampling
     # (CSC format).
@@ -108,7 +119,7 @@ def to_hetero_csc(
         src_node_time = (node_time_dict or {}).get(edge_type[0], None)
         edge_time = (edge_time_dict or {}).get(edge_type, None)
         out = to_csc(store, device, share_memory, is_sorted, src_node_time,
-                     edge_time)
+                     edge_time, to_transpose)
         colptr_dict[edge_type], row_dict[edge_type], perm_dict[edge_type] = out
 
     return colptr_dict, row_dict, perm_dict

--- a/torch_geometric/utils/rag/graph_store.py
+++ b/torch_geometric/utils/rag/graph_store.py
@@ -1,13 +1,12 @@
-from typing import Optional, Union, Dict, Any
+from typing import Any, Dict, Optional, Union
 
 from torch import Tensor
 
 from torch_geometric.data import FeatureStore
 from torch_geometric.distributed import LocalGraphStore
 from torch_geometric.sampler import (
-    HeteroSamplerOutput,
-    NeighborSampler,
     BidirectionalNeighborSampler,
+    HeteroSamplerOutput,
     NodeSamplerInput,
     SamplerOutput,
 )
@@ -38,9 +37,10 @@ class NeighborSamplingRAGGraphStore(LocalGraphStore):
         if self.feature_store is None:
             raise AttributeError("Feature store not registered yet.")
         self.sample_kwargs = self.sample_kwargs or {}
-        self.sample_kwargs['num_neighbors'] = self.sample_kwargs.get('num_neighbors', self._num_neighbors)
-        self.sampler = BidirectionalNeighborSampler(data=(self.feature_store, self),
-                                       **self.sample_kwargs)
+        self.sample_kwargs['num_neighbors'] = self.sample_kwargs.get(
+            'num_neighbors', self._num_neighbors)
+        self.sampler = BidirectionalNeighborSampler(
+            data=(self.feature_store, self), **self.sample_kwargs)
         self._sampler_is_initialized = True
 
     def register_feature_store(self, feature_store: FeatureStore):
@@ -120,7 +120,8 @@ class NeighborSamplingRAGGraphStore(LocalGraphStore):
 
     def sample_subgraph(
         self, seed_nodes: InputNodes, seed_edges: Optional[InputEdges] = None,
-        num_neighbors: Optional[NumNeighborsType] = None, sampler_kwargs: Optional[Dict[str, Any]] = None
+        num_neighbors: Optional[NumNeighborsType] = None,
+        sampler_kwargs: Optional[Dict[str, Any]] = None
     ) -> Union[SamplerOutput, HeteroSamplerOutput]:
         """Sample the graph starting from the given nodes and edges using the
         in-built NeighborSampler.
@@ -163,4 +164,3 @@ class NeighborSamplingRAGGraphStore(LocalGraphStore):
         out = self.sampler.sample_from_nodes(node_sample_input)
 
         return out
-


### PR DESCRIPTION
Fix edge case for Remote Graph Store where no nodes are found while sampling if all seed nodes are leaves.
Fix involves using BidirectionalSampler implemented in [PR 10126](https://github.com/pyg-team/pytorch_geometric/pull/10126).