### PR TITLE
Resolve indexing issue when loading `medshapenet` dataset.

### DIFF
--- a/torch_geometric/datasets/medshapenet.py
+++ b/torch_geometric/datasets/medshapenet.py
@@ -96,7 +96,8 @@ class MedShapeNet(InMemoryDataset):
 
         subset = []
         for dataset in list_of_datasets:
-            self.newpath = self.root + '/' + dataset.split("/")[1]
+            parts = dataset.split("/")
+            self.newpath = self.root + '/' + parts[1 if len(parts) > 1 else 0]
             if not os.path.exists(self.newpath):
                 os.makedirs(self.newpath)
             stl_files = msn_instance.dataset_files(dataset, '.stl')


### PR DESCRIPTION

**Summary**

The `medshapenet` dataset structure has recently changed, which causes an IndexError in `torch_geometric/datasets/medshapenet.py`.

**Details**

At line 98, `list_of_datasets` now contains entries such as:
```
['medshapenet-blood-vessel',
 'medshapenetcore/3DTeethSeg',
 'medshapenetcore/CoronaryArteries',
 'medshapenetcore/FLARE',
 'medshapenetcore/KITS',
 'medshapenetcore/PULMONARY',
 'medshapenetcore/SurgicalInstruments',
 'medshapenetcore/ThoracicAorta_Saitta',
 'medshapenetcore/ToothFairy']
```

When `dataset = 'medshapenet-blood-vessel'`, the `dataset.split("/")` produces only one element.

The current code at line 99 assumes there are at least two elements:
```
self.newpath = self.root + '/' + dataset.split("/")[1]
```

This leads to: `IndexError: list index out of range`

**Fix**

Update the code to handle both cases safely: If `dataset` contains a `/`, use the second element. Otherwise, use the first element.
This ensures compatibility with the updated dataset list and prevents runtime errors.

[PassingLog.TXT](https://github.com/user-attachments/files/22645746/PassingLog.TXT)
