### PR TITLE
Enforce integer type on counting tensor for mean aggregation

### DIFF
--- a/torch_geometric/utils/_scatter.py
+++ b/torch_geometric/utils/_scatter.py
@@ -70,8 +70,9 @@ def scatter(
         return src.new_zeros(size).scatter_add_(dim, index, src)
 
     if reduce == 'mean':
-        count = src.new_zeros(dim_size)
-        count.scatter_add_(0, index, src.new_ones(src.size(dim)))
+        count = src.new_zeros(dim_size, dtype=torch.int)
+        count.scatter_add_(0, index, src.new_ones(src.size(dim),
+                                                  dtype=torch.int))
         count = count.clamp(min=1)
 
         index = broadcast(index, src, dim)


### PR DESCRIPTION
Attempting to use mean aggregation with complex-valued node features leads to a crash. This occurs because the tensor storing the "denominator" for the mean calculation (`count`) inherits the type of the node encodings. The program crashes when `clamp` is called on `count`, as `clamp` is (correctly) incompatible with complex numbers.

Count should really be an integer in all cases, so in this pull request I enforce that by explicitly setting the dtype when creating the tensor of zeros from `src`, and in creating the tensor of ones from `src` that gets added to it.