### PR TITLE
Drop torch.jit.script from SelectOutput and ConnectOutput

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- Removed `torch.jit.script` calls on `SelectOutput` and `ConnectOutput` to avoid `DeprecationWarning` on PyTorch 2.12 ([#10697](https://github.com/pyg-team/pytorch_geometric/issues/10697))
 - Fix MovieLens dataset incompatibility with `sentence-transformers>=5.0.0` ([#10668](https://github.com/pyg-team/pytorch_geometric/pull/10668)
 - Removed an unnecessary device synchronization in `torch_geometric.utils.softmax` ([#10499](https://github.com/pyg-team/pytorch_geometric/pull/10499))
 - Fixed loading of legacy HuggingFace BERT checkpoints ([#10631](https://github.com/pyg-team/pytorch_geometric/pull/10631))

--- a/torch_geometric/nn/pool/connect/base.py
+++ b/torch_geometric/nn/pool/connect/base.py
@@ -1,4 +1,3 @@
-from dataclasses import dataclass
 from typing import Optional
 
 import torch
@@ -7,7 +6,6 @@ from torch import Tensor
 from torch_geometric.nn.pool.select import SelectOutput
 
 
-@dataclass(init=False)
 class ConnectOutput:
     r"""The output of the :class:`Connect` method, which holds the coarsened
     graph structure, and optional pooled edge features and batch vectors.
@@ -20,8 +18,8 @@ class ConnectOutput:
             coarsened graph. (default: :obj:`None`)
     """
     edge_index: Tensor
-    edge_attr: Optional[Tensor] = None
-    batch: Optional[Tensor] = None
+    edge_attr: Optional[Tensor]
+    batch: Optional[Tensor]
 
     def __init__(
         self,
@@ -46,9 +44,6 @@ class ConnectOutput:
         self.edge_index = edge_index
         self.edge_attr = edge_attr
         self.batch = batch
-
-
-ConnectOutput = torch.jit.script(ConnectOutput)
 
 
 class Connect(torch.nn.Module):

--- a/torch_geometric/nn/pool/select/base.py
+++ b/torch_geometric/nn/pool/select/base.py
@@ -1,11 +1,9 @@
-from dataclasses import dataclass
 from typing import Optional
 
 import torch
 from torch import Tensor
 
 
-@dataclass(init=False)
 class SelectOutput:
     r"""The output of the :class:`Select` method, which holds an assignment
     from selected nodes to their respective cluster(s).
@@ -23,7 +21,7 @@ class SelectOutput:
     num_nodes: int
     cluster_index: Tensor
     num_clusters: int
-    weight: Optional[Tensor] = None
+    weight: Optional[Tensor]
 
     def __init__(
         self,
@@ -60,9 +58,6 @@ class SelectOutput:
         self.cluster_index = cluster_index
         self.num_clusters = num_clusters
         self.weight = weight
-
-
-SelectOutput = torch.jit.script(SelectOutput)
 
 
 class Select(torch.nn.Module):


### PR DESCRIPTION
Fixes #10697.

`torch.jit.script` is deprecated in PyTorch 2.12 and emits a `DeprecationWarning` whether its called as a function or used as a decorator. The module level calls: 

    SelectOutput = torch.jit.script(SelectOutput)
    ConnectOutput = torch.jit.script(ConnectOutput)

in `select/base.py` and `connect/base.py` therefore raise the warning at import time, which `pyproject.toml`''s `error:.*torch_geometric.*` filter treats as a test error. There is a workaround in place (`ignore:.*torch.jit.*` further down in the filter list) but the deprecated call itself is still there.

This drops the scripting on both classes. They are now plain Python classes with type annotations and a custom `__init__`. `@dataclass(init=False)` is removed because it isn''t needed once we are not scripting the result (and the synthesized `__repr__` actually trips up TorchScript when downstream modules that return these types are scripted).

Verified on `torch==2.12.0`:

- import is clean (`-W error::DeprecationWarning` passes)
- `test/nn/pool/select/test_select_topk.py` and `test/nn/pool/connect/test_filter_edges.py` both pass (the `is_full_test()` JIT branches are not exercised by default, but I separately confirmed `torch.jit.script(FilterEdges())` still scripts correctly with the refactored `ConnectOutput`)
- broader `test/nn/pool/` suite: 28 passed, 16 skipped (unrelated optional deps)

The `ignore:.*torch.jit.*:DeprecationWarning` filter in `pyproject.toml` is left in place since the remaining `torch.jit.script(module)` calls in the `is_full_test()` paths still emit the same warning.

Screenshot:
<img width="2535" height="864" alt="Untitled" src="https://github.com/user-attachments/assets/8137ec83-4173-413d-b0d9-15c4ae90f10b" />
