### PR TITLE
Update ModelNet10 url in modelnet.py

### DIFF
--- a/torch_geometric/datasets/modelnet.py
+++ b/torch_geometric/datasets/modelnet.py
@@ -78,8 +78,8 @@ class ModelNet(InMemoryDataset):
     """
 
     urls = {
-        '10': 'http://3dvision.princeton.edu/'
-        'projects/2014/3DShapeNets/ModelNet10.zip',
+        '10':
+        'http://3dvision.princeton.edu/projects/2014/3DShapeNets/ModelNet10.zip',
         '40': 'http://modelnet.cs.princeton.edu/ModelNet40.zip'
     }
 

--- a/torch_geometric/datasets/modelnet.py
+++ b/torch_geometric/datasets/modelnet.py
@@ -79,8 +79,9 @@ class ModelNet(InMemoryDataset):
 
     urls = {
         '10':
-        'http://vision.princeton.edu/projects/2014/3DShapeNets/ModelNet10.zip',
-        '40': 'http://modelnet.cs.princeton.edu/ModelNet40.zip'
+        'http://3dvision.princeton.edu/projects/2014/3DShapeNets/ModelNet10.zip',
+        '40':
+        'http://modelnet.cs.princeton.edu/ModelNet40.zip'
     }
 
     def __init__(

--- a/torch_geometric/datasets/modelnet.py
+++ b/torch_geometric/datasets/modelnet.py
@@ -78,7 +78,7 @@ class ModelNet(InMemoryDataset):
     """
 
     urls = {
-        '10': 'http://3dvision.princeton.edu/' \
+        '10': 'http://3dvision.princeton.edu/'
         'projects/2014/3DShapeNets/ModelNet10.zip',
         '40': 'http://modelnet.cs.princeton.edu/ModelNet40.zip'
     }

--- a/torch_geometric/datasets/modelnet.py
+++ b/torch_geometric/datasets/modelnet.py
@@ -79,7 +79,7 @@ class ModelNet(InMemoryDataset):
 
     urls = {
         '10':
-        'http://3dvision.princeton.edu/projects/2014/3DShapeNets/ModelNet10.zip',
+        'http://3dvision.princeton.edu/projects/2014/3DShapeNets/ModelNet10.zip', # noqa
         '40': 'http://modelnet.cs.princeton.edu/ModelNet40.zip'
     }
 

--- a/torch_geometric/datasets/modelnet.py
+++ b/torch_geometric/datasets/modelnet.py
@@ -78,8 +78,8 @@ class ModelNet(InMemoryDataset):
     """
 
     urls = {
-        '10':
-        'http://3dvision.princeton.edu/projects/2014/3DShapeNets/ModelNet10.zip',
+        '10': 'http://3dvision.princeton.edu/' \
+        'projects/2014/3DShapeNets/ModelNet10.zip',
         '40': 'http://modelnet.cs.princeton.edu/ModelNet40.zip'
     }
 

--- a/torch_geometric/datasets/modelnet.py
+++ b/torch_geometric/datasets/modelnet.py
@@ -79,7 +79,7 @@ class ModelNet(InMemoryDataset):
 
     urls = {
         '10':
-        'http://3dvision.princeton.edu/projects/2014/3DShapeNets/ModelNet10.zip', # noqa
+        'http://3dvision.princeton.edu/projects/2014/3DShapeNets/ModelNet10.zip',  # noqa
         '40': 'http://modelnet.cs.princeton.edu/ModelNet40.zip'
     }
 

--- a/torch_geometric/datasets/modelnet.py
+++ b/torch_geometric/datasets/modelnet.py
@@ -80,8 +80,7 @@ class ModelNet(InMemoryDataset):
     urls = {
         '10':
         'http://3dvision.princeton.edu/projects/2014/3DShapeNets/ModelNet10.zip',
-        '40':
-        'http://modelnet.cs.princeton.edu/ModelNet40.zip'
+        '40': 'http://modelnet.cs.princeton.edu/ModelNet40.zip'
     }
 
     def __init__(


### PR DESCRIPTION
Updated URL for ModelNet10 from:

http://vision.princeton.edu/projects/2014/3DShapeNets/ModelNet10.zip

to

http://3dvision.princeton.edu/projects/2014/3DShapeNets/ModelNet10.zip