### PR TITLE
Add ResGConv and res_gconv_norm

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,3 @@
-#https://download.pytorch.org/whl/cpu/torch-2.8.0%2Bcpu-cp310-cp310-manylinux_2_28_x86_64.whl
+https://download.pytorch.org/whl/cpu/torch-2.8.0%2Bcpu-cp310-cp310-manylinux_2_28_x86_64.whl
 numpy>=1.19.5
 git+https://github.com/pyg-team/pyg_sphinx_theme.git

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,3 @@
-https://download.pytorch.org/whl/cpu/torch-2.8.0%2Bcpu-cp310-cp310-manylinux_2_28_x86_64.whl
+#https://download.pytorch.org/whl/cpu/torch-2.8.0%2Bcpu-cp310-cp310-manylinux_2_28_x86_64.whl
 numpy>=1.19.5
 git+https://github.com/pyg-team/pyg_sphinx_theme.git

--- a/test/contrib/nn/conv/test_res_graph_conv.py
+++ b/test/contrib/nn/conv/test_res_graph_conv.py
@@ -6,9 +6,11 @@ from torch_geometric.contrib.nn.conv.res_graph_conv import (
     ResGConv,
     res_gconv_norm,
 )
+from torch_geometric.nn.conv import GCN2Conv
 from torch_geometric.typing import SparseTensor
 from torch_geometric.utils import (
     is_torch_sparse_tensor,
+    sort_edge_index,
     to_edge_index,
     to_torch_csr_tensor,
 )
@@ -23,12 +25,16 @@ def test_res_gconv_norm():
     # is_torch_sparse_tensor(edge_index)
     # are false
     edge_index = torch.tensor([[0, 1, 0, 1], [0, 0, 1, 1]])
-    edge_weight = torch.tensor([1.0, 1.0, 1.0, 1.0])
+    edge_weight = torch.tensor([1.0, 0.0, -1.0, 1.0])
     assert not is_torch_sparse_tensor(edge_index)
     expected_edge_index = torch.tensor([[0, 1, 0, 1], [0, 0, 1, 1]])
-    expected_edge_weight = 0.5 * torch.tensor([1.0, 1.0, 1.0, 1.0])
+    expected_edge_weight = 0.5 * torch.tensor([1.0, 0.0, -1.0, 1.0])
+    expected_edge_index, expected_edge_weight = sort_edge_index(
+        expected_edge_index, expected_edge_weight)
     edge_index_out, edge_weight_out = res_gconv_norm(edge_index, edge_weight,
                                                      add_self_loops=False)
+    edge_index_out, edge_weight_out = sort_edge_index(edge_index_out,
+                                                      edge_weight_out)
     assert torch.equal(edge_index_out, expected_edge_index)
     assert torch.allclose(expected_edge_weight, edge_weight_out)
 
@@ -36,19 +42,49 @@ def test_res_gconv_norm():
     # edge_index passed to res_gconv_norm
     # isinstance(edge_index, SparseTensor)
     if torch_geometric.typing.WITH_TORCH_SPARSE:
+        adj = SparseTensor.from_edge_index(edge_index, edge_weight,
+                                           sparse_sizes=(2, 2))
+        expected_adj = 0.5 * torch.tensor([[1.0, -1.0], [0.0, 1.0]])
+        adj_out = res_gconv_norm(adj, add_self_loops=False)
+        assert torch.equal(adj_out.to_dense(), expected_adj)
+        # check that addding the edge weights via res_gconv_
+        # norm doesn't have the same effect
         adj = SparseTensor.from_edge_index(edge_index, sparse_sizes=(2, 2))
         expected_adj = 0.5 * torch.tensor([[1.0, 1.0], [1.0, 1.0]])
-        adj_out = res_gconv_norm(adj, add_self_loops=False)
-        assert torch.equal(adj_out.t().to_dense(), expected_adj)
+        adj_out = res_gconv_norm(adj, edge_weight=edge_weight,
+                                 add_self_loops=False)
+        assert torch.equal(adj_out.to_dense(), expected_adj)
 
     # this is for the case where
     # edge_index pass to res_gconv_norm
     # is_torch_sparse_tensor(edge_index)
+    adj = to_torch_csr_tensor(edge_index, edge_weight)
+    expected_edge_index = torch.tensor([[0, 1, 0, 1], [0, 0, 1, 1]])
+    expected_edge_weight = 0.5 * torch.tensor([1.0, 0.0, -1.0, 1.0])
+    adj_out, none = res_gconv_norm(adj, add_self_loops=False)
+    expected_edge_index, expected_edge_weight = sort_edge_index(
+        expected_edge_index, expected_edge_weight)
+    edge_index_out, edge_weight_out = to_edge_index(adj_out)
+    edge_index_out, edge_weight_out = sort_edge_index(edge_index_out,
+                                                      edge_weight_out)
+    assert torch.equal(edge_index_out, expected_edge_index)
+    assert torch.equal(edge_weight_out, expected_edge_weight)
+
+    # check that addding out of bound edge weights
+    # don't influence the results, i.e. they are
+    # not taken into account if the adjacency matrix
+    # is provided via a sparse is_torch_sparse_tensor.
     adj = to_torch_csr_tensor(edge_index)
     expected_edge_index = torch.tensor([[0, 1, 0, 1], [0, 0, 1, 1]])
     expected_edge_weight = 0.5 * torch.tensor([1.0, 1.0, 1.0, 1.0])
