### PR TITLE
Fixes for various warnings appearing in examples (part 2)

### DIFF
--- a/test/datasets/test_snap_dataset.py
+++ b/test/datasets/test_snap_dataset.py
@@ -1,9 +1,11 @@
 from torch_geometric.testing import onlyFullTest, onlyOnline
-
+from torch.serialization import add_safe_globals
+from torch_geometric.datasets.snap_dataset import EgoData
 
 @onlyOnline
 @onlyFullTest
 def test_ego_facebook_snap_dataset(get_dataset):
+    add_safe_globals([EgoData])
     dataset = get_dataset(name='ego-facebook')
     assert str(dataset) == 'SNAP-ego-facebook(10)'
     assert len(dataset) == 10

--- a/torch_geometric/contrib/explain/pgm_explainer.py
+++ b/torch_geometric/contrib/explain/pgm_explainer.py
@@ -151,7 +151,7 @@ class PGMExplainer(ExplainerAlgorithm):
 
             pred_change = torch.max(soft_pred) - soft_pred_perturb[pred_label]
 
-            sample[num_nodes] = pred_change
+            sample[num_nodes] = pred_change.detach()
             samples.append(sample)
 
         samples = torch.tensor(np.array(samples))

--- a/torch_geometric/data/extract.py
+++ b/torch_geometric/data/extract.py
@@ -28,7 +28,7 @@ def extract_tar(
     """
     maybe_log(path, log)
     with tarfile.open(path, mode) as f:
-        f.extractall(folder)
+        f.extractall(folder, filter='data')
 
 
 def extract_zip(path: str, folder: str, log: bool = True) -> None:
@@ -42,7 +42,7 @@ def extract_zip(path: str, folder: str, log: bool = True) -> None:
     """
     maybe_log(path, log)
     with zipfile.ZipFile(path, 'r') as f:
-        f.extractall(folder)
+        f.extractall(folder, filter='data')
 
 
 def extract_bz2(path: str, folder: str, log: bool = True) -> None:


### PR DESCRIPTION
Continuation of [PR#10357](https://github.com/pyg-team/pytorch_geometric/pull/10357) for fixing following warnings
```
  /usr/local/lib/python3.12/dist-packages/torch_geometric/contrib/explain/pgm_explainer.py:154: UserWarning: Converting a tensor with requires_grad=True to a scalar may lead to unexpected behavior.
  Consider using tensor.detach() first. (Triggered internally at /opt/pytorch/pytorch/torch/csrc/autograd/generated/python_variable_methods.cpp:835.)
    sample[num_nodes] = pred_change

test/datasets/test_protein_mpnn_dataset.py::test_protein_mpnn_dataset
  /usr/lib/python3.12/tarfile.py:2271: DeprecationWarning: Python 3.14 will, by default, filter extracted tar archives and reject files or modify their metadata. Use the filter argument to control this behavior.
    warnings.warn(

  test/datasets/test_snap_dataset.py::test_ego_facebook_snap_dataset /usr/local/lib/python3.12/dist-packages/torch_geometric/data/in_memory_dataset.py:131: UserWarning: Weights only load failed. Please file an issue to make torch.load(weights_only=True) compatible in your case. Please use torch.serialization.add_safe_globals([torch_geometric.datasets.snap_dataset.EgoData]) to allowlist this global. out = fs.torch_load(path)  
```