### PR TITLE
Fix RandomNodeSplit HeteroData bug for unlabeled nodes (#10632)

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -1,4 +1,5 @@
 name: Setup
+description: 'Sets up the PyTorch Geometric environment'
 
 inputs:
   python-version:
@@ -92,5 +93,9 @@ runs:
       if: ${{ inputs.full_install == 'true' && inputs.torch-version != 'nightly' }}
       run: |
         uv pip install scipy
-        uv pip install --no-index --upgrade torch-scatter torch-sparse torch-cluster -f https://data.pyg.org/whl/torch-${{ inputs.torch-version }}+${{ inputs.cuda-version }}.html
+        if [ "${{ runner.os }}" == "Windows" ] && [ "${{ inputs.cuda-version }}" == "cu130" ]; then
+          echo "Skipping torch-scatter, torch-sparse, and torch-cluster on Windows CUDA 13.0"
+        else
+          uv pip install --no-index --upgrade torch-scatter torch-sparse torch-cluster -f https://data.pyg.org/whl/torch-${{ inputs.torch-version }}+${{ inputs.cuda-version }}.html
+        fi
       shell: bash

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 <!-- markdownlint-disable MD024 -->
+
 # Changelog
 
 All notable changes to this project will be documented in this file.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable MD024 -->
 # Changelog
 
 All notable changes to this project will be documented in this file.
@@ -159,7 +160,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Added `CornellTemporalHyperGraphDataset` ([#9090](https://github.com/pyg-team/pytorch_geometric/pull/9090))
 - Added support for cuGraph data loading and `GAT` in single node Papers100m examples ([#8173](https://github.com/pyg-team/pytorch_geometric/pull/8173))
 - Added the `VariancePreservingAggregation` (VPA) ([#9075](https://github.com/pyg-team/pytorch_geometric/pull/9075))
-- Added option to pass custom` from_smiles` functionality to `PCQM4Mv2` and `MoleculeNet` ([#9073](https://github.com/pyg-team/pytorch_geometric/pull/9073))
+- Added option to pass custom `from_smiles` functionality to `PCQM4Mv2` and `MoleculeNet` ([#9073](https://github.com/pyg-team/pytorch_geometric/pull/9073))
 - Added `group_cat` functionality ([#9029](https://github.com/pyg-team/pytorch_geometric/pull/9029))
 - Added support for `EdgeIndex` in `spmm` ([#9026](https://github.com/pyg-team/pytorch_geometric/pull/9026))
 - Added option to pre-allocate memory in GPU-based `ApproxKNN` ([#9046](https://github.com/pyg-team/pytorch_geometric/pull/9046))
@@ -700,7 +701,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Added `HydroNet` water cluster dataset ([#5537](https://github.com/pyg-team/pytorch_geometric/pull/5537), [#5902](https://github.com/pyg-team/pytorch_geometric/pull/5902), [#5903](https://github.com/pyg-team/pytorch_geometric/pull/5903))
 - Added explainability support for heterogeneous GNNs ([#5886](https://github.com/pyg-team/pytorch_geometric/pull/5886))
 - Added `SparseTensor` support to `SuperGATConv` ([#5888](https://github.com/pyg-team/pytorch_geometric/pull/5888))
-- Added TorchScript support for `AttentiveFP `([#5868](https://github.com/pyg-team/pytorch_geometric/pull/5868))
+- Added TorchScript support for `AttentiveFP` ([#5868](https://github.com/pyg-team/pytorch_geometric/pull/5868))
 - Added `num_steps` argument to training and inference benchmarks ([#5898](https://github.com/pyg-team/pytorch_geometric/pull/5898))
 - Added `torch.onnx.export` support ([#5877](https://github.com/pyg-team/pytorch_geometric/pull/5877), [#5997](https://github.com/pyg-team/pytorch_geometric/pull/5997))
 - Enable VTune ITT in inference and training benchmarks ([#5830](https://github.com/pyg-team/pytorch_geometric/pull/5830), [#5878](https://github.com/pyg-team/pytorch_geometric/pull/5878))
@@ -768,7 +769,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Fix `to_dense_adj` with empty `edge_index` ([#5476](https://github.com/pyg-team/pytorch_geometric/pull/5476))
 - The `AttentionalAggregation` module can now be applied to compute attentin on a per-feature level ([#5449](https://github.com/pyg-team/pytorch_geometric/pull/5449))
 - Ensure equal lenghts of `num_neighbors` across edge types in `NeighborLoader` ([#5444](https://github.com/pyg-team/pytorch_geometric/pull/5444))
-- Fixed a bug in `TUDataset` in which node features were wrongly constructed whenever `node_attributes` only hold a single feature (_e.g._, in `PROTEINS`) ([#5441](https://github.com/pyg-team/pytorch_geometric/pull/5441))
+- Fixed a bug in `TUDataset` in which node features were wrongly constructed whenever `node_attributes` only hold a single feature (*e.g.*, in `PROTEINS`) ([#5441](https://github.com/pyg-team/pytorch_geometric/pull/5441))
 - Breaking change: removed `num_neighbors` as an attribute of loader ([#5404](https://github.com/pyg-team/pytorch_geometric/pull/5404))
 - `ASAPooling` is now jittable ([#5395](https://github.com/pyg-team/pytorch_geometric/pull/5395))
 - Updated unsupervised `GraphSAGE` example to leverage `LinkNeighborLoader` ([#5317](https://github.com/pyg-team/pytorch_geometric/pull/5317))
@@ -844,7 +845,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Added `GroupAddRev` module with support for reducing training GPU memory ([#4671](https://github.com/pyg-team/pytorch_geometric/pull/4671), [#4701](https://github.com/pyg-team/pytorch_geometric/pull/4701), [#4715](https://github.com/pyg-team/pytorch_geometric/pull/4715), [#4730](https://github.com/pyg-team/pytorch_geometric/pull/4730))
 - Added benchmarks via [`wandb`](https://wandb.ai/site) ([#4656](https://github.com/pyg-team/pytorch_geometric/pull/4656), [#4672](https://github.com/pyg-team/pytorch_geometric/pull/4672), [#4676](https://github.com/pyg-team/pytorch_geometric/pull/4676))
 - Added `unbatch` functionality ([#4628](https://github.com/pyg-team/pytorch_geometric/pull/4628))
-- Confirm that `to_hetero()` works with custom functions, _e.g._, `dropout_adj` ([4653](https://github.com/pyg-team/pytorch_geometric/pull/4653))
+- Confirm that `to_hetero()` works with custom functions, *e.g.*, `dropout_adj` ([4653](https://github.com/pyg-team/pytorch_geometric/pull/4653))
 - Added the `MLP.plain_last=False` option ([4652](https://github.com/pyg-team/pytorch_geometric/pull/4652))
 - Added a check in `HeteroConv` and `to_hetero()` to ensure that `MessagePassing.add_self_loops` is disabled ([4647](https://github.com/pyg-team/pytorch_geometric/pull/4647))
 - Added `HeteroData.subgraph()`, `HeteroData.node_type_subgraph()` and `HeteroData.edge_type_subgraph()` support ([#4635](https://github.com/pyg-team/pytorch_geometric/pull/4635))

--- a/test/transforms/test_random_node_split.py
+++ b/test/transforms/test_random_node_split.py
@@ -144,16 +144,32 @@ def test_random_node_split_on_hetero_data():
 
     data['paper'].x = torch.randn(2000, 16)
     data['paper'].y = torch.randint(4, (2000, ), dtype=torch.long)
-    data['author'].x = torch.randn(300, 16)
+    data['author'].x = torch.randn(1000, 16)
 
-    transform = RandomNodeSplit()
+    transform = RandomNodeSplit(num_val=100, num_test=200)
     assert str(transform) == 'RandomNodeSplit(split=train_rest)'
     data = transform(data)
     assert len(data) == 5
 
-    assert len(data['author']) == 1
+    assert len(data['author']) == 4
     assert len(data['paper']) == 5
 
-    assert data['paper'].train_mask.sum() == 500
-    assert data['paper'].val_mask.sum() == 500
-    assert data['paper'].test_mask.sum() == 1000
+    assert data['paper'].train_mask.sum() == 1700
+    assert data['paper'].val_mask.sum() == 100
+    assert data['paper'].test_mask.sum() == 200
+
+    assert data['author'].train_mask.sum() == 700
+    assert data['author'].val_mask.sum() == 100
+    assert data['author'].test_mask.sum() == 200
+
+    data = HeteroData()
+    data['paper'].x = torch.randn(2000, 16)
+    data['paper'].y = torch.randint(4, (2000, ), dtype=torch.long)
+    data['author'].x = torch.randn(1000, 16)
+
+    transform = RandomNodeSplit(split='test_rest', num_train_per_class=10,
+                                num_val=100)
+    data = transform(data)
+    
+    assert len(data['author']) == 1
+    assert len(data['paper']) == 5

--- a/test/transforms/test_random_node_split.py
+++ b/test/transforms/test_random_node_split.py
@@ -170,6 +170,6 @@ def test_random_node_split_on_hetero_data():
     transform = RandomNodeSplit(split='test_rest', num_train_per_class=10,
                                 num_val=100)
     data = transform(data)
-    
+
     assert len(data['author']) == 1
     assert len(data['paper']) == 5

--- a/torch_geometric/transforms/random_node_split.py
+++ b/torch_geometric/transforms/random_node_split.py
@@ -74,7 +74,8 @@ class RandomNodeSplit(BaseTransform):
         data: Union[Data, HeteroData],
     ) -> Union[Data, HeteroData]:
         for store in data.node_stores:
-            if self.key is not None and not hasattr(store, self.key):
+            if (self.split != 'train_rest' and self.key is not None
+                    and not hasattr(store, self.key)):
                 continue
 
             train_masks, val_masks, test_masks = zip(


### PR DESCRIPTION
This PR fixes a bug where `RandomNodeSplit` failed on `HeteroData` objects when some node types lacked a label attribute (`y`), even if the split mode (`train_rest`) didn't require them.

The fix ensures that node stores without labels are only skipped for split modes that actually require labels (`test_rest` or `random`).

Updated unit tests to cover HeteroData scenarios with unlabeled node types.

Fixes #10632.