### PR TITLE
Fix LPFormer attention dimensions

### DIFF
--- a/test/nn/models/test_lpformer.py
+++ b/test/nn/models/test_lpformer.py
@@ -1,4 +1,5 @@
 import torch
+import pytest
 
 from torch_geometric.nn import LPFormer
 from torch_geometric.testing import withPackage
@@ -33,3 +34,23 @@ def test_lpformer():
                                   [num_nodes, num_nodes])
     out2 = model(test_edges, x, adj, ppr_matrix)
     assert out2.size() == (10, )
+
+
+@pytest.mark.parametrize('num_heads', [1, 2])
+@pytest.mark.parametrize('num_transformer_layers', [1, 2])
+@withPackage('numba')  # For ppr calculation
+def test_lpformer_attention_dimensions(num_transformer_layers, num_heads):
+    model = LPFormer(16, 32, num_gnn_layers=2,
+                     num_transformer_layers=num_transformer_layers,
+                     num_heads=num_heads)
+
+    num_nodes = 20
+    x = torch.randn(num_nodes, 16)
+    edges = torch.randint(0, num_nodes - 1, (2, 110))
+    edge_index, test_edges = edges[:, :100], edges[:, 100:]
+    edge_index = to_undirected(edge_index)
+
+    ppr_matrix = model.calc_sparse_ppr(edge_index, num_nodes, eps=1e-4)
+
+    out = model(test_edges, x, edge_index, ppr_matrix)
+    assert out.size() == (10, )

--- a/test/nn/models/test_lpformer.py
+++ b/test/nn/models/test_lpformer.py
@@ -1,5 +1,5 @@
-import torch
 import pytest
+import torch
 
 from torch_geometric.nn import LPFormer
 from torch_geometric.testing import withPackage

--- a/test/nn/models/test_lpformer.py
+++ b/test/nn/models/test_lpformer.py
@@ -37,12 +37,14 @@ def test_lpformer():
 
 
 @pytest.mark.parametrize('num_heads', [1, 2])
-@pytest.mark.parametrize('num_transformer_layers', [1, 2])
+@pytest.mark.parametrize('num_transformer_layers', [1, 2, 3])
 @withPackage('numba')  # For ppr calculation
 def test_lpformer_attention_dimensions(num_transformer_layers, num_heads):
+    torch.manual_seed(12345)
     model = LPFormer(16, 32, num_gnn_layers=2,
                      num_transformer_layers=num_transformer_layers,
-                     num_heads=num_heads)
+                     num_heads=num_heads, gnn_dropout=0.0,
+                     transformer_dropout=0.0).eval()
 
     num_nodes = 20
     x = torch.randn(num_nodes, 16)
@@ -52,5 +54,6 @@ def test_lpformer_attention_dimensions(num_transformer_layers, num_heads):
 
     ppr_matrix = model.calc_sparse_ppr(edge_index, num_nodes, eps=1e-4)
 
-    out = model(test_edges, x, edge_index, ppr_matrix)
+    with torch.no_grad():
+        out = model(test_edges, x, edge_index, ppr_matrix)
     assert out.size() == (10, )

--- a/torch_geometric/nn/models/lpformer.py
+++ b/torch_geometric/nn/models/lpformer.py
@@ -87,16 +87,21 @@ class LPFormer(nn.Module):
         self.att_layers = nn.ModuleList()
         for il in range(num_transformer_layers):
             if il == 0:
+                in_dim = self.hid_dim
                 node_dim = None
                 self.out_dim = self.hid_dim * 2 if num_transformer_layers > 1 \
                     else self.hid_dim
-            elif il == self.num_layers - 1:
+            elif il == num_transformer_layers - 1:
+                in_dim = self.hid_dim * num_heads
                 node_dim = self.hid_dim
+                self.out_dim = self.hid_dim
             else:
-                self.out_dim = node_dim = self.hid_dim
+                in_dim = self.hid_dim * num_heads
+                node_dim = self.hid_dim
+                self.out_dim = self.hid_dim * 2
 
             self.att_layers.append(
-                LPAttLayer(self.hid_dim, self.out_dim, node_dim, num_heads,
+                LPAttLayer(in_dim, self.out_dim, node_dim, num_heads,
                            self.trans_drop))
 
         self.elementwise_lin = MLP(self.hid_dim, self.hid_dim, self.hid_dim)
@@ -667,7 +672,10 @@ class LPAttLayer(MessagePassing):
         self._alpha = None
 
         self.dropout = dropout
-        self.post_att_norm = nn.LayerNorm(out_channels)
+        if concat:
+            self.post_att_norm = nn.LayerNorm(num_heads * out_channels)
+        else:
+            self.post_att_norm = nn.LayerNorm(out_channels)
 
         self.reset_parameters()
 


### PR DESCRIPTION
Fixes LPFormer attention dimensions for multi-layer and multi-head configurations.

The transformer layer construction could reference an undefined `self.num_layers`, and stacked attention layers used incompatible pairwise feature dimensions after the first layer. Multi-head attention also normalized concatenated outputs with `out_channels` instead of `num_heads * out_channels`.

## Changes

- Use `num_transformer_layers` when identifying the final attention layer
- Set each `LPAttLayer` input/output dimension to match the expected feature flow across first, intermediate, and final layers
- Size `post_att_norm` correctly for concatenated multi-head outputs
- Add deterministic regression coverage for `num_transformer_layers in {1, 2, 3}` and `num_heads in {1, 2}`

## Tested with

```bash
/home/jovyan/venvs/pyg-pr-review/bin/python -m pytest -q test/nn/models/test_lpformer.py
```