-    adj_out, none = res_gconv_norm(adj, add_self_loops=False)
-    edge_index_out, edge_weight_out, to_edge_index(adj_out)
+    adj_out, none = res_gconv_norm(
+        adj, edge_weight=torch.tensor([4.0, 4.0, 3.0, 4.0]),
+        add_self_loops=False)
+    expected_edge_index, expected_edge_weight = sort_edge_index(
+        expected_edge_index, expected_edge_weight)
+    edge_index_out, edge_weight_out = to_edge_index(adj_out)
+    edge_index_out, edge_weight_out = sort_edge_index(edge_index_out,
+                                                      edge_weight_out)
     assert torch.equal(edge_index_out, expected_edge_index)
     assert torch.equal(edge_weight_out, expected_edge_weight)
 
@@ -77,18 +113,27 @@ def res_gconv_factory():
     return _create_layer
 
 
-@pytest.mark.parametrize("normalize,bias_u,bias_w,expected_output", [
-    (True, False, False, 2.0),
-    (True, True, True, 4.0),
-    (True, False, True, 3.0),
-    (True, True, False, 3.0),
-    (False, False, False, 3.0),
-    (False, True, True, 6.0),
-    (False, False, True, 5.0),
-    (False, True, False, 4.0),
-])
+@pytest.mark.parametrize(
+    "normalize,bias_u,bias_w,expected_output_ww_1,"
+    "expected_output_ww_2,expected_output_wow_1,expected_output_wow_2", [
+        (True, False, False, 1.5, 1.0, 2.0, 2.0),
+        (True, True, True, 3.0, 2.0, 4.0, 4.0),
+        (True, False, True, 2.0, 1.0, 3.0, 3.0),
+        (True, True, False, 2.5, 2.0, 3.0, 3.0),
+        (False, False, False, 2.0, 1.0, 3.0, 3.0),
+        (False, True, True, 4.0, 2.0, 6.0, 6.0),
+        (False, False, True, 3.0, 1.0, 5.0, 5.0),
+        (False, True, False, 3.0, 2.0, 4.0, 4.0),
+    ])
 def test_res_gconv(res_gconv_factory, normalize, bias_u, bias_w,
-                   expected_output):
+                   expected_output_ww_1, expected_output_ww_2,
+                   expected_output_wow_1, expected_output_wow_2):
+    # we create our simple layer for the test
+    # it contains U, W = 1.0, 1.0 (both a single channel, i.e. scalar)
+    # as well as biases b_u = 1.0, b_w = 1.0 if set to true
+    layer = res_gconv_factory(normalize=normalize, bias_u=bias_u,
+                              bias_w=bias_w)
+
     # test the branch where
     # isinstance(edge_index, Tensor)
     #
