### PR TITLE
Introduce dependabot for GHA workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+# https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+      time: "00:00"
+    labels:
+      - "ci"
+      - "skip-changelog"
+    pull-request-branch-name:
+      separator: "-"
+    open-pull-requests-limit: 10


### PR DESCRIPTION
This is no human work. With #10196, this PR will keep our GHA workflows up to date, and we'll see no repeated useless dependabot alerts anymore.

Regarding the configuration, looking at how infrequently dependabot submits PRs in PyTorch Frame https://github.com/pyg-team/pytorch-frame/pulls?q=sort%3Aupdated-desc+is%3Apr+author%3Adependabot%5Bbot%5D+is%3Aclosed, I think `interval: "daily"` is ok.