### PR TITLE
CI: Upload code coverage from rag tests

### DIFF
--- a/.github/workflows/testing_rag.yml
+++ b/.github/workflows/testing_rag.yml
@@ -46,3 +46,8 @@ jobs:
           TOKENIZERS_PARALLELISM: "false"
           OMP_NUM_THREADS: "1"
           MKL_NUM_THREADS: "1"
+
+      - name: Upload coverage
+        uses: codecov/codecov-action@v5
+        with:
+          fail_ci_if_error: false


### PR DESCRIPTION
Fixes #10644

RAG test coverage was not being reported to Codecov because `.github/workflows/testing_rag.yml` lacked an upload step after the test run. Adds the `codecov/codecov-action@v5` step to `testing_rag.yml`, mirroring the pattern already used in `_testing.yml`.