### PR TITLE
Fix default handling behavior in graphgym.layer.GeneralMultiLayer

### DIFF
--- a/torch_geometric/graphgym/models/layer.py
+++ b/torch_geometric/graphgym/models/layer.py
@@ -138,7 +138,7 @@ class GeneralMultiLayer(torch.nn.Module):
     """
     def __init__(self, name, layer_config: LayerConfig, **kwargs):
         super().__init__()
-        if layer_config.dim_inner:
+        if layer_config.dim_inner is None:
             dim_inner = layer_config.dim_out
         else:
             dim_inner = layer_config.dim_inner


### PR DESCRIPTION
Similar bug to [PR:8486](https://github.com/pyg-team/pytorch_geometric/pull/8486), inverted condition in if clause.