### PR TITLE
Fix return_attention_weights=False not working in GAT/GATv2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
+- Dropped support for TorchScript in `GATConv` and `GATv2Conv` for correctness ([#10596](https://github.com/pyg-team/pytorch_geometric/pull/10596))
+
 ### Deprecated
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
-- Fixed `return_attention_weights=False` still returning attention weights in `GATConv` and `GATv2Conv` ([#10596](https://github.com/pyg-team/pytorch_geometric/pull/10596))
+- Fixed `return_attention_weights: bool` being not respected in `GATConv` and `GATv2Conv` ([#10596](https://github.com/pyg-team/pytorch_geometric/pull/10596))
 - Fixed download links for politifact and gossipcop datasets of `UPFD` ([#10558](https://github.com/pyg-team/pytorch_geometric/pull/10558))
 
 ### Security

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- Fixed `return_attention_weights=False` still returning attention weights in `GATConv` and `GATv2Conv` ([#10596](https://github.com/pyg-team/pytorch_geometric/pull/10596))
 - Fixed download links for politifact and gossipcop datasets of `UPFD` ([#10558](https://github.com/pyg-team/pytorch_geometric/pull/10558))
 
 ### Security

--- a/test/nn/conv/test_message_passing.py
+++ b/test/nn/conv/test_message_passing.py
@@ -9,7 +9,7 @@ from torch.nn import Linear
 
 import torch_geometric.typing
 from torch_geometric import EdgeIndex
-from torch_geometric.nn import GATConv, MessagePassing, aggr
+from torch_geometric.nn import MessagePassing, aggr
 from torch_geometric.typing import (
     Adj,
     OptPairTensor,
@@ -732,11 +732,10 @@ def test_traceable_my_conv_with_self_loops(num_nodes):
 
 def test_pickle(tmp_path):
     path = osp.join(tmp_path, 'model.pt')
-    model = GATConv(16, 32)
+    model = MyConv(16, 32)
     torch.save(model, path)
 
-    GATConv.propagate = GATConv._orig_propagate
-    GATConv.edge_updater = GATConv._orig_edge_updater
+    MyConv.propagate = MyConv._orig_propagate
 
     model = torch.load(path, weights_only=False)
     torch.jit.script(model)

--- a/torch_geometric/nn/conv/gat_conv.py
+++ b/torch_geometric/nn/conv/gat_conv.py
@@ -379,7 +379,7 @@ class GATConv(MessagePassing):
         if self.bias is not None:
             out = out + self.bias
 
-        if isinstance(return_attention_weights, bool):
+        if return_attention_weights:
             if isinstance(edge_index, Tensor):
                 if is_torch_sparse_tensor(edge_index):
                     # TODO TorchScript requires to return a tuple
@@ -389,8 +389,8 @@ class GATConv(MessagePassing):
                     return out, (edge_index, alpha)
             elif isinstance(edge_index, SparseTensor):
                 return out, edge_index.set_value(alpha, layout='coo')
-        else:
-            return out
+
+        return out
 
     def edge_update(self, alpha_j: Tensor, alpha_i: OptTensor,
                     edge_attr: OptTensor, index: Tensor, ptr: OptTensor,

--- a/torch_geometric/nn/conv/gat_conv.py
+++ b/torch_geometric/nn/conv/gat_conv.py
@@ -379,7 +379,7 @@ class GATConv(MessagePassing):
         if self.bias is not None:
             out = out + self.bias
 
-        if return_attention_weights is True:
+        if return_attention_weights:
             if isinstance(edge_index, Tensor):
                 if is_torch_sparse_tensor(edge_index):
                     # TODO TorchScript requires to return a tuple

--- a/torch_geometric/nn/conv/gat_conv.py
+++ b/torch_geometric/nn/conv/gat_conv.py
@@ -379,7 +379,7 @@ class GATConv(MessagePassing):
         if self.bias is not None:
             out = out + self.bias
 
-        if return_attention_weights:
+        if return_attention_weights is True:
             if isinstance(edge_index, Tensor):
                 if is_torch_sparse_tensor(edge_index):
                     # TODO TorchScript requires to return a tuple

--- a/torch_geometric/nn/conv/gat_conv.py
+++ b/torch_geometric/nn/conv/gat_conv.py
@@ -281,14 +281,6 @@ class GATConv(MessagePassing):
                 weights for each edge.
                 (default: :obj:`None`)
         """
-        # NOTE: attention weights will be returned whenever
-        # `return_attention_weights` is set to a value, regardless of its
-        # actual value (might be `True` or `False`). This is a current somewhat
-        # hacky workaround to allow for TorchScript support via the
-        # `torch.jit._overload` decorator, as we can only change the output
-        # arguments conditioned on type (`None` or `bool`), not based on its
-        # actual value.
-
         H, C = self.heads, self.out_channels
 
         res: Optional[Tensor] = None

--- a/torch_geometric/nn/conv/gatv2_conv.py
+++ b/torch_geometric/nn/conv/gatv2_conv.py
@@ -342,7 +342,7 @@ class GATv2Conv(MessagePassing):
         if self.bias is not None:
             out = out + self.bias
 
-        if isinstance(return_attention_weights, bool):
+        if return_attention_weights:
             if isinstance(edge_index, Tensor):
                 if is_torch_sparse_tensor(edge_index):
                     # TODO TorchScript requires to return a tuple
@@ -352,8 +352,8 @@ class GATv2Conv(MessagePassing):
                     return out, (edge_index, alpha)
             elif isinstance(edge_index, SparseTensor):
                 return out, edge_index.set_value(alpha, layout='coo')
-        else:
-            return out
+
+        return out
 
     def edge_update(self, x_j: Tensor, x_i: Tensor, edge_attr: OptTensor,
                     index: Tensor, ptr: OptTensor,

--- a/torch_geometric/nn/conv/gatv2_conv.py
+++ b/torch_geometric/nn/conv/gatv2_conv.py
@@ -342,7 +342,7 @@ class GATv2Conv(MessagePassing):
         if self.bias is not None:
             out = out + self.bias
 
-        if return_attention_weights:
+        if return_attention_weights is True:
             if isinstance(edge_index, Tensor):
                 if is_torch_sparse_tensor(edge_index):
                     # TODO TorchScript requires to return a tuple

--- a/torch_geometric/nn/conv/gatv2_conv.py
+++ b/torch_geometric/nn/conv/gatv2_conv.py
@@ -342,7 +342,7 @@ class GATv2Conv(MessagePassing):
         if self.bias is not None:
             out = out + self.bias
 
-        if return_attention_weights is True:
+        if return_attention_weights:
             if isinstance(edge_index, Tensor):
                 if is_torch_sparse_tensor(edge_index):
                     # TODO TorchScript requires to return a tuple


### PR DESCRIPTION
Fixes #9548

When `return_attention_weights=False` is passed to `GATConv` or `GATv2Conv`, attention weights are still returned. This happens because `isinstance(False, bool)` returns `True`, so the check `if isinstance(return_attention_weights, bool)` passes even when the value is `False`.

Changed the condition to simply `if return_attention_weights:` so that only truthy values trigger the attention weights return.