### PR TITLE
[Bug] DeprecationWarning Crash Fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- Fixed Segfault in `test_molecule_gpt_dataset.py::test_molecule_gpt_dataset` ([#10583](https://github.com/pyg-team/pytorch_geometric/pull/10583))
 - Fixed `ogbn_train_cugraph` example for distributed cuGraph ([#10439](https://github.com/pyg-team/pytorch_geometric/pull/10439))
 - Added `safe_onnx_export` function with workarounds for `onnx_ir.serde.SerdeError` issues in ONNX export ([#10422](https://github.com/pyg-team/pytorch_geometric/pull/10422))
 - Fixed importing PyTorch Lightning in `torch_geometric.graphgym` and `torch_geometric.data.lightning` when using `lightning` instead of `pytorch-lightning` ([#10404](https://github.com/pyg-team/pytorch_geometric/pull/10404), [#10417](https://github.com/pyg-team/pytorch_geometric/pull/10417)))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -204,7 +204,7 @@ filterwarnings = [
     "ignore:.*did not already require gradients, required_grads has been set automatically:UserWarning",
     # Filter `pytorch_lightning` warnings:
     "ignore:GPU available but not used:UserWarning",
-    "error::DeprecationWarning",
+    "error:.*torch_geometric.*:DeprecationWarning",
     # TODO(rishipuri98): Remove usage of `torch_geometric.distributed` from `torch_geometric.llm`
     "ignore:.*torch_geometric.distributed.*:DeprecationWarning",
     # Filter `torch.jit.*` deprication warnings:


### PR DESCRIPTION
While working on fixing a segmentation fault in the test
```
test/datasets/test_molecule_gpt_dataset.py::test_molecule_gpt_dataset
```
Following @puririshi98’s suggestion, I created a minimal Python script, a.py, that reproduces the same segmentation fault:
```
import sentencepiece as spm

def test_spm():
    tokenizer = spm.SentencePieceProcessor()
    print("SentencePieceProcessor created:", tokenizer)

if __name__ == "__main__":
    test_spm() 
```
When executed directly with Python, the script runs successfully regardless of the location of `a.py`. 
However, when executed with pytest, it fails if `a.py` is located in `/opt/pyg/pytorch_geometric` or any of its subdirectories.
```
python3 a.py                                           <<======= OK               
python3 /opt/pyg/pytorch_geometric/test/datasets/a.py  <<======= OK

pytest a.py                                            <<======= OK
pytest /opt/pyg/pytorch_geometric/test/datasets/a.py   <<======= SegFault
```

The rest was straightforward. 

- I found that the presence of `pyproject.toml` alters this behavior; 
- I traced it to a specific line in that file (thanks to @puririshi98, again);
- the solution was obtained with [the help of ChatGPT](https://chatgpt.com/share/69694e3f-293c-8010-9fec-86382af39186).

After applying this change, the following test runs successfully:
```
pytest /opt/pyg/pytorch_geometric/test/datasets/test_molecule_gpt_dataset.py::test_molecule_gpt_dataset
```

