### PR TITLE
E(n) Equivariant GNN Layer and Model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- Added the E(n) Equivariant GNN model and layer ([#2298](https://github.com/pyg-team/pytorch_geometric/issues/2298))
 - Added llm generated explanations to `TAGDataset` ([#9918](https://github.com/pyg-team/pytorch_geometric/pull/9918))
 - Added `torch_geometric.llm` and its examples ([#10436](https://github.com/pyg-team/pytorch_geometric/pull/10436))
 - Added support for negative weights in `sparse_cross_entropy` ([#10432](https://github.com/pyg-team/pytorch_geometric/pull/10432))

--- a/test/nn/models/test_egnn.py
+++ b/test/nn/models/test_egnn.py
@@ -1,6 +1,5 @@
-import pytest 
-
-import torch 
+import pytest
+import torch
 
 from torch_geometric.nn.models import EGNN
 
@@ -21,6 +20,8 @@ pos_dim = [3, 6]
 update_pos = [True, False]
 act = ["SiLU", "ReLU", torch.nn.SiLU()]
 skip_connection = [False]
+
+
 @pytest.mark.parametrize('in_channels', in_channels)
 @pytest.mark.parametrize('hidden_channels', hidden_channels)
 @pytest.mark.parametrize('num_layers', num_layers)
@@ -28,14 +29,11 @@ skip_connection = [False]
 @pytest.mark.parametrize('update_pos', update_pos)
 @pytest.mark.parametrize('act', act)
 @pytest.mark.parametrize('skip_connection', skip_connection)
-def test_egnn_parameters(in_channels, hidden_channels, num_layers, pos_dim, update_pos, act, skip_connection):
-    model = EGNN(in_channels=in_channels,
-                 hidden_channels=hidden_channels,
-                 num_layers=num_layers,
-                 pos_dim=pos_dim,
-                 update_pos=update_pos,
-                 act=act,
-                 skip_connection=skip_connection)
+def test_egnn_parameters(in_channels, hidden_channels, num_layers, pos_dim,
+                         update_pos, act, skip_connection):
+    model = EGNN(in_channels=in_channels, hidden_channels=hidden_channels,
+                 num_layers=num_layers, pos_dim=pos_dim, update_pos=update_pos,
+                 act=act, skip_connection=skip_connection)
     nb_nodes = 3
     edge_index = torch.tensor([[0, 1, 1, 2], [1, 0, 2, 1]])
     x = torch.randn((nb_nodes, in_channels))
@@ -44,19 +42,16 @@ def test_egnn_parameters(in_channels, hidden_channels, num_layers, pos_dim, upda
     assert out_node.size() == (nb_nodes, hidden_channels)
     assert out_pos.size() == (nb_nodes, pos_dim)
 
+
 @pytest.mark.parametrize('pos_dim', pos_dim)
 def test_egnn_equivariance(pos_dim):
     in_channels = 4
     hidden_channels = 4
     num_layers = 2
-    model = EGNN(in_channels=in_channels,
-                 hidden_channels=hidden_channels,
-                 num_layers=num_layers,
-                 pos_dim=pos_dim,
-                 skip_connection=True)
+    model = EGNN(in_channels=in_channels, hidden_channels=hidden_channels,
+                 num_layers=num_layers, pos_dim=pos_dim, skip_connection=True)
     nb_nodes = 5
-    edge_index = torch.tensor([[0, 1, 1, 2, 3, 4, 0],
-                               [1, 0, 2, 1, 4, 3, 4]])
+    edge_index = torch.tensor([[0, 1, 1, 2, 3, 4, 0], [1, 0, 2, 1, 4, 3, 4]])
     x = torch.randn((nb_nodes, in_channels))
     pos = torch.randn((nb_nodes, pos_dim))
 
@@ -72,12 +67,14 @@ def test_egnn_equivariance(pos_dim):
     pos_transformed = (pos @ R_ortho) + t
 
     # Output after transformation
-    out_node_transformed, out_pos_transformed = model(x, pos_transformed, edge_index)
+    out_node_transformed, out_pos_transformed = model(x, pos_transformed,
+                                                      edge_index)
 
     # Transform the original output positions
     out_pos_orig_transformed = (out_pos_orig @ R_ortho) + t
 
     # Check if the transformed outputs match
-    assert torch.allclose(out_pos_transformed, out_pos_orig_transformed, atol=1e-5), "Position outputs are not equivariant"
-    assert torch.allclose(out_node_transformed, out_node_orig, atol=1e-5), "Node features should remain invariant"
-    
+    assert torch.allclose(out_pos_transformed, out_pos_orig_transformed,
+                          atol=1e-5), "Position outputs are not equivariant"
+    assert torch.allclose(out_node_transformed, out_node_orig,
+                          atol=1e-5), "Node features should remain invariant"

--- a/test/nn/models/test_egnn.py
+++ b/test/nn/models/test_egnn.py
@@ -1,0 +1,83 @@
+import pytest 
+
+import torch 
+
+from torch_geometric.nn.models import EGNN
+
+"""
+in_channels = [2, 3]
+hidden_channels = [4, 5]
+num_layers = [1, 5]
+pos_dim = [3, 6]
+edge_dim = [0, 1]
+update_pos = [True, False]
+act = ["SiLU", "ReLU"]
+skip_connection = [True, False]
+"""
+in_channels = [2]
+hidden_channels = [4, 5]
+num_layers = [1, 5]
+pos_dim = [3, 6]
+update_pos = [True, False]
+act = ["SiLU", "ReLU", torch.nn.SiLU()]
+skip_connection = [False]
+@pytest.mark.parametrize('in_channels', in_channels)
+@pytest.mark.parametrize('hidden_channels', hidden_channels)
+@pytest.mark.parametrize('num_layers', num_layers)
+@pytest.mark.parametrize('pos_dim', pos_dim)
+@pytest.mark.parametrize('update_pos', update_pos)
+@pytest.mark.parametrize('act', act)
+@pytest.mark.parametrize('skip_connection', skip_connection)
+def test_egnn_parameters(in_channels, hidden_channels, num_layers, pos_dim, update_pos, act, skip_connection):
+    model = EGNN(in_channels=in_channels,
+                 hidden_channels=hidden_channels,
+                 num_layers=num_layers,
+                 pos_dim=pos_dim,
+                 update_pos=update_pos,
+                 act=act,
+                 skip_connection=skip_connection)
+    nb_nodes = 3
+    edge_index = torch.tensor([[0, 1, 1, 2], [1, 0, 2, 1]])
+    x = torch.randn((nb_nodes, in_channels))
+    pos = torch.randn((nb_nodes, pos_dim))
+    out_node, out_pos = model(x, pos, edge_index)
+    assert out_node.size() == (nb_nodes, hidden_channels)
+    assert out_pos.size() == (nb_nodes, pos_dim)
+
+@pytest.mark.parametrize('pos_dim', pos_dim)
+def test_egnn_equivariance(pos_dim):
+    in_channels = 4
+    hidden_channels = 4
+    num_layers = 2
+    model = EGNN(in_channels=in_channels,
+                 hidden_channels=hidden_channels,
+                 num_layers=num_layers,
+                 pos_dim=pos_dim,
+                 skip_connection=True)
+    nb_nodes = 5
+    edge_index = torch.tensor([[0, 1, 1, 2, 3, 4, 0],
+                               [1, 0, 2, 1, 4, 3, 4]])
+    x = torch.randn((nb_nodes, in_channels))
+    pos = torch.randn((nb_nodes, pos_dim))
+
+    # Original output
+    out_node_orig, out_pos_orig = model(x, pos, edge_index)
+
+    # Apply random rotation and translation
+    R = torch.randn((pos_dim, pos_dim))
+    U, _, Vt = torch.linalg.svd(R)
+    R_ortho = U @ Vt  # Ensure it's a proper rotation matrix
+    t = torch.randn((1, pos_dim))
+
+    pos_transformed = (pos @ R_ortho) + t
+
+    # Output after transformation
+    out_node_transformed, out_pos_transformed = model(x, pos_transformed, edge_index)
+
+    # Transform the original output positions
+    out_pos_orig_transformed = (out_pos_orig @ R_ortho) + t
+
+    # Check if the transformed outputs match
+    assert torch.allclose(out_pos_transformed, out_pos_orig_transformed, atol=1e-5), "Position outputs are not equivariant"
+    assert torch.allclose(out_node_transformed, out_node_orig, atol=1e-5), "Node features should remain invariant"
+    

--- a/torch_geometric/nn/conv/__init__.py
+++ b/torch_geometric/nn/conv/__init__.py
@@ -62,6 +62,7 @@ from .antisymmetric_conv import AntiSymmetricConv
 from .dir_gnn_conv import DirGNNConv
 from .mixhop_conv import MixHopConv
 from .meshcnn_conv import MeshCNNConv
+from .egnn_conv import EGNNConv
 
 import torch_geometric.nn.conv.utils  # noqa
 
@@ -133,6 +134,7 @@ __all__ = [
     'DirGNNConv',
     'MixHopConv',
     'MeshCNNConv',
+    'EGNNConv',
 ]
 
 classes = __all__

--- a/torch_geometric/nn/conv/egnn_conv.py
+++ b/torch_geometric/nn/conv/egnn_conv.py
@@ -1,0 +1,131 @@
+from typing import Callable, Optional, Tuple
+
+import torch
+from torch import Tensor
+
+from torch_geometric.nn.conv import MessagePassing
+from torch_geometric.nn.inits import reset
+from torch_geometric.typing import (
+    Adj,
+    Size,
+)
+
+import torch_scatter
+
+eps = 1e-8
+
+class EGNNConv(MessagePassing):
+    """
+    Equivariant Graph Neural Network Layer.
+    Args:
+        nn_edge  (Callable): Neural network for edge message computation.
+        nn_node  (Callable): Neural network for node feature updates.
+        pos_dim  (int): Dimension of node positions. 
+        nn_pos   (Callable): Neural network for position updates. (optional)
+        skip_connection (bool): If set to :obj:`True`, adds skip connections to node features. (default: :obj:`False`)
+        **kwargs (optional): Additional arguments of
+            :class:`torch_geometric.nn.conv.MessagePassing`.
+
+    Shapes:
+        - **x**: node features :math:`(|\mathcal{V}|, F_{in})`
+        - **pos**: node positions :math:`(|\mathcal{V}|, pos_{dim})`
+        - **edge_index**: graph connectivity :math:`(2, |\mathcal{E}|)`
+        - **edge_attr**: edge features :math:`(|\mathcal{E}|, F_{edge})` *(optional)*
+        - **output**: tuple containing
+            - updated node features :math:`(|\mathcal{V}|, F_{out})`
+            - updated node positions :math:`(|\mathcal{V}|, pos_{dim})`
+        """
+    def __init__(self, 
+                 nn_edge        : Callable,
+                 nn_node        : Callable,
+                 pos_dim        : int,
+                 nn_pos         : Optional[Callable] = None,
+                 skip_connection: bool = False,
+                 **kwargs):
+        super().__init__(**kwargs)
+        self.nn_edge = nn_edge
+        self.nn_node = nn_node
+        self.nn_pos = nn_pos
+        self.skip_connection = skip_connection
+        self.pos_dim = pos_dim
+        self.reset_parameters()
+    
+    def reset_parameters(self):
+        super().reset_parameters()
+        for nn in [self.nn_edge, self.nn_node]:
+            reset(nn)
+        if self.nn_pos is not None:
+            reset(self.nn_pos)
+
+    def forward(self,
+                x          : Tensor,
+                pos        : Tensor,
+                edge_index : Adj, 
+                edge_attr  : Optional[Tensor] = None,
+                size       : Size = None) -> Tuple[Tensor, Tensor]:
+
+        assert x.size(0) == pos.size(0), "x and pos must have same number of nodes"
+        if edge_attr is not None:
+            assert edge_attr.size(0) == edge_index.size(1), "edge_attr must match number of edges"
+        assert self.skip_connection is False or x.size(-1) == self.nn_node[-1].out_features, "For skip connection, input and output node feature dimensions must match"
+    
+        # Perform message passing.
+        message = self.propagate(edge_index, x=(x, x), pos=(pos, pos), edge_attr=edge_attr, size=size)
+        if self.nn_pos is not None:
+            (message_node, message_pos) = torch.split(message, [message.size(-1) - self.pos_dim, self.pos_dim], dim=-1)
+            out_pos = pos + message_pos
+        else:
+            message_node = message
+            out_pos = pos
+        
+        # Update node features.
+        out_node = self.nn_node(torch.cat([x, message_node], dim=-1))
+        if self.skip_connection:
+            out_node = out_node + x
+        return (out_node, out_pos)
+
+    def message(self, 
+                x_i      : Tensor, 
+                x_j      : Tensor, 
+                pos_i    : Tensor, 
+                pos_j    : Tensor, 
+                edge_attr: Optional[Tensor] = None) -> Tensor:
+
+        pos_diff = pos_i - pos_j
+        square_norm = torch.sum(pos_diff ** 2, dim=-1).unsqueeze(-1)
+        if edge_attr is not None:
+            out = torch.cat([x_j, x_i, square_norm, edge_attr], dim=-1)
+        else:
+            out = torch.cat([x_j, x_i, square_norm], dim=-1)
+
+        out = self.nn_edge(out)
+
+        if self.nn_pos is not None:
+            out_pos_j = self.nn_pos(out)
+            pos_diff = pos_diff/(torch.sqrt(square_norm + eps) + eps)
+            message_pos_j = pos_diff * out_pos_j
+            out = torch.cat([out, message_pos_j], dim=-1)
+ 
+        return out
+    
+    def aggregate(self, 
+                  inputs  : Tensor, 
+                  index   : Tensor, 
+                  dim_size: Optional[int] = None) -> Tensor:
+        
+        out_pos = None
+        if self.nn_pos is not None:
+            (message_node, message_pos) = torch.split(inputs, [inputs.size(-1) - self.pos_dim, self.pos_dim], dim=-1)
+            out_pos = torch_scatter.scatter_mean(message_pos, index, dim=0, dim_size=dim_size)
+        else:
+            message_node = inputs
+        
+        out = torch_scatter.scatter_add(message_node, index, dim=0, dim_size=dim_size)
+
+        if out_pos is not None:
+            out = torch.cat([out, out_pos], dim=-1)
+        return out
+
+    def __repr__(self) -> str:
+        return f'{self.__class__.__name__}(nn_edge={self.nn_edge}, nn_node={self.nn_node}, nn_pos={self.nn_pos if self.nn_pos is not None else "None"})'
+    

--- a/torch_geometric/nn/conv/egnn_conv.py
+++ b/torch_geometric/nn/conv/egnn_conv.py
@@ -1,26 +1,23 @@
 from typing import Callable, Optional, Tuple
 
 import torch
+import torch_scatter
 from torch import Tensor
 
 from torch_geometric.nn.conv import MessagePassing
 from torch_geometric.nn.inits import reset
-from torch_geometric.typing import (
-    Adj,
-    Size,
-)
-
-import torch_scatter
+from torch_geometric.typing import Adj, Size
 
 eps = 1e-8
 
+
 class EGNNConv(MessagePassing):
-    """
-    Equivariant Graph Neural Network Layer.
+    r"""Equivariant Graph Neural Network Layer.
+
     Args:
         nn_edge  (Callable): Neural network for edge message computation.
         nn_node  (Callable): Neural network for node feature updates.
-        pos_dim  (int): Dimension of node positions. 
+        pos_dim  (int): Dimension of node positions.
         nn_pos   (Callable): Neural network for position updates. (optional)
         skip_connection (bool): If set to :obj:`True`, adds skip connections to node features. (default: :obj:`False`)
         **kwargs (optional): Additional arguments of
@@ -34,14 +31,10 @@ class EGNNConv(MessagePassing):
         - **output**: tuple containing
             - updated node features :math:`(|\mathcal{V}|, F_{out})`
             - updated node positions :math:`(|\mathcal{V}|, pos_{dim})`
-        """
-    def __init__(self, 
-                 nn_edge        : Callable,
-                 nn_node        : Callable,
-                 pos_dim        : int,
-                 nn_pos         : Optional[Callable] = None,
-                 skip_connection: bool = False,
-                 **kwargs):
+    """
+    def __init__(self, nn_edge: Callable, nn_node: Callable, pos_dim: int,
+                 nn_pos: Optional[Callable] = None,
+                 skip_connection: bool = False, **kwargs):
         super().__init__(**kwargs)
         self.nn_edge = nn_edge
         self.nn_node = nn_node
@@ -49,7 +42,7 @@ class EGNNConv(MessagePassing):
         self.skip_connection = skip_connection
         self.pos_dim = pos_dim
         self.reset_parameters()
-    
+
     def reset_parameters(self):
         super().reset_parameters()
         for nn in [self.nn_edge, self.nn_node]:
@@ -57,42 +50,41 @@ class EGNNConv(MessagePassing):
         if self.nn_pos is not None:
             reset(self.nn_pos)
 
-    def forward(self,
-                x          : Tensor,
-                pos        : Tensor,
-                edge_index : Adj, 
-                edge_attr  : Optional[Tensor] = None,
-                size       : Size = None) -> Tuple[Tensor, Tensor]:
+    def forward(self, x: Tensor, pos: Tensor, edge_index: Adj,
+                edge_attr: Optional[Tensor] = None,
+                size: Size = None) -> Tuple[Tensor, Tensor]:
 
-        assert x.size(0) == pos.size(0), "x and pos must have same number of nodes"
+        assert x.size(0) == pos.size(
+            0), "x and pos must have same number of nodes"
         if edge_attr is not None:
-            assert edge_attr.size(0) == edge_index.size(1), "edge_attr must match number of edges"
-        assert self.skip_connection is False or x.size(-1) == self.nn_node[-1].out_features, "For skip connection, input and output node feature dimensions must match"
-    
+            assert edge_attr.size(0) == edge_index.size(
+                1), "edge_attr must match number of edges"
+        assert self.skip_connection is False or x.size(-1) == self.nn_node[
+            -1].out_features, "For skip connection, input and output node feature dimensions must match"
+
         # Perform message passing.
-        message = self.propagate(edge_index, x=(x, x), pos=(pos, pos), edge_attr=edge_attr, size=size)
+        message = self.propagate(edge_index, x=(x, x), pos=(pos, pos),
+                                 edge_attr=edge_attr, size=size)
         if self.nn_pos is not None:
-            (message_node, message_pos) = torch.split(message, [message.size(-1) - self.pos_dim, self.pos_dim], dim=-1)
+            (message_node, message_pos) = torch.split(
+                message, [message.size(-1) - self.pos_dim, self.pos_dim],
+                dim=-1)
             out_pos = pos + message_pos
         else:
             message_node = message
             out_pos = pos
-        
+
         # Update node features.
         out_node = self.nn_node(torch.cat([x, message_node], dim=-1))
         if self.skip_connection:
             out_node = out_node + x
         return (out_node, out_pos)
 
-    def message(self, 
-                x_i      : Tensor, 
-                x_j      : Tensor, 
-                pos_i    : Tensor, 
-                pos_j    : Tensor, 
+    def message(self, x_i: Tensor, x_j: Tensor, pos_i: Tensor, pos_j: Tensor,
                 edge_attr: Optional[Tensor] = None) -> Tensor:
 
         pos_diff = pos_i - pos_j
-        square_norm = torch.sum(pos_diff ** 2, dim=-1).unsqueeze(-1)
+        square_norm = torch.sum(pos_diff**2, dim=-1).unsqueeze(-1)
         if edge_attr is not None:
             out = torch.cat([x_j, x_i, square_norm, edge_attr], dim=-1)
         else:
@@ -102,25 +94,26 @@ class EGNNConv(MessagePassing):
 
         if self.nn_pos is not None:
             out_pos_j = self.nn_pos(out)
-            pos_diff = pos_diff/(torch.sqrt(square_norm + eps) + eps)
+            pos_diff = pos_diff / (torch.sqrt(square_norm + eps) + eps)
             message_pos_j = pos_diff * out_pos_j
             out = torch.cat([out, message_pos_j], dim=-1)
- 
+
         return out
-    
-    def aggregate(self, 
-                  inputs  : Tensor, 
-                  index   : Tensor, 
+
+    def aggregate(self, inputs: Tensor, index: Tensor,
                   dim_size: Optional[int] = None) -> Tensor:
-        
+
         out_pos = None
         if self.nn_pos is not None:
-            (message_node, message_pos) = torch.split(inputs, [inputs.size(-1) - self.pos_dim, self.pos_dim], dim=-1)
-            out_pos = torch_scatter.scatter_mean(message_pos, index, dim=0, dim_size=dim_size)
+            (message_node, message_pos) = torch.split(
+                inputs, [inputs.size(-1) - self.pos_dim, self.pos_dim], dim=-1)
+            out_pos = torch_scatter.scatter_mean(message_pos, index, dim=0,
+                                                 dim_size=dim_size)
         else:
             message_node = inputs
-        
-        out = torch_scatter.scatter_add(message_node, index, dim=0, dim_size=dim_size)
+
+        out = torch_scatter.scatter_add(message_node, index, dim=0,
+                                        dim_size=dim_size)
 
         if out_pos is not None:
             out = torch.cat([out, out_pos], dim=-1)
@@ -128,4 +121,3 @@ class EGNNConv(MessagePassing):
 
     def __repr__(self) -> str:
         return f'{self.__class__.__name__}(nn_edge={self.nn_edge}, nn_node={self.nn_node}, nn_pos={self.nn_pos if self.nn_pos is not None else "None"})'
-    

--- a/torch_geometric/nn/models/__init__.py
+++ b/torch_geometric/nn/models/__init__.py
@@ -31,6 +31,7 @@ from .neural_fingerprint import NeuralFingerprint
 from .visnet import ViSNet
 from .lpformer import LPFormer
 from .sgformer import SGFormer
+from .egnn import EGNN
 
 from .polynormer import Polynormer
 # Deprecated:
@@ -86,4 +87,5 @@ __all__ = classes = [
     'SGFormer',
     'Polynormer',
     'ARLinkPredictor',
+    'EGNN',
 ]

--- a/torch_geometric/nn/models/egnn.py
+++ b/torch_geometric/nn/models/egnn.py
@@ -1,12 +1,12 @@
-from typing import Union, Callable, Tuple, Optional
+from typing import Callable, Optional, Tuple, Union
 
-import torch 
+import torch
 from torch import Tensor
 
+from torch_geometric.nn.conv import EGNNConv
 from torch_geometric.nn.resolver import activation_resolver
 from torch_geometric.typing import Adj
 
-from  torch_geometric.nn.conv import EGNNConv
 
 class EGNN(torch.nn.Module):
     r"""The Equivariant Graph Neural Network Model from the `"E(n) Equivariant Graph Neural Networks"
@@ -22,70 +22,54 @@ class EGNN(torch.nn.Module):
         update_pos      (bool): If set to :obj:`False`, node positions will not be updated. (default: :obj:`True`)
         act             (str or Callable): Activation function to use. (default: :obj:`"SiLU"`)
     """
-
-    def __init__(
-            self,
-            in_channels    : int,
-            hidden_channels: int,
-            num_layers     : int,
-            pos_dim        : int,
-            edge_dim       : int = 0,
-            update_pos     : bool = True,
-            act            : Union['str', Callable] = "SiLU",
-            skip_connection: bool = False):
+    def __init__(self, in_channels: int, hidden_channels: int, num_layers: int,
+                 pos_dim: int, edge_dim: int = 0, update_pos: bool = True,
+                 act: Union['str',
+                            Callable] = "SiLU", skip_connection: bool = False):
         super().__init__()
 
         assert skip_connection is False or in_channels == hidden_channels, "Skip connection requires in_channels == hidden_channels"
-        act = activation_resolver(act) 
+        act = activation_resolver(act)
         self.convs = torch.nn.ModuleList()
         nn_edge = torch.nn.Sequential(
             torch.nn.Linear(2 * in_channels + 1 + edge_dim, hidden_channels),
-            act,
-            torch.nn.Linear(hidden_channels, hidden_channels),
-            act)
+            act, torch.nn.Linear(hidden_channels, hidden_channels), act)
         nn_node = torch.nn.Sequential(
             torch.nn.Linear(in_channels + hidden_channels, hidden_channels),
-            act,
-            torch.nn.Linear(hidden_channels, hidden_channels))
+            act, torch.nn.Linear(hidden_channels, hidden_channels))
         if update_pos:
             layer_pos = torch.nn.Linear(hidden_channels, 1, bias=True)
             torch.nn.init.xavier_uniform_(layer_pos.weight, gain=0.001)
             nn_pos = torch.nn.Sequential(
-                torch.nn.Linear(hidden_channels, hidden_channels),
-                act,
+                torch.nn.Linear(hidden_channels, hidden_channels), act,
                 layer_pos)
         else:
             nn_pos = None
-        self.convs.append(EGNNConv(nn_edge, nn_node, pos_dim, nn_pos, skip_connection))
-        for _ in range(num_layers-1):
+        self.convs.append(
+            EGNNConv(nn_edge, nn_node, pos_dim, nn_pos, skip_connection))
+        for _ in range(num_layers - 1):
             nn_edge = torch.nn.Sequential(
-                torch.nn.Linear(2 * hidden_channels + 1 + edge_dim, hidden_channels),
-                act,
-                torch.nn.Linear(hidden_channels, hidden_channels),
-                act)
+                torch.nn.Linear(2 * hidden_channels + 1 + edge_dim,
+                                hidden_channels), act,
+                torch.nn.Linear(hidden_channels, hidden_channels), act)
             nn_node = torch.nn.Sequential(
-                torch.nn.Linear(2 * hidden_channels, hidden_channels),
-                act,
+                torch.nn.Linear(2 * hidden_channels, hidden_channels), act,
                 torch.nn.Linear(hidden_channels, hidden_channels))
             if update_pos:
                 layer_pos = torch.nn.Linear(hidden_channels, 1, bias=True)
                 torch.nn.init.xavier_uniform_(layer_pos.weight, gain=0.001)
                 nn_pos = torch.nn.Sequential(
-                    torch.nn.Linear(hidden_channels, hidden_channels),
-                    act,
+                    torch.nn.Linear(hidden_channels, hidden_channels), act,
                     layer_pos)
             else:
                 nn_pos = None
-            self.convs.append(EGNNConv(nn_edge, nn_node, pos_dim, nn_pos, skip_connection))
-            
-    def forward(self,
-                x: Tensor,
-                pos: Tensor,
-                edge_index: Adj,
+            self.convs.append(
+                EGNNConv(nn_edge, nn_node, pos_dim, nn_pos, skip_connection))
+
+    def forward(self, x: Tensor, pos: Tensor, edge_index: Adj,
                 edge_attr: Optional[Tensor] = None) -> Tuple[Tensor, Tensor]:
 
         for conv in self.convs:
             x, pos = conv(x, pos, edge_index, edge_attr)
 
         return (x, pos)
-        

--- a/torch_geometric/nn/models/egnn.py
+++ b/torch_geometric/nn/models/egnn.py
@@ -1,0 +1,91 @@
+from typing import Union, Callable, Tuple, Optional
+
+import torch 
+from torch import Tensor
+
+from torch_geometric.nn.resolver import activation_resolver
+from torch_geometric.typing import Adj
+
+from  torch_geometric.nn.conv import EGNNConv
+
+class EGNN(torch.nn.Module):
+    r"""The Equivariant Graph Neural Network Model from the `"E(n) Equivariant Graph Neural Networks"
+    <https://arxiv.org/abs/2102.09844>`_ paper, using the :class:`EGNNConv` operator for
+    message passing
+
+    Args:
+        in_channels     (int): Size of each input node feature.
+        hidden_channels (int): Size of each hidden node feature.
+        num_layers      (int): Number of EGNNConv layers.
+        pos_dim         (int): Dimension of node positions.
+        edge_dim        (int): Size of each edge feature. (default: :obj:`0`)
+        update_pos      (bool): If set to :obj:`False`, node positions will not be updated. (default: :obj:`True`)
+        act             (str or Callable): Activation function to use. (default: :obj:`"SiLU"`)
+    """
+
+    def __init__(
+            self,
+            in_channels    : int,
+            hidden_channels: int,
+            num_layers     : int,
+            pos_dim        : int,
+            edge_dim       : int = 0,
+            update_pos     : bool = True,
+            act            : Union['str', Callable] = "SiLU",
+            skip_connection: bool = False):
+        super().__init__()
+
+        assert skip_connection is False or in_channels == hidden_channels, "Skip connection requires in_channels == hidden_channels"
+        act = activation_resolver(act) 
+        self.convs = torch.nn.ModuleList()
+        nn_edge = torch.nn.Sequential(
+            torch.nn.Linear(2 * in_channels + 1 + edge_dim, hidden_channels),
+            act,
+            torch.nn.Linear(hidden_channels, hidden_channels),
+            act)
+        nn_node = torch.nn.Sequential(
+            torch.nn.Linear(in_channels + hidden_channels, hidden_channels),
+            act,
+            torch.nn.Linear(hidden_channels, hidden_channels))
+        if update_pos:
+            layer_pos = torch.nn.Linear(hidden_channels, 1, bias=True)
+            torch.nn.init.xavier_uniform_(layer_pos.weight, gain=0.001)
+            nn_pos = torch.nn.Sequential(
+                torch.nn.Linear(hidden_channels, hidden_channels),
+                act,
+                layer_pos)
+        else:
+            nn_pos = None
+        self.convs.append(EGNNConv(nn_edge, nn_node, pos_dim, nn_pos, skip_connection))
+        for _ in range(num_layers-1):
+            nn_edge = torch.nn.Sequential(
+                torch.nn.Linear(2 * hidden_channels + 1 + edge_dim, hidden_channels),
+                act,
+                torch.nn.Linear(hidden_channels, hidden_channels),
+                act)
+            nn_node = torch.nn.Sequential(
+                torch.nn.Linear(2 * hidden_channels, hidden_channels),
+                act,
+                torch.nn.Linear(hidden_channels, hidden_channels))
+            if update_pos:
+                layer_pos = torch.nn.Linear(hidden_channels, 1, bias=True)
+                torch.nn.init.xavier_uniform_(layer_pos.weight, gain=0.001)
+                nn_pos = torch.nn.Sequential(
+                    torch.nn.Linear(hidden_channels, hidden_channels),
+                    act,
+                    layer_pos)
+            else:
+                nn_pos = None
+            self.convs.append(EGNNConv(nn_edge, nn_node, pos_dim, nn_pos, skip_connection))
+            
+    def forward(self,
+                x: Tensor,
+                pos: Tensor,
+                edge_index: Adj,
+                edge_attr: Optional[Tensor] = None) -> Tuple[Tensor, Tensor]:
+
+        for conv in self.convs:
+            x, pos = conv(x, pos, edge_index, edge_attr)
+
+        return (x, pos)
+        


### PR DESCRIPTION
- Implementation of the E(n) Equivariant GNN layer and model, as described by [Satorras et al](https://arxiv.org/abs/2102.09844).
- Related to [Issue #2298](https://github.com/pyg-team/pytorch_geometric/issues/2298).
- Includes unit test, which tests the equivariance property of the model w.r.t. the coordinates. 

I also validated the code by reproducing the results of Experiment 5.2 in the paper: see [here](https://github.com/siavashadpey/CS224W_Project/blob/v1/tests/egnn_ae.py). I include this as an example or a long, integration test if interested.

**Implemented code as part of Project Option 1 of CS224W (will include a link to the blog post once published)**