### PR TITLE
GPrompt Implementation + Unit Tests + Toy Training Loop

### DIFF
--- a/examples/contrib/gprompt_mlm_toy_version.py
+++ b/examples/contrib/gprompt_mlm_toy_version.py
@@ -1,0 +1,201 @@
+#!/usr/bin/env python
+import random
+
+import numpy as np
+import torch
+from torch import nn, optim
+from transformers import AutoModel, AutoTokenizer
+
+from torch_geometric.contrib.nn.models.gprompt import GraphAdapter
+from torch_geometric.data import Data
+
+VERBOSE = True
+
+
+def vprint(*args, **kwargs):
+    if VERBOSE:
+        print(*args, **kwargs)
+
+
+def build_toy_graph():
+    # An undirected linear graph 0 - 1 - 2
+    # (Two directed edges to represent each undirected edge)
+    edge_index = torch.tensor(
+        [
+            [0, 1, 1, 2],  # neighbors (dest)
+            [1, 0, 2, 1],  # centers (src)
+        ],
+        dtype=torch.long,
+    )
+
+    texts = [
+        "This is a course about graph neural networks.",
+        "The goal is to better understand how to do machine learning over "
+        "graphs.",
+        "This project implements a paper to build better node features for "
+        "text-attributed graphs.",
+    ]
+
+    data = Data(edge_index=edge_index)
+    data.text = texts
+    return data
+
+
+def encode_texts_with_masks(tokenizer, model, texts, mlm_prob=0.15):
+    """Randomly mask tokens with probability mlm_prob per node,
+    store original token IDs in target_ids.
+
+    Return:
+        h_mask: [M, H]
+        z: [N, H]  (CLS embeddings per node)
+        target_ids: [M]
+        node_ids: [M]
+    """
+    enc = tokenizer(
+        texts,
+        return_tensors="pt",
+        padding=True,
+        truncation=True,
+        return_special_tokens_mask=True,
+    )
+    N, L = enc["input_ids"].shape
+    mask_token_id = tokenizer.mask_token_id
+
+    # Print out the decoded sequence as a sanity check
+    # We see that the tokenizer automatically adds CLS and SEP, PAD tokens
+    for i, seq in enumerate(enc["input_ids"]):
+        vprint(f"Sanity check: decoded sequence {i} is", tokenizer.decode(seq))
+    masked_input_ids, target_ids_list, node_ids_list = enc["input_ids"].clone(
+    ), [], []
+    special_mask = enc["special_tokens_mask"].to(torch.bool)
+
+    masked_positions = (torch.bernoulli(
+        torch.full(enc["input_ids"].shape, mlm_prob)).bool()) & ~special_mask
+    for i in range(N):
+        positions = masked_positions[i].nonzero(as_tuple=False).view(-1)
+        for p in positions:
+            target_ids_list.append(enc["input_ids"][i, p])
+            node_ids_list.append(i)
+            masked_input_ids[i, p] = mask_token_id
+
+    # Print original tokens that are being masked.
+    for i in range(enc["input_ids"].size(0)):
+        vprint(f"Sentence {i}:")
+        positions = masked_positions[i].nonzero(as_tuple=False).view(-1)
+        for p in positions:
+            orig_token_id = enc["input_ids"][i, p]
+            vprint("  Masked token:", tokenizer.decode([orig_token_id]))
+
+    if len(target_ids_list) == 0:
+        raise ValueError(
+            "MLM sampling produced zero masked tokens. Try a higher mlm_prob.")
+    target_ids = torch.stack(target_ids_list, dim=0)  # [M]
+    node_ids = torch.tensor(node_ids_list, dtype=torch.long)  # [M]
+    with torch.no_grad():
+        outputs = model(
+            input_ids=masked_input_ids,
+            attention_mask=enc["attention_mask"],
+            output_hidden_states=True,
+            return_dict=True,
+        )
+        last_hidden = outputs.hidden_states[-1]  # [N, L, H]
+
+    # Get overall sentence embeddings (CLS tokens)
+    z = last_hidden[:, 0, :]  # [N, H]
+
+    # Collect hidden states at masked positions
+    masked_states = []
+    for i in range(N):
+        positions = masked_positions[i].nonzero(as_tuple=False).view(-1)
+        for p in positions:
+            masked_states.append(last_hidden[i, p])
+
+    h_mask = torch.stack(masked_states, dim=0)  # [M, H]
+
+    return h_mask, z, target_ids, node_ids
+
+
+def main():
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    print(f"Using device: {device}")
+
+    # Prepare input data (toy graph)
+    data = build_toy_graph()
+    edge_index = data.edge_index.to(device)
+    vprint("Graph edges are", edge_index)
+
+    # Load a tiny version of BERT (from https://arxiv.org/abs/1908.08962)
+    model_name = "prajjwal1/bert-tiny"
+    tokenizer = AutoTokenizer.from_pretrained(model_name)
+    lm = AutoModel.from_pretrained(model_name).to(device)
+    lm.eval()
+
+    # Get the hidden token embeddings and also the sentence (CLS) embeddings
+    h_mask, z, target_ids, node_ids = encode_texts_with_masks(
+        tokenizer, lm, data.text)
+    h_mask = h_mask.to(device)  # [M, H]
+    z = z.to(device)  # [N, H]
+    target_ids = target_ids.to(device)
+    node_ids = node_ids.to(device)
+
+    hidden_channels = h_mask.size(-1)
+    node_channels = z.size(-1)
+
+    #    linear layer that maps adapter outputs to vocab logits.
+    vocab_size = tokenizer.vocab_size
+
+    adapter = GraphAdapter(
+        hidden_channels=hidden_channels,
+        node_channels=node_channels,
+    ).to(device)
+
+    # Note: We do NOT use the language model's final prediction layer (denoted
+    # by f_LM in the paper). We instead define a fresh one for simplicity. In
+    # the paper, this final prediction layer is also not explicitly fine-tuned
+    # since it already carries a lot of pre-trained knowledge.
+    predictor = nn.Linear(hidden_channels, vocab_size).to(device)
+    optimizer = optim.Adam(
+        list(adapter.parameters()) + list(predictor.parameters()),
+        lr=1e-3,
+    )
+
+    # A short training loop to demonstrate the E2E flow. We will observe that
+    # the loss quickly goes to 0, which we expect given that it is a toy
+    # dataset and it should overfit quickly.
+    adapter.train()
+    predictor.train()
+
+    num_steps = 10000
+    for step in range(num_steps):
+        optimizer.zero_grad()
+        edge_logits, masked_idx = adapter(
+            h_mask=h_mask,
+            z=z,
+            edge_index=edge_index,
+            node_ids=node_ids,
+            predictor=predictor,
+        )
+
+        loss = GraphAdapter.loss(
+            edge_logits=edge_logits,
+            masked_idx=masked_idx,
+            target_ids=target_ids,
+        )
+
+        loss.backward()
+        optimizer.step()
+        if step % 100 == 0:
+            vprint(f"Step {step:02d} | loss = {loss.item():.4f}")
+
+    print(f"Success! Final loss {loss} should be nearly 0")
+
+
+if __name__ == "__main__":
+    seed = 42
+    random.seed(seed)
+    np.random.seed(seed)
+    torch.manual_seed(seed)
+    if torch.cuda.is_available():
+        torch.cuda.manual_seed(seed)
+        torch.cuda.manual_seed_all(seed)
+    main()

