### PR TITLE
add description of "Theta x_i" in docs for NNConv

### DIFF
--- a/torch_geometric/nn/conv/nn_conv.py
+++ b/torch_geometric/nn/conv/nn_conv.py
@@ -26,7 +26,8 @@ class NNConv(MessagePassing):
         h_{\mathbf{\Theta}}(\mathbf{e}_{i,j}),
 
     where :math:`h_{\mathbf{\Theta}}` denotes a neural network, *.i.e.*
-    a MLP.
+    a MLP. The term :math:`\mathbf{\Theta} \mathbf{x}_i` denotes the
+    optional root-node linear transform controlled by :obj:`root_weight`.
 
     Args:
         in_channels (int or tuple): Size of each input sample, or :obj:`-1` to


### PR DESCRIPTION
I had trouble understanding the docstring for [NNConv](https://pytorch-geometric.readthedocs.io/en/stable/generated/torch_geometric.nn.conv.NNConv.html), as `\Theta` is used both for the linear transformation of the root node and for the parameterization of the of the nn for the edges. 

I had to check the source code to understand what's actually going on here. This extra sentence makes it a bit less ambiguous I think.


(thanks for creating this nice library, I hope I can contribute a bit with housekeeping work like this)