@@ -96,19 +141,21 @@ def test_res_gconv(res_gconv_factory, normalize, bias_u, bias_w,
     # denotes the number of nodes in the graph (2)
     # and the second one denotes the hidden dimension
     # the res_gconv layer expects (1) from the fixture
-    # above. First let's test it for the unnormalized
-    # case, where the output should simply be
-    # :math:`\mathbf{XU} + \mathbf{AXW}`
-    layer = res_gconv_factory(normalize=normalize, bias_u=bias_u,
-                              bias_w=bias_w)
+    # above. We test the general expression
+    # :math:`\mathbf{XU+b_u} + \mathbf{\hat{A}(XW+b_w)}`.
+    #
     x = torch.ones(2, 1)
     edge_index = torch.tensor([[0, 1, 0, 1], [0, 0, 1, 1]])
-    edge_weight = torch.tensor([1.0, 1.0, 1.0, 1.0])
+    edge_weight = torch.tensor([1.0, 0.0, -1.0, 1.0])
     out1 = layer(x, edge_index, edge_weight)
     out2 = layer(x, edge_index)
     # test against the output calculated by hand
-    assert torch.allclose(out1, expected_output * x)
-    assert torch.allclose(out2, expected_output * x)
+    expected_output_ww = torch.tensor([[expected_output_ww_1],
+                                       [expected_output_ww_2]])
+    expected_output_wow = torch.tensor([[expected_output_wow_1],
+                                        [expected_output_wow_2]])
+    assert torch.allclose(out1, expected_output_ww)
+    assert torch.allclose(out2, expected_output_wow)
 
     # test the branch where
     # isinstance(edge_index, SparseTensor)
@@ -117,20 +164,22 @@ def test_res_gconv(res_gconv_factory, normalize, bias_u, bias_w,
     # denotes the number of nodes in the graph (2)
     # and the second one denotes the hidden dimension
     # the res_gconv layer expects (1) from the fixture
-    # above. First let's test it for the unnormalized
-    # case, where the output should simply be
-    # :math:`\mathbf{XU} + \mathbf{AXW}`
+    # above. We test the general expression
+    # :math:`\mathbf{XU+b_u} + \mathbf{\hat{A}(XW+b_w)}`.
+    # Here, adding the edge_weight tensor should have
+    # no effect, since we only focus on the SparseTensor
+    # passed to forward.
     if torch_geometric.typing.WITH_TORCH_SPARSE:
         layer = res_gconv_factory(normalize=normalize, bias_u=bias_u,
                                   bias_w=bias_w)
         x = torch.ones(2, 1)
-        edge_index = torch.tensor([[0, 1, 0, 1], [0, 0, 1, 1]])
-        adj = SparseTensor.from_edge_index(edge_index, sparse_sizes=(2, 2))
-        edge_weight = torch.tensor([1.0, 1.0, 1.0, 1.0])
-        out1 = layer(x, adj, edge_weight)
-        out2 = layer(x, adj)
-        assert torch.allclose(out1, expected_output * x)
-        assert torch.allclose(out2, expected_output * x)
+        adj_dense = torch.tensor([[1.0, -1.0], [0.0, 1.0]])
+        adj = SparseTensor.from_dense(adj_dense)
+        out1 = layer(x, adj.t(), edge_weight)
+        out2 = layer(x, adj.t())
+        assert torch.allclose(out1, expected_output_ww)
+        # check for no effect of the SparseTensor
+        assert torch.allclose(out2, expected_output_ww)
 
     # the following tests that the caching is working correctly
     layer.cached = True
@@ -146,6 +195,20 @@ def test_res_gconv(res_gconv_factory, normalize, bias_u, bias_w,
             assert layer._cached_adj_t is not None
         else:
             assert layer._cached_edge_index is None
+
+    # to check that we didn't make a mistake with a transpose or so, we check
+    # our layer agains the GCN2Conv
+    if bias_u is False and bias_w is False and normalize is False:
+        adj_gcn2conv_dense = torch.tensor([[2.0, -2.0], [0.0, 2.0]])
+        adj_gcn2conv = SparseTensor.from_dense(adj_gcn2conv_dense)
+        gcn2conv_layer = GCN2Conv(1, alpha=0.5, theta=0.0, layer=1,
+                                  normalize=normalize, add_self_loops=False)
+        ours = layer(x, adj.t())
+        gcn2conv_ref = gcn2conv_layer(x, 2 * x, adj_gcn2conv.t())
+        assert torch.allclose(ours, gcn2conv_ref)
+
+    # finally, a quick test for the string
+    assert str(layer) == f'ResGConv({1}, bias_u={bias_u}, bias_w={bias_w})'
 
 
 """

--- a/test/contrib/nn/conv/test_res_graph_conv.py
+++ b/test/contrib/nn/conv/test_res_graph_conv.py
@@ -1,0 +1,76 @@
+import torch
+
+from torch_geometric import EdgeIndex
+from torch_geometric.contrib.nn.conv.res_graph_conv import res_gconv_norm
+from torch_geometric.typing import SparseTensor
+
+
+def test_res_gconv_norm():
+    # we first make a minimal example for all cases of the
+    # sparse tensors
+
+    # this is fo
+    edge_index = torch.tensor([[0, 1, 0, 1], [0, 0, 1, 1]])
+    edge_weight = torch.tensor([1.0, 1.0, 1.0, 1.0])
+    expected_edge_index = torch.tensor([[0, 1, 0, 1], [0, 0, 1, 1]])
+    expected_edge_weight = 0.5 * torch.tensor([1.0, 1.0, 1.0, 1.0])
+    edge_index_out, edge_weight_out = res_gconv_norm(edge_index, edge_weight,
+                                                     add_self_loops=False)
+    assert torch.equal(edge_index_out, expected_edge_index)
+    assert torch.allclose(expected_edge_weight, edge_weight_out)
+    #
+    edge_index = EdgeIndex(
+        [[0, 1, 1, 2], [1, 0, 2, 1]],
+        sparse_size=(3, 3),
+        sort_order='row',
+        is_undirected=True,
+        device='cpu',
+    )
+    edge_index.to_sparse_tensor()
+    print(isinstance(edge_index, SparseTensor))
+
+
+"""
+def test_gcn2_conv():
+    x = torch.randn(4, 16)
+    x_0 = torch.randn(4, 16)
+    edge_index = torch.tensor([[0, 0, 0, 1, 2, 3], [1, 2, 3, 0, 0, 0]])
+    value = torch.rand(edge_index.size(1))
+    adj1 = to_torch_csc_tensor(edge_index, size=(4, 4))
+    adj2 = to_torch_csc_tensor(edge_index, value, size=(4, 4))
+
+    conv = GCN2Conv(16, alpha=0.2)
+    assert str(conv) == 'GCN2Conv(16, alpha=0.2, beta=1.0)'
+    out1 = conv(x, x_0, edge_index)
+    assert out1.size() == (4, 16)
+    assert torch.allclose(conv(x, x_0, adj1.t()), out1, atol=1e-6)
+    out2 = conv(x, x_0, edge_index, value)
+    assert out2.size() == (4, 16)
+    assert torch.allclose(conv(x, x_0, adj2.t()), out2, atol=1e-6)
+
+    if torch_geometric.typing.WITH_TORCH_SPARSE:
+        adj3 = SparseTensor.from_edge_index(edge_index, sparse_sizes=(4, 4))
+        adj4 = SparseTensor.from_edge_index(edge_index, value, (4, 4))
+        assert torch.allclose(conv(x, x_0, adj3.t()), out1, atol=1e-6)
+        assert torch.allclose(conv(x, x_0, adj4.t()), out2, atol=1e-6)
+
+    if is_full_test():
+        jit = torch.jit.script(conv)
+        assert torch.allclose(jit(x, x_0, edge_index), out1, atol=1e-6)
+        assert torch.allclose(jit(x, x_0, edge_index, value), out2, atol=1e-6)
+
+        if torch_geometric.typing.WITH_TORCH_SPARSE:
+            assert torch.allclose(jit(x, x_0, adj3.t()), out1, atol=1e-6)
+            assert torch.allclose(jit(x, x_0, adj4.t()), out2, atol=1e-6)
+
+    conv.cached = True
+    conv(x, x_0, edge_index)
+    assert conv._cached_edge_index is not None
+    assert torch.allclose(conv(x, x_0, edge_index), out1, atol=1e-6)
+    assert torch.allclose(conv(x, x_0, adj1.t()), out1, atol=1e-6)
+
+    if torch_geometric.typing.WITH_TORCH_SPARSE:
+        conv(x, x_0, adj3.t())
+        assert conv._cached_adj_t is not None
+        assert torch.allclose(conv(x, x_0, adj3.t()), out1, atol=1e-6)
+"""

--- a/test/contrib/nn/conv/test_res_graph_conv.py
+++ b/test/contrib/nn/conv/test_res_graph_conv.py
@@ -1,33 +1,144 @@
+import pytest
 import torch
 
-from torch_geometric import EdgeIndex
-from torch_geometric.contrib.nn.conv.res_graph_conv import res_gconv_norm
+import torch_geometric.typing
+from torch_geometric.contrib.nn.conv.res_graph_conv import (
+    ResGConv,
+    res_gconv_norm,
+)
 from torch_geometric.typing import SparseTensor
+from torch_geometric.utils import (
+    is_torch_sparse_tensor,
+    to_edge_index,
+    to_torch_csr_tensor,
+)
 
 
 def test_res_gconv_norm():
     # we first make a minimal example for all cases of the
     # sparse tensors
 
-    # this is fo
+    # this is for the general case if both
+    # isinstance(edge_index, SparseTensor) and
+    # is_torch_sparse_tensor(edge_index)
+    # are false
     edge_index = torch.tensor([[0, 1, 0, 1], [0, 0, 1, 1]])
     edge_weight = torch.tensor([1.0, 1.0, 1.0, 1.0])
+    assert not is_torch_sparse_tensor(edge_index)
     expected_edge_index = torch.tensor([[0, 1, 0, 1], [0, 0, 1, 1]])
     expected_edge_weight = 0.5 * torch.tensor([1.0, 1.0, 1.0, 1.0])
     edge_index_out, edge_weight_out = res_gconv_norm(edge_index, edge_weight,
                                                      add_self_loops=False)
     assert torch.equal(edge_index_out, expected_edge_index)
     assert torch.allclose(expected_edge_weight, edge_weight_out)
+
+    # this is for the case where
+    # edge_index passed to res_gconv_norm
+    # isinstance(edge_index, SparseTensor)
+    if torch_geometric.typing.WITH_TORCH_SPARSE:
+        adj = SparseTensor.from_edge_index(edge_index, sparse_sizes=(2, 2))
+        expected_adj = 0.5 * torch.tensor([[1.0, 1.0], [1.0, 1.0]])
+        adj_out = res_gconv_norm(adj, add_self_loops=False)
+        assert torch.equal(adj_out.t().to_dense(), expected_adj)
+
+    # this is for the case where
+    # edge_index pass to res_gconv_norm
+    # is_torch_sparse_tensor(edge_index)
+    adj = to_torch_csr_tensor(edge_index)
+    expected_edge_index = torch.tensor([[0, 1, 0, 1], [0, 0, 1, 1]])
+    expected_edge_weight = 0.5 * torch.tensor([1.0, 1.0, 1.0, 1.0])
+    adj_out, none = res_gconv_norm(adj, add_self_loops=False)
+    edge_index_out, edge_weight_out, to_edge_index(adj_out)
+    assert torch.equal(edge_index_out, expected_edge_index)
+    assert torch.equal(edge_weight_out, expected_edge_weight)
+
+
+@pytest.fixture
+def res_gconv_factory():
+    def _create_layer(channels: int = 1, shared_weights: bool = False,
+                      add_self_loops: bool = False, cached: bool = False,
+                      normalize: bool = True, **kwargs):
+        """Fixture providing a res_gconv layer with fixed
+        weights for testing.
+        """
+        layer = ResGConv(channels=channels, shared_weights=shared_weights,
+                         add_self_loops=add_self_loops, cached=cached,
+                         normalize=normalize, **kwargs)
+        with torch.no_grad():
+            layer.U.weight.fill_(1.0)
+            if layer.U.bias is not None:
+                layer.U.bias.zero_()
+            layer.W.weight.fill_(1.0)
+            if layer.W.bias is not None:
+                layer.W.bias.zero_()
+        return layer
+
+    return _create_layer
+
+
+def test_res_gconv(res_gconv_factory):
+    # test the branch where
+    # isinstance(edge_index, Tensor)
     #
-    edge_index = EdgeIndex(
-        [[0, 1, 1, 2], [1, 0, 2, 1]],
-        sparse_size=(3, 3),
-        sort_order='row',
-        is_undirected=True,
-        device='cpu',
-    )
-    edge_index.to_sparse_tensor()
-    print(isinstance(edge_index, SparseTensor))
+    # we setup a dummy input where the first index
+    # denotes the number of nodes in the graph (2)
+    # and the second one denotes the hidden dimension
+    # the res_gconv layer expects (1) from the fixture
+    # above. First let's test it for the unnormalized
+    # case, where the output should simply be
+    # :math:`\mathbf{XU} + \mathbf{AXW}`
+    layer = res_gconv_factory(normalize=False)
+    x = torch.ones(2, 1)
+    edge_index = torch.tensor([[0, 1, 0, 1], [0, 0, 1, 1]])
+    edge_weight = torch.tensor([1.0, 1.0, 1.0, 1.0])
+    out1 = layer(x, edge_index, edge_weight)
+    out2 = layer(x, edge_index)
+    # test against the output calculated by hand
+    assert torch.allclose(out1, 3.0 * x)
+    assert torch.allclose(out2, 3.0 * x)
+    # let's do the same using the normalized option
+    # such that the output should now be
+    # :math:`\mathbf{XU} + \mathbf{\hat{A}XW}`
+    layer = res_gconv_factory()
+    x = torch.ones(2, 1)
+    edge_index = torch.tensor([[0, 1, 0, 1], [0, 0, 1, 1]])
+    edge_weight = torch.tensor([1.0, 1.0, 1.0, 1.0])
+    out1 = layer(x, edge_index, edge_weight)
+    out2 = layer(x, edge_index, edge_weight)
+    assert torch.allclose(out1, 2.0 * x)
+    assert torch.allclose(out2, 2.0 * x)
+
+    # test the branch where
+    # isinstance(edge_index, SparseTensor)
+    #
+    # we setup a dummy input where the first index
+    # denotes the number of nodes in the graph (2)
+    # and the second one denotes the hidden dimension
+    # the res_gconv layer expects (1) from the fixture
+    # above. First let's test it for the unnormalized
+    # case, where the output should simply be
+    # :math:`\mathbf{XU} + \mathbf{AXW}`
+    layer = res_gconv_factory(normalize=False)
+    x = torch.ones(2, 1)
+    edge_index = torch.tensor([[0, 1, 0, 1], [0, 0, 1, 1]])
+    adj = SparseTensor.from_edge_index(edge_index, sparse_sizes=(2, 2))
+    edge_weight = torch.tensor([1.0, 1.0, 1.0, 1.0])
+    out1 = layer(x, adj, edge_weight)
+    out2 = layer(x, adj)
+    assert torch.allclose(out1, 3.0 * x)
+    assert torch.allclose(out2, 3.0 * x)
+    # let's do the same using the normalized option
+    # such that the output should now be
+    # :math:`\mathbf{XU} + \mathbf{\hat{A}XW}`
+    layer = res_gconv_factory()
+    x = torch.ones(2, 1)
+    edge_index = torch.tensor([[0, 1, 0, 1], [0, 0, 1, 1]])
+    adj = SparseTensor.from_edge_index(edge_index, sparse_sizes=(2, 2))
+    edge_weight = torch.tensor([1.0, 1.0, 1.0, 1.0])
+    out1 = layer(x, adj, edge_weight)
+    out2 = layer(x, adj, edge_weight)
+    assert torch.allclose(out1, 2.0 * x)
+    assert torch.allclose(out2, 2.0 * x)
 
 
 """

--- a/torch_geometric/contrib/nn/conv/__init__.py
+++ b/torch_geometric/contrib/nn/conv/__init__.py
@@ -1,1 +1,3 @@
-__all__ = classes = []
+from .res_graph_conv import ResGConv
+
+__all__ = classes = ['ResGConv']

--- a/torch_geometric/contrib/nn/conv/res_graph_conv.py
+++ b/torch_geometric/contrib/nn/conv/res_graph_conv.py
@@ -47,6 +47,7 @@ def res_gconv_norm(  # noqa: F811
 
         # Implementation from https://github.com/jiechenjiechen/GNP
         # GNP/utils.py scale_A_by_spectral_radius(A)
+
         adj_t = adj_t.to_dense()
         absA = adj_t.abs()
         m, n = absA.shape
@@ -54,12 +55,8 @@ def res_gconv_norm(  # noqa: F811
         col_sum = torch.ones(1, m, dtype=absA.dtype, device=absA.device) @ absA
         gamma = torch.min(torch.max(row_sum), torch.max(col_sum))
 
-        # deg_inv_sqrt = deg.pow_(-0.5)
-        # deg_inv_sqrt.masked_fill_(deg_inv_sqrt == float('inf'), 0.)
         adj_t = adj_t * (1. / gamma.item())
         adj_t = SparseTensor.from_dense(adj_t)
-        # torch_sparse.mul(adj_t, deg_inv_sqrt.view(-1, 1))
-        # adj_t = torch_sparse.mul(adj_t, deg_inv_sqrt.view(1, -1))
         return adj_t
 
     if is_torch_sparse_tensor(edge_index):
@@ -75,13 +72,9 @@ def res_gconv_norm(  # noqa: F811
 
         edge_index, value = to_edge_index(adj_t)
 
-        # col, row = edge_index[0], edge_index[1]
-        # deg = scatter(value, col, 0, dim_size=num_nodes, reduce='sum')
-        # deg_inv_sqrt = deg.pow_(-0.5)
-        # deg_inv_sqrt.masked_fill_(deg_inv_sqrt == float('inf'), 0)
-        # value = deg_inv_sqrt[row] * value * deg_inv_sqrt[col]
         # Implementation from https://github.com/jiechenjiechen/GNP
         # GNP/utils.py scale_A_by_spectral_radius(A)
+
         absA = torch.absolute(adj_t)
         m, n = absA.shape
         row_sum = absA @ torch.ones(n, 1, dtype=adj_t.dtype,

--- a/torch_geometric/contrib/nn/conv/res_graph_conv.py
+++ b/torch_geometric/contrib/nn/conv/res_graph_conv.py
@@ -1,0 +1,212 @@
+from typing import Optional
+
+import torch
+from torch import Tensor
+
+from torch_geometric.nn.conv import MessagePassing
+from torch_geometric.nn.dense.linear import Linear
+from torch_geometric.typing import (
+    Adj,
+    OptPairTensor,
+    OptTensor,
+    SparseTensor,
+    torch_sparse,
+)
+from torch_geometric.utils import add_remaining_self_loops
+from torch_geometric.utils import add_self_loops as add_self_loops_fn
+from torch_geometric.utils import (
+    is_torch_sparse_tensor,
+    scatter,
+    spmm,
+    to_edge_index,
+)
+from torch_geometric.utils.num_nodes import maybe_num_nodes
+from torch_geometric.utils.sparse import set_sparse_value
+
+
+def res_gconv_norm(  # noqa: F811
+    edge_index: Adj,
+    edge_weight: OptTensor = None,
+    num_nodes: Optional[int] = None,
+    improved: bool = False,
+    add_self_loops: bool = True,
+    flow: str = "source_to_target",
+    dtype: Optional[torch.dtype] = None,
+):
+    fill_value = 2. if improved else 1.
+
+    if isinstance(edge_index, SparseTensor):
+        assert edge_index.size(0) == edge_index.size(1)
+
+        adj_t = edge_index
+
+        if not adj_t.has_value():
+            adj_t = adj_t.fill_value(1., dtype=dtype)
+        if add_self_loops:
+            adj_t = torch_sparse.fill_diag(adj_t, fill_value)
+
+        deg = torch_sparse.sum(adj_t, dim=1)
+        deg_inv_sqrt = deg.pow_(-0.5)
+        deg_inv_sqrt.masked_fill_(deg_inv_sqrt == float('inf'), 0.)
+        adj_t = torch_sparse.mul(adj_t, deg_inv_sqrt.view(-1, 1))
+        adj_t = torch_sparse.mul(adj_t, deg_inv_sqrt.view(1, -1))
+
+        return adj_t
+
+    if is_torch_sparse_tensor(edge_index):
+        assert edge_index.size(0) == edge_index.size(1)
+
+        if edge_index.layout == torch.sparse_csc:
+            raise NotImplementedError("Sparse CSC matrices are not yet "
+                                      "supported in 'gcn_norm'")
+
+        adj_t = edge_index
+        if add_self_loops:
+            adj_t, _ = add_self_loops_fn(adj_t, None, fill_value, num_nodes)
+
+        edge_index, value = to_edge_index(adj_t)
+        col, row = edge_index[0], edge_index[1]
+
+        deg = scatter(value, col, 0, dim_size=num_nodes, reduce='sum')
+        deg_inv_sqrt = deg.pow_(-0.5)
+        deg_inv_sqrt.masked_fill_(deg_inv_sqrt == float('inf'), 0)
+        value = deg_inv_sqrt[row] * value * deg_inv_sqrt[col]
+
+        return set_sparse_value(adj_t, value), None
+
+    assert flow in ['source_to_target', 'target_to_source']
+    num_nodes = maybe_num_nodes(edge_index, num_nodes)
+
+    if add_self_loops:
+        edge_index, edge_weight = add_remaining_self_loops(
+            edge_index, edge_weight, fill_value, num_nodes)
+
+    if edge_weight is None:
+        edge_weight = torch.ones((edge_index.size(1), ), dtype=dtype,
+                                 device=edge_index.device)
+
+    row, col = edge_index[0], edge_index[1]
+    idx = col if flow == 'source_to_target' else row
+    deg = scatter(edge_weight, idx, dim=0, dim_size=num_nodes, reduce='sum')
+    deg_inv_sqrt = deg.pow_(-0.5)
+    deg_inv_sqrt.masked_fill_(deg_inv_sqrt == float('inf'), 0)
+    edge_weight = deg_inv_sqrt[row] * edge_weight * deg_inv_sqrt[col]
+
+    return edge_index, edge_weight
+
+
+class ResGConv(MessagePassing):
+    r"""The graph convolutional operator with residual skip connections from
+    the `"Graph Neural Preconditioners for Iterative Solutions of Sparse
+    Linear Systems" <https://arxiv.org/pdf/2406.00809>`_ paper.
+    .. math::
+        \text{Res-GCONV}(\mathbf{X}) = \text{ReLU}\left(\mathbf{XU} +
+        \mathbf{\hat{A}XW}\right)
+    where
+    :math:`\mathbf{\hat{A}}\in \mathbb{R}^{n\times n}` denotes the weighted
+    adjacency matrix
+    normalized using the normalization
+    :math:`\mathbf{\hat{A}} = \mathbf{A}/\gamma`, where :math:`\gamma =
+    \min\{\max_j\{\sum_j
+    |a|_{ij}\},\max_i\{\sum_i |a|_{ij}\}\}`
+    and :math:`\mathbf{W,U}` are matrices containing the learnable parameters.
+
+    Args:
+        channels (int): Size of each input and output sample.
+        layer (int, optional): The layer :math:`\ell` in which this module is
+            executed. (default: :obj:`None`)
+        shared_weights (bool, optional): If set to :obj:`False`, will use
+            different weight matrices for the smoothed representation and the
+            initial residual ("GCNII*"). (default: :obj:`True`)
+        cached (bool, optional): If set to :obj:`True`, the layer will cache
+            the computation of :math:`\mathbf{\hat{A}} = \mathbf{A}/\gamma` on
+            first execution, and will use the
+            cached version for further executions.
+            This parameter should only be set to :obj:`True` in transductive
+            learning scenarios. (default: :obj:`False`)
+        normalize (bool, optional): Whether to apply normalization by
+        :math:`\gamma`. (default: :obj:`True`)
+        **kwargs (optional): Additional arguments of
+            :class:`torch_geometric.nn.conv.MessagePassing`.
+
+    Shapes:
+        - **input:**
+          node features :math:`(|\mathcal{V}|, F)`,
+          initial node features :math:`(|\mathcal{V}|, F)`,
+          edge indices :math:`(2, |\mathcal{E}|)`,
+          edge weights :math:`(|\mathcal{E}|)` *(optional)*
+        - **output:** node features :math:`(|\mathcal{V}|, F)`
+    """
+    _cached_edge_index: Optional[OptPairTensor]
+    _cached_adj_t: Optional[SparseTensor]
+
+    def __init__(self, channels: int, layer: int = None,
+                 shared_weights: bool = False, add_self_loops: bool = False,
+                 cached: bool = False, normalize: bool = False, **kwargs):
+
+        kwargs.setdefault('aggr', 'add')
+        super().__init__(**kwargs)
+
+        self.channels = channels
+        self.cached = cached
+        self.normalize = normalize
+        self.add_self_loops = add_self_loops
+
+        self._cached_edge_index = None
+        self._cached_adj_t = None
+
+        self.U = Linear(channels, channels)
+        self.W = Linear(channels, channels)
+
+        self.reset_parameters()
+
+    def reset_parameters(self):
+        super().reset_parameters()
+        self._cached_edge_index = None
+        self._cached_adj_t = None
+
+    def forward(self, x: Tensor, edge_index: Adj,
+                edge_weight: OptTensor = None, A: Tensor = None) -> Tensor:
+
+        if self.normalize:
+            if isinstance(edge_index, Tensor):
+                cache = self._cached_edge_index
+                if cache is None:
+                    edge_index, edge_weight = res_gconv_norm(  # yapf: disable
+                        edge_index, edge_weight, x.size(self.node_dim), False,
+                        self.add_self_loops, self.flow, dtype=x.dtype)
+                    if self.cached:
+                        self._cached_edge_index = (edge_index, edge_weight)
+                else:
+                    edge_index, edge_weight = cache[0], cache[1]
+
+            elif isinstance(edge_index, SparseTensor):
+                cache = self._cached_adj_t
+                if cache is None:
+                    edge_index = res_gconv_norm(  # yapf: disable
+                        edge_index, edge_weight, x.size(self.node_dim), False,
+                        self.add_self_loops, self.flow, dtype=x.dtype)
+                    if self.cached:
+                        self._cached_adj_t = edge_index
+                else:
+                    edge_index = cache
+
+        wx = self.W(x)
+
+        # propagate_type: (x: Tensor, edge_weight: OptTensor)
+
+        awx = self.propagate(edge_index, x=wx, edge_weight=edge_weight)
+        out = awx
+        out = out + self.U(x)
+
+        return out
+
+    def message(self, x_j: Tensor, edge_weight: OptTensor) -> Tensor:
+        return edge_weight.view(-1, 1) * x_j  # x_j if edge_weight is None else
+
+    def message_and_aggregate(self, adj_t: Adj, x: Tensor) -> Tensor:
+        return spmm(adj_t, x, reduce=self.aggr)
+
+    def __repr__(self) -> str:
+        return (f'{self.__class__.__name__}({self.channels}, '
+                f'alpha={self.alpha}, beta={self.beta})')

--- a/torch_geometric/contrib/nn/conv/res_graph_conv.py
+++ b/torch_geometric/contrib/nn/conv/res_graph_conv.py
@@ -153,6 +153,7 @@ class ResGConv(MessagePassing):
           edge weights :math:`(|\mathcal{E}|)` *(optional)*
         - **output:** node features :math:`(|\mathcal{V}|, F)`
     """
+
     _cached_edge_index: Optional[OptPairTensor]
     _cached_adj_t: Optional[SparseTensor]
 

--- a/torch_geometric/contrib/nn/conv/res_graph_conv.py
+++ b/torch_geometric/contrib/nn/conv/res_graph_conv.py
@@ -171,12 +171,14 @@ class ResGConv(MessagePassing):
         self.cached = cached
         self.normalize = normalize
         self.add_self_loops = add_self_loops
+        self.bias_u = bias_u
+        self.bias_w = bias_w
 
         self._cached_edge_index = None
         self._cached_adj_t = None
 
-        self.U = Linear(channels, channels, bias=bias_u)
-        self.W = Linear(channels, channels, bias=bias_w)
+        self.U = Linear(self.channels, self.channels, bias=self.bias_u)
+        self.W = Linear(self.channels, self.channels, bias=self.bias_w)
 
         self.reset_parameters()
 
@@ -214,7 +216,6 @@ class ResGConv(MessagePassing):
                     edge_index = cache
 
         wx = self.W(x)
-
         # propagate_type: (x: Tensor, edge_weight: OptTensor)
         awx = self.propagate(edge_index, x=wx, edge_weight=edge_weight)
         out = awx
@@ -229,4 +230,5 @@ class ResGConv(MessagePassing):
         return spmm(adj_t, x, reduce=self.aggr)
 
     def __repr__(self) -> str:
-        return (f'{self.__class__.__name__}({self.channels}, ')
+        return (f'{self.__class__.__name__}({self.channels}, '
+                f'bias_u={self.bias_u}, bias_w={self.bias_w})')

--- a/torch_geometric/contrib/nn/conv/res_graph_conv.py
+++ b/torch_geometric/contrib/nn/conv/res_graph_conv.py
@@ -212,10 +212,12 @@ class ResGConv(MessagePassing):
                 else:
                     edge_index = cache
 
+        # the heart of the ResGConv layer
+        # the linear layer, followed by the message passing
+        # and the addition of the skip connection
         wx = self.W(x)
         awx = self.propagate(edge_index, x=wx, edge_weight=edge_weight)
-        out = awx
-        out = out + self.U(x)
+        out = awx + self.U(x)
 
         return out
 

--- a/torch_geometric/contrib/nn/conv/res_graph_conv.py
+++ b/torch_geometric/contrib/nn/conv/res_graph_conv.py
@@ -128,21 +128,21 @@ class ResGConv(MessagePassing):
 
     Args:
         channels (int): Size of each input and output sample.
+            bias_u (bool, optional): If set to :obj:`False`, the layer will not
+            learn an additive bias together with :math:`\mathbf{U}`.
+            (default: obj:`True`)
         bias_u (bool, optional): If set to :obj:`False`, the layer will not
-        learn an additive bias together with :math:`\mathbf{U}`.
-        (default: obj:`True`)
-        bias_u (bool, optional): If set to :obj:`False`, the layer will not
-        learn an additive bias together with :math:`\mathbf{U}`.
-        (default: obj:`True`)
+            learn an additive bias together with :math:`\mathbf{U}`.
+            (default: obj:`True`)
         add_self_loops (bool, optional): If set to :obj:`True`, will add
-        self-loops to the input graph. (default: :obj:`False`)
+            self-loops to the input graph. (default: :obj:`False`)
         cached (bool, optional): If set to :obj:`True`, the layer will cache
-        the computation of :math:`\mathbf{\hat{A}} = \mathbf{A}/\gamma` on
-        first execution, and will use the cached version for further
-        executions. This parameter should only be set to :obj:`True` in
-        transductive learning scenarios. (default: :obj:`False`)
+            the computation of :math:`\mathbf{\hat{A}} = \mathbf{A}/\gamma` on
+            first execution, and will use the cached version for further
+            executions. This parameter should only be set to :obj:`True` in
+            transductive learning scenarios. (default: :obj:`False`)
         normalize (bool, optional): Whether to apply normalization
-        by :math:`\gamma`. (default: :obj:`True`)
+            by :math:`\gamma`. (default: :obj:`True`)
         **kwargs (optional): Additional arguments of
             :class:`torch_geometric.nn.conv.MessagePassing`.
 

--- a/torch_geometric/contrib/nn/conv/res_graph_conv.py
+++ b/torch_geometric/contrib/nn/conv/res_graph_conv.py
@@ -212,10 +212,8 @@ class ResGConv(MessagePassing):
                 else:
                     edge_index = cache
 
-        # the heart of the ResGConv layer
-        # the linear layer, followed by the message passing
-        # and the addition of the skip connection
         wx = self.W(x)
+        # propagate_type: (x: Tensor, edge_weight: OptTensor)
         awx = self.propagate(edge_index, x=wx, edge_weight=edge_weight)
         out = awx + self.U(x)
 


### PR DESCRIPTION
As part of the CS224W project, @BlakeMasters and I added ResGConv and res_gconv_norm used in [Chen (2025), Graph Neural Preconditioners for Iterative Solutions of Sparse Linear Systems](https://arxiv.org/pdf/2406.00809). It's a PyG implementation of the [GCNConv layer](https://github.com/jiechenjiechen/GNP/blob/main/GNP/nn/ResGCN.py) in @jiechenjiechen's PyTorch implementation of the Graph Neural Preconditioners paper called [GNP](https://github.com/jiechenjiechen/GNP/tree/main).

We started from the [GCN2Conv](https://pytorch-geometric.readthedocs.io/en/latest/generated/torch_geometric.nn.conv.GCN2Conv.html#torch_geometric.nn.conv.GCN2Conv) layer and [gcn_norm](https://pytorch-geometric.readthedocs.io/en/latest/_modules/torch_geometric/nn/conv/gcn_conv.html#GCNConv) and tried to follow these implementations. We used the new layer in a [fork of GNP](https://github.com/chloisu/GNP/tree/feature_integrate_pyg_res_graph_gconv) to implement a PyG version of the ResGCN layer implemented there. If desired, this could be included as an example application of the ResGConv layer.

We hope the layer and/or normalization can be useful for others in the future.
Thank you very much in advance.