### PR TITLE
Fix MovieLens dataset incompatibility with SentenceTransformers =5.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- Fix MovieLens dataset incompatibility with SentenceTransformers =5.x ([#10668](https://github.com/pyg-team/pytorch_geometric/pull/10668)
 - Removed an unnecessary device synchronization in `torch_geometric.utils.softmax` ([#10499](https://github.com/pyg-team/pytorch_geometric/pull/10499))
 - Fixed loading of legacy HuggingFace BERT checkpoints ([#10631](https://github.com/pyg-team/pytorch_geometric/pull/10631))
 - Fixed `return_attention_weights: bool` being not respected in `GATConv` and `GATv2Conv` ([#10596](https://github.com/pyg-team/pytorch_geometric/pull/10596))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
-- Fix MovieLens dataset incompatibility with SentenceTransformers =5.x ([#10668](https://github.com/pyg-team/pytorch_geometric/pull/10668)
+- Fix MovieLens dataset incompatibility with `sentence-transformers>=5.0.0` ([#10668](https://github.com/pyg-team/pytorch_geometric/pull/10668)
 - Removed an unnecessary device synchronization in `torch_geometric.utils.softmax` ([#10499](https://github.com/pyg-team/pytorch_geometric/pull/10499))
 - Fixed loading of legacy HuggingFace BERT checkpoints ([#10631](https://github.com/pyg-team/pytorch_geometric/pull/10631))
 - Fixed `return_attention_weights: bool` being not respected in `GATConv` and `GATv2Conv` ([#10596](https://github.com/pyg-team/pytorch_geometric/pull/10596))

--- a/torch_geometric/datasets/movie_lens.py
+++ b/torch_geometric/datasets/movie_lens.py
@@ -80,9 +80,11 @@ class MovieLens(InMemoryDataset):
 
         model = SentenceTransformer(self.model_name)
         with torch.no_grad():
-            emb = model.encode(df['title'].astype(str).tolist(),
-                               show_progress_bar=True,
-                               convert_to_tensor=True).cpu()
+            emb = model.encode(
+                df['title'].astype(str).tolist(),
+                show_progress_bar=True,
+                convert_to_tensor=True,
+            ).cpu()
 
         data['movie'].x = torch.cat([emb, genres], dim=-1)
 

--- a/torch_geometric/datasets/movie_lens.py
+++ b/torch_geometric/datasets/movie_lens.py
@@ -80,8 +80,11 @@ class MovieLens(InMemoryDataset):
 
         model = SentenceTransformer(self.model_name)
         with torch.no_grad():
-            emb = model.encode(df['title'].values, show_progress_bar=True,
-                               convert_to_tensor=True).cpu()
+            emb = model.encode(
+                df['title'].astype(str).tolist(),
+                show_progress_bar=True,
+                convert_to_tensor=True
+            ).cpu()
 
         data['movie'].x = torch.cat([emb, genres], dim=-1)
 

--- a/torch_geometric/datasets/movie_lens.py
+++ b/torch_geometric/datasets/movie_lens.py
@@ -80,11 +80,9 @@ class MovieLens(InMemoryDataset):
 
         model = SentenceTransformer(self.model_name)
         with torch.no_grad():
-            emb = model.encode(
-                df['title'].astype(str).tolist(),
-                show_progress_bar=True,
-                convert_to_tensor=True
-            ).cpu()
+            emb = model.encode(df['title'].astype(str).tolist(),
+                               show_progress_bar=True,
+                               convert_to_tensor=True).cpu()
 
         data['movie'].x = torch.cat([emb, genres], dim=-1)
 


### PR DESCRIPTION
**Summary**

This PR fixes a runtime error in the `MovieLens` dataset when used with newer versions of sentence-transformers (≥5.x).
The issue arises from passing a NumPy array (df['title'].values) to `SentenceTransformer.encode()`, which leads to incorrect modality inference and raises:
```
ValueError: Modality 'audio' is not supported by this SentenceTransformer model.
```

**Root Cause**

Recent versions of SentenceTransformers` introduced modality-aware input handling.
When a NumPy array is passed:
```
df['title'].values  # np.ndarray(dtype=object)
```
the library may misinterpret the input as a non-text modality (e.g., audio), instead of text.
However, encode() expects a List[str] for text inputs.

**Fix**

Convert the input to an explicit list of strings before encoding: