### PR TITLE
 Fix runtime crash due to Half/Float mismatch in GNN+LLM training and inference.

### DIFF
--- a/examples/llm/g_retriever.py
+++ b/examples/llm/g_retriever.py
@@ -85,6 +85,12 @@ def load_params_dict(model, save_path):
     return model
 
 
+def normalize_batch_dtype(batch):
+    batch.x = batch.x.float()
+    if hasattr(batch, "edge_attr") and batch.edge_attr is not None:
+        batch.edge_attr = batch.edge_attr.float()
+
+
 def get_loss(model, batch, model_save_name="gnn+llm") -> Tensor:
     """Compute the loss for a given model and batch of data.
 
@@ -101,6 +107,7 @@ def get_loss(model, batch, model_save_name="gnn+llm") -> Tensor:
         # For LLM models
         return model(batch.question, batch.label, batch.desc)
     else:  # (GNN+LLM)
+        normalize_batch_dtype(batch)
         return model(
             batch.question,  # ["list", "of", "questions", "here"]
             batch.x,  # [num_nodes, num_features]
@@ -132,6 +139,7 @@ def inference_step(model, batch, model_save_name="gnn+llm",
         return model.inference(batch.question, batch.desc,
                                max_out_tokens=max_out_tokens)
     else:  # (GNN+LLM)
+        normalize_batch_dtype(batch)
         return model.inference(batch.question, batch.x, batch.edge_index,
                                batch.batch, batch.edge_attr, batch.desc,
                                max_out_tokens=max_out_tokens)

--- a/examples/llm/txt2kg_rag.py
+++ b/examples/llm/txt2kg_rag.py
@@ -710,7 +710,7 @@ def train(args, train_loader, val_loader):
             wandb.finish()
 
         torch.cuda.empty_cache()
-        torch.cuda.reset_max_memory_allocated()
+        torch.cuda.reset_peak_memory_stats()
         model.eval()
         if not args.dont_save_model:
             save_params_dict(model, save_path=save_name)

--- a/torch_geometric/llm/utils/backend_utils.py
+++ b/torch_geometric/llm/utils/backend_utils.py
@@ -80,11 +80,9 @@ def retrieval_via_pcst(
             _, topk_n_indices = torch.topk(n_prizes, topk, largest=True)
 
             n_prizes = torch.zeros_like(n_prizes)
-            n_prizes[topk_n_indices] = torch.arange(
-                topk, 0, -1,
-                device=n_prizes.device,
-                dtype=n_prizes.dtype
-            )
+            n_prizes[topk_n_indices] = torch.arange(topk, 0, -1,
+                                                    device=n_prizes.device,
+                                                    dtype=n_prizes.dtype)
         else:
             n_prizes = torch.zeros(data.num_nodes)
 
@@ -445,4 +443,3 @@ def make_pcst_filter(triples: List[Tuple[str, str,
         return out_graph
 
     return apply_retrieval_via_pcst
-

--- a/torch_geometric/llm/utils/backend_utils.py
+++ b/torch_geometric/llm/utils/backend_utils.py
@@ -80,7 +80,11 @@ def retrieval_via_pcst(
             _, topk_n_indices = torch.topk(n_prizes, topk, largest=True)
 
             n_prizes = torch.zeros_like(n_prizes)
-            n_prizes[topk_n_indices] = torch.arange(topk, 0, -1).float()
+            n_prizes[topk_n_indices] = torch.arange(
+                topk, 0, -1,
+                device=n_prizes.device,
+                dtype=n_prizes.dtype
+            )
         else:
             n_prizes = torch.zeros(data.num_nodes)
 
@@ -441,3 +445,4 @@ def make_pcst_filter(triples: List[Tuple[str, str,
         return out_graph
 
     return apply_retrieval_via_pcst
+


### PR DESCRIPTION
**Summary**

This PR fixes a runtime crash observed in `examples/llm/txt2kg_rag.py` caused by FP16/FP32 dtype mismatches between graph node features and GNN model parameters during training, validation, and inference. 

The issue manifested as errors like:
```
RuntimeError: expected mat1 and mat2 to have the same dtype, but got: Half != float
```
originating from GATConv / F.linear.

**Root cause**

- Graph node features (batch.x, and sometimes edge_attr) were silently produced in FP16 by upstream components (e.g. sentence embeddings, RAG utilities).
- GNN parameters (e.g. GATConv weights) are FP32 by default.
- PyTorch does not allow mixed FP16/FP32 inputs in F.linear, causing runtime failures.
- The problem affected multiple execution paths:
    - training
    - validation
    - inference (which bypasses get_loss)

AMP/autocast does not resolve this issue because the tensors were already FP16 before entering the model.

**Fix**

This PR normalizes graph tensor dtypes to FP32 immediately before GNN execution by explicitly casting:
- batch.x
- batch.edge_attr (when present)

A small helper is used to ensure this is applied consistently across:
- training
- validation
- inference

This guarantees dtype alignment at the model boundary and prevents future regressions when upstream components change precision.

The following `FutureWarning` was also corrected.
```
/workspace/examples/llm/txt2kg_rag.py:717: FutureWarning: torch.cuda.reset_max_memory_allocated now calls 
torch.cuda.reset_peak_memory_stats, which resets /all/ peak memory stat
```  