### PR TITLE
Fix #10632: RandomNodeSplit fails on HeteroData

### DIFF
--- a/test/transforms/test_random_node_split.py
+++ b/test/transforms/test_random_node_split.py
@@ -144,16 +144,33 @@ def test_random_node_split_on_hetero_data():
 
     data['paper'].x = torch.randn(2000, 16)
     data['paper'].y = torch.randint(4, (2000, ), dtype=torch.long)
-    data['author'].x = torch.randn(300, 16)
+    data['author'].x = torch.randn(1000, 16)
 
-    transform = RandomNodeSplit()
+    # `split='train_rest'` does not use `key`, so all node types get masks:
+    transform = RandomNodeSplit(split='train_rest', num_val=100, num_test=200)
     assert str(transform) == 'RandomNodeSplit(split=train_rest)'
     data = transform(data)
-    assert len(data) == 5
 
-    assert len(data['author']) == 1
-    assert len(data['paper']) == 5
+    assert len(data['author']) == 4   # x, train_mask, val_mask, test_mask
+    assert len(data['paper']) == 5    # x, y, train_mask, val_mask, test_mask
 
-    assert data['paper'].train_mask.sum() == 500
-    assert data['paper'].val_mask.sum() == 500
-    assert data['paper'].test_mask.sum() == 1000
+    assert data['paper'].train_mask.sum() == 2000 - 100 - 200
+    assert data['paper'].val_mask.sum() == 100
+    assert data['paper'].test_mask.sum() == 200
+
+    assert data['author'].train_mask.sum() == 1000 - 100 - 200
+    assert data['author'].val_mask.sum() == 100
+    assert data['author'].test_mask.sum() == 200
+
+    # `split='test_rest'` and `split='random'` still require `key` to be present:
+    data2 = HeteroData()
+    data2['paper'].x = torch.randn(2000, 16)
+    data2['paper'].y = torch.randint(4, (2000, ), dtype=torch.long)
+    data2['author'].x = torch.randn(1000, 16)
+
+    transform2 = RandomNodeSplit(split='test_rest', num_train_per_class=10,
+                                 num_val=100)
+    data2 = transform2(data2)
+
+    assert len(data2['author']) == 1   # no y → skipped
+    assert len(data2['paper']) == 5    # x, y, train_mask, val_mask, test_mask

--- a/test/transforms/test_random_node_split.py
+++ b/test/transforms/test_random_node_split.py
@@ -151,8 +151,8 @@ def test_random_node_split_on_hetero_data():
     assert str(transform) == 'RandomNodeSplit(split=train_rest)'
     data = transform(data)
 
-    assert len(data['author']) == 4   # x, train_mask, val_mask, test_mask
-    assert len(data['paper']) == 5    # x, y, train_mask, val_mask, test_mask
+    assert len(data['author']) == 4  # x, train_mask, val_mask, test_mask
+    assert len(data['paper']) == 5  # x, y, train_mask, val_mask, test_mask
 
     assert data['paper'].train_mask.sum() == 2000 - 100 - 200
     assert data['paper'].val_mask.sum() == 100
@@ -172,5 +172,5 @@ def test_random_node_split_on_hetero_data():
                                  num_val=100)
     data2 = transform2(data2)
 
-    assert len(data2['author']) == 1   # no y → skipped
-    assert len(data2['paper']) == 5    # x, y, train_mask, val_mask, test_mask
+    assert len(data2['author']) == 1  # no y → skipped
+    assert len(data2['paper']) == 5  # x, y, train_mask, val_mask, test_mask

--- a/torch_geometric/transforms/random_node_split.py
+++ b/torch_geometric/transforms/random_node_split.py
@@ -74,7 +74,8 @@ class RandomNodeSplit(BaseTransform):
         data: Union[Data, HeteroData],
     ) -> Union[Data, HeteroData]:
         for store in data.node_stores:
-            if self.key is not None and not hasattr(store, self.key):
+            if (self.split != 'train_rest' and self.key is not None
+                    and not hasattr(store, self.key)):
                 continue
 
             train_masks, val_masks, test_masks = zip(


### PR DESCRIPTION
Closes #10632

## Before

`RandomNodeSplit.__call__` in `torch_geometric/transforms/random_node_split.py` skipped any node store that lacked `self.key` (default: `'y'`), regardless of the `split` mode. On `HeteroData`, this caused `split='train_rest'` to silently skip every node type that had no `y` attribute, producing a transformed object with no masks at all. Accessing `.train_mask` on the result then raised `AttributeError: 'HeteroData' has no attribute 'train_mask'`.

## After

The skip condition in `random_node_split.py` (line 77) now gates on `self.split != 'train_rest'` in addition to the key check:

```python
if (self.split != 'train_rest' and self.key is not None
        and not hasattr(store, self.key)):
    continue
```

`train_rest` distributes all remaining nodes to the training set without needing class labels, so it correctly processes every node store in a `HeteroData` object — including those without a `y` attribute (e.g., `author` nodes in MovieLens1M or OGB_MAG). `test_rest` and `random` still require the key to be present because they rely on per-class counts.

## Changes

- **`torch_geometric/transforms/random_node_split.py`**: Added `self.split != 'train_rest'` guard to the early-continue condition so unlabeled node stores are not skipped when the split mode doesn't require `y`.
- **`test/transforms/test_random_node_split.py`**: Rewrote `test_random_node_split_on_hetero_data` to:
  - Increase `author` nodes from 300 → 1000 so `num_val=100, num_test=200` fits within the store.
  - Explicitly test `train_rest` on `HeteroData` with both a labeled (`paper`) and unlabeled (`author`) node type, asserting exact mask cardinalities.
  - Add a second sub-test for `test_rest` confirming that `author` (no `y`) is still skipped while `paper` (has `y`) receives masks.

## Testing

The updated `test_random_node_split_on_hetero_data` asserts:

```
data['author']: 4 attrs  → x, train_mask, val_mask, test_mask
data['paper']:  5 attrs  → x, y, train_mask, val_mask, test_mask

paper.train_mask.sum() == 1700   # 2000 - 100 - 200
paper.val_mask.sum()   == 100
paper.test_mask.sum()  == 200

author.train_mask.sum() == 700   # 1000 - 100 - 200
author.val_mask.sum()   == 100
author.test_mask.sum()  == 200
```

For `test_rest` with `num_train_per_class=10, num_val=100`, `author` (no `y`) is skipped (`len == 1`) and `paper` receives all three masks (`len == 5`).

---
*This PR was created with AI assistance (Claude). The changes were reviewed by quality gates and a critic model before submission.*