### PR TITLE
Drop support for PyTorch 1.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Removed
 
+- Dropped support for PyTorch 1.11 ([#10247](https://github.com/pyg-team/pytorch_geometric/pull/10247))
+
 ## [2.6.0] - 2024-09-13
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Removed
 
+- Dropped support for PyTorch 1.12 ([#10248](https://github.com/pyg-team/pytorch_geometric/pull/10248))
 - Dropped support for PyTorch 1.11 ([#10247](https://github.com/pyg-team/pytorch_geometric/pull/10247))
 
 ## [2.6.0] - 2024-09-13

--- a/test/nn/conv/test_gat_conv.py
+++ b/test/nn/conv/test_gat_conv.py
@@ -58,12 +58,10 @@ def test_gat_conv(residual):
     assert result[1][1].size() == (7, 2)
     assert result[1][1].min() >= 0 and result[1][1].max() <= 1
 
-    if torch_geometric.typing.WITH_PT113:
-        # PyTorch < 1.13 does not support multi-dimensional CSR values :(
-        result = conv(x1, adj1.t(), return_attention_weights=True)
-        assert torch.allclose(result[0], out, atol=1e-6)
-        assert result[1][0].size() == torch.Size([4, 4, 2])
-        assert result[1][0]._nnz() == 7
+    result = conv(x1, adj1.t(), return_attention_weights=True)
+    assert torch.allclose(result[0], out, atol=1e-6)
+    assert result[1][0].size() == torch.Size([4, 4, 2])
+    assert result[1][0]._nnz() == 7
 
     if torch_geometric.typing.WITH_TORCH_SPARSE:
         result = conv(x1, adj2.t(), return_attention_weights=True)

--- a/test/nn/conv/test_gatv2_conv.py
+++ b/test/nn/conv/test_gatv2_conv.py
@@ -56,12 +56,10 @@ def test_gatv2_conv(residual):
     assert result[1][1].size() == (7, 2)
     assert result[1][1].min() >= 0 and result[1][1].max() <= 1
 
-    if torch_geometric.typing.WITH_PT113:
-        # PyTorch < 1.13 does not support multi-dimensional CSR values :(
-        result = conv(x1, adj1.t(), return_attention_weights=True)
-        assert torch.allclose(result[0], out, atol=1e-6)
-        assert result[1][0].size() == torch.Size([4, 4, 2])
-        assert result[1][0]._nnz() == 7
+    result = conv(x1, adj1.t(), return_attention_weights=True)
+    assert torch.allclose(result[0], out, atol=1e-6)
+    assert result[1][0].size() == torch.Size([4, 4, 2])
+    assert result[1][0]._nnz() == 7
 
     if torch_geometric.typing.WITH_TORCH_SPARSE:
         result = conv(x1, adj2.t(), return_attention_weights=True)

--- a/test/nn/conv/test_message_passing.py
+++ b/test/nn/conv/test_message_passing.py
@@ -122,12 +122,11 @@ def test_my_conv_basic():
         assert torch.allclose(conv((x1, None), adj2.t()), out2, atol=1e-6)
 
     # Test gradient computation for `torch.sparse` tensors:
-    if torch_geometric.typing.WITH_PT112:
-        conv.fuse = True
-        torch_adj_t = adj1.t().requires_grad_()
-        out = conv((x1, x2), torch_adj_t)
-        out.sum().backward()
-        assert torch_adj_t.grad is not None
+    conv.fuse = True
+    torch_adj_t = adj1.t().requires_grad_()
+    out = conv((x1, x2), torch_adj_t)
+    out.sum().backward()
+    assert torch_adj_t.grad is not None
 
 
 def test_my_conv_save(tmp_path):

--- a/test/nn/conv/test_signed_conv.py
+++ b/test/nn/conv/test_signed_conv.py
@@ -33,7 +33,7 @@ def test_signed_conv():
     if torch_geometric.typing.WITH_TORCH_SPARSE:
         assert torch.allclose(conv2(out1, adj2.t(), adj2.t()), out2)
 
-    if is_full_test() and torch_geometric.typing.WITH_PT112:
+    if is_full_test():
         jit1 = torch.jit.script(conv1)
         jit2 = torch.jit.script(conv2)
         assert torch.allclose(jit1(x, edge_index, edge_index), out1)
@@ -62,7 +62,7 @@ def test_signed_conv():
         assert torch.allclose(conv2((out1, out1[:2]), adj2.t(), adj2.t()),
                               out2[:2], atol=1e-6)
 
-    if is_full_test() and torch_geometric.typing.WITH_PT112:
+    if is_full_test():
         assert torch.allclose(jit1((x, x[:2]), edge_index, edge_index),
                               out1[:2], atol=1e-6)
         assert torch.allclose(jit2((out1, out1[:2]), edge_index, edge_index),

--- a/test/nn/models/test_basic_gnn.py
+++ b/test/nn/models/test_basic_gnn.py
@@ -1,14 +1,12 @@
 import os
 import os.path as osp
 import random
-import sys
 import warnings
 
 import pytest
 import torch
 import torch.nn.functional as F
 
-import torch_geometric.typing
 from torch_geometric.data import Data
 from torch_geometric.loader import NeighborLoader
 from torch_geometric.nn import SAGEConv
@@ -220,10 +218,6 @@ def test_compile_basic(device):
 
 
 def test_packaging():
-    if (not torch_geometric.typing.WITH_PT113 and sys.version_info.major == 3
-            and sys.version_info.minor >= 10):
-        return  # Unsupported Python version
-
     warnings.filterwarnings('ignore', '.*TypedStorage is deprecated.*')
 
     os.makedirs(torch.hub._get_torch_home(), exist_ok=True)

--- a/test/nn/pool/connect/test_filter_edges.py
+++ b/test/nn/pool/connect/test_filter_edges.py
@@ -1,6 +1,5 @@
 import torch
 
-import torch_geometric.typing
 from torch_geometric.nn.pool.connect import FilterEdges
 from torch_geometric.nn.pool.select import SelectOutput
 from torch_geometric.testing import is_full_test
@@ -26,7 +25,7 @@ def test_filter_edges():
     assert out1.edge_attr.tolist() == [3, 5]
     assert out1.batch.tolist() == [0, 1]
 
-    if torch_geometric.typing.WITH_PT113 and is_full_test():
+    if is_full_test():
         jit = torch.jit.script(connect)
         out2 = jit(select_output, edge_index, edge_attr, batch)
         torch.equal(out1.edge_index, out2.edge_index)

--- a/test/nn/pool/test_asap.py
+++ b/test/nn/pool/test_asap.py
@@ -2,7 +2,6 @@ import io
 
 import torch
 
-import torch_geometric.typing
 from torch_geometric.nn import ASAPooling, GCNConv, GraphConv
 from torch_geometric.testing import is_full_test, onlyFullTest, onlyLinux
 
@@ -23,7 +22,7 @@ def test_asap():
         assert out[0].size() == (num_nodes // 2, in_channels)
         assert out[1].size() == (2, 2)
 
-        if torch_geometric.typing.WITH_PT113 and is_full_test():
+        if is_full_test():
             torch.jit.script(pool)
 
         pool = ASAPooling(in_channels, ratio=0.5, GNN=GNN, add_self_loops=True)

--- a/test/nn/pool/test_pan_pool.py
+++ b/test/nn/pool/test_pan_pool.py
@@ -1,6 +1,5 @@
 import torch
 
-import torch_geometric.typing
 from torch_geometric.nn import PANConv, PANPooling
 from torch_geometric.testing import is_full_test, withPackage
 
@@ -25,7 +24,7 @@ def test_pan_pooling():
     assert perm.size() == (2, )
     assert score.size() == (2, )
 
-    if torch_geometric.typing.WITH_PT113 and is_full_test():
+    if is_full_test():
         jit = torch.jit.script(pool)
         out = jit(x, M)
         assert torch.allclose(h, out[0])

--- a/test/nn/pool/test_sag_pool.py
+++ b/test/nn/pool/test_sag_pool.py
@@ -1,6 +1,5 @@
 import torch
 
-import torch_geometric.typing
 from torch_geometric.nn import (
     GATConv,
     GCNConv,
@@ -40,7 +39,7 @@ def test_sag_pooling():
         assert out3[0].size() == (2, in_channels)
         assert out3[1].size() == (2, 2)
 
-        if torch_geometric.typing.WITH_PT113 and is_full_test():
+        if is_full_test():
             jit1 = torch.jit.script(pool1)
             assert torch.allclose(jit1(x, edge_index)[0], out1[0])
 

--- a/test/nn/pool/test_topk_pool.py
+++ b/test/nn/pool/test_topk_pool.py
@@ -1,6 +1,5 @@
 import torch
 
-import torch_geometric.typing
 from torch_geometric.nn.pool import TopKPooling
 from torch_geometric.nn.pool.connect.filter_edges import filter_adj
 from torch_geometric.testing import is_full_test
@@ -49,7 +48,7 @@ def test_topk_pooling():
     assert out3[0].size() == (2, in_channels)
     assert out3[1].size() == (2, 2)
 
-    if torch_geometric.typing.WITH_PT113 and is_full_test():
+    if is_full_test():
         jit1 = torch.jit.script(pool1)
         assert torch.allclose(jit1(x, edge_index)[0], out1[0])
 

--- a/test/utils/test_sort_edge_index.py
+++ b/test/utils/test_sort_edge_index.py
@@ -14,11 +14,10 @@ def test_sort_edge_index():
     out = sort_edge_index(edge_index)
     assert out.tolist() == [[0, 1, 1, 2], [1, 0, 2, 1]]
 
-    if torch_geometric.typing.WITH_PT113:
-        torch_geometric.typing.MAX_INT64 = 1
-        out = sort_edge_index(edge_index)
-        torch_geometric.typing.MAX_INT64 = torch.iinfo(torch.int64).max
-        assert out.tolist() == [[0, 1, 1, 2], [1, 0, 2, 1]]
+    torch_geometric.typing.MAX_INT64 = 1
+    out = sort_edge_index(edge_index)
+    torch_geometric.typing.MAX_INT64 = torch.iinfo(torch.int64).max
+    assert out.tolist() == [[0, 1, 1, 2], [1, 0, 2, 1]]
 
     out = sort_edge_index((edge_index[0], edge_index[1]))
     assert isinstance(out, tuple)

--- a/torch_geometric/__init__.py
+++ b/torch_geometric/__init__.py
@@ -57,6 +57,12 @@ __all__ = [
     '__version__',
 ]
 
+if not torch_geometric.typing.WITH_PT112:
+    import warnings
+
+    warnings.warn("PyG 2.7.0 dropped support for PyTorch 1.11. Consider "
+                  "upgrading to PyTorch 1.12.0+ or downgrading to PyG 2.6.0.")
+
 # Serialization ###############################################################
 
 if torch_geometric.typing.WITH_PT24:

--- a/torch_geometric/__init__.py
+++ b/torch_geometric/__init__.py
@@ -58,10 +58,11 @@ __all__ = [
 ]
 
 if not torch_geometric.typing.WITH_PT112:
-    import warnings
+    import warnings as std_warnings
 
-    warnings.warn("PyG 2.7.0 dropped support for PyTorch 1.11. Consider "
-                  "upgrading to PyTorch 1.12.0+ or downgrading to PyG 2.6.0.")
+    std_warnings.warn("PyG 2.7.0 dropped support for PyTorch 1.11. Consider "
+                      "upgrading to PyTorch 1.12.0+ or downgrading to "
+                      "PyG 2.6.0. ")
 
 # Serialization ###############################################################
 

--- a/torch_geometric/__init__.py
+++ b/torch_geometric/__init__.py
@@ -60,7 +60,7 @@ __all__ = [
 if not torch_geometric.typing.WITH_PT113:
     import warnings as std_warnings
 
-    std_warnings.warn("PyG 2.7 dropped support for PyTorch < 1.13. Consider "
+    std_warnings.warn("PyG 2.7 removed support for PyTorch < 1.13. Consider "
                       "Consider upgrading to PyTorch >= 1.13 or downgrading "
                       "to PyG <= 2.6. ")
 

--- a/torch_geometric/__init__.py
+++ b/torch_geometric/__init__.py
@@ -57,12 +57,12 @@ __all__ = [
     '__version__',
 ]
 
-if not torch_geometric.typing.WITH_PT112:
+if not torch_geometric.typing.WITH_PT113:
     import warnings as std_warnings
 
-    std_warnings.warn("PyG 2.7.0 dropped support for PyTorch 1.11. Consider "
-                      "upgrading to PyTorch 1.12.0+ or downgrading to "
-                      "PyG 2.6.0. ")
+    std_warnings.warn("PyG 2.7.0 dropped support for PyTorch 1.11 and 1.12. "
+                      "Consider upgrading to PyTorch 1.13.0+ or downgrading "
+                      "to PyG 2.6.0. ")
 
 # Serialization ###############################################################
 

--- a/torch_geometric/data/collate.py
+++ b/torch_geometric/data/collate.py
@@ -191,10 +191,8 @@ def _collate(
             if torch_geometric.typing.WITH_PT20:
                 storage = elem.untyped_storage()._new_shared(
                     numel * elem.element_size(), device=elem.device)
-            elif torch_geometric.typing.WITH_PT112:
-                storage = elem.storage()._new_shared(numel, device=elem.device)
             else:
-                storage = elem.storage()._new_shared(numel)
+                storage = elem.storage()._new_shared(numel, device=elem.device)
             shape = list(elem.size())
             if cat_dim is None or elem.dim() == 0:
                 shape = [len(values)] + shape

--- a/torch_geometric/edge_index.py
+++ b/torch_geometric/edge_index.py
@@ -298,8 +298,7 @@ class EdgeIndex(Tensor):
                 indptr = None
             data = torch.stack([row, col], dim=0)
 
-        if (torch_geometric.typing.WITH_PT112
-                and data.layout == torch.sparse_csc):
+        if data.layout == torch.sparse_csc:
             row = data.row_indices()
             indptr = data.ccol_indices()
 
@@ -882,10 +881,6 @@ class EdgeIndex(Tensor):
                 If not specified, non-zero elements will be assigned a value of
                 :obj:`1.0`. (default: :obj:`None`)
         """
-        if not torch_geometric.typing.WITH_PT112:
-            raise NotImplementedError(
-                "'to_sparse_csc' not supported for PyTorch < 1.12")
-
         (colptr, row), perm = self.get_csc()
         if value is not None and perm is not None:
             value = value[perm]
@@ -922,7 +917,7 @@ class EdgeIndex(Tensor):
             return self.to_sparse_coo(value)
         if layout == torch.sparse_csr:
             return self.to_sparse_csr(value)
-        if torch_geometric.typing.WITH_PT112 and layout == torch.sparse_csc:
+        if layout == torch.sparse_csc:
             return self.to_sparse_csc(value)
 
         raise ValueError(f"Unexpected tensor layout (got '{layout}')")

--- a/torch_geometric/nn/dense/linear.py
+++ b/torch_geometric/nn/dense/linear.py
@@ -1,4 +1,3 @@
-import copy
 import math
 import sys
 import time
@@ -113,25 +112,6 @@ class Linear(torch.nn.Module):
             self.register_parameter('bias', None)
 
         self.reset_parameters()
-
-    def __deepcopy__(self, memo):
-        # PyTorch<1.13 cannot handle deep copies of uninitialized parameters :(
-        # TODO Drop this code once PyTorch 1.12 is no longer supported.
-        out = Linear(
-            self.in_channels,
-            self.out_channels,
-            self.bias is not None,
-            self.weight_initializer,
-            self.bias_initializer,
-        ).to(self.weight.device)
-
-        if self.in_channels > 0:
-            out.weight = copy.deepcopy(self.weight, memo)
-
-        if self.bias is not None:
-            out.bias = copy.deepcopy(self.bias, memo)
-
-        return out
 
     def reset_parameters(self):
         r"""Resets all learnable parameters of the module."""

--- a/torch_geometric/nn/pool/connect/base.py
+++ b/torch_geometric/nn/pool/connect/base.py
@@ -4,7 +4,6 @@ from typing import Optional
 import torch
 from torch import Tensor
 
-import torch_geometric.typing
 from torch_geometric.nn.pool.select import SelectOutput
 
 
@@ -49,8 +48,7 @@ class ConnectOutput:
         self.batch = batch
 
 
-if torch_geometric.typing.WITH_PT113:
-    ConnectOutput = torch.jit.script(ConnectOutput)
+ConnectOutput = torch.jit.script(ConnectOutput)
 
 
 class Connect(torch.nn.Module):

--- a/torch_geometric/nn/pool/select/base.py
+++ b/torch_geometric/nn/pool/select/base.py
@@ -4,8 +4,6 @@ from typing import Optional
 import torch
 from torch import Tensor
 
-import torch_geometric.typing
-
 
 @dataclass(init=False)
 class SelectOutput:
@@ -64,8 +62,7 @@ class SelectOutput:
         self.weight = weight
 
 
-if torch_geometric.typing.WITH_PT113:
-    SelectOutput = torch.jit.script(SelectOutput)
+SelectOutput = torch.jit.script(SelectOutput)
 
 
 class Select(torch.nn.Module):

--- a/torch_geometric/typing.py
+++ b/torch_geometric/typing.py
@@ -21,7 +21,6 @@ WITH_PT23 = WITH_PT20 and int(torch.__version__.split('.')[1]) >= 3
 WITH_PT24 = WITH_PT20 and int(torch.__version__.split('.')[1]) >= 4
 WITH_PT25 = WITH_PT20 and int(torch.__version__.split('.')[1]) >= 5
 WITH_PT26 = WITH_PT20 and int(torch.__version__.split('.')[1]) >= 6
-WITH_PT112 = WITH_PT20 or int(torch.__version__.split('.')[1]) >= 12
 WITH_PT113 = WITH_PT20 or int(torch.__version__.split('.')[1]) >= 13
 
 WITH_WINDOWS = os.name == 'nt'

--- a/torch_geometric/typing.py
+++ b/torch_geometric/typing.py
@@ -21,7 +21,6 @@ WITH_PT23 = WITH_PT20 and int(torch.__version__.split('.')[1]) >= 3
 WITH_PT24 = WITH_PT20 and int(torch.__version__.split('.')[1]) >= 4
 WITH_PT25 = WITH_PT20 and int(torch.__version__.split('.')[1]) >= 5
 WITH_PT26 = WITH_PT20 and int(torch.__version__.split('.')[1]) >= 6
-WITH_PT111 = WITH_PT20 or int(torch.__version__.split('.')[1]) >= 11
 WITH_PT112 = WITH_PT20 or int(torch.__version__.split('.')[1]) >= 12
 WITH_PT113 = WITH_PT20 or int(torch.__version__.split('.')[1]) >= 13
 

--- a/torch_geometric/utils/_lexsort.py
+++ b/torch_geometric/utils/_lexsort.py
@@ -1,10 +1,6 @@
 from typing import List
 
-import numpy as np
-import torch
 from torch import Tensor
-
-import torch_geometric.typing
 
 
 def lexsort(
@@ -27,11 +23,6 @@ def lexsort(
             descending). (default: :obj:`False`)
     """
     assert len(keys) >= 1
-
-    if not torch_geometric.typing.WITH_PT113:
-        keys = [k.neg() for k in keys] if descending else keys
-        out = np.lexsort([k.detach().cpu().numpy() for k in keys], axis=dim)
-        return torch.from_numpy(out).to(keys[0].device)
 
     out = keys[0].argsort(dim=dim, descending=descending, stable=True)
     for k in keys[1:]:

--- a/torch_geometric/utils/_scatter.py
+++ b/torch_geometric/utils/_scatter.py
@@ -8,185 +8,132 @@ from torch_geometric import is_compiling, is_in_onnx_export, warnings
 from torch_geometric.typing import torch_scatter
 from torch_geometric.utils.functions import cumsum
 
-if torch_geometric.typing.WITH_PT112:  # pragma: no cover
+warnings.filterwarnings('ignore', '.*is in beta and the API may change.*')
 
-    warnings.filterwarnings('ignore', '.*is in beta and the API may change.*')
 
-    def scatter(
-        src: Tensor,
-        index: Tensor,
-        dim: int = 0,
-        dim_size: Optional[int] = None,
-        reduce: str = 'sum',
-    ) -> Tensor:
-        r"""Reduces all values from the :obj:`src` tensor at the indices
-        specified in the :obj:`index` tensor along a given dimension
-        :obj:`dim`. See the `documentation
-        <https://pytorch-scatter.readthedocs.io/en/latest/functions/
-        scatter.html>`__ of the :obj:`torch_scatter` package for more
-        information.
+def scatter(
+    src: Tensor,
+    index: Tensor,
+    dim: int = 0,
+    dim_size: Optional[int] = None,
+    reduce: str = 'sum',
+) -> Tensor:
+    r"""Reduces all values from the :obj:`src` tensor at the indices specified
+    in the :obj:`index` tensor along a given dimension ``dim``. See the
+    `documentation <https://pytorch-scatter.readthedocs.io/en/latest/functions/scatter.html>`__  # noqa: E501
+    of the ``torch_scatter`` package for more information.
 
-        Args:
-            src (torch.Tensor): The source tensor.
-            index (torch.Tensor): The index tensor.
-            dim (int, optional): The dimension along which to index.
-                (default: :obj:`0`)
-            dim_size (int, optional): The size of the output tensor at
-                dimension :obj:`dim`. If set to :obj:`None`, will create a
-                minimal-sized output tensor according to
-                :obj:`index.max() + 1`. (default: :obj:`None`)
-            reduce (str, optional): The reduce operation (:obj:`"sum"`,
-                :obj:`"mean"`, :obj:`"mul"`, :obj:`"min"` or :obj:`"max"`,
-                :obj:`"any"`). (default: :obj:`"sum"`)
-        """
-        if isinstance(index, Tensor) and index.dim() != 1:
-            raise ValueError(f"The `index` argument must be one-dimensional "
-                             f"(got {index.dim()} dimensions)")
+    Args:
+        src (torch.Tensor): The source tensor.
+        index (torch.Tensor): The index tensor.
+        dim (int, optional): The dimension along which to index.
+            (default: ``0``)
+        dim_size (int, optional): The size of the output tensor at dimension
+            ``dim``. If set to :obj:`None`, will create a minimal-sized output
+            tensor according to ``index.max() + 1``. (default: :obj:`None`)
+        reduce (str, optional): The reduce operation (``"sum"``, ``"mean"``,
+            ``"mul"``, ``"min"``, ``"max"`` or ``"any"``). (default: ``"sum"``)
+    """
+    if isinstance(index, Tensor) and index.dim() != 1:
+        raise ValueError(f"The `index` argument must be one-dimensional "
+                         f"(got {index.dim()} dimensions)")
 
-        dim = src.dim() + dim if dim < 0 else dim
+    dim = src.dim() + dim if dim < 0 else dim
 
-        if isinstance(src, Tensor) and (dim < 0 or dim >= src.dim()):
-            raise ValueError(f"The `dim` argument must lay between 0 and "
-                             f"{src.dim() - 1} (got {dim})")
+    if isinstance(src, Tensor) and (dim < 0 or dim >= src.dim()):
+        raise ValueError(f"The `dim` argument must lay between 0 and "
+                         f"{src.dim() - 1} (got {dim})")
 
-        if dim_size is None:
-            dim_size = int(index.max()) + 1 if index.numel() > 0 else 0
+    if dim_size is None:
+        dim_size = int(index.max()) + 1 if index.numel() > 0 else 0
 
-        # For now, we maintain various different code paths, based on whether
-        # the input requires gradients and whether it lays on the CPU/GPU.
-        # For example, `torch_scatter` is usually faster than
-        # `torch.scatter_reduce` on GPU, while `torch.scatter_reduce` is faster
-        # on CPU.
-        # `torch.scatter_reduce` has a faster forward implementation for
-        # "min"/"max" reductions since it does not compute additional arg
-        # indices, but is therefore way slower in its backward implementation.
-        # More insights can be found in `test/utils/test_scatter.py`.
+    # For now, we maintain various different code paths, based on whether
+    # the input requires gradients and whether it lays on the CPU/GPU.
+    # For example, `torch_scatter` is usually faster than
+    # `torch.scatter_reduce` on GPU, while `torch.scatter_reduce` is faster
+    # on CPU.
+    # `torch.scatter_reduce` has a faster forward implementation for
+    # "min"/"max" reductions since it does not compute additional arg
+    # indices, but is therefore way slower in its backward implementation.
+    # More insights can be found in `test/utils/test_scatter.py`.
 
-        size = src.size()[:dim] + (dim_size, ) + src.size()[dim + 1:]
+    size = src.size()[:dim] + (dim_size, ) + src.size()[dim + 1:]
 
-        # For "any" reduction, we use regular `scatter_`:
-        if reduce == 'any':
-            index = broadcast(index, src, dim)
-            return src.new_zeros(size).scatter_(dim, index, src)
+    # For "any" reduction, we use regular `scatter_`:
+    if reduce == 'any':
+        index = broadcast(index, src, dim)
+        return src.new_zeros(size).scatter_(dim, index, src)
 
-        # For "sum" and "mean" reduction, we make use of `scatter_add_`:
-        if reduce == 'sum' or reduce == 'add':
-            index = broadcast(index, src, dim)
-            return src.new_zeros(size).scatter_add_(dim, index, src)
+    # For "sum" and "mean" reduction, we make use of `scatter_add_`:
+    if reduce == 'sum' or reduce == 'add':
+        index = broadcast(index, src, dim)
+        return src.new_zeros(size).scatter_add_(dim, index, src)
 
-        if reduce == 'mean':
-            count = src.new_zeros(dim_size)
-            count.scatter_add_(0, index, src.new_ones(src.size(dim)))
-            count = count.clamp(min=1)
+    if reduce == 'mean':
+        count = src.new_zeros(dim_size)
+        count.scatter_add_(0, index, src.new_ones(src.size(dim)))
+        count = count.clamp(min=1)
 
-            index = broadcast(index, src, dim)
-            out = src.new_zeros(size).scatter_add_(dim, index, src)
+        index = broadcast(index, src, dim)
+        out = src.new_zeros(size).scatter_add_(dim, index, src)
 
-            return out / broadcast(count, out, dim)
+        return out / broadcast(count, out, dim)
 
-        # For "min" and "max" reduction, we prefer `scatter_reduce_` on CPU or
-        # in case the input does not require gradients:
-        if reduce in ['min', 'max', 'amin', 'amax']:
-            if (not torch_geometric.typing.WITH_TORCH_SCATTER
-                    or is_compiling() or is_in_onnx_export() or not src.is_cuda
-                    or not src.requires_grad):
+    # For "min" and "max" reduction, we prefer `scatter_reduce_` on CPU or
+    # in case the input does not require gradients:
+    if reduce in ['min', 'max', 'amin', 'amax']:
+        if (not torch_geometric.typing.WITH_TORCH_SCATTER or is_compiling()
+                or is_in_onnx_export() or not src.is_cuda
+                or not src.requires_grad):
 
-                if (src.is_cuda and src.requires_grad and not is_compiling()
-                        and not is_in_onnx_export()):
-                    warnings.warn(f"The usage of `scatter(reduce='{reduce}')` "
-                                  f"can be accelerated via the 'torch-scatter'"
-                                  f" package, but it was not found")
-
-                index = broadcast(index, src, dim)
-                if not is_in_onnx_export():
-                    return src.new_zeros(size).scatter_reduce_(
-                        dim, index, src, reduce=f'a{reduce[-3:]}',
-                        include_self=False)
-
-                fill = torch.full(  # type: ignore
-                    size=(1, ),
-                    fill_value=src.min() if 'max' in reduce else src.max(),
-                    dtype=src.dtype,
-                    device=src.device,
-                ).expand_as(src)
-                out = src.new_zeros(size).scatter_reduce_(
-                    dim, index, fill, reduce=f'a{reduce[-3:]}',
-                    include_self=True)
-                return out.scatter_reduce_(dim, index, src,
-                                           reduce=f'a{reduce[-3:]}',
-                                           include_self=True)
-
-            return torch_scatter.scatter(src, index, dim, dim_size=dim_size,
-                                         reduce=reduce[-3:])
-
-        # For "mul" reduction, we prefer `scatter_reduce_` on CPU:
-        if reduce == 'mul':
-            if (not torch_geometric.typing.WITH_TORCH_SCATTER
-                    or is_compiling() or not src.is_cuda):
-
-                if src.is_cuda and not is_compiling():
-                    warnings.warn(f"The usage of `scatter(reduce='{reduce}')` "
-                                  f"can be accelerated via the 'torch-scatter'"
-                                  f" package, but it was not found")
-
-                index = broadcast(index, src, dim)
-                # We initialize with `one` here to match `scatter_mul` output:
-                return src.new_ones(size).scatter_reduce_(
-                    dim, index, src, reduce='prod', include_self=True)
-
-            return torch_scatter.scatter(src, index, dim, dim_size=dim_size,
-                                         reduce='mul')
-
-        raise ValueError(f"Encountered invalid `reduce` argument '{reduce}'")
-
-else:  # pragma: no cover
-
-    def scatter(
-        src: Tensor,
-        index: Tensor,
-        dim: int = 0,
-        dim_size: Optional[int] = None,
-        reduce: str = 'sum',
-    ) -> Tensor:
-        r"""Reduces all values from the :obj:`src` tensor at the indices
-        specified in the :obj:`index` tensor along a given dimension
-        :obj:`dim`. See the `documentation
-        <https://pytorch-scatter.readthedocs.io/en/latest/functions/
-        scatter.html>`_ of the :obj:`torch_scatter` package for more
-        information.
-
-        Args:
-            src (torch.Tensor): The source tensor.
-            index (torch.Tensor): The index tensor.
-            dim (int, optional): The dimension along which to index.
-                (default: :obj:`0`)
-            dim_size (int, optional): The size of the output tensor at
-                dimension :obj:`dim`. If set to :obj:`None`, will create a
-                minimal-sized output tensor according to
-                :obj:`index.max() + 1`. (default: :obj:`None`)
-            reduce (str, optional): The reduce operation (:obj:`"sum"`,
-                :obj:`"mean"`, :obj:`"mul"`, :obj:`"min"` or :obj:`"max"`,
-                :obj:`"any"`). (default: :obj:`"sum"`)
-        """
-        if reduce == 'any':
-            dim = src.dim() + dim if dim < 0 else dim
-
-            if dim_size is None:
-                dim_size = int(index.max()) + 1 if index.numel() > 0 else 0
-
-            size = src.size()[:dim] + (dim_size, ) + src.size()[dim + 1:]
+            if (src.is_cuda and src.requires_grad and not is_compiling()
+                    and not is_in_onnx_export()):
+                warnings.warn(f"The usage of `scatter(reduce='{reduce}')` "
+                              f"can be accelerated via the 'torch-scatter'"
+                              f" package, but it was not found")
 
             index = broadcast(index, src, dim)
-            return src.new_zeros(size).scatter_(dim, index, src)
+            if not is_in_onnx_export():
+                return src.new_zeros(size).scatter_reduce_(
+                    dim, index, src, reduce=f'a{reduce[-3:]}',
+                    include_self=False)
 
-        if not torch_geometric.typing.WITH_TORCH_SCATTER:
-            raise ImportError("'scatter' requires the 'torch-scatter' package")
-
-        if reduce == 'amin' or reduce == 'amax':
-            reduce = reduce[-3:]
+            fill = torch.full(  # type: ignore
+                size=(1, ),
+                fill_value=src.min() if 'max' in reduce else src.max(),
+                dtype=src.dtype,
+                device=src.device,
+            ).expand_as(src)
+            out = src.new_zeros(size).scatter_reduce_(dim, index, fill,
+                                                      reduce=f'a{reduce[-3:]}',
+                                                      include_self=True)
+            return out.scatter_reduce_(dim, index, src,
+                                       reduce=f'a{reduce[-3:]}',
+                                       include_self=True)
 
         return torch_scatter.scatter(src, index, dim, dim_size=dim_size,
-                                     reduce=reduce)
+                                     reduce=reduce[-3:])
+
+    # For "mul" reduction, we prefer `scatter_reduce_` on CPU:
+    if reduce == 'mul':
+        if (not torch_geometric.typing.WITH_TORCH_SCATTER or is_compiling()
+                or not src.is_cuda):
+
+            if src.is_cuda and not is_compiling():
+                warnings.warn(f"The usage of `scatter(reduce='{reduce}')` "
+                              f"can be accelerated via the 'torch-scatter'"
+                              f" package, but it was not found")
+
+            index = broadcast(index, src, dim)
+            # We initialize with `one` here to match `scatter_mul` output:
+            return src.new_ones(size).scatter_reduce_(dim, index, src,
+                                                      reduce='prod',
+                                                      include_self=True)
+
+        return torch_scatter.scatter(src, index, dim, dim_size=dim_size,
+                                     reduce='mul')
+
+    raise ValueError(f"Encountered invalid `reduce` argument '{reduce}'")
 
 
 def broadcast(src: Tensor, ref: Tensor, dim: int) -> Tensor:
@@ -284,13 +231,7 @@ def group_argsort(
 
     # Compute `grouped_argsort`:
     src = src - 2 * index if descending else src + 2 * index
-    if torch_geometric.typing.WITH_PT113:
-        perm = src.argsort(descending=descending, stable=stable)
-    else:
-        perm = src.argsort(descending=descending)
-        if stable:
-            warnings.warn("Ignoring option `stable=True` in 'group_argsort' "
-                          "since it requires PyTorch >= 1.13.0")
+    perm = src.argsort(descending=descending, stable=stable)
     out = torch.empty_like(index)
     out[perm] = torch.arange(index.numel(), device=index.device)
 

--- a/torch_geometric/utils/_scatter.py
+++ b/torch_geometric/utils/_scatter.py
@@ -215,24 +215,18 @@ def scatter_argmax(
     if dim_size is None:
         dim_size = int(index.max()) + 1 if index.numel() > 0 else 0
 
-    if torch_geometric.typing.WITH_PT112:
-        if not is_in_onnx_export():
-            res = src.new_empty(dim_size)
-            res.scatter_reduce_(0, index, src.detach(), reduce='amax',
-                                include_self=False)
-        else:
-            # `include_self=False` is currently not supported by ONNX:
-            res = src.new_full(
-                size=(dim_size, ),
-                fill_value=src.min(),  # type: ignore
-            )
-            res.scatter_reduce_(0, index, src.detach(), reduce="amax",
-                                include_self=True)
-    elif torch_geometric.typing.WITH_PT111:
-        res = torch.scatter_reduce(src.detach(), 0, index, reduce='amax',
-                                   output_size=dim_size)  # type: ignore
+    if not is_in_onnx_export():
+        res = src.new_empty(dim_size)
+        res.scatter_reduce_(0, index, src.detach(), reduce='amax',
+                            include_self=False)
     else:
-        raise ValueError("'scatter_argmax' requires PyTorch >= 1.11")
+        # `include_self=False` is currently not supported by ONNX:
+        res = src.new_full(
+            size=(dim_size, ),
+            fill_value=src.min(),  # type: ignore
+        )
+        res.scatter_reduce_(0, index, src.detach(), reduce="amax",
+                            include_self=True)
 
     out = index.new_full((dim_size, ), fill_value=dim_size - 1)
     nonzero = (src == res[index]).nonzero().view(-1)

--- a/torch_geometric/utils/_sort_edge_index.py
+++ b/torch_geometric/utils/_sort_edge_index.py
@@ -107,8 +107,6 @@ def sort_edge_index(  # noqa: F811
     num_nodes = maybe_num_nodes(edge_index, num_nodes)
 
     if num_nodes * num_nodes > torch_geometric.typing.MAX_INT64:
-        if not torch_geometric.typing.WITH_PT113:
-            raise ValueError("'sort_edge_index' will result in an overflow")
         perm = lexsort(keys=[
             edge_index[int(sort_by_row)],
             edge_index[1 - int(sort_by_row)],

--- a/torch_geometric/utils/_spmm.py
+++ b/torch_geometric/utils/_spmm.py
@@ -115,8 +115,7 @@ def spmm(
         if src.layout == torch.sparse_csr:
             ptr = src.crow_indices()
             deg = ptr[1:] - ptr[:-1]
-        elif (torch_geometric.typing.WITH_PT112
-              and src.layout == torch.sparse_csc):
+        elif src.layout == torch.sparse_csc:
             assert src.layout == torch.sparse_csc
             ones = torch.ones_like(src.values())
             index = src.row_indices()

--- a/torch_geometric/utils/sparse.py
+++ b/torch_geometric/utils/sparse.py
@@ -1,4 +1,3 @@
-import typing
 import warnings
 from typing import Any, List, Optional, Tuple, Union
 
@@ -124,8 +123,7 @@ def is_torch_sparse_tensor(src: Any) -> bool:
             return True
         if src.layout == torch.sparse_csr:
             return True
-        if (torch_geometric.typing.WITH_PT112
-                and src.layout == torch.sparse_csc):
+        if src.layout == torch.sparse_csc:
             return True
     return False
 
@@ -320,12 +318,6 @@ def to_torch_csc_tensor(
                size=(4, 4), nnz=6, layout=torch.sparse_csc)
 
     """
-    if not torch_geometric.typing.WITH_PT112:
-        if typing.TYPE_CHECKING:
-            raise NotImplementedError
-        return torch_geometric.typing.MockTorchCSCTensor(
-            edge_index, edge_attr, size)
-
     if size is None:
         size = int(edge_index.max()) + 1
 
@@ -392,7 +384,7 @@ def to_torch_sparse_tensor(
         return to_torch_coo_tensor(edge_index, edge_attr, size, is_coalesced)
     if layout == torch.sparse_csr:
         return to_torch_csr_tensor(edge_index, edge_attr, size, is_coalesced)
-    if torch_geometric.typing.WITH_PT112 and layout == torch.sparse_csc:
+    if layout == torch.sparse_csc:
         return to_torch_csc_tensor(edge_index, edge_attr, size, is_coalesced)
 
     raise ValueError(f"Unexpected sparse tensor layout (got '{layout}')")
@@ -431,7 +423,7 @@ def to_edge_index(adj: Union[Tensor, SparseTensor]) -> Tuple[Tensor, Tensor]:
         col = adj.col_indices().detach()
         return torch.stack([row, col], dim=0).long(), adj.values()
 
-    if torch_geometric.typing.WITH_PT112 and adj.layout == torch.sparse_csc:
+    if adj.layout == torch.sparse_csc:
         col = ptr2index(adj.ccol_indices().detach())
         row = adj.row_indices().detach()
         return torch.stack([row, col], dim=0).long(), adj.values()
@@ -480,7 +472,7 @@ def set_sparse_value(adj: Tensor, value: Tensor) -> Tensor:
             device=value.device,
         )
 
-    if torch_geometric.typing.WITH_PT112 and adj.layout == torch.sparse_csc:
+    if adj.layout == torch.sparse_csc:
         return torch.sparse_csc_tensor(
             ccol_indices=adj.ccol_indices(),
             row_indices=adj.row_indices(),


### PR DESCRIPTION
Follow up to #10247 for similar reasons.

* PyTorch 1.12 is 3 years old (https://github.com/pytorch/pytorch/releases/tag/v1.12.0)
* Almost no one uses PyTorch 1.12 (https://pepy.tech/projects/torch?timeRange=threeMonths&category=version&includeCIDownloads=true&granularity=daily&viewType=line&versions=2.7.0%2C2.6.0%2C1.13.1%2C1.12.1)
  <img width="600" alt="image" src="https://github.com/user-attachments/assets/e643c1d2-e51c-411d-9168-74a189d18c01" />
* We haven't tested PyTorch 1.12 in CI since #8885.