### PR TITLE
[Dataset] Add BigSolDB solubility dataset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- Added `BigSolDB` dataset (`torch_geometric.datasets.BigSolDB`), containing 112,465 experimental solubility values for 1,525 organic compounds in 218 solvents, based on BigSolDB 2.1 ([#XXXX](https://github.com/pyg-team/pytorch_geometric/pull/XXXX))
 - Added `txt2qa.py` example for synthetic multi-hop QA generation from text documents, supporting vLLM (local) and NVIDIA NIM (API) backends ([#10559](https://github.com/pyg-team/pytorch_geometric/pull/10559))
 
 ### Changed

--- a/test/datasets/test_bigsoldb.py
+++ b/test/datasets/test_bigsoldb.py
@@ -1,0 +1,124 @@
+import os
+import os.path as osp
+
+import pytest
+import torch
+
+from torch_geometric.datasets import BigSolDB
+
+
+# Minimal fake CSV matching BigSolDB column schema
+FAKE_CSV = (
+    "SMILES_Solute,Temperature_K,Solvent,SMILES_Solvent,"
+    "Solubility(mole_fraction),Solubility(mol/L),LogS(mol/L),"
+    "Compound_Name,CAS,PubChem_CID,FDA_Approved,Source\n"
+    "CCO,298.15,ethanol,CCO,0.1,1.5,0.176,Ethanol,64-17-5,702,Yes,DOI1\n"
+    "c1ccccc1,298.15,toluene,Cc1ccccc1,0.05,0.8,-0.097,Benzene,"
+    "71-43-2,241,No,DOI2\n"
+    "CC(=O)O,310.0,ethanol,CCO,0.2,2.0,0.301,AceticAcid,"
+    "64-19-7,176,No,DOI3\n"
+    "CCN,298.15,water,O,0.3,3.0,0.477,Ethylamine,"
+    "75-04-7,6329,No,DOI4\n"
+)
+
+
+@pytest.fixture()
+def dataset(tmp_path):
+    """Create a BigSolDB dataset backed by a fake CSV (no download)."""
+    raw_dir = tmp_path / 'BigSolDB' / 'raw'
+    raw_dir.mkdir(parents=True)
+    csv_path = raw_dir / 'BigSolDBv2.1.csv'
+    csv_path.write_text(FAKE_CSV)
+
+    return BigSolDB(root=str(tmp_path / 'BigSolDB'))
+
+
+def test_bigsoldb_len(dataset):
+    # 4 rows in fake CSV, all have valid SMILES → 4 graphs
+    assert len(dataset) == 4
+
+
+def test_bigsoldb_data_object(dataset):
+    d = dataset[0]
+
+    # solute graph
+    assert d.x.dim() == 2
+    assert d.x.size(1) == 9          # 9 atom features (from_smiles default)
+    assert d.edge_index.size(0) == 2
+
+    # solvent graph
+    assert d.x_solvent.dim() == 2
+    assert d.x_solvent.size(1) == 9
+    assert d.edge_index_solvent.size(0) == 2
+
+    # measurement conditions
+    assert d.temperature.shape == torch.Size([1])
+    assert isinstance(d.solvent_name, str)
+    assert isinstance(d.compound_name, str)
+
+    # target
+    assert d.y.shape == torch.Size([1])
+    assert d.y.dtype == torch.float
+
+
+def test_bigsoldb_solvent_filter(tmp_path):
+    raw_dir = tmp_path / 'BigSolDB_eth' / 'raw'
+    raw_dir.mkdir(parents=True)
+    (raw_dir / 'BigSolDBv2.1.csv').write_text(FAKE_CSV)
+
+    eth = BigSolDB(root=str(tmp_path / 'BigSolDB_eth'), solvent='ethanol')
+    # fake CSV has 2 ethanol rows (CCO and CC(=O)O)
+    assert len(eth) == 2
+    for d in eth:
+        assert d.solvent_name.lower() == 'ethanol'
+
+
+def test_bigsoldb_solvent_filter_case_insensitive(tmp_path):
+    raw_dir = tmp_path / 'BigSolDB_case' / 'raw'
+    raw_dir.mkdir(parents=True)
+    (raw_dir / 'BigSolDBv2.1.csv').write_text(FAKE_CSV)
+
+    ds = BigSolDB(root=str(tmp_path / 'BigSolDB_case'), solvent='Ethanol')
+    assert len(ds) == 2
+
+
+def test_bigsoldb_repr(dataset):
+    assert 'BigSolDB' in repr(dataset)
+    assert str(len(dataset)) in repr(dataset)
+
+
+def test_bigsoldb_repr_with_solvent(tmp_path):
+    raw_dir = tmp_path / 'BigSolDB_repr' / 'raw'
+    raw_dir.mkdir(parents=True)
+    (raw_dir / 'BigSolDBv2.1.csv').write_text(FAKE_CSV)
+
+    ds = BigSolDB(root=str(tmp_path / 'BigSolDB_repr'), solvent='toluene')
+    assert "solvent='toluene'" in repr(ds)
+
+
+def test_bigsoldb_separate_cache_per_solvent(tmp_path):
+    """Different solvent filters must produce different processed files."""
+    for subdir in ['raw']:
+        d = tmp_path / 'BigSolDB_cache' / subdir
+        d.mkdir(parents=True)
+    (tmp_path / 'BigSolDB_cache' / 'raw' / 'BigSolDBv2.1.csv').write_text(
+        FAKE_CSV)
+
+    root = str(tmp_path / 'BigSolDB_cache')
+    all_ds = BigSolDB(root=root)
+    eth_ds = BigSolDB(root=root, solvent='ethanol')
+
+    assert len(all_ds) != len(eth_ds)
+
+    # processed files must be different
+    processed = os.listdir(osp.join(root, 'processed'))
+    assert 'data.pt' in processed
+    assert 'data_ethanol.pt' in processed
+
+
+def test_bigsoldb_y_values(dataset):
+    """LogS values should match the fake CSV entries."""
+    log_s_values = [d.y.item() for d in dataset]
+    expected = [0.176, -0.097, 0.301, 0.477]
+    for actual, exp in zip(sorted(log_s_values), sorted(expected)):
+        assert abs(actual - exp) < 1e-3

--- a/test/datasets/test_bigsoldb.py
+++ b/test/datasets/test_bigsoldb.py
@@ -6,7 +6,6 @@ import torch
 
 from torch_geometric.datasets import BigSolDB
 
-
 # Minimal fake CSV matching BigSolDB column schema
 FAKE_CSV = (
     "SMILES_Solute,Temperature_K,Solvent,SMILES_Solvent,"
@@ -18,8 +17,7 @@ FAKE_CSV = (
     "CC(=O)O,310.0,ethanol,CCO,0.2,2.0,0.301,AceticAcid,"
     "64-19-7,176,No,DOI3\n"
     "CCN,298.15,water,O,0.3,3.0,0.477,Ethylamine,"
-    "75-04-7,6329,No,DOI4\n"
-)
+    "75-04-7,6329,No,DOI4\n")
 
 
 @pytest.fixture()
@@ -43,7 +41,7 @@ def test_bigsoldb_data_object(dataset):
 
     # solute graph
     assert d.x.dim() == 2
-    assert d.x.size(1) == 9          # 9 atom features (from_smiles default)
+    assert d.x.size(1) == 9  # 9 atom features (from_smiles default)
     assert d.edge_index.size(0) == 2
 
     # solvent graph
@@ -101,8 +99,8 @@ def test_bigsoldb_separate_cache_per_solvent(tmp_path):
     for subdir in ['raw']:
         d = tmp_path / 'BigSolDB_cache' / subdir
         d.mkdir(parents=True)
-    (tmp_path / 'BigSolDB_cache' / 'raw' / 'BigSolDBv2.1.csv').write_text(
-        FAKE_CSV)
+    (tmp_path / 'BigSolDB_cache' / 'raw' /
+     'BigSolDBv2.1.csv').write_text(FAKE_CSV)
 
     root = str(tmp_path / 'BigSolDB_cache')
     all_ds = BigSolDB(root=root)

--- a/torch_geometric/datasets/__init__.py
+++ b/torch_geometric/datasets/__init__.py
@@ -19,6 +19,7 @@ from .qm9 import QM9
 from .md17 import MD17
 from .zinc import ZINC
 from .aqsol import AQSOL
+from .bigsoldb import BigSolDB
 from .molecule_net import MoleculeNet
 from .pcqm4m import PCQM4Mv2
 from .entities import Entities
@@ -140,6 +141,7 @@ homo_datasets = [
     'MD17',
     'ZINC',
     'AQSOL',
+    'BigSolDB',
     'MoleculeNet',
     'PCQM4Mv2',
     'Entities',

--- a/torch_geometric/datasets/bigsoldb.py
+++ b/torch_geometric/datasets/bigsoldb.py
@@ -74,10 +74,8 @@ class BigSolDB(InMemoryDataset):
           - 1
     """
 
-    url = (
-            'https://zenodo.org/records/18552681/files/'
-            'BigSolDBv2.1.csv?download=1'
-        )
+    url = ('https://zenodo.org/records/18552681/files/'
+           'BigSolDBv2.1.csv?download=1')
 
     def __init__(
         self,

--- a/torch_geometric/datasets/bigsoldb.py
+++ b/torch_geometric/datasets/bigsoldb.py
@@ -1,0 +1,162 @@
+import os.path as osp
+from typing import Callable, List, Optional
+
+import torch
+
+from torch_geometric.data import Data, InMemoryDataset, download_url
+from torch_geometric.utils import from_smiles
+
+
+class BigSolDB(InMemoryDataset):
+    r"""The BigSolDB 2.1 dataset from the `"BigSolDB 2.0, dataset of
+    solubility values for organic compounds in different solvents at
+    various temperatures"
+    <https://www.nature.com/articles/s41597-025-05559-8>`_ paper
+    (Zenodo: `10.5281/zenodo.18552681
+    <https://doi.org/10.5281/zenodo.18552681>`_), containing 112,465
+    experimental solubility values for 1,525 organic compounds measured
+    in 218 individual solvents, extracted from 1,687 peer-reviewed
+    articles.
+
+    Each data point represents a (solute, solvent, temperature) triplet
+    with an experimental LogS value. Both solute and solvent are encoded
+    as molecular graphs using standard atom and bond features from
+    :func:`torch_geometric.utils.from_smiles`.
+
+    Solvent information is stored alongside the solute graph as
+    :obj:`x_solvent`, :obj:`edge_index_solvent`, :obj:`edge_attr_solvent`.
+    Measurement temperature (in K) is stored as :obj:`temperature`.
+    The regression target :obj:`y` is LogS in mol/L.
+
+    No official train/val/test split is provided. Use
+    :class:`torch.utils.data.random_split` or a scaffold-based splitter
+    (e.g. from `DeepChem <https://deepchem.io>`_) depending on your
+    evaluation protocol.
+
+    Args:
+        root (str): Root directory where the dataset should be saved.
+        solvent (str, optional): If given, only load measurements for
+            this solvent (case-insensitive, e.g. :obj:`"ethanol"`).
+            If :obj:`None`, all solvents are included.
+            (default: :obj:`None`)
+        transform (callable, optional): A function/transform that takes
+            in a :obj:`torch_geometric.data.Data` object and returns a
+            transformed version. The data object will be transformed
+            before every access. (default: :obj:`None`)
+        pre_transform (callable, optional): A function/transform that
+            takes in a :obj:`torch_geometric.data.Data` object and
+            returns a transformed version. The data object will be
+            transformed before being saved to disk.
+            (default: :obj:`None`)
+        pre_filter (callable, optional): A function that takes in a
+            :obj:`torch_geometric.data.Data` object and returns a boolean
+            value, indicating whether the data object should be included
+            in the final dataset. (default: :obj:`None`)
+        force_reload (bool, optional): Whether to re-process the dataset.
+            (default: :obj:`False`)
+
+    **STATS:**
+
+    .. list-table::
+        :widths: 15 10 10 10 10 10
+        :header-rows: 1
+
+        * - #graphs
+          - #nodes (solute)
+          - #edges (solute)
+          - #solvents
+          - #features
+          - #tasks
+        * - 112,465
+          - ~17.2
+          - ~35.6
+          - 218
+          - 9
+          - 1
+    """
+
+    url = 'https://zenodo.org/records/18552681/files/BigSolDBv2.1.csv?download=1'
+
+    def __init__(
+        self,
+        root: str,
+        solvent: Optional[str] = None,
+        transform: Optional[Callable] = None,
+        pre_transform: Optional[Callable] = None,
+        pre_filter: Optional[Callable] = None,
+        force_reload: bool = False,
+    ):
+        self.solvent = solvent
+        super().__init__(root, transform, pre_transform, pre_filter,
+                         force_reload=force_reload)
+        self.load(self.processed_paths[0])
+
+    @property
+    def raw_file_names(self) -> List[str]:
+        return ['BigSolDBv2.1.csv']
+
+    @property
+    def processed_file_names(self) -> str:
+        suffix = f'_{self.solvent.lower()}' if self.solvent else ''
+        return [f'data{suffix}.pt']
+
+    def download(self) -> None:
+        download_url(self.url, self.raw_dir)
+
+    def process(self) -> None:
+        import pandas as pd
+
+        df = pd.read_csv(self.raw_paths[0])
+
+        # Columns: SMILES_Solute, Temperature_K, Solvent, SMILES_Solvent,
+        # Solubility(mole_fraction), Solubility(mol/L), LogS(mol/L),
+        # Compound_Name, CAS, PubChem_CID, FDA_Approved, Source
+
+        if self.solvent is not None:
+            df = df[df['Solvent'].str.lower() == self.solvent.lower()]
+            df = df.reset_index(drop=True)
+
+        data_list: List[Data] = []
+        for _, row in df.iterrows():
+            try:
+                sol_data = from_smiles(str(row['SMILES_Solute']))
+                solv_data = from_smiles(str(row['SMILES_Solvent']))
+            except Exception:
+                continue
+
+            if sol_data.edge_index.numel() == 0:
+                continue  # skip single-atom entries
+
+            data = Data(
+                # solute graph
+                x=sol_data.x,
+                edge_index=sol_data.edge_index,
+                edge_attr=sol_data.edge_attr,
+                # solvent graph
+                x_solvent=solv_data.x,
+                edge_index_solvent=solv_data.edge_index,
+                edge_attr_solvent=solv_data.edge_attr,
+                # measurement conditions
+                temperature=torch.tensor(
+                    [row['Temperature_K']], dtype=torch.float),
+                solvent_name=str(row['Solvent']),
+                solute_smiles=str(row['SMILES_Solute']),
+                compound_name=str(row['Compound_Name']),
+                fda_approved=str(row['FDA_Approved']),
+                # target
+                y=torch.tensor([row['LogS(mol/L)']], dtype=torch.float),
+            )
+
+            if self.pre_filter is not None and not self.pre_filter(data):
+                continue
+            if self.pre_transform is not None:
+                data = self.pre_transform(data)
+
+            data_list.append(data)
+
+        self.save(data_list, self.processed_paths[0])
+
+    def __repr__(self) -> str:
+        solvent_str = (f", solvent='{self.solvent}'"
+                       if self.solvent is not None else '')
+        return f'{self.__class__.__name__}({len(self)}{solvent_str})'

--- a/torch_geometric/datasets/bigsoldb.py
+++ b/torch_geometric/datasets/bigsoldb.py
@@ -1,4 +1,3 @@
-import os.path as osp
 from typing import Callable, List, Optional
 
 import torch
@@ -137,8 +136,8 @@ class BigSolDB(InMemoryDataset):
                 edge_index_solvent=solv_data.edge_index,
                 edge_attr_solvent=solv_data.edge_attr,
                 # measurement conditions
-                temperature=torch.tensor(
-                    [row['Temperature_K']], dtype=torch.float),
+                temperature=torch.tensor([row['Temperature_K']],
+                                         dtype=torch.float),
                 solvent_name=str(row['Solvent']),
                 solute_smiles=str(row['SMILES_Solute']),
                 compound_name=str(row['Compound_Name']),

--- a/torch_geometric/datasets/bigsoldb.py
+++ b/torch_geometric/datasets/bigsoldb.py
@@ -74,7 +74,10 @@ class BigSolDB(InMemoryDataset):
           - 1
     """
 
-    url = 'https://zenodo.org/records/18552681/files/BigSolDBv2.1.csv?download=1'
+    url = (
+            'https://zenodo.org/records/18552681/files/'
+            'BigSolDBv2.1.csv?download=1'
+        )
 
     def __init__(
         self,


### PR DESCRIPTION
## Description

Adds the `BigSolDB` dataset (`torch_geometric.datasets.BigSolDB`), a large-scale experimental solubility database covering organic compounds in diverse solvents across a wide temperature range.

**Paper:** [BigSolDB 2.0](https://www.nature.com/articles/s41597-025-05559-8), Scientific Data 2025  
**Zenodo:** https://doi.org/10.5281/zenodo.18552681  

## Stats

- 112,465 experimental solubility values
- 1,525 unique organic compounds
- 218 solvents (water + organic)
- Temperature range: 243-425 K
- Extracted from 1,687 peer-reviewed articles

## Why BigSolDB?

BigSolDB is significantly larger and more diverse than the existing `AQSOL` dataset
(9,800 aqueous-only datapoints). It covers 218 solvents vs. water-only, making it
suitable for multi-solvent solubility prediction - an important task in drug
formulation, synthesis, and crystallization.

## New files

- `torch_geometric/datasets/bigsoldb.py` — dataset class
- `test/datasets/test_bigsoldb.py` — unit tests (8 tests)

## Notes

- No official train/val/test split is provided (unlike AQSOL). Users are encouraged
  to apply scaffold-based or cold-solvent splits depending on their evaluation protocol.
- Solvent graph is stored as `x_solvent`, `edge_index_solvent`, `edge_attr_solvent`.
- Use `follow_batch=['x_solvent']` in `DataLoader` for correct solvent pooling.

## Impact

- **3,800+ downloads** on Zenodo across all versions
- Cited in peer-reviewed works across top venues:

1. Attia et al., *Nature Communications* 2025 (https://doi.org/10.1038/s41467-025-62717-7)
2. Al Ibrahim et al., *JACS* 2025 (https://doi.org/10.1021/jacs.5c13746)
3. Ramani et al., *JCTC* 2024 (https://doi.org/10.1021/acs.jctc.4c00382)
4. Krzyżanowski et al., *Digital Discovery* 2025 (https://doi.org/10.1039/D5DD00134J)
5. Guo et al., *JCIM* 2025 (https://doi.org/10.1021/acs.jcim.5c00781)
6. Gopichand et al., *ACS Omega* 2025 (https://doi.org/10.1021/acsomega.5c13630)
7. Broadbent et al., *ICLR 2026 Workshop* (https://openreview.net/forum?id=znY51c4s04)
8. Pimonova et al., *Digital Discovery* 2026 (https://doi.org/10.1039/D5DD00443H)
9. Fan et al., *Digital Discovery* 2026 (https://doi.org/10.1039/D5DD00407A)
10. Da Vià et al., *Org. Process Res. Dev.* 2025 (https://doi.org/10.1021/acs.oprd.4c00384)
11. Gomes et al., *JCIM* 2026 (https://doi.org/10.1021/acs.jcim.6c00606)
12. Wang et al., *Digital Discovery* 2026 (https://doi.org/10.1039/D5DD00456J)
