### PR TITLE
Remove `auto-skip-changelog` label

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -65,6 +65,3 @@ graphgym:
 benchmark:
   - changed-files:
       - any-glob-to-any-file: ["benchmark/**/*", "torch_geometric/profile/**/*"]
-
-auto-skip-changelog:
-  - head-branch: ['^skip', '^pre-commit-ci']

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -13,4 +13,4 @@ jobs:
       - name: Enforce changelog entry
         uses: dangoslen/changelog-enforcer@v3
         with:
-          skipLabels: skip-changelog, auto-skip-changelog
+          skipLabels: skip-changelog


### PR DESCRIPTION
It's confusing and hasn't been working properly. Now that we have `.github/workflows/auto-merge.yml`, we don't need this label at all.