### PR TITLE
Adding separate() Method to Data and HeteroData for extracting connected components

### DIFF
--- a/test/data/test_data.py
+++ b/test/data/test_data.py
@@ -418,6 +418,133 @@ def test_data_update():
     assert torch.equal(data.z, torch.arange(10, 15))
 
 
+def test_data_separate():
+    data = Data()
+    data.x = torch.tensor([[1.0], [2.0], [3.0], [4.0], [5.0]])
+    data.y = torch.tensor([[1.1, 1.2], [2.1, 2.2], [3.1, 3.2], [4.1, 4.2],
+                           [5.1, 5.2]])
+    data.edge_index = torch.tensor([[0, 1, 2, 3], [1, 0, 3, 2]],
+                                   dtype=torch.long)
+
+    split_data = data.separate()
+    assert isinstance(split_data, list)
+    assert len(split_data) == 3
+
+    assert torch.equal(split_data[0].x, torch.tensor([[1.0], [2.0]]))
+    assert torch.equal(split_data[0].y, torch.tensor([[1.1, 1.2], [2.1, 2.2]]))
+    assert torch.equal(split_data[0].edge_index, torch.tensor([[0, 1], [1,
+                                                                        0]]))
+
+    assert torch.equal(split_data[1].x, torch.tensor([[3.0], [4.0]]))
+    assert torch.equal(split_data[1].y, torch.tensor([[3.1, 3.2], [4.1, 4.2]]))
+    assert torch.equal(split_data[1].edge_index, torch.tensor([[0, 1], [1,
+                                                                        0]]))
+
+    assert torch.equal(split_data[2].x, torch.tensor([[5.0]]))
+    assert torch.equal(split_data[2].y, torch.tensor([[5.1, 5.2]]))
+    assert torch.equal(split_data[2].edge_index,
+                       torch.tensor([[], []], dtype=torch.long))
+
+
+@pytest.fixture
+def unmutable_obj():
+    class NotMutable:
+        def __getitem__(self, idx):
+            return 0
+
+    yield NotMutable()
+
+
+def test_data_check_slicable_and_mutable(unmutable_obj):
+
+    # Case 1: All attributes are sliceable and mutable (should not raise)
+    data = Data()
+    data.x = torch.zeros(3, 4)
+    data.y = torch.ones(2, 5)
+    data.edge_index = torch.zeros(2, 2)
+    data.edge_weight = torch.ones(2)
+    try:
+        data._check_slicable_and_mutable()
+    except Exception as e:
+        pytest.fail(f"Unexpected exception: {e}")
+
+    # Case 2: Attribute not sliceable
+    data = Data()
+    data.x = 123
+    with pytest.raises(TypeError,
+                       match=("Attribute 'x' " + "does not support slicing.")):
+        data._check_slicable_and_mutable()
+
+    # Case 3: Attribute not mutable
+    data = Data()
+    data.x = unmutable_obj
+    with pytest.raises(TypeError,
+                       match=("Attribute 'x' " + "is not mutable.")):
+        data._check_slicable_and_mutable()
+
+
+def test_data_find_parent():
+
+    # Case 1: Parent does not exist
+    data = Data()
+    data._parents = {}
+    data._ranks = {}
+    node = 1
+    assert data._find_parent(node) == node
+    assert data._parents == {1: 1}
+    assert data._ranks == {1: 0}
+
+    # Case 2: Parent exists
+    data._parents[node] = 0
+    assert data._find_parent(node) == 0
+
+
+def test_data_union():
+
+    # Setup: two nodes in different sets
+    data = Data()
+    data._parents = {}
+    data._ranks = {}
+    node1 = 1
+    node2 = 2
+
+    # Initially, both nodes are their own parents with rank 0
+    assert data._find_parent(node1) == node1
+    assert data._find_parent(node2) == node2
+    data._ranks[node1] = 0
+    data._ranks[node2] = 0
+
+    # Union them: node2 should now point to node1, and node1's rank increases
+    data._union(node1, node2)
+    assert data._find_parent(node1) == node1
+    assert data._find_parent(node2) == node1
+    assert data._ranks[node1] == 1
+
+    # Add a third node with higher rank and union with node1
+    node3 = 3
+    data._parents[node3] = node3
+    data._ranks[node3] = 2
+    data._union(node1, node3)
+    # node1's parent should now be node3, since node3 has higher rank
+    assert data._find_parent(node1) == node3
+    assert data._find_parent(node3) == node3
+
+    # Add a fourth node with lower rank and union with node3
+    node4 = 4
+    data._parents[node4] = node4
+    data._ranks[node4] = 0
+    data._union(node3, node4)
+    assert data._find_parent(node4) == node3
+    assert data._find_parent(node3) == node3
+
+    # Union of already connected nodes should not change anything
+    prev_ranks = data._ranks.copy()
+    prev_parents = data._parents.copy()
+    data._union(node1, node3)
+    assert data._ranks == prev_ranks
+    assert data._parents == prev_parents
+
+
 # Feature Store ###############################################################
 
 

