### PR TITLE
Fix AttributeError when installing QM9 dataset

### DIFF
--- a/torch_geometric/datasets/qm9.py
+++ b/torch_geometric/datasets/qm9.py
@@ -245,7 +245,8 @@ class QM9(InMemoryDataset):
         for i, mol in enumerate(tqdm(suppl)):
             if i in skip:
                 continue
-
+            if mol is None:
+                continue
             N = mol.GetNumAtoms()
 
             conf = mol.GetConformer()


### PR DESCRIPTION
When downloading the QM9 dataset, the script encounters complex and very strained molecules which RDKit cannot parse; since it cannot successfully parse the molecule `mol`, its as a `NoneType` object. The `AttributeError` is thrown when the function tries to call the `GetNumAtoms()` on the `NoneType` molecule `mol`.

This fix adds a safety check to skip molecules that RDKit fails to parse (returning None), preventing a crash when calling GetNumAtoms().