### PR TITLE
blocking sgformer as an option for cugraph until disjoint sampling is…

### DIFF
--- a/examples/ogbn_train_cugraph.py
+++ b/examples/ogbn_train_cugraph.py
@@ -76,9 +76,9 @@ def arg_parse():
     parser.add_argument(
         "--model",
         type=str,
-        default='SGFormer',
-        choices=['SAGE', 'GAT', 'GCN', 'SGFormer'],
-        help="Model used for training, default SGFormer",
+        default='SAGE',
+        choices=['SAGE', 'GAT', 'GCN',], # 'SGFormer'],
+        help="Model used for training, default SAGE",
     )
     parser.add_argument(
         "--num_heads",
@@ -88,7 +88,6 @@ def arg_parse():
     )
     parser.add_argument('--tempdir_root', type=str, default=None)
     args = parser.parse_args()
-
     return args
 
 


### PR DESCRIPTION
… enabled

this PR https://github.com/pyg-team/pytorch_geometric/pull/9908 handles things more elegantly but until then this shouldnt be allowed. I had forgotten to make these changes when adding disjoint support in previous PRs