### PR TITLE
Fix CI Test for PGM Explainer

### DIFF
--- a/test/contrib/explain/test_pgm_explainer.py
+++ b/test/contrib/explain/test_pgm_explainer.py
@@ -5,7 +5,7 @@ from torch_geometric.contrib.explain import PGMExplainer
 from torch_geometric.explain import Explainer
 from torch_geometric.explain.config import ModelConfig
 from torch_geometric.nn import GCNConv, global_add_pool
-from torch_geometric.testing import withPackage
+from torch_geometric.testing import withPackage, minPython
 
 
 class GCN(torch.nn.Module):
@@ -45,6 +45,7 @@ target = torch.tensor([0, 0, 0, 1, 1, 2, 2, 2])
 edge_label_index = torch.tensor([[0, 1, 2], [3, 4, 5]])
 
 
+@minPython('3.10')
 @withPackage('pgmpy', 'pandas')
 @pytest.mark.parametrize('node_idx', [2, 6])
 @pytest.mark.parametrize('task_level, perturbation_mode', [

--- a/test/contrib/explain/test_pgm_explainer.py
+++ b/test/contrib/explain/test_pgm_explainer.py
@@ -5,7 +5,7 @@ from torch_geometric.contrib.explain import PGMExplainer
 from torch_geometric.explain import Explainer
 from torch_geometric.explain.config import ModelConfig
 from torch_geometric.nn import GCNConv, global_add_pool
-from torch_geometric.testing import withPackage, minPython
+from torch_geometric.testing import minPython, withPackage
 
 
 class GCN(torch.nn.Module):


### PR DESCRIPTION
Fix for CI failing on a test that relies on `|` operator in upstream dependency on Python 3.9.