### PR TITLE
Add helpful error message when running rag_loader.py directly

### DIFF
--- a/torch_geometric/llm/rag_loader.py
+++ b/torch_geometric/llm/rag_loader.py
@@ -2,8 +2,7 @@ if __name__ == "__main__" and __package__ is None:
     raise RuntimeError(
         "Direct execution of 'rag_loader.py' is not supported.\n"
         "Please run this module from the repository root using:\n"
-        "    python -m torch_geometric.llm.rag_loader"
-    )
+        "    python -m torch_geometric.llm.rag_loader")
 
 from abc import abstractmethod
 from typing import Any, Callable, Dict, Optional, Protocol, Tuple, Union


### PR DESCRIPTION
This PR improves developer experience by adding a clear error message at the top of rag_loader.py. Previously, running the file directly using:
`python torch_geometric/llm/rag_loader.py`
would lead to a confusing ModuleNotFoundError. This happens because direct execution breaks relative imports within the package.

The new message explicitly instructs users to run the module correctly via:
`python -m torch_geometric.llm.rag_loader`
This provides better guidance for new contributors working with the llm examples and aligns with Python’s recommended module execution practices.