### PR TITLE
make `coalesce` compile friendly

### DIFF
--- a/test/utils/test_coalesce.py
+++ b/test/utils/test_coalesce.py
@@ -10,12 +10,12 @@ from torch_geometric.utils import coalesce
 def test_coalesce_overflow():
     edge_index = torch.tensor([[0, 1], [1, 0]])
     with pytest.raises(ValueError):
-        coalesce(edge_index, num_nodes=1e10)
+        coalesce(edge_index, num_nodes=int(1e10))
 
     torch._dynamo.config.capture_dynamic_output_shape_ops = True
     coalesce_compiled = torch.compile(coalesce, fullgraph=True)
     with pytest.raises(torch._dynamo.exc.TorchRuntimeError):
-        coalesce_compiled(edge_index, num_nodes=1e10)
+        coalesce_compiled(edge_index, num_nodes=int(1e10))
 
 
 def test_coalesce():
@@ -84,6 +84,10 @@ def test_coalesce_jit():
     ) -> Tuple[Tensor, List[Tensor]]:
         return coalesce(edge_index, edge_attr)
 
+    @torch.jit.script
+    def wrapper4(edge_index: Tensor, num_nodes: int) -> Tensor:
+        return coalesce(edge_index, num_nodes=num_nodes)
+
     edge_index = torch.tensor([[2, 1, 1, 0], [1, 2, 0, 1]])
     edge_attr = torch.tensor([[1], [2], [3], [4]])
 
@@ -103,3 +107,9 @@ def test_coalesce_jit():
     assert len(out[1]) == 2
     assert out[1][0].size() == edge_attr.size()
     assert out[1][1].size() == edge_attr.view(-1).size()
+
+    with pytest.raises(
+            torch.jit.Error,
+            match="builtins.ValueError: 'coalesce' will result in an overflow"
+    ):
+        wrapper4(edge_index, num_nodes=int(1e10))

--- a/test/utils/test_coalesce.py
+++ b/test/utils/test_coalesce.py
@@ -1,9 +1,17 @@
 from typing import List, Optional, Tuple
 
+import pytest
 import torch
 from torch import Tensor
 
 from torch_geometric.utils import coalesce
+
+
+def test_coalesce_overflow():
+    edge_index = torch.tensor([[0, 1], [1, 0]])
+    with pytest.raises(ValueError,
+                       match="'coalesce' will result in an overflow"):
+        coalesce(edge_index, num_nodes=1e10)
 
 
 def test_coalesce():

--- a/test/utils/test_coalesce.py
+++ b/test/utils/test_coalesce.py
@@ -9,7 +9,7 @@ from torch_geometric.utils import coalesce
 
 def test_coalesce_overflow():
     edge_index = torch.tensor([[0, 1], [1, 0]])
-    with pytest.raises(ValueError,
+    with pytest.raises(RuntimeError,
                        match="'coalesce' will result in an overflow"):
         coalesce(edge_index, num_nodes=1e10)
 

--- a/torch_geometric/utils/_coalesce.py
+++ b/torch_geometric/utils/_coalesce.py
@@ -131,12 +131,12 @@ def coalesce(  # noqa: F811
     num_edges = edge_index[0].size(0)
     num_nodes = maybe_num_nodes(edge_index, num_nodes)
 
+    MAX_NUM_NODES = torch_geometric.typing.MAX_INT64**0.5
     if torch.jit.is_scripting():
-        if num_nodes * num_nodes > torch_geometric.typing.MAX_INT64:
+        if num_nodes > MAX_NUM_NODES:
             raise ValueError("'coalesce' will result in an overflow")
     else:
-        torch._check_value(num_nodes *
-                           num_nodes <= torch_geometric.typing.MAX_INT64)
+        torch._check_value(num_nodes <= MAX_NUM_NODES)
 
     idx = edge_index[0].new_empty(num_edges + 1)
     idx[0] = -1

--- a/torch_geometric/utils/_coalesce.py
+++ b/torch_geometric/utils/_coalesce.py
@@ -131,9 +131,10 @@ def coalesce(  # noqa: F811
     num_edges = edge_index[0].size(0)
     num_nodes = maybe_num_nodes(edge_index, num_nodes)
 
-    torch._check(
+    torch._check_with(
+        ValueError,
         num_nodes * num_nodes <= torch_geometric.typing.MAX_INT64,
-        "'coalesce' will result in an overflow",
+        lambda: "'coalesce' will result in an overflow",
     )
 
     idx = edge_index[0].new_empty(num_edges + 1)

--- a/torch_geometric/utils/_coalesce.py
+++ b/torch_geometric/utils/_coalesce.py
@@ -131,8 +131,10 @@ def coalesce(  # noqa: F811
     num_edges = edge_index[0].size(0)
     num_nodes = maybe_num_nodes(edge_index, num_nodes)
 
-    torch._check(num_nodes * num_nodes < torch_geometric.typing.MAX_INT64,
-                 "'coalesce' will result in an overflow")
+    torch._check(
+        num_nodes * num_nodes <= torch_geometric.typing.MAX_INT64,
+        "'coalesce' will result in an overflow",
+    )
 
     idx = edge_index[0].new_empty(num_edges + 1)
     idx[0] = -1

--- a/torch_geometric/utils/_coalesce.py
+++ b/torch_geometric/utils/_coalesce.py
@@ -19,10 +19,6 @@ else:
 MISSING = '???'
 
 
-def _overflow_message() -> str:
-    return "'coalesce' will result in an overflow"
-
-
 @overload
 def coalesce(
     edge_index: Tensor,
@@ -136,10 +132,10 @@ def coalesce(  # noqa: F811
     num_nodes = maybe_num_nodes(edge_index, num_nodes)
 
     if not torch.jit.is_scripting():
-        torch._check(num_nodes * num_nodes <= torch_geometric.typing.MAX_INT64,
-                     _overflow_message)
+        torch._check_value(num_nodes *
+                           num_nodes <= torch_geometric.typing.MAX_INT64)
     elif num_nodes * num_nodes > torch_geometric.typing.MAX_INT64:
-        raise RuntimeError(_overflow_message())
+        raise ValueError("'coalesce' will result in an overflow")
 
     idx = edge_index[0].new_empty(num_edges + 1)
     idx[0] = -1


### PR DESCRIPTION
Update coalesce to be torch compiled without graph breaks.