--- a/test/contrib/nn/models/test_gprompt.py
+++ b/test/contrib/nn/models/test_gprompt.py
@@ -1,0 +1,199 @@
+from __future__ import annotations
+
+import torch
+import torch.nn.functional as F
+from torch import nn
+
+from torch_geometric.contrib.nn.models.gprompt import GraphAdapter
+
+
+def test_graph_adapter_forward_shapes():
+    N, M, H, Z, V = 4, 2, 8, 8, 5
+    masked_edges = 2
+
+    z = torch.randn(N, Z)
+    h_mask = torch.randn(M, H)
+    edge_index = torch.tensor([[0, 1, 2, 3], [1, 2, 3, 0]])
+    node_ids = torch.tensor([1, 2])
+    predictor = nn.Linear(H, V)
+
+    adapter = GraphAdapter(hidden_channels=H, node_channels=Z)
+    logits, masked_idx = adapter(
+        h_mask=h_mask,
+        z=z,
+        edge_index=edge_index,
+        node_ids=node_ids,
+        predictor=predictor,
+    )
+
+    assert logits.shape == (masked_edges, V)
+    assert masked_idx.shape == (masked_edges, )
+
+
+def test_graph_adapter_loss_equivalence():
+    # Verify that the loss function matches manual average of
+    # cross-entropy for a single masked token.
+    edge_logits = torch.tensor([[1.0, 0.0, -1.0], [0.5, 0.5, -1.0]])
+    masked_idx = torch.tensor([0, 0])
+    target_ids = torch.tensor([1])
+
+    loss = GraphAdapter.loss(
+        edge_logits=edge_logits,
+        masked_idx=masked_idx,
+        target_ids=target_ids,
+    )
+
+    log_probs = F.log_softmax(edge_logits, dim=-1)
+    gt = torch.tensor([1, 1])
+    manual = F.nll_loss(log_probs, gt, reduction="mean")
+
+    assert torch.allclose(loss, manual)
+
+
+def test_graph_adapter_reduces_to_predictor_when_gate_is_large():
+    N, M, H, Z, V = 3, 1, 4, 4, 6
+
+    torch.manual_seed(0)
+    z = torch.zeros(N, Z)
+    h_mask = torch.randn(M, H)
+    edge_index = torch.tensor([[1, 2],
+                               [0, 0]])  # two neighbors -> same center node 0
+    node_ids = torch.tensor([0])
+    predictor = nn.Linear(H, V, bias=False)
+
+    adapter = GraphAdapter(hidden_channels=H, node_channels=Z)
+
+    # Make q_proj and k_proj output large positive values for node 0
+    # to push a_ij -> 1
+    with torch.no_grad():
+        adapter.q_proj.weight.fill_(1.0)
+        adapter.q_proj.bias.fill_(100.0)
+        adapter.k_proj.weight.fill_(1.0)
+        adapter.k_proj.bias.fill_(100.0)
+
+        # Make g_mlp ~ 0 so the second term vanishes:
+        for p in adapter.g_mlp.parameters():
+            p.zero_()
+
+    logits_pooled, _ = adapter(
+        h_mask=h_mask,
+        z=z,
+        edge_index=edge_index,
+        node_ids=node_ids,
+        predictor=predictor,
+    )
+
+    # Direct predictor on h_mask:
+    direct_logits = predictor(h_mask)
+
+    # They won't be exactly identical (sigmoid not exactly 1), but
+    # should be close.
+    assert torch.allclose(logits_pooled, direct_logits, atol=1e-3, rtol=1e-3)
+
+
+def test_pool_outputs_log_vs_prob():
+    edge_logits = torch.tensor([[1.0, 0.0],
+                                [3.0, 0.0]])  # two edges, same masked token
+    masked_idx = torch.tensor([0, 0])
+    M = 1
+    # Arithmetic mean of log probs (log of geometric mean of probs)
+    log_pooled = GraphAdapter.pool_outputs(edge_logits, masked_idx, M,
+                                           use_log_probs=True)
+    assert log_pooled.shape == (M, 2)
+    per_edge_log_probs = F.log_softmax(edge_logits, dim=-1)
+    manual_log_mean = per_edge_log_probs.mean(dim=0)
+    assert torch.allclose(log_pooled[0], manual_log_mean, atol=1e-6)
+    # Arithmetic mean of probs
+    prob_pooled = GraphAdapter.pool_outputs(edge_logits, masked_idx, M,
+                                            use_log_probs=False)
+    assert prob_pooled.shape == (M, 2)
+    per_edge_probs = F.softmax(edge_logits, dim=-1)
+    manual_prob_mean = per_edge_probs.mean(dim=0)
+    assert torch.allclose(prob_pooled[0], manual_prob_mean, atol=1e-6)
+
+
+def test_multiple_masked_tokens_same_node():
+    # Node 0 has two masked tokens, and two neighbors.
+    N, H, V = 3, 4, 7
+    z = torch.randn(N, H)
+    h_mask = torch.randn(2, H)  # two tokens on node 0
+    edge_index = torch.tensor([[1, 2], [0, 0]])  # 1->0, 2->0
+    node_ids = torch.tensor([0, 0])
+    predictor = nn.Linear(H, V)
+
+    adapter = GraphAdapter(hidden_channels=H, node_channels=H)
+    edge_logits, masked_idx = adapter(
+        h_mask=h_mask,
+        z=z,
+        edge_index=edge_index,
+        node_ids=node_ids,
+        predictor=predictor,
+    )
+    assert edge_logits.shape[0] == 4
+    assert masked_idx.tolist().count(0) == 2
+    assert masked_idx.tolist().count(1) == 2
+
+
+def test_forward_no_neighbors():
+    N, M, H, Z, V = 4, 2, 8, 8, 5
+    h_mask = torch.randn(M, H)
+    z = torch.randn(N, Z)
+    # No edges with dest being 0 or 1
+    edge_index = torch.tensor(
+        [
+            [1, 0],
+            [2, 3],
+        ],
+        dtype=torch.long,
+    )
+    node_ids = torch.tensor([0, 1], dtype=torch.long)
+    predictor = nn.Linear(H, V)
+    adapter = GraphAdapter(hidden_channels=H, node_channels=Z)
+    edge_logits, masked_idx = adapter(
+        h_mask=h_mask,
+        z=z,
+        edge_index=edge_index,
+        node_ids=node_ids,
+        predictor=predictor,
+    )
+    assert edge_logits.shape == (0, V)
+    assert masked_idx.numel() == 0
+    assert masked_idx.dtype == torch.long
+
+
+def test_loss_no_neighbors():
+    V = 5
+    edge_logits = torch.empty((0, V))
+    masked_idx = torch.empty((0, ), dtype=torch.long)
+    target_ids = torch.tensor([1, 2])
+
+    loss = GraphAdapter.loss(
+        edge_logits=edge_logits,
+        masked_idx=masked_idx,
+        target_ids=target_ids,
+    )
+    assert loss.item() == 0.0
+
+
+def test_backward_computes_gradients():
+    N, M, H, Z, V = 4, 2, 8, 8, 5
+    z = torch.randn(N, Z, requires_grad=False)
+    h_mask = torch.randn(M, H, requires_grad=False)
+    edge_index = torch.tensor([[0, 1, 2, 3], [1, 2, 3, 0]])
+    node_ids = torch.tensor([1, 2])
+    target_ids = torch.tensor([1, 2])
+    predictor = nn.Linear(H, V)
+
+    adapter = GraphAdapter(hidden_channels=H, node_channels=Z)
+    edge_logits, masked_idx = adapter(
+        h_mask=h_mask,
+        z=z,
+        edge_index=edge_index,
+        node_ids=node_ids,
+        predictor=predictor,
+    )
+    loss = adapter.loss(edge_logits, masked_idx, target_ids)
+    loss.backward()
+
+    grads = [p.grad for p in adapter.parameters()]
+    assert any(g is not None and g.abs().sum() > 0 for g in grads)

