### PR TITLE
Add HomologySanitizer transform for anomalous cyclic subgraph detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- Added `HomologySanitizer` transform for anomalous cyclic subgraph detection ([#10721](https://github.com/pyg-team/pytorch_geometric/pull/10721))
+
 ### Changed
 
 ### Deprecated

--- a/test/transforms/test_homology_sanitizer.py
+++ b/test/transforms/test_homology_sanitizer.py
@@ -26,8 +26,8 @@ def test_homology_sanitizer_trigger_removal():
     out = transform(data)
 
     # Clique edges should be removed; tree edges should remain
-    out_set = set(tuple(e) for e in out.edge_index.t().tolist())
-    tree_set = set(tuple(e) for e in tree_edges.t().tolist())
+    out_set = {tuple(e) for e in out.edge_index.t().tolist()}
+    tree_set = {tuple(e) for e in tree_edges.t().tolist()}
 
     assert tree_set.issubset(out_set), "Tree edges were incorrectly removed"
 
@@ -77,8 +77,8 @@ def test_homology_sanitizer_community_isolation():
     out = transform(data)
 
     # Tree component should be untouched
-    out_set = set(tuple(e) for e in out.edge_index.t().tolist())
-    tree_set = set(tuple(e) for e in tree.t().tolist())
+    out_set = {tuple(e) for e in out.edge_index.t().tolist()}
+    tree_set = {tuple(e) for e in tree.t().tolist()}
     assert tree_set.issubset(out_set)
 
     # Trigger component should be pruned
@@ -142,8 +142,7 @@ def test_homology_sanitizer_fast_path():
 
 @withPackage('networkx', 'scipy')
 def test_homology_sanitizer_repr():
-    transform = HomologySanitizer(
-        threshold=3, ego_hops=1, community_cycle_ratio=0.5)
-    assert str(transform) == (
-        'HomologySanitizer(threshold=3, ego_hops=1, '
-        'community_cycle_ratio=0.5)')
+    transform = HomologySanitizer(threshold=3, ego_hops=1,
+                                  community_cycle_ratio=0.5)
+    assert str(transform) == ('HomologySanitizer(threshold=3, ego_hops=1, '
+                              'community_cycle_ratio=0.5)')

--- a/test/transforms/test_homology_sanitizer.py
+++ b/test/transforms/test_homology_sanitizer.py
@@ -1,0 +1,149 @@
+import torch
+
+from torch_geometric.data import Data
+from torch_geometric.testing import withPackage
+from torch_geometric.transforms import HomologySanitizer
+
+
+@withPackage('networkx', 'scipy')
+def test_homology_sanitizer_trigger_removal():
+    # Build a tree (Betti-1 = 0)
+    tree_edges = torch.tensor([
+        [0, 1, 1, 2, 2, 3, 3, 4],
+        [1, 0, 2, 1, 3, 2, 4, 3],
+    ])
+    # Attach a 5-clique trigger (nodes 5-9)
+    clique_edges = []
+    for i in range(5, 10):
+        for j in range(i + 1, 10):
+            clique_edges.append([i, j])
+            clique_edges.append([j, i])
+    clique_edges_t = torch.tensor(clique_edges).t()
+    edge_index = torch.cat([tree_edges, clique_edges_t], dim=1)
+    data = Data(edge_index=edge_index, num_nodes=10)
+
+    transform = HomologySanitizer(threshold=2, ego_hops=2)
+    out = transform(data)
+
+    # Clique edges should be removed; tree edges should remain
+    out_set = set(tuple(e) for e in out.edge_index.t().tolist())
+    tree_set = set(tuple(e) for e in tree_edges.t().tolist())
+
+    assert tree_set.issubset(out_set), "Tree edges were incorrectly removed"
+
+    # None of the clique edges should remain (both endpoints anomalous)
+    for i in range(5, 10):
+        for j in range(i + 1, 10):
+            assert (i, j) not in out_set
+            assert (j, i) not in out_set
+
+
+@withPackage('networkx', 'scipy')
+def test_homology_sanitizer_clean_graph():
+    # Sparse ER graph with low cycle density
+    torch.manual_seed(42)
+    num_nodes = 50
+    p = 0.05
+    edge_list = []
+    for i in range(num_nodes):
+        for j in range(i + 1, num_nodes):
+            if torch.rand(1).item() < p:
+                edge_list.append([i, j])
+    if len(edge_list) == 0:
+        edge_list = [[0, 1]]
+    edge_index = torch.tensor(edge_list).t()
+    data = Data(edge_index=edge_index, num_nodes=num_nodes)
+
+    transform = HomologySanitizer(threshold=2, community_cycle_ratio=0.5)
+    out = transform(data)
+
+    # With a high threshold, no edges should be removed from a sparse graph
+    assert out.edge_index.shape[1] == data.edge_index.shape[1]
+
+
+@withPackage('networkx', 'scipy')
+def test_homology_sanitizer_community_isolation():
+    # Two disconnected components: tree + dense trigger
+    tree = torch.tensor([[0, 1, 2, 3], [1, 2, 3, 4]])
+    trigger = []
+    for i in range(5, 10):
+        for j in range(i + 1, 10):
+            trigger.extend([[i, j], [j, i]])
+    trigger = torch.tensor(trigger).t()
+    edge_index = torch.cat([tree, trigger], dim=1)
+    data = Data(edge_index=edge_index, num_nodes=10)
+
+    transform = HomologySanitizer(threshold=2)
+    out = transform(data)
+
+    # Tree component should be untouched
+    out_set = set(tuple(e) for e in out.edge_index.t().tolist())
+    tree_set = set(tuple(e) for e in tree.t().tolist())
+    assert tree_set.issubset(out_set)
+
+    # Trigger component should be pruned
+    for i in range(5, 10):
+        for j in range(i + 1, 10):
+            assert (i, j) not in out_set
+
+
+@withPackage('networkx', 'scipy')
+def test_homology_sanitizer_edge_attr():
+    tree_edges = torch.tensor([
+        [0, 1, 1, 2, 2, 3, 3, 4],
+        [1, 0, 2, 1, 3, 2, 4, 3],
+    ])
+    clique_edges = []
+    for i in range(5, 10):
+        for j in range(i + 1, 10):
+            clique_edges.append([i, j])
+            clique_edges.append([j, i])
+    clique_edges_t = torch.tensor(clique_edges).t()
+    edge_index = torch.cat([tree_edges, clique_edges_t], dim=1)
+    edge_attr = torch.arange(edge_index.shape[1], dtype=torch.float)
+    data = Data(edge_index=edge_index, edge_attr=edge_attr, num_nodes=10)
+
+    transform = HomologySanitizer(threshold=2)
+    out = transform(data)
+
+    # Edge attr should be filtered in sync with edge_index
+    assert out.edge_attr.shape[0] == out.edge_index.shape[1]
+
+    # Verify tree edge attributes preserved by value matching
+    out_edge_dict = {}
+    for i in range(out.edge_index.shape[1]):
+        src = int(out.edge_index[0, i])
+        dst = int(out.edge_index[1, i])
+        out_edge_dict[(src, dst)] = float(out.edge_attr[i])
+
+    in_edge_dict = {}
+    for i in range(data.edge_index.shape[1]):
+        src = int(data.edge_index[0, i])
+        dst = int(data.edge_index[1, i])
+        in_edge_dict[(src, dst)] = float(data.edge_attr[i])
+
+    for e in tree_edges.t().tolist():
+        assert out_edge_dict[tuple(e)] == in_edge_dict[tuple(e)]
+
+
+@withPackage('networkx', 'scipy')
+def test_homology_sanitizer_fast_path():
+    # Synthetic graph larger than fast_path_limit
+    num_nodes = 6000
+    edge_index = torch.tensor([[0, 1], [1, 0]])
+    data = Data(edge_index=edge_index, num_nodes=num_nodes)
+
+    transform = HomologySanitizer(threshold=2, fast_path_limit=5000)
+    out = transform(data)
+
+    # Fast path should not crash; with only one edge no pruning occurs
+    assert out.edge_index.shape[1] == 2
+
+
+@withPackage('networkx', 'scipy')
+def test_homology_sanitizer_repr():
+    transform = HomologySanitizer(
+        threshold=3, ego_hops=1, community_cycle_ratio=0.5)
+    assert str(transform) == (
+        'HomologySanitizer(threshold=3, ego_hops=1, '
+        'community_cycle_ratio=0.5)')

--- a/torch_geometric/transforms/__init__.py
+++ b/torch_geometric/transforms/__init__.py
@@ -40,6 +40,7 @@ from .add_positional_encoding import AddLaplacianEigenvectorPE, AddRandomWalkPE
 from .add_gpse import AddGPSE
 from .feature_propagation import FeaturePropagation
 from .half_hop import HalfHop
+from .homology_sanitizer import HomologySanitizer
 
 from .distance import Distance
 from .cartesian import Cartesian
@@ -112,6 +113,7 @@ graph_transforms = [
     'AddGPSE',
     'FeaturePropagation',
     'HalfHop',
+    'HomologySanitizer',
 ]
 
 vision_transforms = [

--- a/torch_geometric/transforms/homology_sanitizer.py
+++ b/torch_geometric/transforms/homology_sanitizer.py
@@ -76,8 +76,8 @@ class HomologySanitizer(BaseTransform):
                 continue
 
             # Convert to undirected for cycle analysis
-            edge_index_undirected = to_undirected(
-                edge_index, num_nodes=num_nodes)
+            edge_index_undirected = to_undirected(edge_index,
+                                                  num_nodes=num_nodes)
             edge_list = edge_index_undirected.t().cpu().numpy()
 
             # Import optional dependencies lazily
@@ -125,12 +125,10 @@ class HomologySanitizer(BaseTransform):
 
             # --- Phase 2: Ego-Network Surgical Audit ---
             anomalous_nodes = set()
-            run_exact = (
-                self.use_exact and
-                (self.fast_path_limit is None or
-                 num_nodes <= self.fast_path_limit) and
-                len(suspicious_nodes) > 0
-            )
+            run_exact = (self.use_exact
+                         and (self.fast_path_limit is None
+                              or num_nodes <= self.fast_path_limit)
+                         and len(suspicious_nodes) > 0)
 
             if run_exact:
                 G = nx.Graph()
@@ -161,11 +159,14 @@ class HomologySanitizer(BaseTransform):
                 continue
 
             anomalous_tensor = torch.tensor(
-                sorted(anomalous_nodes), dtype=torch.long,
+                sorted(anomalous_nodes),
+                dtype=torch.long,
                 device=edge_index.device,
             )
             is_anomalous = torch.zeros(
-                num_nodes, dtype=torch.bool, device=edge_index.device,
+                num_nodes,
+                dtype=torch.bool,
+                device=edge_index.device,
             )
             is_anomalous[anomalous_tensor] = True
 

--- a/torch_geometric/transforms/homology_sanitizer.py
+++ b/torch_geometric/transforms/homology_sanitizer.py
@@ -1,0 +1,196 @@
+from typing import Optional, Union
+
+import torch
+
+from torch_geometric.data import Data, HeteroData
+from torch_geometric.data.datapipes import functional_transform
+from torch_geometric.transforms import BaseTransform
+from torch_geometric.utils import to_undirected
+
+
+@functional_transform('homology_sanitizer')
+class HomologySanitizer(BaseTransform):
+    r"""Detects and removes anomalously dense cyclic subgraphs (topological
+    homology backdoor triggers) from a homogeneous or heterogeneous graph.
+
+    This transform uses a two-phase cascade:
+
+    1. **Community Anomaly Screening:** Computes the normalized cycle density
+       of each connected component. Components with density exceeding
+       :obj:`community_cycle_ratio` are flagged as suspicious.
+    2. **Ego-Network Surgical Audit:** Inside suspicious components, extracts
+       the :obj:`ego_hops`-hop ego network for each node and computes its
+       exact Betti-1 number (independent cycle count). Nodes whose ego
+       network has a Betti-1 number ≥ :obj:`threshold` are flagged as
+       anomalous, and all edges between pairs of anomalous nodes are
+       removed.
+
+    For massive graphs (:obj:`num_nodes > fast_path_limit`), Phase 2 is
+    skipped and only Phase 1 is used. Setting :obj:`use_exact=False`
+    also disables Phase 2 unconditionally.
+
+    Args:
+        threshold (int): Minimum Betti-1 number of an ego network to flag
+            its center node as anomalous. (default: :obj:`2`)
+        ego_hops (int): Hop radius for ego-network extraction in Phase 2.
+            (default: :obj:`2`)
+        community_cycle_ratio (float): Normalized cycle-density threshold
+            for Phase 1. A component is suspicious if
+            :obj:`(E - V + C) / V > community_cycle_ratio`.
+            (default: :obj:`0.3`)
+        fast_path_limit (int, optional): If :obj:`data.num_nodes` exceeds
+            this value, skip Phase 2. :obj:`None` disables the fast path.
+            (default: :obj:`5000`)
+        use_exact (bool): Whether to run Phase 2 at all. If :obj:`False`,
+            only Phase 1 is used regardless of graph size.
+            (default: :obj:`True`)
+    """
+    def __init__(
+        self,
+        threshold: int = 2,
+        ego_hops: int = 2,
+        community_cycle_ratio: float = 0.3,
+        fast_path_limit: Optional[int] = 5000,
+        use_exact: bool = True,
+    ) -> None:
+        self.threshold = threshold
+        self.ego_hops = ego_hops
+        self.community_cycle_ratio = community_cycle_ratio
+        self.fast_path_limit = fast_path_limit
+        self.use_exact = use_exact
+
+    def forward(
+        self,
+        data: Union[Data, HeteroData],
+    ) -> Union[Data, HeteroData]:
+        for store in data.edge_stores:
+            if 'edge_index' not in store or store.edge_index.numel() == 0:
+                continue
+
+            edge_index = store.edge_index
+
+            # Determine node-space size for this edge store
+            size = [s for s in store.size() if s is not None]
+            num_nodes = max(size) if len(size) > 0 else None
+            if num_nodes is None or num_nodes == 0:
+                continue
+
+            # Convert to undirected for cycle analysis
+            edge_index_undirected = to_undirected(
+                edge_index, num_nodes=num_nodes)
+            edge_list = edge_index_undirected.t().cpu().numpy()
+
+            # Import optional dependencies lazily
+            try:
+                import networkx as nx
+                import numpy as np
+                from scipy.sparse import csr_matrix
+                from scipy.sparse.csgraph import connected_components
+            except ImportError as e:
+                raise ImportError(
+                    f"'{self.__class__.__name__}' requires 'networkx' "
+                    f"and 'scipy'. Install them via 'pip install "
+                    f"networkx scipy'.") from e
+
+            # --- Phase 1: Community Anomaly Screening ---
+            adj = csr_matrix(
+                (np.ones(edge_list.shape[0]),
+                 (edge_list[:, 0], edge_list[:, 1])),
+                shape=(num_nodes, num_nodes),
+            )
+            # Symmetrise (undirected) and binarise
+            adj = adj.maximum(adj.T)
+            adj.data = np.ones_like(adj.data)
+
+            n_components, labels = connected_components(
+                csgraph=adj, directed=False, return_labels=True)
+
+            # Compute cycle density per component and collect suspicious nodes
+            suspicious_nodes = set()
+            for comp_id in range(n_components):
+                nodes_in_comp = np.where(labels == comp_id)[0]
+                v = int(nodes_in_comp.shape[0])
+                if v == 0:
+                    continue
+
+                # Count unique undirected edges internal to the component
+                mask_src = np.isin(edge_list[:, 0], nodes_in_comp)
+                mask_dst = np.isin(edge_list[:, 1], nodes_in_comp)
+                internal_edges = edge_list[mask_src & mask_dst]
+                e = int(internal_edges.shape[0]) // 2
+
+                cycle_density = (e - v + 1) / v
+                if cycle_density > self.community_cycle_ratio:
+                    suspicious_nodes.update(nodes_in_comp.tolist())
+
+            # --- Phase 2: Ego-Network Surgical Audit ---
+            anomalous_nodes = set()
+            run_exact = (
+                self.use_exact and
+                (self.fast_path_limit is None or
+                 num_nodes <= self.fast_path_limit) and
+                len(suspicious_nodes) > 0
+            )
+
+            if run_exact:
+                G = nx.Graph()
+                G.add_nodes_from(range(num_nodes))
+                G.add_edges_from(edge_list.tolist())
+
+                for node in suspicious_nodes:
+                    ego = nx.ego_graph(G, node, radius=self.ego_hops)
+                    v_ego = ego.number_of_nodes()
+                    if v_ego == 0:
+                        continue
+
+                    # Quick lower-bound: a tree has E = V - 1
+                    e_ego = ego.number_of_edges()
+                    if e_ego < v_ego + self.threshold - 1:
+                        continue
+
+                    c_ego = nx.number_connected_components(ego)
+                    betti_1 = e_ego - v_ego + c_ego
+                    if betti_1 >= self.threshold:
+                        anomalous_nodes.add(node)
+            elif not self.use_exact and len(suspicious_nodes) > 0:
+                # Fallback: treat all suspicious nodes as anomalous
+                anomalous_nodes = suspicious_nodes
+
+            # --- Mitigation: prune edges between anomalous nodes ---
+            if len(anomalous_nodes) == 0:
+                continue
+
+            anomalous_tensor = torch.tensor(
+                sorted(anomalous_nodes), dtype=torch.long,
+                device=edge_index.device,
+            )
+            is_anomalous = torch.zeros(
+                num_nodes, dtype=torch.bool, device=edge_index.device,
+            )
+            is_anomalous[anomalous_tensor] = True
+
+            # Build mask on the *original* edge_index (preserves direction)
+            src = edge_index[0]
+            dst = edge_index[1]
+            keep_mask = ~(is_anomalous[src] & is_anomalous[dst])
+
+            # Collect edge attributes *before* mutating edge_index so that
+            # is_edge_attr() still evaluates against the original num_edges.
+            edge_attr_keys = [
+                key for key in store.keys()
+                if key != 'edge_index' and store.is_edge_attr(key)
+            ]
+
+            store.edge_index = edge_index[:, keep_mask]
+
+            # Filter edge-level attributes in lock-step
+            for key in edge_attr_keys:
+                store[key] = store[key][keep_mask]
+
+        return data
+
+    def __repr__(self) -> str:
+        return (f'{self.__class__.__name__}('
+                f'threshold={self.threshold}, '
+                f'ego_hops={self.ego_hops}, '
+                f'community_cycle_ratio={self.community_cycle_ratio})')


### PR DESCRIPTION
Introduces a new transform that detects anomalous cyclic subgraphs via persistent homology. Useful for sanitizing graph datasets containing spurious loops or cycles that may degrade GNN performance.