### PR TITLE
`LineGraph` improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
+- Accelerated `LineGraph` and fixed issue with self-connected inputs ([#10212](https://github.com/pyg-team/pytorch_geometric/pull/10212))
 - Updated cuGraph examples to use buffered sampling which keeps data in memory and is significantly faster than the deprecated buffered sampling ([#10079](https://github.com/pyg-team/pytorch_geometric/pull/10079))
 - Updated Dockerfile to use latest from NVIDIA ([#9794](https://github.com/pyg-team/pytorch_geometric/pull/9794))
 - Dropped Python 3.8 support ([#9696](https://github.com/pyg-team/pytorch_geometric/pull/9606))


### PR DESCRIPTION
This PR improves the efficiency of the `LineGraph` transformation by replacing several for-loops with vectorized operations. These changes significantly speed up the computation, especially for larger graphs.

It also resolves the issue described in issue described in #10014, where undirected graphs with self-loops were not handled correctly.

The documentation for `LineGraph` has also been updated:

- It now reflects the fix for self-connected undirected graphs.
- It clarifies that the output graph does not contain self-loops, addressing a previous ambiguity in the description.


