### PR TITLE
Add support for custom callbacks in graphgym.train

### DIFF
--- a/torch_geometric/graphgym/train.py
+++ b/torch_geometric/graphgym/train.py
@@ -62,6 +62,15 @@ def train(
         callbacks.append(ckpt_cbk)
 
     trainer_config = trainer_config or {}
+
+    # Allow custom callbacks to be passed via trainer_config
+    if 'callbacks' in trainer_config:
+        custom_callbacks = trainer_config.pop('callbacks')
+        if isinstance(custom_callbacks, list):
+            callbacks.extend(custom_callbacks)
+        else:
+            callbacks.append(custom_callbacks)
+
     trainer = pl.Trainer(
         **trainer_config,
         enable_checkpointing=cfg.train.enable_ckpt,


### PR DESCRIPTION
## Description

This PR implements the feature requested in #10386 to allow users to pass custom PyTorch Lightning callbacks via the `trainer_config` parameter in `torch_geometric.graphgym.train`.

## Changes

- Modified `torch_geometric/graphgym/train.py` to extract and extend custom callbacks from `trainer_config`
- Handles both single callback and list of callbacks
- Maintains backward compatibility with existing code

## Usage Example

```python
from torch_geometric.graphgym.train import train

# Pass custom callbacks
trainer_config = {
    'callbacks': [my_custom_callback],
    # other trainer config options...
}

train(model, datamodule, trainer_config=trainer_config)
```

## Testing

- ✅ All pre-commit hooks pass (linting, formatting, etc.)
- ✅ Existing tests remain compatible
- ✅ The implementation follows the exact suggestion from the issue

Fixes #10386
