### PR TITLE
Drop support for PyTorch 1.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Removed
 
+- Dropped support for PyTorch 1.11 ([#10247](https://github.com/pyg-team/pytorch_geometric/pull/10247))
+
 ## [2.6.0] - 2024-09-13
 
 ### Added

--- a/torch_geometric/__init__.py
+++ b/torch_geometric/__init__.py
@@ -57,6 +57,12 @@ __all__ = [
     '__version__',
 ]
 
+if not torch_geometric.typing.WITH_PT112:
+    import warnings
+
+    warnings.warn("PyG 2.7.0 dropped support for PyTorch 1.11. Consider "
+                  "upgrading to PyTorch 1.12.0+ or downgrading to PyG 2.6.0.")
+
 # Serialization ###############################################################
 
 if torch_geometric.typing.WITH_PT24:

--- a/torch_geometric/__init__.py
+++ b/torch_geometric/__init__.py
@@ -58,10 +58,11 @@ __all__ = [
 ]
 
 if not torch_geometric.typing.WITH_PT112:
-    import warnings
+    import warnings as std_warnings
 
-    warnings.warn("PyG 2.7.0 dropped support for PyTorch 1.11. Consider "
-                  "upgrading to PyTorch 1.12.0+ or downgrading to PyG 2.6.0.")
+    std_warnings.warn("PyG 2.7.0 dropped support for PyTorch 1.11. Consider "
+                      "upgrading to PyTorch 1.12.0+ or downgrading to "
+                      "PyG 2.6.0. ")
 
 # Serialization ###############################################################
 

--- a/torch_geometric/typing.py
+++ b/torch_geometric/typing.py
@@ -21,7 +21,6 @@ WITH_PT23 = WITH_PT20 and int(torch.__version__.split('.')[1]) >= 3
 WITH_PT24 = WITH_PT20 and int(torch.__version__.split('.')[1]) >= 4
 WITH_PT25 = WITH_PT20 and int(torch.__version__.split('.')[1]) >= 5
 WITH_PT26 = WITH_PT20 and int(torch.__version__.split('.')[1]) >= 6
-WITH_PT111 = WITH_PT20 or int(torch.__version__.split('.')[1]) >= 11
 WITH_PT112 = WITH_PT20 or int(torch.__version__.split('.')[1]) >= 12
 WITH_PT113 = WITH_PT20 or int(torch.__version__.split('.')[1]) >= 13
 

--- a/torch_geometric/utils/_scatter.py
+++ b/torch_geometric/utils/_scatter.py
@@ -215,24 +215,18 @@ def scatter_argmax(
     if dim_size is None:
         dim_size = int(index.max()) + 1 if index.numel() > 0 else 0
 
-    if torch_geometric.typing.WITH_PT112:
-        if not is_in_onnx_export():
-            res = src.new_empty(dim_size)
-            res.scatter_reduce_(0, index, src.detach(), reduce='amax',
-                                include_self=False)
-        else:
-            # `include_self=False` is currently not supported by ONNX:
-            res = src.new_full(
-                size=(dim_size, ),
-                fill_value=src.min(),  # type: ignore
-            )
-            res.scatter_reduce_(0, index, src.detach(), reduce="amax",
-                                include_self=True)
-    elif torch_geometric.typing.WITH_PT111:
-        res = torch.scatter_reduce(src.detach(), 0, index, reduce='amax',
-                                   output_size=dim_size)  # type: ignore
+    if not is_in_onnx_export():
+        res = src.new_empty(dim_size)
+        res.scatter_reduce_(0, index, src.detach(), reduce='amax',
+                            include_self=False)
     else:
-        raise ValueError("'scatter_argmax' requires PyTorch >= 1.11")
+        # `include_self=False` is currently not supported by ONNX:
+        res = src.new_full(
+            size=(dim_size, ),
+            fill_value=src.min(),  # type: ignore
+        )
+        res.scatter_reduce_(0, index, src.detach(), reduce="amax",
+                            include_self=True)
 
     out = index.new_full((dim_size, ), fill_value=dim_size - 1)
     nonzero = (src == res[index]).nonzero().view(-1)


### PR DESCRIPTION
Removes support for PyTorch 1.11 for the following reasons, but still keeps raising a warning for those who are very passionate about using the legacy PyTorch version.

* PyTorch 1.11 is 3+ years old (https://github.com/pytorch/pytorch/releases/tag/v1.11.0).
* PyTorch 1.11 is a relic of interest to almost no one. (https://pepy.tech/projects/torch?timeRange=threeMonths&category=version&includeCIDownloads=true&granularity=daily&viewType=line&versions=2.7.0%2C2.6.0%2C1.13.1%2C1.11.0).
  <img width="600" alt="image" src="https://github.com/user-attachments/assets/d4849ca8-e058-44cf-979e-4e0172be1e7c" />
* We haven't tested PyTorch 1.11 in CI since #8199.