### PR TITLE
fix supports_bipartite_graphs in Python3.14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- Fix `supports_bipartite_graphs` in Python3.14 ([#10693](https://github.com/pyg-team/pytorch_geometric/pull/10693))
 - Fix MovieLens dataset incompatibility with `sentence-transformers>=5.0.0` ([#10668](https://github.com/pyg-team/pytorch_geometric/pull/10668)
 - Removed an unnecessary device synchronization in `torch_geometric.utils.softmax` ([#10499](https://github.com/pyg-team/pytorch_geometric/pull/10499))
 - Fixed loading of legacy HuggingFace BERT checkpoints ([#10631](https://github.com/pyg-team/pytorch_geometric/pull/10631))

--- a/torch_geometric/nn/conv/utils/cheatsheet.py
+++ b/torch_geometric/nn/conv/utils/cheatsheet.py
@@ -37,7 +37,9 @@ def supports_edge_features(cls: str) -> bool:
 def supports_bipartite_graphs(cls: str) -> bool:
     cls = importlib.import_module('torch_geometric.nn.conv').__dict__[cls]
     signature = inspect.signature(cls.forward)
-    return 'Union[torch.Tensor, Tuple[torch.Tensor' in str(signature)
+    sig_str = str(signature)
+    return ('Union[torch.Tensor, Tuple[torch.Tensor' in sig_str
+            or 'torch.Tensor | Tuple[torch.Tensor' in sig_str)
 
 
 def supports_static_graphs(cls: str) -> bool:


### PR DESCRIPTION
I got this error in Python3.14:

```
+  where False = <function supports_bipartite_graphs at 0x10feeca26f00>('SAGEConv')
 +    where <function supports_bipartite_graphs at 0x10feeca26f00> = utils.supports_bipartite_graphs
def test_gnn_cheatsheet():
        assert utils.paper_title('GCNConv') == ('Semi-supervised Classification '
                                                'with Graph Convolutional '
                                                'Networks')
        assert utils.paper_link('GCNConv') == 'https://arxiv.org/abs/1609.02907'
    
        assert utils.supports_sparse_tensor('GCNConv')
        assert not utils.supports_sparse_tensor('ChebConv')
    
        assert utils.supports_edge_weights('GraphConv')
        assert not utils.supports_edge_weights('SAGEConv')
    
        assert utils.supports_edge_features('GATConv')
        assert not utils.supports_edge_features('SimpleConv')
    
>       assert utils.supports_bipartite_graphs('SAGEConv')
E       AssertionError: assert False
E        +  where False = <function supports_bipartite_graphs at 0x10feeca26f00>('SAGEConv')
E        +    where <function supports_bipartite_graphs at 0x10feeca26f00> = utils.supports_bipartite_graphs

test/nn/conv/utils/test_gnn_cheatsheet.py:19: AssertionError
```

Python 3.14 uses the `|` operator for unions in the string representation of signatures, resulting in `torch.Tensor | Tuple[torch.Tensor, torch.Tensor | None]`. This change adds support for this format.