### PR TITLE
Fix DeprecationWarning for torch.jit.script in SelectOutput and ConnectOutput

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- Fixed `DeprecationWarning` for `torch.jit.script` in `SelectOutput` and `ConnectOutput` by switching to the `@torch.jit.script` class decorator form ([#10697](https://github.com/pyg-team/pytorch_geometric/issues/10697))
 - Fix MovieLens dataset incompatibility with `sentence-transformers>=5.0.0` ([#10668](https://github.com/pyg-team/pytorch_geometric/pull/10668)
 - Removed an unnecessary device synchronization in `torch_geometric.utils.softmax` ([#10499](https://github.com/pyg-team/pytorch_geometric/pull/10499))
 - Fixed loading of legacy HuggingFace BERT checkpoints ([#10631](https://github.com/pyg-team/pytorch_geometric/pull/10631))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -218,8 +218,6 @@ filterwarnings = [
     "error:.*torch_geometric.*:DeprecationWarning",
     # TODO(rishipuri98): Remove usage of `torch_geometric.distributed` from `torch_geometric.llm`
     "ignore:.*torch_geometric.distributed.*:DeprecationWarning",
-    # Filter `torch.jit.*` deprication warnings:
-    "ignore:.*torch.jit.*:DeprecationWarning",
 ]
 markers = [
     "rag: mark test as RAG test",

--- a/torch_geometric/nn/pool/connect/base.py
+++ b/torch_geometric/nn/pool/connect/base.py
@@ -1,4 +1,3 @@
-from dataclasses import dataclass
 from typing import Optional
 
 import torch
@@ -7,7 +6,7 @@ from torch import Tensor
 from torch_geometric.nn.pool.select import SelectOutput
 
 
-@dataclass(init=False)
+@torch.jit.script
 class ConnectOutput:
     r"""The output of the :class:`Connect` method, which holds the coarsened
     graph structure, and optional pooled edge features and batch vectors.
@@ -20,8 +19,8 @@ class ConnectOutput:
             coarsened graph. (default: :obj:`None`)
     """
     edge_index: Tensor
-    edge_attr: Optional[Tensor] = None
-    batch: Optional[Tensor] = None
+    edge_attr: Optional[Tensor]
+    batch: Optional[Tensor]
 
     def __init__(
         self,
@@ -46,9 +45,6 @@ class ConnectOutput:
         self.edge_index = edge_index
         self.edge_attr = edge_attr
         self.batch = batch
-
-
-ConnectOutput = torch.jit.script(ConnectOutput)
 
 
 class Connect(torch.nn.Module):

--- a/torch_geometric/nn/pool/select/base.py
+++ b/torch_geometric/nn/pool/select/base.py
@@ -1,11 +1,10 @@
-from dataclasses import dataclass
 from typing import Optional
 
 import torch
 from torch import Tensor
 
 
-@dataclass(init=False)
+@torch.jit.script
 class SelectOutput:
     r"""The output of the :class:`Select` method, which holds an assignment
     from selected nodes to their respective cluster(s).
@@ -23,7 +22,7 @@ class SelectOutput:
     num_nodes: int
     cluster_index: Tensor
     num_clusters: int
-    weight: Optional[Tensor] = None
+    weight: Optional[Tensor]
 
     def __init__(
         self,
@@ -60,9 +59,6 @@ class SelectOutput:
         self.cluster_index = cluster_index
         self.num_clusters = num_clusters
         self.weight = weight
-
-
-SelectOutput = torch.jit.script(SelectOutput)
 
 
 class Select(torch.nn.Module):


### PR DESCRIPTION
Fixes #10697.

`torch.jit.script` is deprecated in PyTorch 2.12. The module level calls

    SelectOutput = torch.jit.script(SelectOutput)
    ConnectOutput = torch.jit.script(ConnectOutput)

in `select/base.py` and `connect/base.py` trigger a DeprecationWarning at
import time. `pyproject.toml` treats DeprecationWarning from `torch_geometric.*`
as an error so this breaks tests. There's a temporary
`ignore:.*torch.jit.*:DeprecationWarning` filter in `pyproject.toml` working
around it.

Changes:

- `SelectOutput` and `ConnectOutput` now use `@torch.jit.script` as a class
  decorator instead of the post hoc call.
- Removed `@dataclass(init=False)`. The decorator approach doesn't need it,
  and the manually written `__init__` already handles construction + validation.
- Removed `= None` from the class level `Optional` annotations. The default
  is still in `__init__` so the behavior is the same.
- Removed the temporary `ignore:.*torch.jit.*` filter from `pyproject.toml`.

Verified locally on torch 2.9.1 that the classes still instantiate, the
validation in `__init__` still fires, and `torch.jit.script(FilterEdges())`
still works (so the `is_full_test()` JIT paths in `test_select_topk.py` and
`test_filter_edges.py` should keep working).