### PR TITLE
Add missing .relu() to heterogeneous.rst

### DIFF
--- a/docs/source/tutorial/heterogeneous.rst
+++ b/docs/source/tutorial/heterogeneous.rst
@@ -228,7 +228,7 @@ The following `example <https://github.com/pyg-team/pytorch_geometric/blob/maste
 
         def forward(self, x, edge_index):
             x = self.conv1(x, edge_index).relu()
-            x = self.conv2(x, edge_index)
+            x = self.conv2(x, edge_index).relu()
             return x
 
 


### PR DESCRIPTION
Adding a missing `.relu()` to the heterogeneous docs. 

The figure illustrating the code example visualises this relu, but it is missing in the code.
<img width="712" alt="Screenshot 2025-04-23 at 13 56 15" src="https://github.com/user-attachments/assets/fe74a1c1-da80-4063-8113-5802fb411e3f" />


The same illustration is used in the `.to_hetero()` [docs](https://pytorch-geometric.readthedocs.io/en/latest/modules/nn.html), but there the `.relu()` is also included in the code example.
