### PR TITLE
[BUG] Fixing attribute error in `test_tag_dataset`

### DIFF
--- a/test/datasets/test_tag_dataset.py
+++ b/test/datasets/test_tag_dataset.py
@@ -17,5 +17,5 @@ def test_tag_dataset() -> None:
 
     assert 169343 == tag_dataset[0].num_nodes \
         == len(tag_dataset.text) \
-        == len(tag_dataset.llm_explanation
+        == len(tag_dataset.llm_explanation)
     assert 1166243 == tag_dataset[0].num_edges


### PR DESCRIPTION
The following `AttributeError` was fixed:
```
    def __getattr__(self, key: str) -> Any:
        data = self.__dict__.get('_data')
        if isinstance(data, Data) and key in data:
            if self._indices is None and data.__inc__(key, data[key]) == 0:
                return data[key]
            else:
                data_list = [self.get(i) for i in self.indices()]
                return Batch.from_data_list(data_list)[key]
   
        import pdb; pdb.set_trace()
>       raise AttributeError(f"'{self.__class__.__name__}' object has no "
                             f"attribute '{key}'")
E       AttributeError: 'TAGDataset' object has no attribute 'llm_prediction'. Did you mean: 'llm_prediction_url'?

/usr/local/lib/python3.12/dist-packages/torch_geometric/data/in_memory_dataset.py:319: AttributeError
```