### PR TITLE
Update `examples/cpp/CMakeLists.txt` to fix C++ example compilation failures

### DIFF
--- a/examples/cpp/CMakeLists.txt
+++ b/examples/cpp/CMakeLists.txt
@@ -15,8 +15,7 @@ add_executable(hello-world main.cpp)
 # to our executable. We can do that by using the
 # TorchScatter::TorchScatter and TorchSparse::TorchSparse targets,
 # which also adds all the necessary torch dependencies.
-target_compile_features(hello-world PUBLIC cxx_range_for)
 target_link_libraries(hello-world TorchScatter::TorchScatter)
 target_link_libraries(hello-world TorchSparse::TorchSparse)
 target_link_libraries(hello-world ${CUDA_cusparse_LIBRARY})
-set_property(TARGET hello-world PROPERTY CXX_STANDARD 14)
+set_property(TARGET hello-world PROPERTY CXX_STANDARD 17)


### PR DESCRIPTION
## Bug Description

I followed the instructions in [examples/cpp/README.md](https://github.com/pyg-team/pytorch_geometric/blob/master/examples/cpp/README.md) to build the C++ example, and I encountered errors as below:

```text
$ make
[ 50%] Building CXX object CMakeFiles/hello-world.dir/main.cpp.o
In file included from /path/to/torch/include/torch/csrc/api/include/torch/types.h:3,
                 from /path/to/torch/include/torch/script.h:3,
                 from /path/to/pytorch_geometric/examples/cpp/main.cpp:1:
/path/to/torch/include/ATen/ATen.h:4:2: error: #error C++17 or later compatible compiler is required to use ATen.
    4 | #error C++17 or later compatible compiler is required to use ATen.
      |  ^~~~~
In file included from /path/to/torch/include/c10/util/CallOnce.h:4,
                 from /path/to/torch/include/ATen/Context.h:25,
                 from /path/to/torch/include/ATen/ATen.h:7:
/path/to/torch/include/c10/util/C++17.h:24:2: error: #error You need C++17 to compile PyTorch
   24 | #error You need C++17 to compile PyTorch
      |  ^~~~~
In file included from /path/to/torch/include/torch/csrc/api/include/torch/torch.h:3,
                 from /path/to/torchscatter/include/torchscatter/extensions.h:2,
                 from /path/to/torchscatter/include/torchscatter/scatter.h:3,
                 from /path/to/pytorch_geometric/examples/cpp/main.cpp:2:
/path/to/torch/include/torch/csrc/api/include/torch/all.h:4:2: error: #error C++17 or later compatible compiler is required to use PyTorch.
    4 | #error C++17 or later compatible compiler is required to use PyTorch.
      |  ^~~~~
```

## Bug Fix

### What causes the bug

The C++ example fails to compile with the current C++14 standard setting in [examples/cpp/CMakeLists.txt](https://github.com/pyg-team/pytorch_geometric/blob/master/examples/cpp/CMakeLists.txt):
https://github.com/pyg-team/pytorch_geometric/blob/9af3cedd2d3753ea592aaf47bd593ae371103238/examples/cpp/CMakeLists.txt#L22

This is due to a breaking change introduced in PyTorch v2.1.0 [(Release Note)](https://github.com/pytorch/pytorch/releases/tag/v2.1.0) as quoted below.

> The PyTorch codebase has migrated from the C++14 to the C++17 standard, so a C++17 compatible compiler is now required to compile PyTorch, to integrate with libtorch, or to implement a C++ PyTorch extension.

### Proposed solution

Bump C++ standard from C++14 to C++17 to resolve compilation failures.

P.S.: The following `target_compile_features` in CMakeLists.txt is unnecessary and can also be cleaned up.

https://github.com/pyg-team/pytorch_geometric/blob/9af3cedd2d3753ea592aaf47bd593ae371103238/examples/cpp/CMakeLists.txt#L18