### PR TITLE
Revert Revert EdgeIndex usage in Planetoid datasets

### DIFF
--- a/test/datasets/test_planetoid.py
+++ b/test/datasets/test_planetoid.py
@@ -1,3 +1,4 @@
+from torch_geometric import EdgeIndex
 from torch_geometric.loader import DataLoader
 from torch_geometric.testing import onlyOnline, withPackage
 
@@ -53,11 +54,10 @@ def test_citeseer_with_random_split(get_dataset):
         num_test=41,
     )
     data = dataset[0]
-    # from torch_geometric import EdgeIndex
-    # assert isinstance(data.edge_index, EdgeIndex)
-    # assert data.edge_index.sparse_size() == (data.num_nodes, data.num_nodes)
-    # assert data.edge_index.is_undirected
-    # assert data.edge_index.is_sorted_by_col
+    assert isinstance(data.edge_index, EdgeIndex)
+    assert data.edge_index.sparse_size() == (data.num_nodes, data.num_nodes)
+    assert data.edge_index.is_undirected
+    assert data.edge_index.is_sorted_by_col
 
     assert data.train_mask.sum() == dataset.num_classes * 11
     assert data.val_mask.sum() == 29

--- a/test/loader/test_hgt_loader.py
+++ b/test/loader/test_hgt_loader.py
@@ -146,7 +146,7 @@ def test_hgt_loader_on_cora(get_dataset):
     hetero_data = HeteroData()
     hetero_data['paper'].x = data.x
     hetero_data['paper'].n_id = torch.arange(data.num_nodes)
-    hetero_data['paper', 'paper'].edge_index = data.edge_index
+    hetero_data['paper', 'paper'].edge_index = data.edge_index._data
     hetero_data['paper', 'paper'].edge_weight = data.edge_weight
 
     split_idx = torch.arange(5, 8)

--- a/torch_geometric/io/planetoid.py
+++ b/torch_geometric/io/planetoid.py
@@ -1,12 +1,13 @@
 import os.path as osp
 import warnings
 from itertools import repeat
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Union
 
 import fsspec
 import torch
 from torch import Tensor
 
+from torch_geometric import EdgeIndex
 from torch_geometric.data import Data
 from torch_geometric.io import read_txt_array
 from torch_geometric.utils import (
@@ -117,7 +118,7 @@ def read_file(folder: str, prefix: str, name: str) -> Tensor:
 def edge_index_from_dict(
     graph_dict: Dict[int, List[int]],
     num_nodes: Optional[int] = None,
-) -> Tensor:
+) -> EdgeIndex:
     rows: List[int] = []
     cols: List[int] = []
     for key, value in graph_dict.items():