--- a/test/data/test_hetero_data.py
+++ b/test/data/test_hetero_data.py
@@ -594,6 +594,177 @@ def test_hetero_data_update():
                        other['paper', 'paper'].edge_index)
 
 
+def test_hetero_data_separate():
+    data = HeteroData()
+    data["red"].x = torch.tensor([[1.0], [2.0], [3.0], [4.0], [5.0]])
+    data["red"].y = torch.tensor([1, 2, 3, 4, 5])
+    data["red"].z = torch.tensor([[1.1, 1.2], [2.1, 2.2], [3.1, 3.2],
+                                  [4.1, 4.2], [5.1, 5.2]])
+    data["blue"].x = torch.tensor([[6.0], [7.0]])
+    data["red", "to",
+         "red"].edge_index = torch.tensor([[0, 1, 2, 3], [1, 0, 3, 2]],
+                                          dtype=torch.long)
+    data["red", "with", "red"].edge_index = torch.tensor([[1], [1]],
+                                                         dtype=torch.long)
+    split_data = data.separate()
+
+    assert isinstance(split_data, list)
+    assert len(split_data) == 5
+    assert isinstance(split_data[0], HeteroData)
+    assert isinstance(split_data[1], HeteroData)
+    assert isinstance(split_data[2], HeteroData)
+    assert isinstance(split_data[3], HeteroData)
+    assert split_data[0].node_types == ['red']
+    assert split_data[1].node_types == ['red']
+    assert split_data[2].node_types == ['red']
+    assert split_data[3].node_types == ['blue']
+    assert split_data[4].node_types == ['blue']
+    assert split_data[0].edge_types == [('red', 'to', 'red'),
+                                        ('red', 'with', 'red')]
+    assert split_data[1].edge_types == [('red', 'to', 'red')]
+    assert split_data[2].edge_types == []
+    assert split_data[3].edge_types == []
+    assert split_data[4].edge_types == []
+    assert torch.equal(split_data[0]["red"].x, torch.tensor([[1.0], [2.0]]))
+    assert torch.equal(split_data[0]["red"].y, torch.tensor([1, 2]))
+    assert torch.equal(split_data[0]["red"].z,
+                       torch.tensor([[1.1, 1.2], [2.1, 2.2]]))
+    assert torch.equal(split_data[1]["red"].x, torch.tensor([[3.0], [4.0]]))
+    assert torch.equal(split_data[1]["red"].y, torch.tensor([3, 4]))
+    assert torch.equal(split_data[1]["red"].z,
+                       torch.tensor([[3.1, 3.2], [4.1, 4.2]]))
+    assert torch.equal(split_data[2]["red"].x, torch.tensor([[5.0]]))
+    assert torch.equal(split_data[2]["red"].y, torch.tensor([5]))
+    assert torch.equal(split_data[2]["red"].z, torch.tensor([[5.1, 5.2]]))
+    assert torch.equal(split_data[3]["blue"].x, torch.tensor([[6.0]]))
+    assert torch.equal(split_data[4]["blue"].x, torch.tensor([[7.0]]))
+    assert torch.equal(split_data[0]["red", "to", "red"].edge_index,
+                       torch.tensor([[0, 1], [1, 0]]))
+    assert torch.equal(split_data[0]["red", "with", "red"].edge_index,
+                       torch.tensor([[1], [1]]))
+    assert torch.equal(split_data[1]["red", "to", "red"].edge_index,
+                       torch.tensor([[0, 1], [1, 0]]))
+
+
+@pytest.fixture
+def unmutable_obj():
+    class NotMutable:
+        def __getitem__(self, idx):
+            return 0
+
+    yield NotMutable()
+
+
+def test_hetero_data_heck_slicable_and_mutable(unmutable_obj):
+
+    # Case 1: All attributes are sliceable and mutable (should not raise)
+    data = HeteroData()
+    data['paper'].x = torch.zeros(3, 4)
+    data['author'].y = torch.ones(2, 5)
+    data['paper', 'to', 'author'].edge_index = torch.zeros(2, 2)
+    data['paper', 'to', 'author'].edge_weight = torch.ones(2)
+    try:
+        data._check_slicable_and_mutable()
+    except Exception as e:
+        pytest.fail(f"Unexpected exception: {e}")
+
+    # Case 2: Node attribute not sliceable
+    data = HeteroData()
+    data['paper'].x = 123  # int, not sliceable
+    with pytest.raises(
+            TypeError, match=("Node type 'paper' with key 'x' " +
+                              "does not support slicing.")):
+        data._check_slicable_and_mutable()
+
+    # Case 3: Node attribute not mutable
+    data = HeteroData()
+    data['paper'].x = unmutable_obj
+    with pytest.raises(
+            TypeError,
+            match=("Node type 'paper' with key 'x' " + "is not mutable.")):
+        data._check_slicable_and_mutable()
+
+    # Case 4: Edge attribute not sliceable
+    data = HeteroData()
+    data['paper', 'to', 'author'].edge_index = torch.zeros(2, 2)
+    data['paper', 'to', 'author'].edge_weight = 123  # int, not sliceable
+    with pytest.raises(
+            TypeError, match=("Edge type \\('paper', 'to', 'author'\\) with " +
+                              "key 'edge_weight' does not support slicing.")):
+        data._check_slicable_and_mutable()
+
+    # Case 5: Edge attribute not mutable
+    data = HeteroData()
+    data['paper', 'to', 'author'].edge_index = torch.zeros(2, 2)
+    data['paper', 'to', 'author'].edge_weight = unmutable_obj
+    with pytest.raises(
+            TypeError, match=("Edge type \\('paper', 'to', 'author'\\) " +
+                              "with key 'edge_weight' is not mutable.")):
+        data._check_slicable_and_mutable()
+
+
+def test_hetero_data_find_parent():
+
+    # Case 1: Parent does not exist
+    data = HeteroData()
+    data._parents = {}
+    data._ranks = {}
+    node = ('paper', 1)
+    assert data._find_parent(node) == node
+    assert data._parents == {node: node}
+    assert data._ranks == {node: 0}
+
+    # Case 2: Parent exists
+    data._parents[node] = ('paper', 0)
+    assert data._find_parent(node) == ('paper', 0)
+
+
+def test_hetero_data_union():
+
+    # Setup: two nodes in different sets
+    data = HeteroData()
+    data._parents = {}
+    data._ranks = {}
+    node1 = ('paper', 1)
+    node2 = ('paper', 2)
+
+    # Initially, both nodes are their own parents with rank 0
+    assert data._find_parent(node1) == node1
+    assert data._find_parent(node2) == node2
+    data._ranks[node1] = 0
+    data._ranks[node2] = 0
+
+    # Union them: node2 should now point to node1, and node1's rank increases
+    data._union(node1, node2)
+    assert data._find_parent(node1) == node1
+    assert data._find_parent(node2) == node1
+    assert data._ranks[node1] == 1
+
+    # Add a third node with higher rank and union with node1
+    node3 = ('paper', 3)
+    data._parents[node3] = node3
+    data._ranks[node3] = 2
+    data._union(node1, node3)
+    # node1's parent should now be node3, since node3 has higher rank
+    assert data._find_parent(node1) == node3
+    assert data._find_parent(node3) == node3
+
+    # Add a fourth node with lower rank and union with node3
+    node4 = ('paper', 4)
+    data._parents[node4] = node4
+    data._ranks[node4] = 0
+    data._union(node3, node4)
+    assert data._find_parent(node4) == node3
+    assert data._find_parent(node3) == node3
+
+    # Union of already connected nodes should not change anything
+    prev_ranks = data._ranks.copy()
+    prev_parents = data._parents.copy()
+    data._union(node1, node3)
+    assert data._ranks == prev_ranks
+    assert data._parents == prev_parents
+
+
 # Feature Store ###############################################################
 
 

