### PR TITLE
Implement error check for negative edge weights in GCNConv

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Removed
 
 ### Fixed
+- Fixed GCNConv.forward to raise an error in case edge_weight has negative values ([#10549](https://github.com/pyg-team/pytorch_geometric/pull/10549))
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Removed
 
 ### Fixed
+
 - Fixed GCNConv.forward to raise an error in case edge_weight has negative values ([#10549](https://github.com/pyg-team/pytorch_geometric/pull/10549))
 
 ### Security

--- a/torch_geometric/nn/conv/gcn_conv.py
+++ b/torch_geometric/nn/conv/gcn_conv.py
@@ -233,7 +233,7 @@ class GCNConv(MessagePassing):
                              f"does not support bipartite message passing. "
                              f"Please try other layers such as 'SAGEConv' or "
                              f"'GraphConv' instead")
-            
+
         if edge_weight is not None and (edge_weight < 0).any().item():
             raise ValueError(f"'{self.__class__.__name__}' does not support "
                              f"negative edge weights as input. Please try "

--- a/torch_geometric/nn/conv/gcn_conv.py
+++ b/torch_geometric/nn/conv/gcn_conv.py
@@ -233,6 +233,11 @@ class GCNConv(MessagePassing):
                              f"does not support bipartite message passing. "
                              f"Please try other layers such as 'SAGEConv' or "
                              f"'GraphConv' instead")
+            
+        if edge_weight is not None and (edge_weight < 0).any().item():
+            raise ValueError(f"'{self.__class__.__name__}' does not support "
+                             f"negative edge weights as input. Please try "
+                             f"'SignedConv' instead if they are necessary.")
 
         if self.normalize:
             if isinstance(edge_index, Tensor):


### PR DESCRIPTION
Negative weights lead to NaN values during normalization and may cause an indefinite hang when executed on CUDA. This adds a small check to validate the edge weights supplied as input are positive. Related to https://github.com/pyg-team/pytorch_geometric/issues/10548 Fixes https://github.com/pyg-team/pytorch_geometric/issues/795,  https://github.com/pyg-team/pytorch_geometric/issues/61