### PR TITLE
Fix write-permission errors in test_profile.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- Fix write-permission errors in test_profile.py
+
 ### Security
 
 ## [2.8.0] - 2026-06-05

--- a/test/profile/test_profile.py
+++ b/test/profile/test_profile.py
@@ -23,6 +23,14 @@ from torch_geometric.testing import (
 )
 
 
+@pytest.fixture(autouse=True)
+def chdir_to_tmp_path(tmp_path):
+    old_cwd = os.getcwd()
+    os.chdir(tmp_path)
+    yield
+    os.chdir(old_cwd)
+
+
 @withDevice
 @onlyLinux
 def test_timeit(device):


### PR DESCRIPTION
This fixture, `chdir_to_tmp_path`, is needed because the profiling tests write profiling output files to the current working directory which doesn't have write permissions in our environment.

