### PR TITLE
Fix Python 3.14 compatibility in `config_store.py`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
-- Fix Python 3.14 compatibility in `config_store.py`
+- Fix Python 3.14 compatibility in `config_store.py`([#10692](https://github.com/pyg-team/pytorch_geometric/pull/10692))
 - Fix MovieLens dataset incompatibility with `sentence-transformers>=5.0.0` ([#10668](https://github.com/pyg-team/pytorch_geometric/pull/10668)
 - Removed an unnecessary device synchronization in `torch_geometric.utils.softmax` ([#10499](https://github.com/pyg-team/pytorch_geometric/pull/10499))
 - Fixed loading of legacy HuggingFace BERT checkpoints ([#10631](https://github.com/pyg-team/pytorch_geometric/pull/10631))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- Fix Python 3.14 compatibility in `config_store.py`
 - Fix MovieLens dataset incompatibility with `sentence-transformers>=5.0.0` ([#10668](https://github.com/pyg-team/pytorch_geometric/pull/10668)
 - Removed an unnecessary device synchronization in `torch_geometric.utils.softmax` ([#10499](https://github.com/pyg-team/pytorch_geometric/pull/10499))
 - Fixed loading of legacy HuggingFace BERT checkpoints ([#10631](https://github.com/pyg-team/pytorch_geometric/pull/10631))

--- a/test/test_config_store.py
+++ b/test/test_config_store.py
@@ -48,10 +48,10 @@ def test_to_dataclass():
 def test_map_annotation():
     mapping = {int: Any}
     assert map_annotation(dict[str, int], mapping) == dict[str, Any]
-    assert map_annotation(Dict[str, float], mapping) == Dict[str, float]
-    assert map_annotation(List[str], mapping) == List[str]
-    assert map_annotation(List[int], mapping) == List[Any]
-    assert map_annotation(Tuple[int], mapping) == Tuple[Any]
+    assert map_annotation(Dict[str, float], mapping) == dict[str, float]
+    assert map_annotation(List[str], mapping) == list[str]
+    assert map_annotation(List[int], mapping) == list[Any]
+    assert map_annotation(Tuple[int], mapping) == tuple[Any]
     assert map_annotation(dict[str, int], mapping) == dict[str, Any]
     assert map_annotation(dict[str, float], mapping) == dict[str, float]
     assert map_annotation(list[str], mapping) == list[str]

--- a/torch_geometric/config_store.py
+++ b/torch_geometric/config_store.py
@@ -1,4 +1,3 @@
-import copy
 import inspect
 import typing
 from collections import defaultdict

--- a/torch_geometric/config_store.py
+++ b/torch_geometric/config_store.py
@@ -167,14 +167,7 @@ def map_annotation(
     if origin in {Union, list, dict, tuple}:
         assert origin is not None
         args = tuple(map_annotation(a, mapping) for a in args)
-        if type(annotation).__name__ == 'GenericAlias':
-            # If annotated with `list[...]` or `dict[...]`:
-            annotation = origin[args]  # type: ignore[index]
-        else:
-            # If annotated with `typing.List[...]` or `typing.Dict[...]`:
-            annotation = copy.copy(annotation)
-            annotation.__args__ = args
-
+        annotation = origin[args]  # type: ignore[index]
         return annotation
 
     if mapping is not None and annotation in mapping:


### PR DESCRIPTION
I got this error in Python3.14:
```console
test/test_config_store.py:24: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
config_store.py:262: in to_dataclass
    annotation = map_annotation(annotation, mapping=MAPPING)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

annotation = float | torch.Tensor | str
mapping = {<class 'torch.nn.modules.module.Module'>: typing.Any, <class 'torch.Tensor'>: typing.Any}

    def map_annotation(
        annotation: Any,
        mapping: Optional[Dict[Any, Any]] = None,
    ) -> Any:
        origin = getattr(annotation, '__origin__', None)
        args: Tuple[Any, ...] = getattr(annotation, '__args__', tuple())
        if origin in {Union, list, dict, tuple}:
            assert origin is not None
            args = tuple(map_annotation(a, mapping) for a in args)
            if type(annotation).__name__ == 'GenericAlias':
                # If annotated with `list[...]` or `dict[...]`:
                annotation = origin[args]
            else:
                # If annotated with `typing.List[...]` or `typing.Dict[...]`:
                annotation = copy.copy(annotation)
>               annotation.__args__ = args
E               AttributeError: readonly attribute

config_store.py:176: AttributeError
```

In Python 3.14, the `__args__` attribute of generic aliases (like `typing.Dict`) is read-only. The original code attempted to copy the annotation and mutate `__args__`. This change replaced this logic to use `origin[args]` directly, which is the standard way to construct these types in modern Python.