### PR TITLE
Make `swish` compatible with `nn.Sequential`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- Fixed use of `swish` activation function with `nn.Sequential`([#10348](https://github.com/pyg-team/pytorch_geometric/pull/10348/commits))
 - Fixed conversion to/from `cuGraph` graph objects by ensuring `cudf` column names are correctly specified ([#10343](https://github.com/pyg-team/pytorch_geometric/pull/10343))
 - Fixed `_recursive_config()` for `torch.nn.ModuleList` and `torch.nn.ModuleDict` ([#10124](https://github.com/pyg-team/pytorch_geometric/pull/10124), [#10129](https://github.com/pyg-team/pytorch_geometric/pull/10129))
 - Fixed the `k_hop_subgraph()` method for directed graphs ([#9756](https://github.com/pyg-team/pytorch_geometric/pull/9756))

--- a/torch_geometric/nn/resolver.py
+++ b/torch_geometric/nn/resolver.py
@@ -23,8 +23,9 @@ except ImportError:  # PyTorch < 2.0
 # Activation Resolver #########################################################
 
 
-def swish(x: Tensor) -> Tensor:
-    return x * x.sigmoid()
+class Swish(torch.nn.Module):
+    def forward(self, x: Tensor) -> Tensor:
+        return x * x.sigmoid()
 
 
 def activation_resolver(query: Union[Any, str] = 'relu', *args, **kwargs):
@@ -35,7 +36,7 @@ def activation_resolver(query: Union[Any, str] = 'relu', *args, **kwargs):
         if isinstance(act, type) and issubclass(act, base_cls)
     ]
     acts += [
-        swish,
+        Swish,
     ]
     act_dict = {}
     return resolver(acts, act_dict, query, base_cls, base_cls_repr, *args,


### PR DESCRIPTION
`nn.Sequential` is used in multiple graph convolutional layers throughout the code. However, the current implementation of the `swish` activation is incompatible with this pattern:
``` python
from torch import nn
from torch_geometric.nn.resolver import activation_resolver
nn.Sequential(activation_resolver('swish'))
```
``` python
TypeError: torch_geometric.nn.resolver.swish is not a Module subclass
```
This PR replaces `swish` with `class Swish(nn.Module)`. 