@@ -126,18 +127,16 @@ def edge_index_from_dict(
     row = torch.tensor(rows)
     col = torch.tensor(cols)
     edge_index = torch.stack([row, col], dim=0)
-
-    # `torch.compile` is not yet ready for `EdgeIndex` :(
-    # from torch_geometric import EdgeIndex
-    # edge_index: Union[EdgeIndex, Tensor] = EdgeIndex(
-    #     torch.stack([row, col], dim=0),
-    #     is_undirected=True,
-    #     sparse_size=(num_nodes, num_nodes),
-    # )
+    edge_index: Union[EdgeIndex, Tensor] = EdgeIndex(
+        torch.stack([row, col], dim=0),
+        is_undirected=True,
+        sparse_size=(num_nodes, num_nodes),
+    )
 
     # NOTE: There are some duplicated edges and self loops in the datasets.
     #       Other implementations do not remove them!
     edge_index, _ = remove_self_loops(edge_index)
     edge_index = coalesce(edge_index, num_nodes=num_nodes, sort_by_row=False)
 
+    assert isinstance(edge_index, EdgeIndex)
     return edge_index

--- a/torch_geometric/io/planetoid.py
+++ b/torch_geometric/io/planetoid.py
@@ -126,7 +126,6 @@ def edge_index_from_dict(
         cols += value
     row = torch.tensor(rows)
     col = torch.tensor(cols)
-    edge_index = torch.stack([row, col], dim=0)
     edge_index: Union[EdgeIndex, Tensor] = EdgeIndex(
         torch.stack([row, col], dim=0),
         is_undirected=True,

--- a/torch_geometric/loader/neighbor_sampler.py
+++ b/torch_geometric/loader/neighbor_sampler.py
@@ -3,6 +3,7 @@ from typing import Callable, List, NamedTuple, Optional, Tuple, Union
 import torch
 from torch import Tensor
 
+from torch_geometric import EdgeIndex as EdgeIndexTensor
 from torch_geometric.typing import SparseTensor
 
 
@@ -144,6 +145,9 @@ class NeighborSampler(torch.utils.data.DataLoader):
                 num_nodes = int(edge_index.max()) + 1
 
             value = torch.arange(edge_index.size(1)) if return_e_id else None
+            if (not torch.jit.is_scripting()
+                    and isinstance(edge_index, EdgeIndexTensor)):
+                edge_index = edge_index._data
             self.adj_t = SparseTensor(row=edge_index[0], col=edge_index[1],
                                       value=value,
                                       sparse_sizes=(num_nodes, num_nodes)).t()

--- a/torch_geometric/utils/_coalesce.py
+++ b/torch_geometric/utils/_coalesce.py
@@ -139,9 +139,11 @@ def coalesce(  # noqa: F811
     idx[1:] = edge_index[1 - int(sort_by_row)]
     idx[1:].mul_(num_nodes)
 
-    # Note: torch.tensor(...) is needed to transform Index to Tensor when
-    # edge_index is an EdgeIndex object.
-    idx[1:] += torch.tensor(edge_index[int(sort_by_row)])
+    # idx[1:] += torch.tensor(edge_index[int(sort_by_row)])
+    edge_index_sort_by_row = edge_index[int(sort_by_row)]
+    if not torch.jit.is_scripting() and isinstance(edge_index, EdgeIndex):
+        edge_index_sort_by_row = edge_index_sort_by_row._data
+    idx[1:] += edge_index_sort_by_row
 
     is_undirected = False
     if not torch.jit.is_scripting() and isinstance(edge_index, EdgeIndex):

--- a/torch_geometric/utils/_coalesce.py
+++ b/torch_geometric/utils/_coalesce.py
@@ -5,7 +5,7 @@ import torch
 from torch import Tensor
 
 import torch_geometric.typing
-from torch_geometric import EdgeIndex
+from torch_geometric import EdgeIndex, Index
 from torch_geometric.edge_index import SortOrder
 from torch_geometric.typing import OptTensor
 from torch_geometric.utils import index_sort, scatter
@@ -142,6 +142,7 @@ def coalesce(  # noqa: F811
     # idx[1:] += torch.tensor(edge_index[int(sort_by_row)])
     edge_index_sort_by_row = edge_index[int(sort_by_row)]
     if not torch.jit.is_scripting() and isinstance(edge_index, EdgeIndex):
+        assert isinstance(edge_index_sort_by_row, Index)
         edge_index_sort_by_row = edge_index_sort_by_row._data
     idx[1:] += edge_index_sort_by_row
 

--- a/torch_geometric/utils/_sort_edge_index.py
+++ b/torch_geometric/utils/_sort_edge_index.py
@@ -116,9 +116,10 @@ def sort_edge_index(  # noqa: F811
     else:
         idx = edge_index[1 - int(sort_by_row)] * num_nodes
 
-        # Note: torch.tensor(...) is needed to transform Index to Tensor when
-        # edge_index is an EdgeIndex object.
-        idx += torch.tensor(edge_index[int(sort_by_row)])
+        edge_index_sort_by_row = edge_index[int(sort_by_row)]
+        if not torch.jit.is_scripting() and isinstance(edge_index, EdgeIndex):
+            edge_index_sort_by_row = edge_index_sort_by_row._data
+        idx += edge_index_sort_by_row
         _, perm = index_sort(idx, max_value=num_nodes * num_nodes)
 
     if isinstance(edge_index, Tensor):

--- a/torch_geometric/utils/_sort_edge_index.py
+++ b/torch_geometric/utils/_sort_edge_index.py
@@ -115,7 +115,10 @@ def sort_edge_index(  # noqa: F811
         ])
     else:
         idx = edge_index[1 - int(sort_by_row)] * num_nodes
-        idx += edge_index[int(sort_by_row)]
+
+        # Note: torch.tensor(...) is needed to transform Index to Tensor when
+        # edge_index is an EdgeIndex object.
+        idx += torch.tensor(edge_index[int(sort_by_row)])
         _, perm = index_sort(idx, max_value=num_nodes * num_nodes)
 
     if isinstance(edge_index, Tensor):

--- a/torch_geometric/utils/_sort_edge_index.py
+++ b/torch_geometric/utils/_sort_edge_index.py
@@ -5,7 +5,7 @@ import torch
 from torch import Tensor
 
 import torch_geometric.typing
-from torch_geometric import EdgeIndex
+from torch_geometric import EdgeIndex, Index
 from torch_geometric.edge_index import SortOrder
 from torch_geometric.typing import OptTensor
 from torch_geometric.utils import index_sort, lexsort
@@ -118,6 +118,7 @@ def sort_edge_index(  # noqa: F811
 
         edge_index_sort_by_row = edge_index[int(sort_by_row)]
         if not torch.jit.is_scripting() and isinstance(edge_index, EdgeIndex):
+            assert isinstance(edge_index_sort_by_row, Index)
             edge_index_sort_by_row = edge_index_sort_by_row._data
         idx += edge_index_sort_by_row
         _, perm = index_sort(idx, max_value=num_nodes * num_nodes)


### PR DESCRIPTION
Follow up of https://github.com/pyg-team/pytorch_geometric/pull/8700/files
after message passing class is updated with `EdgeIndex` support.
Fixes https://github.com/pyg-team/pytorch_geometric/issues/8628