### PR TITLE
fix/reduce cuda stream syncs in bipartite_subgraph()

### DIFF
--- a/torch_geometric/utils/_subgraph.py
+++ b/torch_geometric/utils/_subgraph.py
@@ -138,7 +138,7 @@ def subgraph(
     else:
         num_nodes = subset.size(0)
         node_mask = subset
-        subset = node_mask.nonzero().view(-1)
+        subset = node_mask.nonzero_static(size=num_nodes).view(-1)
 
     edge_mask = node_mask[edge_index[0]] & node_mask[edge_index[1]]
     edge_index = edge_index[:, edge_mask]
@@ -219,7 +219,7 @@ def bipartite_subgraph(
     else:
         src_size = src_subset.size(0)
         src_node_mask = src_subset
-        src_subset = src_subset.nonzero().view(-1)
+        src_subset = src_subset.nonzero_static(size=src_size).view(-1)
 
     if dst_subset.dtype != torch.bool:
         dst_size = int(edge_index[1].max()) + 1 if size is None else size[1]
@@ -227,7 +227,8 @@ def bipartite_subgraph(
     else:
         dst_size = dst_subset.size(0)
         dst_node_mask = dst_subset
-        dst_subset = dst_subset.nonzero().view(-1)
+        dst_subset = dst_subset.nonzero_static(size=dst_size).view(-1)
+
 
     edge_mask = src_node_mask[edge_index[0]] & dst_node_mask[edge_index[1]]
     edge_index = edge_index[:, edge_mask]

--- a/torch_geometric/utils/_subgraph.py
+++ b/torch_geometric/utils/_subgraph.py
@@ -229,7 +229,6 @@ def bipartite_subgraph(
         dst_node_mask = dst_subset
         dst_subset = dst_subset.nonzero_static(size=dst_size).view(-1)
 
-
     edge_mask = src_node_mask[edge_index[0]] & dst_node_mask[edge_index[1]]
     edge_index = edge_index[:, edge_mask]
     edge_attr = edge_attr[edge_mask] if edge_attr is not None else None

--- a/torch_geometric/utils/mask.py
+++ b/torch_geometric/utils/mask.py
@@ -57,7 +57,7 @@ def index_to_mask(index: Tensor, size: Optional[int] = None) -> Tensor:
     index = index.view(-1)
     size = int(index.max()) + 1 if size is None else size
     mask = index.new_zeros(size, dtype=torch.bool)
-    mask[index] = True
+    mask.scatter_(0, index, True)
     return mask
 
 


### PR DESCRIPTION
Hello,

this PR reduces the number of CUDA stream syncs when running ```torch_geometric/utils/_subgraph.py bipartite_subgraph()``` on GPU from 4 to 1.
This is done by replacing the use of nonzero() with nonzero_static() and replacing an indexing operation in ```torch_geometric/utils/mask.py index_to_mask()``` with scatter()

there is still 1 more sync, i think it is this indexing here which calls nonzero()
```python
#torch_geometric/utils/_subgraph.py bipartite_subgraph()
    edge_index = edge_index[:, edge_mask]
    edge_attr = edge_attr[edge_mask] if edge_attr is not None else None
```

the unit tests ``` test/utils/test_mask.py``` and ``` test/utils/test_subgraph.py``` pass.

See the screenshots below of pytorch perfetto traces before and after. This is accompanied by a speedup in my use case
<img width="706" height="209" alt="Screenshot 2025-11-19 at 10 14 56" src="https://github.com/user-attachments/assets/e0f601db-de5c-43ab-a824-48b4f0a4e310" />
<img width="356" height="206" alt="Screenshot 2025-11-19 at 11 30 48" src="https://github.com/user-attachments/assets/6065a535-d49e-4019-9154-9375b598d4cb" />
