### PR TITLE
Replace deprecated tag in MoleculeGPT dataset preprocessing.

### DIFF
--- a/torch_geometric/datasets/molecule_gpt_dataset.py
+++ b/torch_geometric/datasets/molecule_gpt_dataset.py
@@ -438,7 +438,7 @@ class MoleculeGPTDataset(InMemoryDataset):
         for mol in tqdm(suppl):
             if mol.HasProp('PUBCHEM_COMPOUND_CID'):
                 CID = mol.GetProp("PUBCHEM_COMPOUND_CID")
-                CAN_SMILES = mol.GetProp("PUBCHEM_OPENEYE_CAN_SMILES")
+                CAN_SMILES = mol.GetProp("PUBCHEM_SMILES")
 
                 m: Chem.Mol = Chem.MolFromSmiles(CAN_SMILES)
                 if m is None:


### PR DESCRIPTION
This PR addresses a breaking change in the PubChem dataset introduced in [version 04-18-2025](https://huggingface.co/datasets/molssiai-hub/pubchem-04-18-2025). 
```
PubChem Dataset (version 04-18-2025)
Important Note: The current version of the PubChem dataset includes a new entry, PUBCHEM_SMILES, which is equivalent 
to isomeric SMILES and contains both stereochemical and isotopic information. This entry is set to replace both 
PUBCHEM_OPENEYE_CAN_SMILES and PUBCHEM_OPENEYE_ISO_SMILES in the future. 
```

On 07/01/2025 this dataset was updated:
```
andreii@a4u8g-0057:~$ lftp ftp.ncbi.nlm.nih.gov -e "ls /pubchem/Compound/Extras/; bye"
-r--r--r--   1 ftp      anonymous 129819912 Jul  1 17:45 CID-Component.gz
-r--r--r--   1 ftp      anonymous       51 Jul  1 17:45 CID-Component.gz.md5
-r--r--r--   1 ftp      anonymous 321806434 Jul  1 17:50 CID-Date.gz
-r--r--r--   1 ftp      anonymous       46 Jul  1 17:50 CID-Date.gz.md5
-r--r--r--   1 ftp      anonymous 7142724582 Jul  1 18:59 CID-InChI-Key.gz
-r--r--r--   1 ftp      anonymous       51 Jul  1 18:59 CID-InChI-Key.gz.md5
```
As a result of that update, the property PUBCHEM_OPENEYE_CAN_SMILES, which was previously used in MoleculeGPT preprocessing, is no longer present in the updated dataset and we started seeing CI failures:
```
        for mol in tqdm(suppl):
            if mol.HasProp('PUBCHEM_COMPOUND_CID'):
                CID = mol.GetProp("PUBCHEM_COMPOUND_CID")
>               CAN_SMILES = mol.GetProp("PUBCHEM_OPENEYE_CAN_SMILES")
E               KeyError: 'PUBCHEM_OPENEYE_CAN_SMILES'
``` 

PubChem now provides a new field, PUBCHEM_SMILES, intended to replace both PUBCHEM_OPENEYE_CAN_SMILES and PUBCHEM_OPENEYE_ISO_SMILES.

**Changes Introduced**

Replaces `mol.GetProp("PUBCHEM_OPENEYE_CAN_SMILES")` with `mol.GetProp("PUBCHEM_SMILES")`


**Testing**

- Confirmed that molecule entries with the new PUBCHEM_SMILES field are successfully processed
- Ensured that lists dependent on SMILES strings are populated as expected
- CI tests involving the MoleculeGPT dataset now pass without error