--- a/torch_geometric/data/hetero_data.py
+++ b/torch_geometric/data/hetero_data.py
@@ -487,6 +487,152 @@ class HeteroData(BaseData, FeatureStore, GraphStore):
 
         return status
 
+    def separate(self) -> List[Self]:
+        r"""Extracts connected components of the heterogeneous graph using
+        a union-find algorithm. The components are returned as a list of
+        :class:`~torch_geometric.data.HeteroData` objects. Only works if
+        attributes are sliceable (i.e. implement `__getitem__`) and mutable
+        (i.e. implement `__setitem__`).
+
+        .. code-block::
+
+            data = HeteroData()
+            data["red"].x = torch.tensor([[1.0], [2.0], [3.0], [4.0]])
+            data["blue"].x = torch.tensor([[5.0], [6.0]])
+            data["red", "to", "red"].edge_index = torch.tensor(
+                [[0, 1, 2, 3], [1, 0, 3, 2]], dtype=torch.long
+            )
+
+            split_data = data.separate()
+            print(len(split_data))
+            >>> 4
+
+            print(type(split_data))
+            >>> <class 'list'>
+
+            print(split_data[0])
+            >>> HeteroData(
+                red={x: tensor([[1.], [2.]])},
+                red, to, red={edge_index: tensor([[0, 1], [1, 0]])}
+            )
+
+            print(split_data[1])
+            >>> HeteroData(
+                red={x: tensor([[3.], [4.]])},
+                red, to, red={edge_index: tensor([[0, 1], [1, 0]])},
+            )
+
+            print(split_data[2])
+            >>> HeteroData(
+                blue={x: tensor([[5.]])},
+            )
+
+            print(split_data[3])
+            >>> HeteroData(
+                blue={x: tensor([[6.]])},
+            )
+
+        Returns:
+            List[HeteroData]: A list of disconnected components.
+        """
+        self._check_slicable_and_mutable()
+
+        # Initialize union-find structures
+        self._parents: Dict[Tuple[str, int], Tuple[str, int]] = {}
+        self._ranks: Dict[Tuple[str, int], int] = {}
+
+        # Union-Find algorithm to find connected components
+        for edge_type in self.edge_types:
+            src, _, dst = edge_type
+            edge_index = self[edge_type].edge_index
+            for src_node, dst_node in edge_index.t().tolist():
+                self._union((src, src_node), (dst, dst_node))
+        del self._ranks
+
+        # Group nodes by their representative parent
+        components_map = defaultdict(list)
+        for node, parent in self._parents.items():
+            components_map[parent].append(node)
+
+        # Get all nodes that were not connected to any edge
+        for node_type in self.node_types:
+            for node_index in range(self[node_type].num_nodes):
+                if (node_type, node_index) not in self._parents:
+                    components_map[(node_type, node_index)].append(
+                        (node_type, node_index))
+        del self._parents
+
+        components: List[Self] = []
+        for nodes in components_map.values():
+            # Map old indices to new indices per node type
+            node_map = defaultdict(dict)
+            for node_type, old_index in nodes:
+                node_map[node_type].update(
+                    {old_index: len(node_map[node_type])})
+
+            edges = {}
+            edge_masks = {}
+            for edge_type in self.edge_types:
+                src, _, dst = edge_type
+                if src not in node_map or dst not in node_map:
+                    continue
+
+                # Filter edges based on the node map
+                edge_index = self[edge_type].edge_index
+                src_mask = torch.isin(
+                    edge_index[0],
+                    torch.tensor(list(node_map[src].keys()),
+                                 device=edge_index.device))
+                dst_mask = torch.isin(
+                    edge_index[1],
+                    torch.tensor(list(node_map[dst].keys()),
+                                 device=edge_index.device))
+                edge_mask = src_mask & dst_mask
+                if not edge_mask.any():
+                    continue
+
+                # Reindex edges based on the node map
+                filtered_src = [
+                    node_map[src][i.item()] for i in edge_index[0][edge_mask]
+                ]
+                filtered_dst = [
+                    node_map[dst][i.item()] for i in edge_index[1][edge_mask]
+                ]
+                edges[edge_type] = torch.tensor([filtered_src, filtered_dst],
+                                                dtype=torch.long)
+                edge_masks[edge_type] = edge_mask
+
+            # Create new node and edge attributes based on the mapping
+            node_attrs = {
+                node_type: {
+                    attr: self[node_type][attr][list(mapping.keys())]
+                    for attr in self[node_type].keys()
+                }
+                for node_type, mapping in node_map.items()
+            }
+
+            edge_attrs = {}
+            for edge_type, edge_mask in edge_masks.items():
+                edge_attrs[edge_type] = {
+                    attr: self[edge_type][attr][edge_mask]
+                    for attr in self[edge_type].keys() if attr != 'edge_index'
+                }
+                edge_attrs[edge_type]['edge_index'] = edges[edge_type]
+
+            data = self.__class__()
+            for target, attr_value in {**node_attrs, **edge_attrs}.items():
+                for attr, value in attr_value.items():
+                    print(f"Setting {target}.{attr} with value {value}")
+                    if isinstance(value, Tensor):
+                        value = value.clone()
+                    elif isinstance(value, SparseTensor):
+                        value = value.clone().coalesce()
+                    data[target][attr] = value
+
+            components.append(data)
+
+        return components
+
     def debug(self):
         pass  # TODO
 
