### PR TITLE
fix: Optional representation in Python3.14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- Fix Optional representation in Python3.14 ([#10691](https://github.com/pyg-team/pytorch_geometric/pull/10691))
 - Fix MovieLens dataset incompatibility with `sentence-transformers>=5.0.0` ([#10668](https://github.com/pyg-team/pytorch_geometric/pull/10668)
 - Removed an unnecessary device synchronization in `torch_geometric.utils.softmax` ([#10499](https://github.com/pyg-team/pytorch_geometric/pull/10499))
 - Fixed loading of legacy HuggingFace BERT checkpoints ([#10631](https://github.com/pyg-team/pytorch_geometric/pull/10631))

--- a/torch_geometric/inspector.py
+++ b/torch_geometric/inspector.py
@@ -449,12 +449,15 @@ def type_repr(obj: Any, _globals: Dict[str, Any]) -> str:
 
     if obj.__module__ == 'typing':  # Special logic for `typing.*` types:
 
-        if not hasattr(obj, '_name'):
-            return repr(obj)
-
-        name = obj._name
-        if name is None:  # In some cases, `_name` is not populated.
-            name = str(obj.__origin__).split('.')[-1]
+        name = getattr(obj, '_name', None)
+        if name is None:
+            origin = getattr(obj, '__origin__', None)
+            if origin is typing.Union:
+                name = 'Union'
+            elif origin is not None:
+                name = str(origin).split('.')[-1].rstrip("'>")
+            else:
+                return repr(obj)
 
         args = getattr(obj, '__args__', None)
         if args is None or len(args) == 0:


### PR DESCRIPTION
I got the following error with Python3.14:
```
=================================== FAILURES ===================================
________________________________ test_type_repr ________________________________

    def test_type_repr() -> None:
        inspector = Inspector(SAGEConv)
    
        assert inspector.type_repr(Any) == 'typing.Any'
        assert inspector.type_repr(Final) == 'typing.Final'
>       assert inspector.type_repr(OptPairTensor) == (
            'Tuple[Tensor, Optional[Tensor]]')
E       AssertionError: assert 'Tuple[Tensor...ensor | None]' == 'Tuple[Tensor...onal[Tensor]]'
E         
E         - Tuple[Tensor, Optional[Tensor]]
E         + Tuple[Tensor, torch.Tensor | None]

[test/test_inspector](http://test/test_inspector).py:26: AssertionError
```

In Python 3.14, `typing.Union` objects (like `Optional[Tensor]`) do not have the `_name` attribute populated in the same way as before, causing `Inspector.type_repr` to fall back to `repr(obj)`, which uses the new `|` syntax for Unions.
This change checks `__origin__` if `_name` is missing, helping to identify `Union` types and maintain the expected `'Optional[Tensor]'` output format