### PR TITLE
Fix to_dense_adj for unsorted batch vectors

### DIFF
--- a/test/utils/test_to_dense_adj.py
+++ b/test/utils/test_to_dense_adj.py
@@ -64,6 +64,30 @@ def test_to_dense_adj():
     assert adj.size() == (4, 3, 3)
 
 
+def test_to_dense_adj_with_unsorted_batch():
+    edge_index = torch.tensor([
+        [0, 1, 2, 3],
+        [3, 2, 1, 0],
+    ])
+    batch = torch.tensor([0, 1, 1, 0])
+
+    adj = to_dense_adj(edge_index, batch)
+    assert adj.size() == (2, 2, 2)
+    assert adj[0].tolist() == [[0, 1], [1, 0]]
+    assert adj[1].tolist() == [[0, 1], [1, 0]]
+
+    edge_attr = torch.tensor([1.0, 3.0, 4.0, 2.0])
+    adj = to_dense_adj(edge_index, batch, edge_attr)
+    assert adj.size() == (2, 2, 2)
+    assert adj[0].tolist() == [[0, 1], [2, 0]]
+    assert adj[1].tolist() == [[0, 3], [4, 0]]
+
+    adj = to_dense_adj(edge_index, batch, edge_attr, max_num_nodes=1)
+    assert adj.size() == (2, 1, 1)
+    assert adj[0].tolist() == [[0]]
+    assert adj[1].tolist() == [[0]]
+
+
 def test_to_dense_adj_with_empty_edge_index():
     edge_index = torch.tensor([[], []], dtype=torch.long)
     batch = torch.tensor([0, 0, 1, 1, 1])

--- a/test/utils/test_to_dense_adj.py
+++ b/test/utils/test_to_dense_adj.py
@@ -76,6 +76,13 @@ def test_to_dense_adj_with_unsorted_batch():
     assert adj[0].tolist() == [[0, 1], [1, 0]]
     assert adj[1].tolist() == [[0, 1], [1, 0]]
 
+    if is_full_test():
+        jit = torch.jit.script(to_dense_adj)
+        adj = jit(edge_index, batch)
+        assert adj.size() == (2, 2, 2)
+        assert adj[0].tolist() == [[0, 1], [1, 0]]
+        assert adj[1].tolist() == [[0, 1], [1, 0]]
+
     edge_attr = torch.tensor([1.0, 3.0, 4.0, 2.0])
     adj = to_dense_adj(edge_index, batch, edge_attr)
     assert adj.size() == (2, 2, 2)

--- a/torch_geometric/utils/_to_dense_adj.py
+++ b/torch_geometric/utils/_to_dense_adj.py
@@ -21,7 +21,9 @@ def to_dense_adj(
         edge_index (LongTensor): The edge indices.
         batch (LongTensor, optional): Batch vector
             :math:`\mathbf{b} \in {\{ 0, \ldots, B-1\}}^N`, which assigns each
-            node to a specific example. (default: :obj:`None`)
+            node to a specific example. It does not need to be sorted. Nodes
+            are ordered in each dense adjacency matrix by their relative node
+            order in the input :obj:`batch` vector. (default: :obj:`None`)
         edge_attr (Tensor, optional): Edge weights or multi-dimensional edge
             features.
             If :obj:`edge_index` contains duplicated edges, the dense adjacency

--- a/torch_geometric/utils/_to_dense_adj.py
+++ b/torch_geometric/utils/_to_dense_adj.py
@@ -72,8 +72,18 @@ def to_dense_adj(
     cum_nodes = cumsum(num_nodes)
 
     idx0 = batch[edge_index[0]]
-    idx1 = edge_index[0] - cum_nodes[batch][edge_index[0]]
-    idx2 = edge_index[1] - cum_nodes[batch][edge_index[1]]
+    if batch.numel() > 0 and bool((batch[1:] < batch[:-1]).any()):
+        # Compute per-graph local node indices for unsorted `batch` vectors.
+        node_idx = torch.arange(batch.size(0), device=batch.device)
+        perm = torch.argsort(batch * batch.size(0) + node_idx)
+        local_idx = torch.empty_like(batch)
+        local_idx[perm] = node_idx - cum_nodes[batch[perm]]
+
+        idx1 = local_idx[edge_index[0]]
+        idx2 = local_idx[edge_index[1]]
+    else:
+        idx1 = edge_index[0] - cum_nodes[batch][edge_index[0]]
+        idx2 = edge_index[1] - cum_nodes[batch][edge_index[1]]
 
     if max_num_nodes is None:
         max_num_nodes = int(num_nodes.max())


### PR DESCRIPTION
Fixes #10534

## Summary

Fix `to_dense_adj` for unsorted `batch` vectors by computing per-graph local node indices when graph ids are not contiguous in the input node order, while preserving the existing sorted-batch path.

This also clarifies the `batch` docstring: sorting is not required, and nodes in each dense adjacency matrix follow their relative node order in the input `batch` vector.

## Changes

- Fix local node index computation for unsorted `batch` vectors
- Preserve existing behavior for sorted `batch` vectors
- Document unordered `batch` support and dense node ordering
- Add regression coverage without `edge_attr`, with `edge_attr`, with `max_num_nodes`, and under TorchScript in full-test mode

## Tested with

```bash
/home/jovyan/venvs/pyg-pr-review/bin/python -m pytest -q test/utils/test_to_dense_adj.py
```