@@ -1147,6 +1293,83 @@ class HeteroData(BaseData, FeatureStore, GraphStore):
                     store._key, 'csc', size=size)
 
         return list(edge_attrs.values())
+
+    # Separate Helper Functions ##########################################
+
+    def _check_slicable_and_mutable(self):
+        r"""Checks if the node and edge attributes are slicable and mutable.
+        Raises a TypeError if any of the attributes do not support slicing or
+        are not mutable. This is necessary for the `separate` method to work
+        correctly.
+
+        Raises:
+            TypeError: If any node or edge type does not support slicing or is
+                not mutable.
+        """
+        for node_type in self.node_types:
+            for key in self[node_type].keys():
+                if not hasattr(self[node_type][key], "__getitem__"):
+                    raise TypeError(
+                        f"Node type '{node_type}' with key '{key}' " +
+                        "does not support slicing.")
+                if not hasattr(self[node_type][key], "__setitem__"):
+                    raise TypeError(
+                        f"Node type '{node_type}' with key '{key}' " +
+                        "is not mutable.")
+
+        for edge_type in self.edge_types:
+            for key in self[edge_type].keys():
+                if not hasattr(self[edge_type][key], "__getitem__"):
+                    raise TypeError(
+                        f"Edge type {edge_type} with key '{key}' " +
+                        "does not support slicing.")
+                if not hasattr(self[edge_type][key], "__setitem__"):
+                    raise TypeError(
+                        f"Edge type {edge_type} with key '{key}' " +
+                        "is not mutable.")
+
+    def _find_parent(self, node: Tuple[str, int]) -> Tuple[str, int]:
+        r"""Finds and returns the representative parent of the given node in a
+        disjoint-set (union-find) data structure. Implements path compression
+        to optimize future queries.
+
+        Args:
+            node (tuple[str, int]): The node for which to find the parent.
+            First element is the node type, second is the node index.
+
+        Returns:
+            tuple[str, int]: The representative parent of the node.
+        """
+        if node not in self._parents:
+            self._parents[node] = node
+            self._ranks[node] = 0
+        if self._parents[node] != node:
+            self._parents[node] = self._find_parent(self._parents[node])
+        return self._parents[node]
+
+    def _union(self, node1: Tuple[str, int], node2: Tuple[str, int]):
+        r"""Merges the node1 and node2 in the disjoint-set data structure.
+
+        Finds the root parents of node1 and node2 using the _find_parent
+        method. If they belong to different sets, updates the parent of
+        root2 to be root1, effectively merging the two sets.
+
+        Args:
+            node1 (Tuple[str, int]): The first node to union. First element is
+                the node type, second is the node index.
+            node2 (Tuple[str, int]): The second node to union. First element is
+                the node type, second is the node index.
+        """
+        root1 = self._find_parent(node1)
+        root2 = self._find_parent(node2)
+        if root1 != root2:
+            if self._ranks[root1] < self._ranks[root2]:
+                self._parents[root1] = root2
+            elif self._ranks[root1] > self._ranks[root2]:
+                self._parents[root2] = root1
+            else:
+                self._parents[root2] = root1
+                self._ranks[root1] += 1
 
 
 # Helper functions ############################################################


