### PR TITLE
Add `to_batch_edge_index` utility function

### DIFF
--- a/test/utils/test_unbatch.py
+++ b/test/utils/test_unbatch.py
@@ -1,6 +1,10 @@
 import torch
 
-from torch_geometric.utils import unbatch, unbatch_edge_index
+from torch_geometric.utils import (
+    to_batch_edge_index,
+    unbatch,
+    unbatch_edge_index,
+)
 
 
 def test_unbatch():
@@ -23,3 +27,94 @@ def test_unbatch_edge_index():
     edge_indices = unbatch_edge_index(edge_index, batch)
     assert edge_indices[0].tolist() == [[0, 1, 1, 2, 2, 3], [1, 0, 2, 1, 3, 2]]
     assert edge_indices[1].tolist() == [[0, 1, 1, 2], [1, 0, 2, 1]]
+
+
+def test_to_batch_edge_index():
+    # Test basic functionality
+    edge_index_list = [
+        torch.tensor([[0, 1, 1, 2, 2, 3], [1, 0, 2, 1, 3, 2]]),
+        torch.tensor([[0, 1, 1, 2], [1, 0, 2, 1]]),
+    ]
+
+    edge_index, batch = to_batch_edge_index(edge_index_list)
+
+    expected_edge_index = torch.tensor([
+        [0, 1, 1, 2, 2, 3, 4, 5, 5, 6],
+        [1, 0, 2, 1, 3, 2, 5, 4, 6, 5],
+    ])
+    expected_batch = torch.tensor([0, 0, 0, 0, 1, 1, 1])
+
+    assert torch.equal(edge_index, expected_edge_index)
+    assert torch.equal(batch, expected_batch)
+
+
+def test_to_batch_edge_index_empty_list():
+    # Test with empty list
+    edge_index, batch = to_batch_edge_index([])
+    assert edge_index.shape == (2, 0)
+    assert batch.shape == (0, )
+
+
+def test_to_batch_edge_index_single_graph():
+    # Test with single graph
+    edge_index_list = [torch.tensor([[0, 1, 2], [1, 2, 0]])]
+    edge_index, batch = to_batch_edge_index(edge_index_list)
+
+    assert torch.equal(edge_index, edge_index_list[0])
+    assert torch.equal(batch, torch.tensor([0, 0, 0]))
+
+
+def test_to_batch_edge_index_with_empty_graphs():
+    # Test with some empty graphs
+    edge_index_list = [
+        torch.tensor([[0, 1], [1, 0]]),
+        torch.empty((2, 0), dtype=torch.long),
+        torch.tensor([[0, 1], [1, 0]]),
+    ]
+
+    edge_index, batch = to_batch_edge_index(edge_index_list)
+
+    expected_edge_index = torch.tensor([[0, 1, 2, 3], [1, 0, 3, 2]])
+    expected_batch = torch.tensor([0, 0, 2, 2])
+
+    assert torch.equal(edge_index, expected_edge_index)
+    assert torch.equal(batch, expected_batch)
+
+
+def test_to_batch_edge_index_roundtrip():
+    # Test that to_batch_edge_index and unbatch_edge_index are inverses
+    edge_index_list = [
+        torch.tensor([[0, 1, 1, 2, 2, 3], [1, 0, 2, 1, 3, 2]]),
+        torch.tensor([[0, 1, 1, 2], [1, 0, 2, 1]]),
+        torch.tensor([[0, 1, 2, 3], [1, 2, 3, 0]]),
+    ]
+
+    edge_index, batch = to_batch_edge_index(edge_index_list)
+    unbatched = unbatch_edge_index(edge_index, batch)
+
+    assert len(unbatched) == len(edge_index_list)
+    for i, (original, recovered) in enumerate(zip(edge_index_list, unbatched)):
+        assert torch.equal(original, recovered), f"Mismatch at index {i}"
+
+
+def test_to_batch_edge_index_different_sizes():
+    # Test with graphs of different sizes
+    edge_index_list = [
+        torch.tensor([[0], [0]]),  # Self-loop
+        torch.tensor([[0, 1, 2, 3, 4], [1, 2, 3, 4, 0]]),  # 5-node cycle
+        torch.tensor([[0, 1], [1, 0]]),  # 2-node bidirectional
+    ]
+
+    edge_index, batch = to_batch_edge_index(edge_index_list)
+
+    # Verify the batch vector has correct size
+    assert batch.shape[0] == 1 + 5 + 2  # Total nodes
+
+    # Verify edge_index has correct number of edges
+    assert edge_index.shape[1] == 1 + 5 + 2  # Total edges
+
+    # Verify roundtrip
+    unbatched = unbatch_edge_index(edge_index, batch)
+    assert len(unbatched) == len(edge_index_list)
+    for original, recovered in zip(edge_index_list, unbatched):
+        assert torch.equal(original, recovered)

