### PR TITLE
Avoid stream sync in `torch_geometric.utils.softmax`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- Removed an unnecessary device synchronization in `torch_geometric.utils.softmax` ([#10499](https://github.com/pyg-team/pytorch_geometric/pull/10499))
 - Fixed loading of legacy HuggingFace BERT checkpoints ([#10631](https://github.com/pyg-team/pytorch_geometric/pull/10631))
 - Fixed `return_attention_weights: bool` being not respected in `GATConv` and `GATv2Conv` ([#10596](https://github.com/pyg-team/pytorch_geometric/pull/10596))
 - Fixed download links for politifact and gossipcop datasets of `UPFD` ([#10558](https://github.com/pyg-team/pytorch_geometric/pull/10558))

--- a/test/utils/test_softmax.py
+++ b/test/utils/test_softmax.py
@@ -17,11 +17,13 @@ def test_softmax():
     out = softmax(src, index)
     assert out.tolist() == [0.5, 0.5, 1, 1]
     assert softmax(src, ptr=ptr).tolist() == out.tolist()
+    assert softmax(src, index=index, ptr=ptr).tolist() == out.tolist()
 
     src = src.view(-1, 1)
     out = softmax(src, index)
     assert out.tolist() == [[0.5], [0.5], [1], [1]]
     assert softmax(src, ptr=ptr).tolist() == out.tolist()
+    assert softmax(src, index=index, ptr=ptr).tolist() == out.tolist()
 
     jit = torch.jit.script(softmax)
     assert torch.allclose(jit(src, index), out)

--- a/test/utils/test_softmax.py
+++ b/test/utils/test_softmax.py
@@ -17,13 +17,11 @@ def test_softmax():
     out = softmax(src, index)
     assert out.tolist() == [0.5, 0.5, 1, 1]
     assert softmax(src, ptr=ptr).tolist() == out.tolist()
-    assert softmax(src, index=index, ptr=ptr).tolist() == out.tolist()
 
     src = src.view(-1, 1)
     out = softmax(src, index)
     assert out.tolist() == [[0.5], [0.5], [1], [1]]
     assert softmax(src, ptr=ptr).tolist() == out.tolist()
-    assert softmax(src, index=index, ptr=ptr).tolist() == out.tolist()
 
     jit = torch.jit.script(softmax)
     assert torch.allclose(jit(src, index), out)

--- a/torch_geometric/utils/_softmax.py
+++ b/torch_geometric/utils/_softmax.py
@@ -67,10 +67,12 @@ def softmax(
         ptr = ptr.view(size)
         output_size = index.shape[dim] if index is not None else None
         src_max = segment(src.detach(), ptr, reduce='max')
-        src_max = src_max.repeat_interleave(count, dim=dim, output_size=output_size)
+        src_max = src_max.repeat_interleave(count, dim=dim,
+                                            output_size=output_size)
         out = (src - src_max).exp()
         out_sum = segment(out, ptr, reduce='sum') + 1e-16
-        out_sum = out_sum.repeat_interleave(count, dim=dim, output_size=output_size)
+        out_sum = out_sum.repeat_interleave(count, dim=dim,
+                                            output_size=output_size)
     elif index is not None:
         N = maybe_num_nodes(index, num_nodes)
         src_max = scatter(src.detach(), index, dim, dim_size=N, reduce='max')

--- a/torch_geometric/utils/_softmax.py
+++ b/torch_geometric/utils/_softmax.py
@@ -65,11 +65,12 @@ def softmax(
         size = ([1] * dim) + [-1]
         count = ptr[1:] - ptr[:-1]
         ptr = ptr.view(size)
+        output_size = index.shape[dim] if index is not None else None
         src_max = segment(src.detach(), ptr, reduce='max')
-        src_max = src_max.repeat_interleave(count, dim=dim)
+        src_max = src_max.repeat_interleave(count, dim=dim, output_size=output_size)
         out = (src - src_max).exp()
         out_sum = segment(out, ptr, reduce='sum') + 1e-16
-        out_sum = out_sum.repeat_interleave(count, dim=dim)
+        out_sum = out_sum.repeat_interleave(count, dim=dim, output_size=output_size)
     elif index is not None:
         N = maybe_num_nodes(index, num_nodes)
         src_max = scatter(src.detach(), index, dim, dim_size=N, reduce='max')

--- a/torch_geometric/utils/_softmax.py
+++ b/torch_geometric/utils/_softmax.py
@@ -65,14 +65,20 @@ def softmax(
         size = ([1] * dim) + [-1]
         count = ptr[1:] - ptr[:-1]
         ptr = ptr.view(size)
-        output_size = index.shape[dim] if index is not None else None
+        output_size = src.size(dim)
         src_max = segment(src.detach(), ptr, reduce='max')
-        src_max = src_max.repeat_interleave(count, dim=dim,
-                                            output_size=output_size)
+        src_max = src_max.repeat_interleave(
+            count,
+            dim=dim,
+            output_size=output_size,
+        )
         out = (src - src_max).exp()
         out_sum = segment(out, ptr, reduce='sum') + 1e-16
-        out_sum = out_sum.repeat_interleave(count, dim=dim,
-                                            output_size=output_size)
+        out_sum = out_sum.repeat_interleave(
+            count,
+            dim=dim,
+            output_size=output_size,
+        )
     elif index is not None:
         N = maybe_num_nodes(index, num_nodes)
         src_max = scatter(src.detach(), index, dim, dim_size=N, reduce='max')


### PR DESCRIPTION
# Bug in `torch_geometric.utils.softmax`

If the `output_size` argument is not provided in `torch.repeat_interleave`, then the `output_size` is calculated on the fly, at the cost of a stream synchronization, see https://docs.pytorch.org/docs/stable/generated/torch.repeat_interleave.html. But if the `torch_geometric.utils.softmax` function gets the `index` argument in addition to `ptr`, we get `output_size` for free - so we should use it.

# Proposed fix

When `ptr` and `index` are both provided in `torch_geometric.utils.softmax`, use `index` to set the `output_size` in `torch.repeat_interleave`. Added a unit test for this case.