### PR TITLE
Fix gradient clipping failure with DTensor parameters on GB200/B200 architecture.

### DIFF
--- a/examples/llm/molecule_gpt.py
+++ b/examples/llm/molecule_gpt.py
@@ -63,6 +63,9 @@ def train(
         param_group['lr'] = lr
         return lr
 
+    def get_clippable_params(params):
+        return [p for p in params if isinstance(p, torch.Tensor) and not hasattr(p, '_spec')]
+
     start_time = time.time()
     # Load dataset ================================================
     path = osp.dirname(osp.realpath(__file__))
@@ -144,14 +147,14 @@ def train(
                          batch.edge_attr, batch.smiles, batch.instruction,
                          batch.y)
             loss.backward()
-            clip_grad_norm_(optimizer.param_groups[0]['params'], 0.1)
+            clip_grad_norm_(get_clippable_params(optimizer.param_groups[0]['params']), 0.1)
 
             if (step + 1) % grad_steps == 0:
                 adjust_learning_rate(optimizer.param_groups[0], lr,
                                      step / len(train_loader) + epoch)
 
             optimizer.step()
-            epoch_loss += loss.item()
+            epoch_loss += loss.detach().item()
 
             if (step + 1) % grad_steps == 0:
                 lr = optimizer.param_groups[0]['lr']

--- a/examples/llm/molecule_gpt.py
+++ b/examples/llm/molecule_gpt.py
@@ -64,7 +64,10 @@ def train(
         return lr
 
     def get_clippable_params(params):
-        return [p for p in params if isinstance(p, torch.Tensor) and not hasattr(p, '_spec')]
+        return [
+            p for p in params
+            if isinstance(p, torch.Tensor) and not hasattr(p, '_spec')
+        ]
 
     start_time = time.time()
     # Load dataset ================================================
@@ -147,7 +150,8 @@ def train(
                          batch.edge_attr, batch.smiles, batch.instruction,
                          batch.y)
             loss.backward()
-            clip_grad_norm_(get_clippable_params(optimizer.param_groups[0]['params']), 0.1)
+            clip_grad_norm_(
+                get_clippable_params(optimizer.param_groups[0]['params']), 0.1)
 
             if (step + 1) % grad_steps == 0:
                 adjust_learning_rate(optimizer.param_groups[0], lr,


### PR DESCRIPTION
This PR resolves a runtime failure encountered  `during clip_grad_norm_()` on GB200 and B200 machines (e.g., Grace Hopper and Blackwell) due to mixed usage of torch. Tensor and DTensor objects in the optimizer parameter list.

✅ Problem
On architectures where `torch.distributed.tensor` is more actively used (e.g., with device_map='auto' or model parallelism), model parameters may be wrapped as `DTensor`. This causes:
```
Epoch: 1|3:   0%|                                                                                                                                        | 0/1686 [00:00<?, ?it/s]/usr/local/lib/python3.12/dist-packages/torch/distributed/tensor/_dispatch.py:439: UserWarning: Found a non-scalar tensor with numel=1 and ndim!=0, we are implicitly creating a replicated DTensor for it. However, please consider changing it to a scalar tensor or explicitly create a DTensor under distributed enviroment.
  warnings.warn(
[rank0]: Traceback (most recent call last):
[rank0]:   File "/workspace/examples/llm/molecule_gpt.py", line 194, in <module>
[rank0]:     train(
[rank0]:   File "/workspace/examples/llm/molecule_gpt.py", line 147, in train
[rank0]:     clip_grad_norm_(optimizer.param_groups[0]['params'], 0.1)
[rank0]:   File "/usr/local/lib/python3.12/dist-packages/torch/nn/utils/clip_grad.py", line 38, in _no_grad_wrapper
[rank0]:     return func(*args, **kwargs)
[rank0]:            ^^^^^^^^^^^^^^^^^^^^^
[rank0]:   File "/usr/local/lib/python3.12/dist-packages/torch/nn/utils/clip_grad.py", line 220, in clip_grad_norm_
[rank0]:     _clip_grads_with_norm_(parameters, max_norm, total_norm, foreach)
[rank0]:   File "/usr/local/lib/python3.12/dist-packages/torch/nn/utils/clip_grad.py", line 38, in _no_grad_wrapper
[rank0]:     return func(*args, **kwargs)
[rank0]:            ^^^^^^^^^^^^^^^^^^^^^
[rank0]:   File "/usr/local/lib/python3.12/dist-packages/torch/nn/utils/clip_grad.py", line 168, in _clip_grads_with_norm_
[rank0]:     torch._foreach_mul_(device_grads, clip_coef_clamped.to(device))
[rank0]:   File "/usr/local/lib/python3.12/dist-packages/torch/_compile.py", line 51, in inner
[rank0]:     return disable_fn(*args, **kwargs)
[rank0]:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank0]:   File "/usr/local/lib/python3.12/dist-packages/torch/_dynamo/eval_frame.py", line 850, in _fn
[rank0]:     return fn(*args, **kwargs)
[rank0]:            ^^^^^^^^^^^^^^^^^^^
[rank0]:   File "/usr/local/lib/python3.12/dist-packages/torch/distributed/tensor/_api.py", line 350, in __torch_dispatch__
[rank0]:     return DTensor._op_dispatcher.dispatch(
[rank0]:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank0]:   File "/usr/local/lib/python3.12/dist-packages/torch/distributed/tensor/_dispatch.py", line 157, in dispatch
[rank0]:     op_info = self.unwrap_to_op_info(op_call, args, kwargs)
[rank0]:               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank0]:   File "/usr/local/lib/python3.12/dist-packages/torch/distributed/tensor/_dispatch.py", line 356, in unwrap_to_op_info
[rank0]:     self._try_replicate_spec_for_scalar_tensor(
[rank0]:   File "/usr/local/lib/python3.12/dist-packages/torch/distributed/tensor/_dispatch.py", line 458, in _try_replicate_spec_for_scalar_tensor
[rank0]:     raise RuntimeError(
[rank0]: RuntimeError: aten._foreach_mul_.Tensor: got mixed torch.Tensor and DTensor, need to convert all torch.Tensor to DTensor before calling distributed operators!
```
when calling `torch.nn.utils.clip_grad_norm_()`.

🛠 Fix
- Filters out any DTensor-wrapped parameters prior to gradient clipping;
- Ensures compatibility with torch._foreach_* functions which expect homogeneously typed inputs.

 Tested On
✅ Grace Hopper (GH200)

✅ Blackwell (GB200)

✅ Standard Ampere/Volta systems (non-distributed)


I also addressed the following warning:
```
/workspace/examples/llm/molecule_gpt.py:157: UserWarning: Converting a tensor with requires_grad=True to a scalar may lead to unexpected behavior.5M/14.0M [00:00<00:00, 84.9MB/s]
Consider using tensor.detach() first. (Triggered internally at /opt/pytorch/pytorch/aten/src/ATen/native/Scalar.cpp:22.)
```
