### PR TITLE
Fixes for various warnings appearing in examples (part 3)

### DIFF
--- a/torch_geometric/contrib/explain/pgm_explainer.py
+++ b/torch_geometric/contrib/explain/pgm_explainer.py
@@ -151,7 +151,7 @@ class PGMExplainer(ExplainerAlgorithm):
 
             pred_change = torch.max(soft_pred) - soft_pred_perturb[pred_label]
 
-            sample[num_nodes] = pred_change
+            sample[num_nodes] = pred_change.detach()
             samples.append(sample)
 
         samples = torch.tensor(np.array(samples))


### PR DESCRIPTION
Follow-up to [PR#10357](https://github.com/pyg-team/pytorch_geometric/pull/10357) to address and resolve the following warning:

```
  /usr/local/lib/python3.12/dist-packages/torch_geometric/contrib/explain/pgm_explainer.py:154: UserWarning: Converting 
a tensor with requires_grad=True to a scalar may lead to unexpected behavior.
  Consider using tensor.detach() first. (Triggered internally at /opt/pytorch/pytorch/torch/csrc/autograd/generated/python_variable_methods.cpp:835.)
    sample[num_nodes] = pred_change
```