### PR TITLE
Adding the possibility to make alpha learnable in DirGNNConv

### DIFF
--- a/test/nn/conv/test_dir_gnn_conv.py
+++ b/test/nn/conv/test_dir_gnn_conv.py
@@ -24,13 +24,14 @@ def test_static_dir_gnn_conv():
     out = conv(x, edge_index)
     assert out.size() == (3, 4, 32)
 
-    
+
 def test_dir_gnn_conv_trainable_alpha():
     x = torch.randn(4, 16)
     edge_index = torch.tensor([[0, 1, 2], [1, 2, 3]])
 
     # Test non-trainable alpha
-    conv_fixed_alpha = DirGNNConv(SAGEConv(16, 32), alpha=0.3, trainable_alpha=False)
+    conv_fixed_alpha = DirGNNConv(SAGEConv(16, 32), alpha=0.3,
+                                  trainable_alpha=False)
     assert not conv_fixed_alpha.alpha.requires_grad
     optimizer = torch.optim.SGD(conv_fixed_alpha.parameters(), lr=0.01)
     out = conv_fixed_alpha(x, edge_index)
@@ -40,9 +41,10 @@ def test_dir_gnn_conv_trainable_alpha():
     optimizer.step()
     new_alpha = conv_fixed_alpha.alpha.item()
     assert old_alpha == pytest.approx(new_alpha)
-    
+
     # Test trainable alpha
-    conv_trainable_alpha = DirGNNConv(SAGEConv(16, 32), alpha=0.3, trainable_alpha=True)
+    conv_trainable_alpha = DirGNNConv(SAGEConv(16, 32), alpha=0.3,
+                                      trainable_alpha=True)
     assert conv_trainable_alpha.alpha.requires_grad
     optimizer = torch.optim.SGD(conv_trainable_alpha.parameters(), lr=0.01)
     out = conv_trainable_alpha(x, edge_index)

--- a/test/nn/conv/test_dir_gnn_conv.py
+++ b/test/nn/conv/test_dir_gnn_conv.py
@@ -1,3 +1,4 @@
+import pytest
 import torch
 
 from torch_geometric.nn import DirGNNConv, SAGEConv
@@ -22,3 +23,32 @@ def test_static_dir_gnn_conv():
 
     out = conv(x, edge_index)
     assert out.size() == (3, 4, 32)
+
+    
+def test_dir_gnn_conv_trainable_alpha():
+    x = torch.randn(4, 16)
+    edge_index = torch.tensor([[0, 1, 2], [1, 2, 3]])
+
+    # Test non-trainable alpha
+    conv_fixed_alpha = DirGNNConv(SAGEConv(16, 32), alpha=0.3, trainable_alpha=False)
+    assert not conv_fixed_alpha.alpha.requires_grad
+    optimizer = torch.optim.SGD(conv_fixed_alpha.parameters(), lr=0.01)
+    out = conv_fixed_alpha(x, edge_index)
+    loss = out.sum()
+    loss.backward()
+    old_alpha = conv_fixed_alpha.alpha.item()
+    optimizer.step()
+    new_alpha = conv_fixed_alpha.alpha.item()
+    assert old_alpha == pytest.approx(new_alpha)
+    
+    # Test trainable alpha
+    conv_trainable_alpha = DirGNNConv(SAGEConv(16, 32), alpha=0.3, trainable_alpha=True)
+    assert conv_trainable_alpha.alpha.requires_grad
+    optimizer = torch.optim.SGD(conv_trainable_alpha.parameters(), lr=0.01)
+    out = conv_trainable_alpha(x, edge_index)
+    loss = out.sum()
+    loss.backward()
+    old_alpha = conv_trainable_alpha.alpha.item()
+    optimizer.step()
+    new_alpha = conv_trainable_alpha.alpha.item()
+    assert not old_alpha == pytest.approx(new_alpha)

--- a/torch_geometric/nn/conv/dir_gnn_conv.py
+++ b/torch_geometric/nn/conv/dir_gnn_conv.py
@@ -19,7 +19,7 @@ class DirGNNConv(torch.nn.Module):
         alpha (float, optional): The alpha coefficient used to weight the
             aggregations of in- and out-edges as part of a convex combination.
             (default: :obj:`0.5`)
-        trainable_alpha (bool): Whether the alpha coefficient should be a 
+        trainable_alpha (bool): Whether the alpha coefficient should be a
             learnable parameter. If `True`, alpha will be initialized to the value
             provided via the :obj:`alpha` argument.
             (default: :obj:`False`)
@@ -64,7 +64,7 @@ class DirGNNConv(torch.nn.Module):
             self.lin = None
 
         self.reset_parameters()
-    
+
     @property
     def alpha(self) -> torch.Tensor:
         return torch.sigmoid(self.logit_alpha)


### PR DESCRIPTION
# Changes
Class `DirGNNConv` now offers the possibility for the `alpha` coefficient to be learnable through boolean argument `trainable_alpha`. 
In order to make sure `alpha` stays between 0 and 1 during learning, the `torch.nn.Parameter` that is added is actually the logit of `alpha`, while `alpha` itself is now a `property` of `DirGNNConv` that applies a sigmoid transformation to `self.logiy_alpha` every time it is called.

# Reason
So far, it was impossible to tune `alpha` during training together with other learning parameters. Finding the most relevant `alpha` is very problem dependent (e.g., in some graphs, incoming edges may have a different importance than outgoing edges, etc.) but it may not be clear which value to pick. It seems overkill to run a black-box hyperparameter optimization in this case to find the best alpha while the  `DirGNNConv` output is differentiable w.r.t. `alpha`.

# Testing
I have implemented a unit test `test_dir_gnn_conv_trainable_alpha` in file `test/nn/conv/test_dir_gnn_conv.py`. Both cases are tested: when `trainable_alpha` is `False` (equivalent to previous implementation), and when `trainable_alpha` is `True` (not possible before).
I have also used this new feature in a professional project and the `alpha` that is obtained after training is different from 0.5. Even though the performance gain is minor in my case, I think it could be beneficial in some other situations (I did not observe any overfitting in my project, which is expected since `alpha` is a single parameter and so the risk is low).

# Impact
`trainable_alpha` defaults to False in which case the code behaves just as before. There may be a small computational overhead when `trainable_alpha` is `False` since a sigmoid function is applied (to the logit) every time the forward method of `DirGNNConv` is called, but I think it is negligible. I tried to minimize the changes in the code but if you think it's better to focus on computational efficiency, we can easily introduce more modifications in the code to store alpha directly when `trainable_alpha` is `False`.