--- a/torch_geometric/utils/__init__.py
+++ b/torch_geometric/utils/__init__.py
@@ -34,7 +34,7 @@ from .sparse import (dense_to_sparse, is_sparse, is_torch_sparse_tensor,
                      to_torch_csc_tensor, to_torch_sparse_tensor,
                      to_edge_index)
 from ._spmm import spmm
-from ._unbatch import unbatch, unbatch_edge_index
+from ._unbatch import unbatch, unbatch_edge_index, to_batch_edge_index
 from ._one_hot import one_hot
 from ._normalized_cut import normalized_cut
 from ._grid import grid
@@ -114,6 +114,7 @@ __all__ = [
     'spmm',
     'unbatch',
     'unbatch_edge_index',
+    'to_batch_edge_index',
     'one_hot',
     'normalized_cut',
     'grid',

--- a/torch_geometric/utils/_unbatch.py
+++ b/torch_geometric/utils/_unbatch.py
@@ -1,4 +1,4 @@
-from typing import List, Optional
+from typing import List, Optional, Tuple
 
 import torch
 from torch import Tensor
@@ -69,3 +69,67 @@ def unbatch_edge_index(
     edge_index = edge_index - ptr[edge_batch]
     sizes = degree(edge_batch, batch_size, dtype=torch.long).cpu().tolist()
     return edge_index.split(sizes, dim=1)
+
+
+def to_batch_edge_index(
+        edge_index_list: List[Tensor]) -> Tuple[Tensor, Tensor]:
+    r"""Merges a list of :obj:`edge_index` tensors into a single batched
+    :obj:`edge_index` tensor and returns the corresponding :obj:`batch` vector.
+
+    Args:
+        edge_index_list (List[Tensor]): A list of :obj:`edge_index` tensors.
+
+    :rtype: (:class:`Tensor`, :class:`Tensor`)
+
+    Example:
+        >>> edge_index_list = [
+        ...     torch.tensor([[0, 1, 1, 2, 2, 3],
+        ...                   [1, 0, 2, 1, 3, 2]]),
+        ...     torch.tensor([[0, 1, 1, 2],
+        ...                   [1, 0, 2, 1]]),
+        ... ]
+        >>> edge_index, batch = to_batch_edge_index(edge_index_list)
+        >>> edge_index
+        tensor([[0, 1, 1, 2, 2, 3, 4, 5, 5, 6],
+                [1, 0, 2, 1, 3, 2, 5, 4, 6, 5]])
+        >>> batch
+        tensor([0, 0, 0, 0, 1, 1, 1])
+    """
+    if len(edge_index_list) == 0:
+        return torch.empty((2, 0),
+                           dtype=torch.long), torch.empty(0, dtype=torch.long)
+
+    # Get the number of nodes in each graph
+    num_nodes_list = []
+    for edge_index in edge_index_list:
+        if edge_index.numel() == 0:
+            num_nodes_list.append(0)
+        else:
+            num_nodes_list.append(int(edge_index.max()) + 1)
+
+    # Compute cumulative sum for node offsets
+    cumsum_nodes = cumsum(torch.tensor(num_nodes_list, dtype=torch.long))
+
+    # Offset each edge_index and concatenate
+    batched_edge_indices = []
+    for i, edge_index in enumerate(edge_index_list):
+        if edge_index.numel() > 0:
+            offset = cumsum_nodes[i]
+            batched_edge_indices.append(edge_index + offset)
+        else:
+            batched_edge_indices.append(edge_index)
+
+    # Concatenate all edge indices
+    if all(ei.numel() == 0 for ei in batched_edge_indices):
+        batched_edge_index = torch.empty((2, 0), dtype=torch.long)
+    else:
+        batched_edge_index = torch.cat(
+            [ei for ei in batched_edge_indices if ei.numel() > 0], dim=1)
+
+    # Create batch vector
+    batch = torch.cat([
+        torch.full((num_nodes, ), i, dtype=torch.long)
+        for i, num_nodes in enumerate(num_nodes_list)
+    ])
+
+    return batched_edge_index, batch


### PR DESCRIPTION
## Description

Implements `to_batch_edge_index` as the inverse operation of `unbatch_edge_index`. This function merges a list of `edge_index` tensors into a single batched `edge_index` tensor and returns the corresponding batch vector.

Closes #6099

## Motivation

Currently, PyG provides `unbatch_edge_index` to split a batched edge_index into individual graphs, but lacks the inverse operation to merge multiple edge_index tensors into a batch. This function completes the API by providing the batching counterpart, enabling users to:

- Manually construct batched graphs from individual edge_index tensors
- Implement custom batching logic
- Work with dynamic graph batching scenarios

## Changes

### Core Implementation
- **Added `to_batch_edge_index()` function** in `torch_geometric/utils/_unbatch.py`
  - Takes a list of edge_index tensors as input
  - Returns a tuple of (batched_edge_index, batch_vector)
  - Properly offsets node indices for each graph
  - Handles edge cases: empty lists, empty graphs, mixed scenarios

### API Updates
- Exported `to_batch_edge_index` in `torch_geometric/utils/__init__.py`

### Testing
- Added 6 comprehensive test cases in `test/utils/test_unbatch.py`:
  - Basic functionality
  - Empty list handling
  - Single graph handling
  - Mixed empty/non-empty graphs
  - Roundtrip verification (proves it's the inverse of `unbatch_edge_index`)
  - Different sized graphs

## Usage Example

```python
import torch
from torch_geometric.utils import to_batch_edge_index, unbatch_edge_index

# Create individual edge_index tensors
edge_index_list = [
    torch.tensor([[0, 1, 1, 2, 2, 3],
                  [1, 0, 2, 1, 3, 2]]),
    torch.tensor([[0, 1, 1, 2],
                  [1, 0, 2, 1]]),
]

# Batch them together
edge_index, batch = to_batch_edge_index(edge_index_list)

print(edge_index)
# tensor([[0, 1, 1, 2, 2, 3, 4, 5, 5, 6],
#         [1, 0, 2, 1, 3, 2, 5, 4, 6, 5]])

print(batch)
# tensor([0, 0, 0, 0, 1, 1, 1])

# Verify roundtrip
unbatched = unbatch_edge_index(edge_index, batch)
assert all(torch.equal(a, b) for a, b in zip(edge_index_list, unbatched))
```

## Testing

All tests pass:
```bash
pytest test/utils/test_unbatch.py -v
# 8 passed in 0.04s
```

Pre-commit hooks pass:
```bash
pre-commit run --all-files
# All checks passed
```

## Checklist

- [x] Implementation follows PyG conventions
- [x] Comprehensive test coverage added
- [x] Documentation with examples included
- [x] Type hints provided
- [x] Pre-commit hooks pass (yapf, flake8, ruff)
- [x] Roundtrip test verifies correctness
- [x] Edge cases handled (empty lists, empty graphs)

## Related Issues

Closes #6099