### PR TITLE
fix: multiplying two CPU-based Sparse CSR tensors without  support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+-Fix multiplying two CPU-based Sparse CSR tensors without `MKL` support.
+
 ### Security
 
 ## [2.8.0] - 2026-06-05

--- a/torch_geometric/nn/models/graph_unet.py
+++ b/torch_geometric/nn/models/graph_unet.py
@@ -3,12 +3,14 @@ from typing import Callable, List, Union
 import torch
 from torch import Tensor
 
+import torch_geometric.typing
 from torch_geometric.nn import GCNConv, TopKPooling
 from torch_geometric.nn.resolver import activation_resolver
 from torch_geometric.typing import OptTensor, PairTensor
 from torch_geometric.utils import (
     add_self_loops,
     remove_self_loops,
+    to_torch_coo_tensor,
     to_torch_csr_tensor,
 )
 from torch_geometric.utils.repeat import repeat
@@ -140,8 +142,12 @@ class GraphUNet(torch.nn.Module):
         edge_index, edge_weight = remove_self_loops(edge_index, edge_weight)
         edge_index, edge_weight = add_self_loops(edge_index, edge_weight,
                                                  num_nodes=num_nodes)
-        adj = to_torch_csr_tensor(edge_index, edge_weight,
-                                  size=(num_nodes, num_nodes))
+        if torch_geometric.typing.NO_MKL:  # pragma: no cover
+            adj = to_torch_coo_tensor(edge_index, edge_weight,
+                                      size=(num_nodes, num_nodes))
+        else:
+            adj = to_torch_csr_tensor(edge_index, edge_weight,
+                                      size=(num_nodes, num_nodes))
         adj = (adj @ adj).to_sparse_coo()
         edge_index, edge_weight = adj.indices(), adj.values()
         edge_index, edge_weight = remove_self_loops(edge_index, edge_weight)

--- a/torch_geometric/nn/pool/asap.py
+++ b/torch_geometric/nn/pool/asap.py
@@ -5,6 +5,7 @@ import torch.nn.functional as F
 from torch import Tensor
 from torch.nn import Linear
 
+import torch_geometric.typing
 from torch_geometric.nn import LEConv
 from torch_geometric.nn.pool.select import SelectTopK
 from torch_geometric.utils import (
@@ -144,10 +145,16 @@ class ASAPooling(torch.nn.Module):
         batch = batch[perm]
 
         # Graph coarsening.
-        A = to_torch_csr_tensor(edge_index, edge_weight, size=(N, N))
-        S = to_torch_coo_tensor(edge_index, score, size=(N, N))
-        S = S.index_select(1, perm).to_sparse_csr()
-        A = S.t().to_sparse_csr() @ (A @ S)
+        if torch_geometric.typing.NO_MKL:  # pragma: no cover
+            A = to_torch_coo_tensor(edge_index, edge_weight, size=(N, N))
+            S = to_torch_coo_tensor(edge_index, score, size=(N, N))
+            S = S.index_select(1, perm)
+            A = S.t() @ (A @ S)
+        else:
+            A = to_torch_csr_tensor(edge_index, edge_weight, size=(N, N))
+            S = to_torch_coo_tensor(edge_index, score, size=(N, N))
+            S = S.index_select(1, perm).to_sparse_csr()
+            A = S.t().to_sparse_csr() @ (A @ S)
 
         if edge_weight is None:
             edge_index, _ = to_edge_index(A)


### PR DESCRIPTION
Without Intel MKL support enabled in PyTorch CPU builds, PyTorch lacks support for multiplying two CPU-based Sparse CSR tensors (`SparseCsr @ SparseCsr`), throwing the error: `addmm: computation on CPU is not implemented for SparseCsr + SparseCsr @ SparseCsr without MKL.`

In the codebase, this issue occurs during graph coarsening/augmentation at two locations where CSR matrix multiplications are performed on CPU:

1. `ASAPooling.forward` in  `asap.py` does `S.t().to_sparse_csr() @ (A @ S)` using CSR tensors.
2. `GraphUNet.augment_adj` in `graph_unet.py` does `adj @ adj` using CSR tensors.

This change implemements a fallback CPU path.
