### PR TITLE
Fixes for various warnings appearing in examples (part 2)

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -50,4 +50,4 @@ jobs:
       - name: Check type hints
         if: steps.changed-files-specific.outputs.only_changed != 'true'
         run: |
-          uv run --no-project mypy
+          uv run --no-project mypy --cache-dir=/dev/null

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -47,7 +47,7 @@ jobs:
           uv pip install mypy
           uv pip install -e ".[full,test]"
           uv pip install types-requests
-          
+
       - name: Check type hints
         if: steps.changed-files-specific.outputs.only_changed != 'true'
         run: |

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -46,7 +46,8 @@ jobs:
         run: |
           uv pip install mypy
           uv pip install -e ".[full,test]"
-
+          uv pip install types-requests
+          
       - name: Check type hints
         if: steps.changed-files-specific.outputs.only_changed != 'true'
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
-- Fix `detach()` warnings in example scripts involving tensor conversions. ([#10370](https://github.com/pyg-team/pytorch_geometric/pull/10370))
+- Fix `detach()` warnings in example scripts involving tensor conversions. ([#10357](https://github.com/pyg-team/pytorch_geometric/pull/10357))
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ## [2.7.0] - 2025-MM-DD
 
-### Added
+### Fixed
+- Fix `detach()` warnings in example scripts involving tensor conversions. ([#10370](https://github.com/pyg-team/pytorch_geometric/pull/10370))
 
+### Added
+ 
 - Added `Polynormer` model and example ([#9908](https://github.com/pyg-team/pytorch_geometric/pull/9908))
 - Added `ProteinMPNN` model and example ([#10289](https://github.com/pyg-team/pytorch_geometric/pull/10289))
 - Added the `Teeth3DS` dataset, an extended benchmark for intraoral 3D scan analysis ([#9833](https://github.com/pyg-team/pytorch_geometric/pull/9833))

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -42,7 +42,7 @@ suppress_warnings = ['autodoc.import_object']
 intersphinx_mapping = {
     'python': ('https://docs.python.org/', None),
     # 'numpy': ('http://docs.scipy.org/doc/numpy', None),
-    'pandas': ('http://pandas.pydata.org/pandas-docs/dev', None),
+    'pandas': ('http://pandas.pydata.org/pandas-docs/stable', None),
     'torch': ('https://pytorch.org/docs/main', None),
 }
 

--- a/test/datasets/test_snap_dataset.py
+++ b/test/datasets/test_snap_dataset.py
@@ -4,6 +4,27 @@ from torch_geometric.testing import onlyFullTest, onlyOnline
 @onlyOnline
 @onlyFullTest
 def test_ego_facebook_snap_dataset(get_dataset):
+    import warnings
+
+    import torch
+    from packaging import version
+
+    if version.parse(torch.__version__) >= version.parse("2.2.0"):
+        try:
+            from torch.serialization import add_safe_globals
+
+            from torch_geometric.datasets.snap_dataset import EgoData
+
+            add_safe_globals([EgoData])
+        except ImportError:
+            warnings.warn(
+                "add_safe_globals is expected but not found in "
+                "torch.serialization.", stacklevel=2)
+    else:
+        warnings.warn(
+            "add_safe_globals is not available in this version "
+            "of PyTorch; continuing without it.", stacklevel=2)
+
     dataset = get_dataset(name='ego-facebook')
     assert str(dataset) == 'SNAP-ego-facebook(10)'
     assert len(dataset) == 10

--- a/torch_geometric/data/extract.py
+++ b/torch_geometric/data/extract.py
@@ -28,7 +28,7 @@ def extract_tar(
     """
     maybe_log(path, log)
     with tarfile.open(path, mode) as f:
-        f.extractall(folder)
+        f.extractall(folder, filter='data')
 
 
 def extract_zip(path: str, folder: str, log: bool = True) -> None:


### PR DESCRIPTION
Follow-up to [PR#10357](https://github.com/pyg-team/pytorch_geometric/pull/10357) to address and resolve the following remaining warning:
```
  test/datasets/test_snap_dataset.py::test_ego_facebook_snap_dataset /usr/local/lib/python3.12/dist-packages/torch_geometric/data/in_memory_dataset.py:131: 
UserWarning: Weights only load failed. Please file an issue to make torch.load(weights_only=True) compatible 
in your case. Please use torch.serialization.add_safe_globals([torch_geometric.datasets.snap_dataset.EgoData]) 
to allowlist this global. out = fs.torch_load(path)  
```