### PR TITLE
Parsing bug for subclassing `MessagePassing`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,6 +106,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- Fixed caching of source code for parsing when subclassing `MessagePassing` to not skip implementations with the same class name ([#10569](https://github.com/pyg-team/pytorch_geometric/pull/10569))
 - Fixed conversion to/from `cuGraph` graph objects by ensuring `cudf` column names are correctly specified ([#10343](https://github.com/pyg-team/pytorch_geometric/pull/10343))
 - Fixed `_recursive_config()` for `torch.nn.ModuleList` and `torch.nn.ModuleDict` ([#10124](https://github.com/pyg-team/pytorch_geometric/pull/10124), [#10129](https://github.com/pyg-team/pytorch_geometric/pull/10129))
 - Fixed the `k_hop_subgraph()` method for directed graphs ([#9756](https://github.com/pyg-team/pytorch_geometric/pull/9756))

--- a/torch_geometric/inspector.py
+++ b/torch_geometric/inspector.py
@@ -325,12 +325,13 @@ class Inspector:
         from torch_geometric.nn import MessagePassing
 
         cls = cls or self._cls
-        if cls.__name__ in self._source_dict:
-            return self._source_dict[cls.__name__]
+        key = ".".join((cls.__module__, cls.__name__))
+        if key in self._source_dict:
+            return self._source_dict[key]
         if cls in {object, torch.nn.Module, MessagePassing}:
             return ''
         source = inspect.getsource(cls)
-        self._source_dict[cls.__name__] = source
+        self._source_dict[key] = source
         return source
 
     def get_params_from_method_call(


### PR DESCRIPTION
When subclassing `MessagePassing` PyG tries to infer the signature of `self.propagate` by parsing the user's implementation (see [1](https://github.com/pyg-team/pytorch_geometric/blob/94eae251a71a798a54a2b9fe631ef4e6fada9a84/torch_geometric/nn/conv/message_passing.py#L171), [2](https://github.com/pyg-team/pytorch_geometric/blob/94eae251a71a798a54a2b9fe631ef4e6fada9a84/torch_geometric/nn/conv/message_passing.py#L945), [3](https://github.com/pyg-team/pytorch_geometric/blob/94eae251a71a798a54a2b9fe631ef4e6fada9a84/torch_geometric/nn/conv/message_passing.py#L1002) and [4](https://github.com/pyg-team/pytorch_geometric/blob/94eae251a71a798a54a2b9fe631ef4e6fada9a84/torch_geometric/inspector.py#L399)). The source code is cached and accessed by class name (see [5](https://github.com/pyg-team/pytorch_geometric/blob/94eae251a71a798a54a2b9fe631ef4e6fada9a84/torch_geometric/inspector.py#L328)) for parsing.

In the following is an example where this fails. Consider a directory
```
src
├ __init__.py
├ one.py
└ two.py
main.py
```
where `one.py` contains
```python
from torch_geometric.nn import MessagePassing

class MyMessagePassing(MessagePassing):
    def forward(self, edge_index, x, pos):
        return self.propagate(edge_index, x=x, pos=pos)
```
and `two.py` implements a subclass with the same name:
```python
from .one import MyMessagePassing

class MyMessagePassing(MyMessagePassing):
    pass
```
Running `main.py` with contents
```python
from src.two import MyMessagePassing
from inspect import signature
import torch

my_message_passing = MyMessagePassing()

propagate = my_message_passing.propagate
args = tuple(signature(propagate).parameters.keys())

print(args)

edge_index, x, pos = torch.randint(12, (2, 24)), torch.rand(12, 4), torch.rand(12, 3)
my_message_passing(edge_index, x, pos)
```
fails with
```
('edge_index', 'size')
...
TypeError: propagate() got an unexpected keyword argument 'x'
```
because the superclass implementation `src.one.MyMessagePassing` is never parsed. If this behaviour is not intended it can be fixed by caching the source code by **module and** class name. After the fix `main.py` executes successfully with:
```
('edge_index', 'x', 'pos', 'size')
```