### PR TITLE
Shorten `MoleculeGPTDataset` CI

### DIFF
--- a/test/datasets/test_molecule_gpt_dataset.py
+++ b/test/datasets/test_molecule_gpt_dataset.py
@@ -5,7 +5,10 @@ from torch_geometric.testing import onlyOnline, withPackage
 @onlyOnline
 @withPackage('transformers', 'sentencepiece', 'accelerate', 'rdkit')
 def test_molecule_gpt_dataset():
-    dataset = MoleculeGPTDataset(root='./data/MoleculeGPT')
+    dataset = MoleculeGPTDataset(
+        root='./data/MoleculeGPT',
+        skip_generate_instruction=True,
+    )
     assert str(dataset) == f'MoleculeGPTDataset({len(dataset)})'
     assert dataset.num_edge_features == 4
     assert dataset.num_node_features == 6

--- a/torch_geometric/datasets/molecule_gpt_dataset.py
+++ b/torch_geometric/datasets/molecule_gpt_dataset.py
@@ -196,6 +196,9 @@ class MoleculeGPTDataset(InMemoryDataset):
             (default: :obj:`10`)
         total_block_num (int, optional): The blocks of SDF files from PubChem.
             (default: :obj:`1`)
+        skip_generate_instruction (bool, optional): Whether to skip generating
+            instructions for the molecules by LLM.
+            (default: :obj:`False`)
     """
     description_url = (
         'https://pubchem.ncbi.nlm.nih.gov/rest/pug_view/annotations/'
@@ -213,9 +216,11 @@ class MoleculeGPTDataset(InMemoryDataset):
         force_reload: bool = False,
         total_page_num: int = 10,
         total_block_num: int = 1,
+        skip_generate_instruction: bool = False,
     ):
         self.total_page_num = total_page_num
         self.total_block_num = total_block_num
+        self.skip_generate_instruction = skip_generate_instruction
 
         super().__init__(root, transform, pre_transform, pre_filter,
                          force_reload=force_reload)
@@ -447,7 +452,11 @@ class MoleculeGPTDataset(InMemoryDataset):
 
                 ground_truth = CID2text_data[CID][0]
 
-                instruction = llm.inference([prompt.format(ground_truth)])[0]
+                if self.skip_generate_instruction:
+                    instruction = "What is the property of this molecule?"
+                else:
+                    instruction = llm.inference([prompt.format(ground_truth)
+                                                 ])[0]
 
                 x: torch.Tensor = torch.tensor([
                     types[atom.GetSymbol()] if atom.GetSymbol() in types else 5


### PR DESCRIPTION
- Skip generating instructions when testing `MoleculeGPTDataset` in CI
- As LLM inference is tested under `test/nn/nlp/test_llm.py`