### PR TITLE
Fix #10627: post_step clamping process doesn't preserve training labe...

### DIFF
--- a/test/nn/models/test_label_prop.py
+++ b/test/nn/models/test_label_prop.py
@@ -32,8 +32,8 @@ def test_label_prop():
 
     # Test that labeled node values are preserved after propagation:
     y2 = torch.tensor([0, 0, 0, 0, 0, 0, 0, 1, 1])
-    edge_index2 = torch.tensor(
-        [[0, 1, 2, 3, 4, 5, 6, 7, 8], [0, 0, 0, 0, 0, 0, 0, 0, 0]])
+    edge_index2 = torch.tensor([[0, 1, 2, 3, 4, 5, 6, 7, 8],
+                                [0, 0, 0, 0, 0, 0, 0, 0, 0]])
     mask2 = torch.tensor(
         [False, True, True, True, True, True, True, True, True])
     edge_weight2 = torch.ones(9)

--- a/test/nn/models/test_label_prop.py
+++ b/test/nn/models/test_label_prop.py
@@ -29,3 +29,18 @@ def test_label_prop():
     # Test post step:
     out = model(y, edge_index, mask, post_step=lambda y: torch.zeros_like(y))
     assert torch.sum(out) == 0.
+
+    # Test that labeled node values are preserved after propagation:
+    y2 = torch.tensor([0, 0, 0, 0, 0, 0, 0, 1, 1])
+    edge_index2 = torch.tensor(
+        [[0, 1, 2, 3, 4, 5, 6, 7, 8], [0, 0, 0, 0, 0, 0, 0, 0, 0]])
+    mask2 = torch.tensor(
+        [False, True, True, True, True, True, True, True, True])
+    edge_weight2 = torch.ones(9)
+    model2 = LabelPropagation(num_layers=2, alpha=0.9)
+    out2 = model2(y=y2, edge_index=edge_index2, mask=mask2,
+                  edge_weight=edge_weight2)
+    # Labeled nodes must retain their original one-hot values
+    from torch_geometric.utils import one_hot
+    y2_oh = one_hot(y2)
+    assert torch.allclose(out2[mask2], y2_oh[mask2].float())

--- a/torch_geometric/nn/models/label_prop.py
+++ b/torch_geometric/nn/models/label_prop.py
@@ -87,6 +87,8 @@ class LabelPropagation(MessagePassing):
                 out = post_step(out)
             else:
                 out.clamp_(0., 1.)
+                if mask is not None:
+                    out[mask] = y[mask]
 
         return out
 


### PR DESCRIPTION
Closes #10627

The default `post_step` in `LabelPropagation.forward` (`torch_geometric/nn/models/label_prop.py`) clamped propagated values to `[0, 1]` but did not restore labeled node values afterward, causing training labels to be overwritten and collapsing class evidence at high-degree nodes. After the `out.clamp_(0., 1.)` call, labeled node outputs are now reset to their original one-hot values via `out[mask] = y[mask]` when `mask is not None`.

- `torch_geometric/nn/models/label_prop.py` — `LabelPropagation.forward`: added two lines after the default clamp to restore `out[mask]` from `y[mask]`
- `test/nn/models/test_label_prop.py` — `test_label_prop`: added a regression case using a star graph with 6 class-0 and 2 class-1 labeled neighbors aggregating into a single unlabeled hub node, asserting `torch.allclose(out2[mask2], y2_oh[mask2].float())`

The fix is verified by the new test, which previously failed because the labeled nodes' outputs diverged from their one-hot targets after clamping.

---
*This PR was created with AI assistance (Claude). The changes were reviewed by quality gates and a critic model before submission.*