### PR TITLE
Fix: Replace non-tuple indexing to resolve PyTorch deprecation warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 ### Fixed
 
 - Fix `detach()` warnings in example scripts involving tensor conversions. ([#10357](https://github.com/pyg-team/pytorch_geometric/pull/10357))
+- Fix non-tuple indexing to resolve PyTorch deprecation warning. ([#10389](https://github.com/pyg-team/pytorch_geometric/pull/10389))
 
 ### Added
 

--- a/examples/llm/git_mol.py
+++ b/examples/llm/git_mol.py
@@ -6,6 +6,7 @@ import os.path as osp
 
 import torch
 from accelerate import Accelerator
+from accelerate.utils import DistributedDataParallelKwargs
 from torch.optim.lr_scheduler import StepLR
 from tqdm import tqdm
 
@@ -52,7 +53,8 @@ def train(
                              drop_last=False, pin_memory=True, shuffle=False)
 
     # Create model ===============================================
-    accelerator = Accelerator()
+    ddp_kwargs = DistributedDataParallelKwargs(find_unused_parameters=True)
+    accelerator = Accelerator(kwargs_handlers=[ddp_kwargs])
     device = accelerator.device
     model = GITMol().to(device)
     optimizer = torch.optim.AdamW(

--- a/torch_geometric/data/large_graph_indexer.py
+++ b/torch_geometric/data/large_graph_indexer.py
@@ -297,7 +297,7 @@ class LargeGraphIndexer:
             idxs = list(
                 self.get_node_features_iter(feature_name, pids,
                                             index_only=True))
-            return values[idxs]
+            return values[torch.tensor(idxs)]
         return list(self.get_node_features_iter(feature_name, pids))
 
     def get_node_features_iter(
@@ -421,7 +421,7 @@ class LargeGraphIndexer:
             idxs = list(
                 self.get_edge_features_iter(feature_name, pids,
                                             index_only=True))
-            return values[idxs]
+            return values[torch.tensor(idxs)]
         return list(self.get_edge_features_iter(feature_name, pids))
 
     def get_edge_features_iter(


### PR DESCRIPTION
PR fixes the following warnings:
```
test/data/test_large_graph_indexer.py::test_large_graph_index
  /usr/local/lib/python3.12/dist-packages/torch_geometric/data/large_graph_indexer.py:300: UserWarning: Using a non-tuple 
sequence for multidimensional indexing is deprecated and will be changed in pytorch 2.9; use x[tuple(seq)] instead of 
x[seq]. In pytorch 2.9 this will be interpreted as tensor index, x[torch.tensor(seq)], which will result either in 
an error or a different result (Triggered internally at /opt/pytorch/pytorch/torch/csrc/autograd/python_variable_indexing.cpp:296.)
    return values[idxs]

test/data/test_large_graph_indexer.py::test_large_graph_index
  /usr/local/lib/python3.12/dist-packages/torch_geometric/data/large_graph_indexer.py:424: UserWarning: Using a non-tuple 
sequence for multidimensional indexing is deprecated and will be changed in pytorch 2.9; use x[tuple(seq)] instead of 
x[seq]. In pytorch 2.9 this will be interpreted as tensor index, x[torch.tensor(seq)], which will result either in 
an error or a different result (Triggered internally at /opt/pytorch/pytorch/torch/csrc/autograd/python_variable_indexing.cpp:296.)
    return values[idxs]
```