### PR TITLE
fix: NO_MKL is true if USE_MKL is an empty string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- Fix `NO_MKL` is true if `USE_MKL` is an empty string
+
 ### Security
 
 ## [2.8.0] - 2026-06-05

--- a/torch_geometric/typing.py
+++ b/torch_geometric/typing.py
@@ -25,7 +25,7 @@ WITH_PT212 = WITH_PT20 and int(torch.__version__.split('.')[1]) >= 12
 WITH_PT113 = WITH_PT20 or int(torch.__version__.split('.')[1]) >= 13
 
 WITH_WINDOWS = os.name == 'nt'
-NO_MKL = 'USE_MKL=OFF' in torch.__config__.show() or WITH_WINDOWS
+NO_MKL = 'USE_MKL=ON' not in torch.__config__.show() or WITH_WINDOWS
 
 MAX_INT64 = torch.iinfo(torch.int64).max
 


### PR DESCRIPTION
PyTorch sets `USE_MK` as an empty string in the bazel build. This is due to a limitation of bazel when using the `cmake_configure_file` rule.
https://github.com/pytorch/pytorch/blob/80af7b35bb25e48f647d25e4e6864a908380a88f/build.bzl#L14-L27

This change just changes the logic to check that `USE_MKL=ON` is `in torch.__config__.show()` to determine if it has `MKL` available.