### PR TITLE
assign back to self.l2 in reset_parameters in RGATConv

### DIFF
--- a/torch_geometric/nn/conv/rgat_conv.py
+++ b/torch_geometric/nn/conv/rgat_conv.py
@@ -307,7 +307,7 @@ class RGATConv(MessagePassing):
         zeros(self.bias)
         ones(self.l1)
         zeros(self.b1)
-        torch.full(self.l2.size(), 1 / self.out_channels)
+        self.l2 = torch.full(self.l2.size(), 1 / self.out_channels)
         zeros(self.b2)
         if self.lin_edge is not None:
             glorot(self.lin_edge)


### PR DESCRIPTION
I can't quite explain this, and I do not (yet) have the minimal code to reproduce this, but I was randomly getting all nan's for the `l2` parameter of RGATConv. Randomly meaning I would start up my script multiple times and initialize 13 models with RGATConv layers and I would end up with different numbers of ones with `l2` being all nan. This is my workaround

```
      for _ in range(100):

        layer = RGATConv(
          inp,
          out,
          num_relations=edges["Type"].unique().shape[0],
          heads=heads,
          edge_dim=len(["Direction", "Delta"]),
        )

        if not torch.isnan(layer.get_parameter("l2")).any():
          break

        print("Found nans in l2 parameter during layer initialization, retrying.")

      else:
        raise ValueError("Always got nans in l2 parameter during layer initialization")

```

So I don't know why my fix would fix the randomness, but in investigating it I found this bug where the result of torch.full is dropped and not assigned back to self.l2.

```
diff --git a/torch_geometric/nn/conv/rgat_conv.py b/torch_geometric/nn/conv/rgat_conv.py
index 4c3a9937..b6f87b87 100644
--- a/torch_geometric/nn/conv/rgat_conv.py
+++ b/torch_geometric/nn/conv/rgat_conv.py
@@ -307,7 +307,7 @@ class RGATConv(MessagePassing):
         zeros(self.bias)
         ones(self.l1)
         zeros(self.b1)
-        torch.full(self.l2.size(), 1 / self.out_channels)
+        self.l2 = torch.full(self.l2.size(), 1 / self.out_channels)
         zeros(self.b2)
         if self.lin_edge is not None:
             glorot(self.lin_edge)
```