### PR TITLE
bugfix: Second GNNExplainer with custom config overwrites first

### DIFF
--- a/torch_geometric/explain/algorithm/gnn_explainer.py
+++ b/torch_geometric/explain/algorithm/gnn_explainer.py
@@ -61,7 +61,7 @@ class GNNExplainer(ExplainerAlgorithm):
             :attr:`~torch_geometric.explain.algorithm.GNNExplainer.coeffs`.
     """
 
-    coeffs = {
+    default_coeffs = {
         'edge_size': 0.005,
         'edge_reduction': 'sum',
         'node_feat_size': 1.0,
@@ -75,6 +75,7 @@ class GNNExplainer(ExplainerAlgorithm):
         super().__init__()
         self.epochs = epochs
         self.lr = lr
+        self.coeffs = dict(self.default_coeffs)
         self.coeffs.update(kwargs)
 
         self.node_mask = self.hard_node_mask = None
@@ -559,7 +560,7 @@ class GNNExplainer(ExplainerAlgorithm):
 class GNNExplainer_:
     r"""Deprecated version for :class:`GNNExplainer`."""
 
-    coeffs = GNNExplainer.coeffs
+    coeffs = GNNExplainer.default_coeffs
 
     conversion_node_mask_type = {
         'feature': 'common_attributes',


### PR DESCRIPTION
Here's an example test program
``` python
from torch_geometric.explain.algorithm.gnn_explainer import GNNExplainer
summing_explainer = GNNExplainer(edge_reduction='sum')
multiplying_explainer = GNNExplainer(edge_reduction='prod')
print(summing_explainer.coeffs['edge_reduction'])
```

Without the bugfix, this prints "prod" even though it's printing the edge_reduction for the **summing_explainer**. This is because `GNNExplainer.coeffs` is a class-level variable. When we instantiate multiplying_explainer, it overwrites GNNExplainer.coeffs['edge_reduction'] which is the same dictionary item summing_explainer uses.

The bugfix renames GNNExplainer.coeffs to GNNExplainer.default_coeffs, and each GNNExplainer instance gets its own copy of the coeffs dict, so they don't step on one another.