--- a/torch_geometric/contrib/nn/models/__init__.py
+++ b/torch_geometric/contrib/nn/models/__init__.py
@@ -1,6 +1,8 @@
 from .rbcd_attack import PRBCDAttack, GRBCDAttack
+from .gprompt import GraphAdapter
 
 __all__ = classes = [
-    'PRBCDAttack',
-    'GRBCDAttack',
+    "PRBCDAttack",
+    "GRBCDAttack",
+    "GraphAdapter",
 ]

--- a/torch_geometric/contrib/nn/models/gprompt.py
+++ b/torch_geometric/contrib/nn/models/gprompt.py
@@ -1,0 +1,268 @@
+from __future__ import annotations
+
+from typing import Callable
+
+import torch
+import torch.nn.functional as F
+from torch import Tensor, nn
+
+
+class GraphAdapter(nn.Module):
+    r"""Graph Adapter from the
+    `Prompt-based Node Feature Extractor for Few-shot Learning on
+    Text-Attributed Graphs (Huang et al., 2023)
+    <https://arxiv.org/pdf/2309.02848>` _ paper.
+
+    This module augments masked-token representations from a pre-trained
+    language model with information from neighboring nodes in a
+    text-attributed graph.
+
+    It implements the gating mechanism and neighbor aggregation described
+    in Section 3.2 of the paper.
+
+    Args:
+        hidden_channels (int): Dimensionality of masked-token hidden states
+            :math:`\hat{h}_{i,k}`.
+        node_channels (int): Dimensionality of node / sentence embeddings
+            :math:`z_i`.
+        attn_channels (int, optional): Dimensionality of attention
+            projections :math:`W_q, W_k`. If set to :obj:`None`, defaults
+            to :obj:`node_channels`.
+        mlp_hidden_channels (int, optional): Hidden size of the MLP
+            :math:`g(\cdot)` projecting node embeddings into the same space
+            as :math:`\hat{h}_{i,k}`. If set to :obj:`None`, defaults to
+            :obj:`node_channels`.
+    """
+    def __init__(
+        self,
+        hidden_channels: int,
+        node_channels: int,
+        attn_channels: int | None = None,
+        mlp_hidden_channels: int | None = None,
+    ) -> None:
+        super().__init__()
+
+        if attn_channels is None:
+            attn_channels = node_channels
+        if mlp_hidden_channels is None:
+            mlp_hidden_channels = node_channels
+
+        self.hidden_channels = hidden_channels
+        self.node_channels = node_channels
+        self.attn_channels = attn_channels
+        self.mlp_hidden_channels = mlp_hidden_channels
+
+        # Projections used in the neighbor gate a_ij:
+        self.q_proj = nn.Linear(node_channels, attn_channels)
+        self.k_proj = nn.Linear(node_channels, attn_channels)
+
+        # MLP g(z_j) mapping node embeddings to the same space as h_mask:
+        self.g_mlp = nn.Sequential(
+            nn.Linear(node_channels, mlp_hidden_channels),
+            nn.ReLU(),
+            nn.Linear(mlp_hidden_channels, hidden_channels),
+        )
+
+    def forward(
+        self,
+        h_mask: Tensor,
+        z: Tensor,
+        edge_index: Tensor,
+        node_ids: Tensor,
+        predictor: nn.Module | Callable[[Tensor], Tensor],
+    ) -> tuple[Tensor, Tensor | None]:
+        r"""Runs the graph adapter.
+
+        Args:
+            h_mask (Tensor): Hidden states of masked tokens of shape
+                :obj:`[M, hidden_channels]`.
+            z (Tensor): Node / sentence embeddings of shape
+                :obj:`[N, node_channels]`.
+            edge_index (Tensor): Graph connectivity (src, dest) with
+                shape :obj:`[2, E]`. edge_index[1] will correspond to the
+                "center" nodes whose masked tokens we'll be predicting based
+                on their neighbors in edge_index[0]
+            node_ids (Tensor): Node index for each masked token of shape
+                :obj:`[M]`, mapping masked tokens to graph nodes.
+            predictor (Module or Callable): The language model's prediction
+                head :math:`f_{\text{LM}}` that maps hidden states of shape
+                :obj:`[..., hidden_channels]` to vocabulary logits
+                :obj:`[..., vocab_size]`.
+
+        Returns:
+            (Tensor, Tensor): The first element is the per-edge logits
+            and the second element are the masked-token indices of shape
+            :obj:`[masked_edges]`.
+        """
+        device = h_mask.device
+        src, dst = edge_index
+        M, E = h_mask.size(0), src.numel()
+        assert node_ids.dim() == 1 and len(node_ids) == M
+
+        # Precompute attention projections q_i, k_j for all nodes.
+        q = self.q_proj(z)  # [N, A]
+        k = self.k_proj(z)  # [N, A]
+
+        # Get the masked token id's for each node
+        node_to_masked_dict: dict[int, list[int]] = {}
+        for m, n in enumerate(node_ids.tolist()):
+            if n not in node_to_masked_dict:
+                node_to_masked_dict[n] = []
+            node_to_masked_dict[n].append(m)
+
+        # For each edge (src, dst) where dst has masked tokens,
+        # we create one pair per token.
+        masked_idx_list: list[tuple[int, int]] = []
+        for e in range(E):
+            center = int(dst[e].item())
+            if center in node_to_masked_dict:
+                for m in node_to_masked_dict[center]:
+                    masked_idx_list.append((m, e))
+
+        masked_idx_tensor = torch.tensor(
+            [m for (m, _) in masked_idx_list],
+            device=device,
+            dtype=torch.long,
+        )
+        edge_idx_tensor = torch.tensor(
+            [e for (_, e) in masked_idx_list],
+            device=device,
+            dtype=torch.long,
+        )
+
+        # For each (masked token m, edge e), get center node i and neighbor j:
+        center_nodes = node_ids[masked_idx_tensor]  # [masked_edges]
+        neighbor_nodes = src[edge_idx_tensor]  # [masked_edges]
+
+        # Gate a_ij = sigmoid( (z_i W_q) (z_j W_k)^T ).
+        q_i = q[center_nodes]  # [masked_edges, A]
+        k_j = k[neighbor_nodes]  # [masked_edges, A]
+        a_ij = torch.sigmoid(
+            (q_i * k_j).sum(dim=-1, keepdim=True))  # [masked_edges, 1]
+
+        # Neighbor influence:
+        h_i = h_mask[masked_idx_tensor]  # [masked_edges, H]
+        g_zj = self.g_mlp(z[neighbor_nodes])  # [masked_edges, H]
+        h_tilde = a_ij * h_i + (1.0 - a_ij) * g_zj  # [masked_edges, H]
+
+        # Apply pre-trained language model prediction head f_LM:
+        edge_logits = predictor(h_tilde)  # [masked_edges, V]
+        return edge_logits, masked_idx_tensor
+
+    @staticmethod
+    def pool_outputs(
+        edge_logits: Tensor,
+        masked_idx: Tensor,
+        num_masked_tokens: int,
+        use_log_probs: bool,
+    ) -> Tensor:
+        r"""Computes pooled probabilities per masked token by either taking the
+        arithmetic mean of each masked token's neighbors' probabilities or
+        taking the arithmetic mean of their log probs (corresponding to the
+        geometric mean of the probabilities that is described in section 3.3
+        in the paper). The paper formulates it in terms of the arithmetic mean
+        but mentions that it is better to use the geometric mean when training
+        (which is implicitly done in our loss function). We allow for both
+        options here.
+
+        Args:
+            edge_logits (Tensor): Per-edge logits of shape
+                :obj:`[masked_edges, vocab_size]`.
+            masked_idx (Tensor): Index of the masked token for each edge of
+                shape :obj:`[masked_edges]`.
+            num_masked_tokens (int): Total number of masked tokens
+                :math:`M`. The reason to have this as an explicit argument
+                instead of inferring it from masked_idx is to handle cases
+                where some masked tokens belong to nodes with no neighbors.
+            use_log_probs (bool): If this is true, we will return the
+            arithmetic mean of the log probabilities - i.e. if we take the exp
+            of this, we will get the geometric mean of the probabilities.
+            Otherwise, we will return the arithmetic mean of the probabilities
+            directly.
+
+        Returns:
+            Tensor: output of shape
+            :obj:`[M, vocab_size]` - if use_log_probs is True, this will
+            represent the log-probabilities and otherwise this will represent
+            the probabilities; if a masked token has no edges, we return
+            negative inf in the case of log probs for that entry
+            and 0 in the case of probabilities.
+        """
+        if use_log_probs:
+            unpooled_outputs = F.log_softmax(edge_logits,
+                                             dim=-1)  # [masked_edges, V]
+        else:
+            unpooled_outputs = F.softmax(edge_logits, dim=-1)
+        pooled_sums = torch.zeros(
+            num_masked_tokens,
+            unpooled_outputs.shape[-1],
+            device=unpooled_outputs.device,
+            dtype=unpooled_outputs.dtype,
+        )
+        counts = torch.zeros(
+            num_masked_tokens,
+            device=unpooled_outputs.device,
+            dtype=unpooled_outputs.dtype,
+        )
+        pooled_sums.index_add_(0, masked_idx,
+                               unpooled_outputs)  # [num_masked_tokens, V]
+        counts.index_add_(
+            0,
+            masked_idx,
+            torch.ones(
+                unpooled_outputs.shape[-2],
+                device=unpooled_outputs.device,
+                dtype=unpooled_outputs.dtype,
+            ),
+        )
+        pooled_outputs = unpooled_outputs.new_full(
+            (num_masked_tokens, unpooled_outputs.size(-1)),
+            float("-inf") if use_log_probs else 0.0,
+        )
+        mask = counts > 0
+        pooled_outputs[mask] = pooled_sums[mask] / counts[mask].unsqueeze(-1)
+        return pooled_outputs
+
+    @staticmethod
+    def loss(
+        edge_logits: Tensor,
+        masked_idx: Tensor,
+        target_ids: Tensor,
+    ) -> Tensor:
+        r"""Computes the graph-adapter loss as described in Eq. (8) of the
+        paper.
+
+        The loss corresponds to averaging the cross-entropy over neighbors
+        for each masked token, which is equivalent to the negative log of
+        the geometric mean of the probabilities, as formulated in the paper.
+
+        Args:
+            edge_logits (Tensor): Per-edge logits of shape
+                :obj:`[masked_edges, vocab_size]`, where :obj:`masked_edges`
+                is the number of edges summed over all masked tokens (i.e. the
+                length of all (masked-token, neighbor) pairs).
+            masked_idx (Tensor): Index of the masked token for each edge of
+                shape :obj:`[masked_edges]`.
+            target_ids (Tensor): Ground-truth token ids for each masked token
+                of shape :obj:`[M]`.
+
+        Returns:
+            Tensor: Scalar loss.
+        """
+        # We compute the negative log loss with respect to all of the
+        # neighbors of each masked central node. Then we scale it down by the
+        # number of neighbors for that node.
+        edge_targets = target_ids[masked_idx]  # [masked_edges]
+        edge_losses = F.cross_entropy(edge_logits, edge_targets,
+                                      reduction="none")  # [masked_edges]
+        numerator = torch.zeros(target_ids.size(0), device=edge_logits.device)
+        denominator = torch.zeros(target_ids.size(0),
+                                  device=edge_logits.device)
+        numerator.scatter_add_(0, masked_idx, edge_losses)
+        denominator.scatter_add_(
+            0, masked_idx, torch.ones_like(masked_idx,
+                                           dtype=edge_losses.dtype))
+        if not denominator.any():
+            return torch.tensor(0.0)
+        return (numerator[denominator > 0] /
+                denominator[denominator > 0]).mean()


### PR DESCRIPTION
This implements the G-Prompt graph adapter module from the paper [https://arxiv.org/abs/2309.02848](Prompt-based Node Feature Extractor for Few-shot Learning on Text-Attributed Graphs), submitted as a project for CS224W.

It includes the implementation of the adapter module, unit tests to verify it, and an example training loop with a toy dataset to demonstrate the overall flow of how to train it.