### PR TITLE
Fix batched OnDiskDataset subset access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- Fixed inconsistent `OnDiskDataset` subset access after `index_select()` ([#10674](https://github.com/pyg-team/pytorch_geometric/pull/10674))
 - Fix MovieLens dataset incompatibility with `sentence-transformers>=5.0.0` ([#10668](https://github.com/pyg-team/pytorch_geometric/pull/10668)
 - Removed an unnecessary device synchronization in `torch_geometric.utils.softmax` ([#10499](https://github.com/pyg-team/pytorch_geometric/pull/10499))
 - Fixed loading of legacy HuggingFace BERT checkpoints ([#10631](https://github.com/pyg-team/pytorch_geometric/pull/10631))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
-- Fixed inconsistent `OnDiskDataset` subset access after `index_select()` ([#10674](https://github.com/pyg-team/pytorch_geometric/pull/10674))
+- Fixed batched `OnDiskDataset` subset access after `index_select()` ([#10674](https://github.com/pyg-team/pytorch_geometric/pull/10674))
 - Fix MovieLens dataset incompatibility with `sentence-transformers>=5.0.0` ([#10668](https://github.com/pyg-team/pytorch_geometric/pull/10668)
 - Removed an unnecessary device synchronization in `torch_geometric.utils.softmax` ([#10499](https://github.com/pyg-team/pytorch_geometric/pull/10499))
 - Fixed loading of legacy HuggingFace BERT checkpoints ([#10631](https://github.com/pyg-team/pytorch_geometric/pull/10631))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
-- Fixed batched `OnDiskDataset` subset access after `index_select()` ([#10674](https://github.com/pyg-team/pytorch_geometric/pull/10674))
+- Fixed batched `OnDiskDataset` access for subsets and split-specific indices via `DataLoader` ([#10674](https://github.com/pyg-team/pytorch_geometric/pull/10674))
 - Fix MovieLens dataset incompatibility with `sentence-transformers>=5.0.0` ([#10668](https://github.com/pyg-team/pytorch_geometric/pull/10668)
 - Removed an unnecessary device synchronization in `torch_geometric.utils.softmax` ([#10499](https://github.com/pyg-team/pytorch_geometric/pull/10499))
 - Fixed loading of legacy HuggingFace BERT checkpoints ([#10631](https://github.com/pyg-team/pytorch_geometric/pull/10631))

--- a/test/data/test_on_disk_dataset.py
+++ b/test/data/test_on_disk_dataset.py
@@ -109,3 +109,26 @@ def test_custom_schema(tmp_path):
         assert out.num_nodes == data.num_nodes
 
     dataset.close()
+
+
+@withPackage('sqlite3')
+def test_index_select_get(tmp_path):
+    dataset = OnDiskDataset(tmp_path)
+    data_list = [Data(x=torch.tensor([i])) for i in range(10)]
+    dataset.extend(data_list)
+
+    subset = dataset.index_select([5, 6, 7, 8, 9])
+    nested_subset = subset.index_select([1, 3])
+
+    assert torch.equal(subset[0].x, data_list[5].x)
+    assert torch.equal(subset.get(0).x, data_list[5].x)
+
+    out_list = subset.multi_get([0, 2, 4])
+    for out, data in zip(out_list, data_list[5:10:2]):
+        assert torch.equal(out.x, data.x)
+
+    out_list = nested_subset.__getitems__([0, 1])
+    assert torch.equal(out_list[0].x, data_list[6].x)
+    assert torch.equal(out_list[1].x, data_list[8].x)
+
+    dataset.close()

--- a/test/data/test_on_disk_dataset.py
+++ b/test/data/test_on_disk_dataset.py
@@ -1,6 +1,7 @@
 import os.path as osp
 from typing import Any, Dict
 
+import numpy as np
 import torch
 
 from torch_geometric.data import Data, OnDiskDataset
@@ -125,6 +126,10 @@ def test_index_select_multi_get(tmp_path):
     assert torch.equal(subset.get(0).x, data_list[0].x)
 
     out_list = subset.multi_get([0, 2, 4])
+    for out, data in zip(out_list, data_list[5:10:2]):
+        assert torch.equal(out.x, data.x)
+
+    out_list = subset.multi_get(np.array([True, False, True, False, True]))
     for out, data in zip(out_list, data_list[5:10:2]):
         assert torch.equal(out.x, data.x)
 

--- a/test/data/test_on_disk_dataset.py
+++ b/test/data/test_on_disk_dataset.py
@@ -4,6 +4,7 @@ from typing import Any, Dict
 import torch
 
 from torch_geometric.data import Data, OnDiskDataset
+from torch_geometric.loader import DataLoader
 from torch_geometric.testing import withPackage
 
 
@@ -112,7 +113,7 @@ def test_custom_schema(tmp_path):
 
 
 @withPackage('sqlite3')
-def test_index_select_get(tmp_path):
+def test_index_select_multi_get(tmp_path):
     dataset = OnDiskDataset(tmp_path)
     data_list = [Data(x=torch.tensor([i])) for i in range(10)]
     dataset.extend(data_list)
@@ -121,7 +122,7 @@ def test_index_select_get(tmp_path):
     nested_subset = subset.index_select([1, 3])
 
     assert torch.equal(subset[0].x, data_list[5].x)
-    assert torch.equal(subset.get(0).x, data_list[5].x)
+    assert torch.equal(subset.get(0).x, data_list[0].x)
 
     out_list = subset.multi_get([0, 2, 4])
     for out, data in zip(out_list, data_list[5:10:2]):
@@ -130,5 +131,9 @@ def test_index_select_get(tmp_path):
     out_list = nested_subset.__getitems__([0, 1])
     assert torch.equal(out_list[0].x, data_list[6].x)
     assert torch.equal(out_list[1].x, data_list[8].x)
+
+    loader = DataLoader(subset, batch_size=3, shuffle=False)
+    batch = next(iter(loader))
+    assert batch.x.view(-1).tolist() == [5, 6, 7]
 
     dataset.close()

--- a/test/data/test_on_disk_dataset.py
+++ b/test/data/test_on_disk_dataset.py
@@ -164,6 +164,9 @@ def test_direct_indices_multi_get(tmp_path):
     out_list = dataset.multi_get([0, 1, 2])
     assert [int(data.x.item()) for data in out_list] == [5, 6, 7]
 
+    out_list = dataset.__getitems__([0, 1, 2])
+    assert [int(data.x.item()) for data in out_list] == [5, 6, 7]
+
     loader = DataLoader(dataset, batch_size=3, shuffle=False)
     batch = next(iter(loader))
     assert batch.x.view(-1).tolist() == [5, 6, 7]

--- a/test/data/test_on_disk_dataset.py
+++ b/test/data/test_on_disk_dataset.py
@@ -136,8 +136,7 @@ def test_index_select_multi_get(tmp_path):
     assert subset.multi_get([]) == []
     assert subset.multi_get(torch.tensor([], dtype=torch.long)) == []
     assert subset.multi_get(torch.tensor([], dtype=torch.bool)) == []
-    assert subset.multi_get(np.array([False, False, False, False,
-                                      False]), ) == []
+    assert subset.multi_get(np.zeros(5, dtype=bool)) == []
 
     out_list = nested_subset.__getitems__([0, 1])
     assert torch.equal(out_list[0].x, data_list[6].x)

--- a/test/data/test_on_disk_dataset.py
+++ b/test/data/test_on_disk_dataset.py
@@ -136,9 +136,8 @@ def test_index_select_multi_get(tmp_path):
     assert subset.multi_get([]) == []
     assert subset.multi_get(torch.tensor([], dtype=torch.long)) == []
     assert subset.multi_get(torch.tensor([], dtype=torch.bool)) == []
-    assert subset.multi_get(
-        np.array([False, False, False, False, False]),
-    ) == []
+    assert subset.multi_get(np.array([False, False, False, False,
+                                      False]), ) == []
 
     out_list = nested_subset.__getitems__([0, 1])
     assert torch.equal(out_list[0].x, data_list[6].x)

--- a/test/data/test_on_disk_dataset.py
+++ b/test/data/test_on_disk_dataset.py
@@ -133,11 +133,39 @@ def test_index_select_multi_get(tmp_path):
     for out, data in zip(out_list, data_list[5:10:2]):
         assert torch.equal(out.x, data.x)
 
+    assert subset.multi_get([]) == []
+    assert subset.multi_get(torch.tensor([], dtype=torch.long)) == []
+    assert subset.multi_get(torch.tensor([], dtype=torch.bool)) == []
+    assert subset.multi_get(
+        np.array([False, False, False, False, False]),
+    ) == []
+
     out_list = nested_subset.__getitems__([0, 1])
     assert torch.equal(out_list[0].x, data_list[6].x)
     assert torch.equal(out_list[1].x, data_list[8].x)
 
     loader = DataLoader(subset, batch_size=3, shuffle=False)
+    batch = next(iter(loader))
+    assert batch.x.view(-1).tolist() == [5, 6, 7]
+
+    dataset.close()
+
+
+@withPackage('sqlite3')
+def test_direct_indices_multi_get(tmp_path):
+    dataset = OnDiskDataset(tmp_path)
+    data_list = [Data(x=torch.tensor([i])) for i in range(10)]
+    dataset.extend(data_list)
+
+    dataset._indices = [5, 6, 7, 8, 9]
+
+    assert torch.equal(dataset[0].x, data_list[5].x)
+    assert torch.equal(dataset.get(0).x, data_list[0].x)
+
+    out_list = dataset.multi_get([0, 1, 2])
+    assert [int(data.x.item()) for data in out_list] == [5, 6, 7]
+
+    loader = DataLoader(dataset, batch_size=3, shuffle=False)
     batch = next(iter(loader))
     assert batch.x.view(-1).tolist() == [5, 6, 7]
 

--- a/test/data/test_on_disk_dataset.py
+++ b/test/data/test_on_disk_dataset.py
@@ -126,12 +126,10 @@ def test_index_select_multi_get(tmp_path):
     assert torch.equal(subset.get(0).x, data_list[0].x)
 
     out_list = subset.multi_get([0, 2, 4])
-    for out, data in zip(out_list, data_list[5:10:2]):
-        assert torch.equal(out.x, data.x)
+    assert [int(data.x.item()) for data in out_list] == [5, 7, 9]
 
     out_list = subset.multi_get(np.array([True, False, True, False, True]))
-    for out, data in zip(out_list, data_list[5:10:2]):
-        assert torch.equal(out.x, data.x)
+    assert [int(data.x.item()) for data in out_list] == [5, 7, 9]
 
     assert subset.multi_get([]) == []
     assert subset.multi_get(torch.tensor([], dtype=torch.long)) == []

--- a/torch_geometric/data/on_disk_dataset.py
+++ b/torch_geometric/data/on_disk_dataset.py
@@ -1,6 +1,8 @@
 import os
 from typing import Any, Callable, Iterable, List, Optional, Sequence, Union
 
+import numpy as np
+import torch
 from torch import Tensor
 
 from torch_geometric.data import Database, RocksDatabase, SQLiteDatabase
@@ -137,9 +139,53 @@ class OnDiskDataset(Dataset):
         self.db.multi_insert(range(start, end), data_list, batch_size)
         self._numel += (end - start)
 
+    def _resolve_index(
+        self,
+        idx: Union[int, np.integer, Tensor, np.ndarray],
+    ) -> int:
+        if isinstance(idx, Tensor):
+            idx = idx.item()
+        elif isinstance(idx, np.ndarray):
+            idx = idx.item()
+
+        return self.indices()[idx]
+
+    def _resolve_indices(
+        self,
+        indices: Union[Iterable[int], Tensor, slice, range],
+    ) -> Union[Sequence[int], range]:
+        base_indices = self.indices()
+
+        if isinstance(indices, slice):
+            return base_indices[indices]
+
+        if isinstance(indices, Tensor):
+            if indices.dtype == torch.bool:
+                indices = indices.flatten().nonzero(as_tuple=False).flatten()
+            indices = indices.flatten().tolist()
+        elif isinstance(indices, range):
+            indices = list(indices)
+        elif not isinstance(indices, Sequence):
+            indices = list(indices)
+
+        return [base_indices[idx] for idx in indices]
+
     def get(self, idx: int) -> BaseData:
         r"""Gets the data object at index :obj:`idx`."""
-        return self.deserialize(self.db.get(idx))
+        return self.deserialize(self.db.get(self._resolve_index(idx)))
+
+    def __getitem__(
+        self,
+        idx: Union[int, np.integer, Tensor, np.ndarray, slice, Sequence[int]],
+    ) -> Union['OnDiskDataset', BaseData]:
+        if (isinstance(idx, (int, np.integer))
+                or (isinstance(idx, Tensor) and idx.dim() == 0)
+                or (isinstance(idx, np.ndarray) and np.isscalar(idx))):
+            data = self.get(idx)
+            data = data if self.transform is None else self.transform(data)
+            return data
+
+        return self.index_select(idx)
 
     def multi_get(
         self,
@@ -147,6 +193,8 @@ class OnDiskDataset(Dataset):
         batch_size: Optional[int] = None,
     ) -> List[BaseData]:
         r"""Gets a list of data objects from the specified indices."""
+        indices = self._resolve_indices(indices)
+
         if len(indices) == 1:
             data_list = [self.db.get(indices[0])]
         else:

--- a/torch_geometric/data/on_disk_dataset.py
+++ b/torch_geometric/data/on_disk_dataset.py
@@ -173,7 +173,12 @@ class OnDiskDataset(Dataset):
         return [int(base_indices[idx]) for idx in indices]
 
     def get(self, idx: int) -> BaseData:
-        r"""Gets the data object at index :obj:`idx`."""
+        r"""Gets the data object at the raw database index :obj:`idx`.
+
+        Note that subset-aware integer access is handled by
+        :meth:`Dataset.__getitem__`, which resolves :obj:`self.indices()[idx]`
+        before calling :meth:`get`.
+        """
         return self.deserialize(self.db.get(idx))
 
     def multi_get(
@@ -181,7 +186,13 @@ class OnDiskDataset(Dataset):
         indices: IndexType,
         batch_size: Optional[int] = None,
     ) -> List[BaseData]:
-        r"""Gets a list of data objects from the specified indices."""
+        r"""Gets a list of data objects from the specified subset-local
+        indices.
+
+        In contrast to :meth:`get`, batched access is expected to follow the
+        same subset semantics as ``[self[idx] for idx in indices]``. As such,
+        indices are first resolved through :obj:`self.indices()`.
+        """
         indices = self._resolve_indices(indices)
 
         if len(indices) == 0:
@@ -197,6 +208,7 @@ class OnDiskDataset(Dataset):
         return data_list
 
     def __getitems__(self, indices: List[int]) -> List[BaseData]:
+        r"""Gets a list of data objects for batched subset-aware access."""
         return self.multi_get(indices)
 
     def len(self) -> int:

--- a/torch_geometric/data/on_disk_dataset.py
+++ b/torch_geometric/data/on_disk_dataset.py
@@ -175,7 +175,9 @@ class OnDiskDataset(Dataset):
         r"""Gets a list of data objects from the specified indices."""
         indices = self._resolve_indices(indices)
 
-        if len(indices) == 1:
+        if len(indices) == 0:
+            data_list = []
+        elif len(indices) == 1:
             data_list = [self.db.get(indices[0])]
         else:
             data_list = self.db.multi_get(indices, batch_size)

--- a/torch_geometric/data/on_disk_dataset.py
+++ b/torch_geometric/data/on_disk_dataset.py
@@ -144,11 +144,18 @@ class OnDiskDataset(Dataset):
     def _resolve_indices(
         self,
         indices: IndexType,
-    ) -> Sequence[int]:
+    ) -> List[int]:
         base_indices = self.indices()
 
         if isinstance(indices, slice):
-            return base_indices[indices]
+            indices = base_indices[indices]
+
+            if isinstance(indices, Tensor):
+                indices = indices.flatten().tolist()
+            elif isinstance(indices, np.ndarray):
+                indices = indices.flatten().tolist()
+
+            return [int(idx) for idx in indices]
 
         if isinstance(indices, Tensor):
             if indices.dtype == torch.bool:
@@ -163,7 +170,7 @@ class OnDiskDataset(Dataset):
         elif not isinstance(indices, Sequence):
             indices = list(indices)
 
-        return [base_indices[idx] for idx in indices]
+        return [int(base_indices[idx]) for idx in indices]
 
     def get(self, idx: int) -> BaseData:
         r"""Gets the data object at index :obj:`idx`."""

--- a/torch_geometric/data/on_disk_dataset.py
+++ b/torch_geometric/data/on_disk_dataset.py
@@ -1,7 +1,6 @@
 import os
 from typing import Any, Callable, Iterable, List, Optional, Sequence, Union
 
-import numpy as np
 import torch
 from torch import Tensor
 
@@ -139,17 +138,6 @@ class OnDiskDataset(Dataset):
         self.db.multi_insert(range(start, end), data_list, batch_size)
         self._numel += (end - start)
 
-    def _resolve_index(
-        self,
-        idx: Union[int, np.integer, Tensor, np.ndarray],
-    ) -> int:
-        if isinstance(idx, Tensor):
-            idx = idx.item()
-        elif isinstance(idx, np.ndarray):
-            idx = idx.item()
-
-        return self.indices()[idx]
-
     def _resolve_indices(
         self,
         indices: Union[Iterable[int], Tensor, slice, range],
@@ -172,20 +160,7 @@ class OnDiskDataset(Dataset):
 
     def get(self, idx: int) -> BaseData:
         r"""Gets the data object at index :obj:`idx`."""
-        return self.deserialize(self.db.get(self._resolve_index(idx)))
-
-    def __getitem__(
-        self,
-        idx: Union[int, np.integer, Tensor, np.ndarray, slice, Sequence[int]],
-    ) -> Union['OnDiskDataset', BaseData]:
-        if (isinstance(idx, (int, np.integer))
-                or (isinstance(idx, Tensor) and idx.dim() == 0)
-                or (isinstance(idx, np.ndarray) and np.isscalar(idx))):
-            data = self.get(idx)
-            data = data if self.transform is None else self.transform(data)
-            return data
-
-        return self.index_select(idx)
+        return self.deserialize(self.db.get(idx))
 
     def multi_get(
         self,

--- a/torch_geometric/data/on_disk_dataset.py
+++ b/torch_geometric/data/on_disk_dataset.py
@@ -10,6 +10,8 @@ from torch_geometric.data.data import BaseData
 from torch_geometric.data.database import Schema
 from torch_geometric.data.dataset import Dataset
 
+IndexType = Union[Iterable[int], Tensor, np.ndarray, slice, range]
+
 
 class OnDiskDataset(Dataset):
     r"""Dataset base class for creating large graph datasets which do not
@@ -141,8 +143,8 @@ class OnDiskDataset(Dataset):
 
     def _resolve_indices(
         self,
-        indices: Union[Iterable[int], Tensor, np.ndarray, slice, range],
-    ) -> Union[Sequence[int], range]:
+        indices: IndexType,
+    ) -> Sequence[int]:
         base_indices = self.indices()
 
         if isinstance(indices, slice):
@@ -169,7 +171,7 @@ class OnDiskDataset(Dataset):
 
     def multi_get(
         self,
-        indices: Union[Iterable[int], Tensor, slice, range],
+        indices: IndexType,
         batch_size: Optional[int] = None,
     ) -> List[BaseData]:
         r"""Gets a list of data objects from the specified indices."""

--- a/torch_geometric/data/on_disk_dataset.py
+++ b/torch_geometric/data/on_disk_dataset.py
@@ -1,6 +1,7 @@
 import os
 from typing import Any, Callable, Iterable, List, Optional, Sequence, Union
 
+import numpy as np
 import torch
 from torch import Tensor
 
@@ -140,7 +141,7 @@ class OnDiskDataset(Dataset):
 
     def _resolve_indices(
         self,
-        indices: Union[Iterable[int], Tensor, slice, range],
+        indices: Union[Iterable[int], Tensor, np.ndarray, slice, range],
     ) -> Union[Sequence[int], range]:
         base_indices = self.indices()
 
@@ -150,6 +151,10 @@ class OnDiskDataset(Dataset):
         if isinstance(indices, Tensor):
             if indices.dtype == torch.bool:
                 indices = indices.flatten().nonzero(as_tuple=False).flatten()
+            indices = indices.flatten().tolist()
+        elif isinstance(indices, np.ndarray):
+            if indices.dtype == bool:
+                indices = indices.flatten().nonzero()[0]
             indices = indices.flatten().tolist()
         elif isinstance(indices, range):
             indices = list(indices)


### PR DESCRIPTION
Fix batched `OnDiskDataset` subset access via `multi_get()` and
`__getitems__()`.

`OnDiskDataset.get()` intentionally keeps raw database index semantics,
matching `Dataset.__getitem__()`, which already resolves subset-local indices
through `self.indices()` before calling `get()`.

The bug was in the batched path: `__getitems__()` delegated to `multi_get()`
without resolving subset-local batch indices to raw database indices. As a
result, `DataLoader(subset, ...)` could return the first N raw DB rows instead
of the subset or split rows.

This PR resolves indices in `multi_get()`, covering:
- subsets created by `index_select()`
- nested subsets
- split-specific `_indices`, such as `PCQM4Mv2`
- tensor and NumPy array indices
- empty batches

## Testing

```bash
python -m pytest -q test/data/test_on_disk_dataset.py -k "multi_get or direct_indices"
python -m pytest -q test/data/test_on_disk_dataset.py