### PR DESCRIPTION
**Summary**

This PR adds a new method, `separate()`, to both `HeteroData` and `Data` classes in PyTorch Geometric. It identifies and extracts disjoint connected components from a (heterogeneous or homogeneous) graph using a union-find algorithm.

**Motivation**

While PyG provides convenient utilities such as `subgraph`, `edge_subgraph`, and `node_type_subgraph`, it does not currently offer a built-in method to extract connected components from graphs. This functionality could be useful for:

- Preprocessing or cleaning sparse or noisy graphs
- Isolating disconnected structures
- Enabling mini-batching strategies for large, sparse datasets

This PR provides a general-purpose implementation that complements existing subgraph utilities.

**API**

```
components = data.separate()
components = hetero_data.separate()
```

- Returns: A `List[Data]` or `List[HeteroData]`, with each item corresponding to a connected component.
- Optional filtering: For heterogeneous graphs, users are encouraged to pre-filter using existing methods like `node_type_subgraph` or `edge_type_subgraph` if they wish to limit the types involved.

**Highlights**

- Implementation for both Data and `HeteroData`
- Union-Find algorithm ensures O($\alpha$(n)), where $\alpha$: Ackermann function
- Compatible with PyG idioms and retains all feature and edge attributes if present in the connected component
    
**Discussion Points**

Based on feedback from the original issue, this version avoids introducing new arguments like `allowed_edge_types` or `allowed_node_types` and instead suggests combining the new method with existing filtering utilities.

Happy to further extend or refine the method based on team preferences!