### PR TITLE
Remove deprecated `proxies` and `resume_download` from `PyGModelHubMixin`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,7 +87,6 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Deprecated
 
-- Removing deprecated parameters `proxi` and `resume_download` used in `from_pretrained` functions ([#10521](https://github.com/pyg-team/pytorch_geometric/pull/10521)
 - Deprecated `torch_geometric.distributed` ([#10411](https://github.com/pyg-team/pytorch_geometric/pull/10411))
 
 ### Fixed
@@ -102,6 +101,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Removed
 
+- Removed `proxies` and `resume_download` arguments from `PyGModelHubMixin` ([#10521](https://github.com/pyg-team/pytorch_geometric/pull/10521)
 - Dropped support for Python 3.9 ([#10461](https://github.com/pyg-team/pytorch_geometric/pull/10461))
 - Dropped support for PyTorch 1.12 ([#10248](https://github.com/pyg-team/pytorch_geometric/pull/10248))
 - Dropped support for PyTorch 1.11 ([#10247](https://github.com/pyg-team/pytorch_geometric/pull/10247))

--- a/test/nn/test_model_hub.py
+++ b/test/nn/test_model_hub.py
@@ -105,8 +105,6 @@ def test_from_pretrained_internal(model, monkeypatch):
         revision=None,
         cache_dir=None,
         force_download=False,
-        proxies=None,
-        resume_download=True,
         local_files_only=False,
         token=False,
         dataset_name=DATASET_NAME,

--- a/torch_geometric/nn/model_hub.py
+++ b/torch_geometric/nn/model_hub.py
@@ -184,8 +184,6 @@ class PyGModelHubMixin(ModelHubMixin):
         cls,
         pretrained_model_name_or_path: str,
         force_download: bool = False,
-        resume_download: bool = False,
-        proxies: Optional[Dict] = None,
         token: Optional[Union[str, bool]] = None,
         cache_dir: Optional[str] = None,
         local_files_only: bool = False,
@@ -211,13 +209,6 @@ class PyGModelHubMixin(ModelHubMixin):
                 (re-)download of the model weights and configuration files,
                 overriding the cached versions if they exist.
                 (default: :obj:`False`)
-            resume_download (bool, optional): Whether to delete incompletely
-                received files. Will attempt to resume the download if such a
-                file exists. (default: :obj:`False`)
-            proxies (Dict[str, str], optional): A dictionary of proxy servers
-                to use by protocol or endpoint, *e.g.*,
-                :obj:`{'http': 'foo.bar:3128', 'http://host': 'foo.bar:4012'}`.
-                The proxies are used on each request. (default: :obj:`None`)
             token (str or bool, optional): The token to use as HTTP bearer
                 authorization for remote files. If set to :obj:`True`, will use
                 the token generated when running :obj:`transformers-cli login`


### PR DESCRIPTION
These parameters are deprecated:
```
  /usr/local/lib/python3.12/dist-packages/huggingface_hub/utils/_validators.py:186: UserWarning: The `resume_download` 
argument is deprecated and ignored in `from_pretrained`. Downloads always resume whenever possible.
    warnings.warn(
```
and `huggingface_hub` 1.0.1 no longer supports them. 

Additionally, these changes incorporate a fix for [the issue](https://github.com/pyg-team/pytorch_geometric/actions/runs/18986566645/job/54231457100?pr=10383) observed in [PR#0383](https://github.com/pyg-team/pytorch_geometric/pull/10383), ensuring the problem is fully resolved