### PR TITLE
Fix undirected negative sampling overlap in RandomLinkSplit

### DIFF
--- a/test/transforms/test_random_link_split.py
+++ b/test/transforms/test_random_link_split.py
@@ -336,3 +336,22 @@ def test_random_link_split_on_dataset(get_dataset):
     assert isinstance(test_dataset[0], Data)
     assert test_dataset[0].edge_label.min() == 0.0
     assert test_dataset[0].edge_label.max() == 1.0
+
+
+def test_random_link_split_undirected_overlap():
+    # Tests that negative samples do not leak across val/test when undirected
+    edge_index = to_undirected(torch.tensor([[0, 1, 2], [1, 2, 3]]))
+    data = Data(edge_index=edge_index, num_nodes=4)
+
+    transform = RandomLinkSplit(num_val=1, num_test=1, is_undirected=True,
+                                add_negative_train_samples=False)
+    train_data, val_data, test_data = transform(data)
+
+    val_neg = val_data.edge_label_index[:, val_data.edge_label == 0]
+    test_neg = test_data.edge_label_index[:, test_data.edge_label == 0]
+
+    val_neg_set = set(map(tuple, val_neg.t().tolist()))
+    test_neg_set = set(map(tuple, test_neg.t().tolist()))
+    test_neg_rev_set = set([(v, u) for u, v in test_neg_set])
+
+    assert not val_neg_set.intersection(test_neg_rev_set)

--- a/test/transforms/test_random_link_split.py
+++ b/test/transforms/test_random_link_split.py
@@ -352,6 +352,6 @@ def test_random_link_split_undirected_overlap():
 
     val_neg_set = set(map(tuple, val_neg.t().tolist()))
     test_neg_set = set(map(tuple, test_neg.t().tolist()))
-    test_neg_rev_set = set([(v, u) for u, v in test_neg_set])
+    test_neg_rev_set = {(v, u) for u, v in test_neg_set}
 
     assert not val_neg_set.intersection(test_neg_rev_set)

--- a/torch_geometric/transforms/random_link_split.py
+++ b/torch_geometric/transforms/random_link_split.py
@@ -234,9 +234,18 @@ class RandomLinkSplit(BaseTransform):
             size = store.size()
             if store._key is None or store._key[0] == store._key[-1]:
                 size = size[0]
+
+            num_neg_samples = num_neg
+            if is_undirected:
+                num_neg_samples = num_neg * 2
+
             neg_edge_index = negative_sampling(edge_index, size,
-                                               num_neg_samples=num_neg,
-                                               method='sparse')
+                                               num_neg_samples=num_neg_samples,
+                                               method='sparse',
+                                               force_undirected=is_undirected)
+
+            if is_undirected:
+                neg_edge_index = neg_edge_index[:, :num_neg]
 
             # Adjust ratio if not enough negative edges exist
             if neg_edge_index.size(1) < num_neg:


### PR DESCRIPTION
Fixes #10706. RandomLinkSplit with is_undirected=True used to generate negative samples across the full edge index space without forcing undirected sampling, which caused independent negative edges to overlap when split across the validation and test sets (e.g., (a,b) in val, (b,a) in test). This fix passes orce_undirected=is_undirected and correctly slices the unique pairs to prevent leakage. Added a regression test.