### PR TITLE
Add NPU support to basic GNN examples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -196,6 +196,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Breaking Change: Added support for `EdgeIndex` in `cugraph` GNN layers ([#8938](https://github.com/pyg-team/pytorch_geometric/pull/8937))
 - Added the `dim` arg to `torch.cross` calls ([#8918](https://github.com/pyg-team/pytorch_geometric/pull/8918))
 - Added XPU support to basic GNN examples ([#9421](https://github.com/pyg-team/pytorch_geometric/pull/9421), [#9439](https://github.com/pyg-team/pytorch_geometric/pull/9439))
+- Added NPU support to basic GNN examples ([#10696](https://github.com/pyg-team/pytorch_geometric/pull/10696))
 
 ### Deprecated
 

--- a/examples/gat.py
+++ b/examples/gat.py
@@ -24,6 +24,8 @@ if torch.cuda.is_available():
     device = torch.device('cuda')
 elif torch_geometric.is_xpu_available():
     device = torch.device('xpu')
+elif torch_geometric.is_npu_available():
+    device = torch.device('npu')
 else:
     device = torch.device('cpu')
 

--- a/examples/graph_sage_unsup.py
+++ b/examples/graph_sage_unsup.py
@@ -27,6 +27,8 @@ if torch.cuda.is_available():
     device = torch.device('cuda')
 elif torch_geometric.is_xpu_available():
     device = torch.device('xpu')
+elif torch_geometric.is_npu_available():
+    device = torch.device('npu')
 else:
     device = torch.device('cpu')
 data = data.to(device, 'x', 'edge_index')

--- a/examples/graph_sage_unsup_ppi.py
+++ b/examples/graph_sage_unsup_ppi.py
@@ -34,6 +34,8 @@ if torch.cuda.is_available():
     device = torch.device('cuda')
 elif torch_geometric.is_xpu_available():
     device = torch.device('xpu')
+elif torch_geometric.is_npu_available():
+    device = torch.device('npu')
 else:
     device = torch.device('cpu')
 model = GraphSAGE(

--- a/examples/pna.py
+++ b/examples/pna.py
@@ -71,6 +71,8 @@ if torch.cuda.is_available():
     device = torch.device('cuda')
 elif torch_geometric.is_xpu_available():
     device = torch.device('xpu')
+elif torch_geometric.is_npu_available():
+    device = torch.device('npu')
 else:
     device = torch.device('cpu')
 model = Net().to(device)

--- a/torch_geometric/__init__.py
+++ b/torch_geometric/__init__.py
@@ -10,7 +10,12 @@ from .edge_index import EdgeIndex
 from .hash_tensor import HashTensor
 from .seed import seed_everything
 from .home import get_home_dir, set_home_dir
-from .device import is_mps_available, is_xpu_available, device
+from .device import (
+    is_mps_available,
+    is_xpu_available,
+    is_npu_available,
+    device,
+)
 from .isinstance import is_torch_instance
 from .debug import is_debug_enabled, debug, set_debug
 
@@ -46,6 +51,7 @@ __all__ = [
     'safe_onnx_export',
     'is_mps_available',
     'is_xpu_available',
+    'is_npu_available',
     'device',
     'is_torch_instance',
     'is_debug_enabled',

--- a/torch_geometric/device.py
+++ b/torch_geometric/device.py
@@ -25,6 +25,14 @@ def is_xpu_available() -> bool:
         return False
 
 
+def is_npu_available() -> bool:
+    r"""Returns a bool indicating if NPU is currently available."""
+    if hasattr(torch, 'npu') and torch.npu.is_available():
+        return True
+    else:
+        return False
+
+
 def device(device: Any) -> torch.device:
     r"""Returns a :class:`torch.device`.
 
@@ -39,4 +47,6 @@ def device(device: Any) -> torch.device:
         return torch.device('mps')
     if is_xpu_available():
         return torch.device('xpu')
+    if is_npu_available():
+        return torch.device('npu')
     return torch.device('cpu')

--- a/torch_geometric/testing/decorators.py
+++ b/torch_geometric/testing/decorators.py
@@ -121,6 +121,15 @@ def onlyXPU(func: Callable) -> Callable:
     )(func)
 
 
+def onlyNPU(func: Callable) -> Callable:
+    r"""A decorator to skip tests if NPU is not found."""
+    import pytest
+    return pytest.mark.skipif(
+        not torch_geometric.is_npu_available(),
+        reason="NPU not available",
+    )(func)
+
+
 def onlyOnline(func: Callable) -> Callable:
     r"""A decorator to skip tests if there exists no connection to the
     internet.
@@ -229,6 +238,9 @@ def withDevice(func: Callable) -> Callable:
 
     if torch_geometric.is_xpu_available():
         devices.append(pytest.param(torch.device('xpu:0'), id='xpu'))
+
+    if torch_geometric.is_npu_available():
+        devices.append(pytest.param(torch.device('npu:0'), id='npu'))
 
     # Additional devices can be registered through environment variables:
     device = os.getenv('TORCH_DEVICE')


### PR DESCRIPTION
This PR adds support for Huawei's Ascend NPU via the `torch_npu` backend to basic GNN examples, including GAT, GCN, GraphSAGE, etc. It follows the existing integration pattern for XPU (Intel) devices. 