### PR TITLE
fix '`torch_dtype` is deprecated! Use `dtype` instead!' in LLM

### DIFF
--- a/torch_geometric/llm/models/llm.py
+++ b/torch_geometric/llm/models/llm.py
@@ -43,7 +43,7 @@ def get_llm_kwargs(required_memory: int, dtype=torch.dtype) -> Dict[str, Any]:
         }
         kwargs['low_cpu_mem_usage'] = True
         kwargs['device_map'] = 'auto'
-        kwargs['torch_dtype'] = dtype
+        kwargs['dtype'] = dtype
 
     return kwargs
 


### PR DESCRIPTION
before:
```
>>> LLM("meta-llama/Meta-Llama-3.1-8B-Instruct")
model.safetensors.index.json: 100%
...
`torch_dtype` is deprecated! Use `dtype` instead!
...
```

after: warning removed
