### PR TITLE
Use constant opacity when node/edge weights are given for visualisation

### DIFF
--- a/torch_geometric/visualization/graph.py
+++ b/torch_geometric/visualization/graph.py
@@ -160,9 +160,9 @@ def visualize_hetero_graph(
         node_labels_dict: Optional[Dict[str, List[str]]] = None,
         node_weight_dict: Optional[Dict[str, Tensor]] = None,
         node_size_range: Tuple[float, float] = (50, 500),
-        node_opacity_range: Tuple[float, float] = (0.2, 1.0),
+        node_opacity_range: Tuple[float, float] = (1.0, 1.0),
         edge_width_range: Tuple[float, float] = (0.1, 2.0),
-        edge_opacity_range: Tuple[float, float] = (0.2, 1.0),
+        edge_opacity_range: Tuple[float, float] = (1.0, 1.0),
 ) -> Any:
     """Visualizes a heterogeneous graph using networkx."""
     if backend is not None and backend != "networkx":
@@ -231,9 +231,9 @@ def _visualize_hetero_graph_via_networkx(
         node_labels_dict: Optional[Dict[str, List[str]]] = None,
         node_weight_dict: Optional[Dict[str, Tensor]] = None,
         node_size_range: Tuple[float, float] = (50, 500),
-        node_opacity_range: Tuple[float, float] = (0.2, 1.0),
+        node_opacity_range: Tuple[float, float] = (1.0, 1.0),
         edge_width_range: Tuple[float, float] = (0.1, 2.0),
-        edge_opacity_range: Tuple[float, float] = (0.2, 1.0),
+        edge_opacity_range: Tuple[float, float] = (1.0, 1.0),
 ) -> Any:
     import matplotlib.pyplot as plt
     import networkx as nx


### PR DESCRIPTION
As a user, I found it very confusing to change both opacity and width size depending on weights.

### Before
<img width="200" alt="image" src="https://github.com/user-attachments/assets/92ce52b6-0eec-4a10-b6f0-22e6fc909931" />

### After
<img width="200" alt="image" src="https://github.com/user-attachments/assets/778138e6-b459-440f-990e-3a4a10fa7278" />