### PR TITLE
Fix bug in parsing `nvidia-smi` output on certain machines.

### DIFF
--- a/torch_geometric/profile/utils.py
+++ b/torch_geometric/profile/utils.py
@@ -123,10 +123,9 @@ def get_gpu_memory_from_nvidia_smi(  # pragma: no cover
         lines = output.decode('utf-8').split('\n')[1:-1]
         mem_list = []
         for line in lines:
-            val = line.split()[0]
-            if val != '[N/A]':
-                mem_list.append(int(val))
-            else:
+            try:
+                mem_list.append(int(line.split()[0]))
+            except (TypeError, ValueError):
                 mem_list.append(None)
         return mem_list
 


### PR DESCRIPTION
On some machines, `nvidia-smi` produces output values (such as `[Insufficient`) that were not previously. This leads to parsing errors in the memory extraction logic.

**Problem**

When parsing nvidia-smi output:
```
for line in lines:
    val = line.split()[0]
    if val != '[N/A]':
        mem_list.append(int(val))
```

the code attempts to convert `[Insufficient` into an integer, causing:
```
ValueError: invalid literal for int() with base 10: '[Insufficient'
```
**Fix**

Updated the parser to handle unexpected non-numeric values more robustly.
Non-integer outputs (e.g., `[N/A]`, `[Insufficient]`, malformed strings) are now safely mapped to `None` instead of raising an exception.

**Impact**

Prevents runtime errors on systems that return unexpected nvidia-smi output.
Ensures consistent behavior across different environments.