### PR TITLE
Populate `_model_args` on `HeteroExplanation`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- Populated `_model_args` on `HeteroExplanation` to mirror the homogeneous `Explanation`, exposing the original kwargs passed to the model ([#10672](https://github.com/pyg-team/pytorch_geometric/pull/10672))
+
 ### Changed
 
 - Dropped support for TorchScript in `GATConv` and `GATv2Conv` for correctness ([#10596](https://github.com/pyg-team/pytorch_geometric/pull/10596))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
-- Populated `_model_args` on `HeteroExplanation` to mirror the homogeneous `Explanation`, exposing the original kwargs passed to the model ([#10672](https://github.com/pyg-team/pytorch_geometric/pull/10672))
+- Populated `_model_args` on `HeteroExplanation` to mirror the homogeneous `Explanation`, exposing the original kwargs passed to the model ([#10676](https://github.com/pyg-team/pytorch_geometric/pull/10676))
 
 ### Changed
 

--- a/test/explain/test_hetero_explainer.py
+++ b/test/explain/test_hetero_explainer.py
@@ -10,7 +10,8 @@ from torch_geometric.explain.config import ExplanationType
 
 
 class DummyModel(torch.nn.Module):
-    def forward(self, x_dict, edge_index_dict, *args, **kwargs) -> torch.Tensor:
+    def forward(self, x_dict, edge_index_dict, *args,
+                **kwargs) -> torch.Tensor:
         return x_dict['paper'].mean().view(-1)
 
 

--- a/test/explain/test_hetero_explainer.py
+++ b/test/explain/test_hetero_explainer.py
@@ -10,7 +10,7 @@ from torch_geometric.explain.config import ExplanationType
 
 
 class DummyModel(torch.nn.Module):
-    def forward(self, x_dict, edge_index_dict, *args) -> torch.Tensor:
+    def forward(self, x_dict, edge_index_dict, *args, **kwargs) -> torch.Tensor:
         return x_dict['paper'].mean().view(-1)
 
 
@@ -67,6 +67,39 @@ def test_forward(hetero_data, target, explanation_type):
         for key in explanation.node_types:
             expected_size = hetero_data[key].x.size()
             assert explanation[key].node_mask.size() == expected_size
+
+
+def test_model_args(hetero_data):
+    explainer = Explainer(
+        DummyModel(),
+        algorithm=DummyExplainer(),
+        explanation_type='model',
+        node_mask_type='attributes',
+        edge_mask_type='object',
+        model_config=dict(
+            mode='regression',
+            task_level='graph',
+        ),
+    )
+
+    explanation = explainer(
+        hetero_data.x_dict,
+        hetero_data.edge_index_dict,
+        edge_attr_dict=hetero_data.edge_attr_dict,
+        additonal_arg=1,
+    )
+
+    assert explanation._model_args == ['edge_attr_dict', 'additonal_arg']
+
+    # Dict-valued kwargs are stored per-type and accessible via the `_dict`
+    # attribute accessor:
+    assert set(explanation.edge_attr_dict.keys()) == set(
+        hetero_data.edge_types)
+    for edge_type, edge_attr in hetero_data.edge_attr_dict.items():
+        assert torch.equal(explanation.edge_attr_dict[edge_type], edge_attr)
+
+    # Scalar kwargs are stored in the global store:
+    assert explanation.additonal_arg == 1
 
 
 @pytest.mark.parametrize('threshold_value', [0.2, 0.5, 0.8])

--- a/torch_geometric/explain/explainer.py
+++ b/torch_geometric/explain/explainer.py
@@ -229,7 +229,7 @@ class Explainer:
                 explanation[key] = arg
 
         elif isinstance(explanation, HeteroExplanation):
-            # TODO Add `explanation._model_args`
+            explanation._model_args = list(kwargs.keys())
 
             assert isinstance(x, dict)
             explanation.set_value_dict('x', x)


### PR DESCRIPTION
On the homogeneous path, `Explainer.__call__` records the original kwargs passed to the model in `explanation._model_args`, which downstream consumers (e.g. `fidelity`, `unfaithfulness`) rely on to reconstruct the model invocation:

```python
kwargs = {key: explanation[key] for key in explanation._model_args}
```

The heterogeneous path was missing this step (# TODO Add explanation._model_args), so any extra model argument (e.g. edge_attr_dict) was inaccessible to consumers once the explanation was produced.

# Changes
- `torch_geometric/explain/explainer.py`: set `explanation._model_args = list(kwargs.keys())` in the `HeteroExplanation` branch, mirroring the homogeneous case. 

- `test/explain/test_hetero_explainer.py`: add `test_model_args` covering both dict-valued kwargs (stored per-type, accessible via the `_dict` attribute accessor) and scalar kwargs (stored in the global store).

# Follow-up
This unblocks adapting fidelity, unfaithfulness and characterization_score to HeteroExplanation ( #9112 ) , which will come in a separate PR.