### PR TITLE
Add 'Attri2Vec' model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- Added `Attri2Vec` model and example ([#10734](https://github.com/pyg-team/pytorch_geometric/pull/10734))
 - Added `torch_geometric.contrib.nn.models.MGNAN` (M-GNAN, an extension of `GNAN` to multivariate shape functions) model plus an example ([#10371](https://github.com/pyg-team/pytorch_geometric/pull/10371))
 
 ### Changed

--- a/examples/attri2vec.py
+++ b/examples/attri2vec.py
@@ -14,15 +14,15 @@ data = dataset[0]
 
 device = 'cuda' if torch.cuda.is_available() else 'cpu'
 model = Attri2Vec(
-        data.edge_index,
-        data.x,
-        embedding_dim=128,
-        walk_length=20,
-        context_size=10,
-        walks_per_node=10,
-        num_negative_samples=1,
-        mapping='linear',
-        sparse=False,
+    data.edge_index,
+    data.x,
+    embedding_dim=128,
+    walk_length=20,
+    context_size=10,
+    walks_per_node=10,
+    num_negative_samples=1,
+    mapping='linear',
+    sparse=False,
 ).to(device)
 
 num_workers = 4 if sys.platform == 'linux' else 0

--- a/examples/attri2vec.py
+++ b/examples/attri2vec.py
@@ -1,0 +1,82 @@
+import os.path as osp
+import sys
+
+import matplotlib.pyplot as plt
+import torch
+from sklearn.manifold import TSNE
+
+from torch_geometric.datasets import Planetoid
+from torch_geometric.nn import Attri2Vec
+
+path = osp.join(osp.dirname(osp.realpath(__file__)), '..', 'data', 'Planetoid')
+dataset = Planetoid(path, name='Cora')
+data = dataset[0]
+
+device = 'cuda' if torch.cuda.is_available() else 'cpu'
+model = Attri2Vec(
+        data.edge_index,
+        data.x,
+        embedding_dim=128,
+        walk_length=20,
+        context_size=10,
+        walks_per_node=10,
+        num_negative_samples=1,
+        mapping='linear',
+        sparse=False,
+).to(device)
+
+num_workers = 4 if sys.platform == 'linux' else 0
+loader = model.loader(batch_size=128, shuffle=True, num_workers=num_workers)
+optimizer = torch.optim.Adam(model.parameters(), lr=0.01)
+
+
+def train():
+    model.train()
+    total_loss = 0
+    for pos_rw, neg_rw in loader:
+        optimizer.zero_grad()
+        loss = model.loss(pos_rw.to(device), neg_rw.to(device))
+        loss.backward()
+        optimizer.step()
+        total_loss += loss.item()
+    return total_loss / len(loader)
+
+
+@torch.no_grad()
+def test():
+    model.eval()
+    z = model()
+    acc = model.test(
+        train_z=z[data.train_mask],
+        train_y=data.y[data.train_mask],
+        test_z=z[data.test_mask],
+        test_y=data.y[data.test_mask],
+        max_iter=150,
+    )
+    return acc
+
+
+for epoch in range(1, 101):
+    loss = train()
+    acc = test()
+    print(f'Epoch: {epoch:03d}, Loss: {loss:.4f}, Acc: {acc:.4f}')
+
+
+@torch.no_grad()
+def plot_points(colors):
+    model.eval()
+    z = model().cpu().numpy()
+    z = TSNE(n_components=2).fit_transform(z)
+    y = data.y.cpu().numpy()
+
+    plt.figure(figsize=(8, 8))
+    for i in range(dataset.num_classes):
+        plt.scatter(z[y == i, 0], z[y == i, 1], s=20, color=colors[i])
+    plt.axis('off')
+    plt.show()
+
+
+colors = [
+    '#ffc0cb', '#bada55', '#008080', '#420420', '#7fe5f0', '#065535', '#ffd700'
+]
+plot_points(colors)

--- a/test/nn/models/test_attri2vec.py
+++ b/test/nn/models/test_attri2vec.py
@@ -1,0 +1,62 @@
+import pytest
+import torch
+
+from torch_geometric.nn import Attri2Vec
+from torch_geometric.testing import (
+    has_package,
+    is_full_test,
+    withDevice,
+    withPackage,
+)
+
+
+@withDevice
+@withPackage('pyg_lib')
+@pytest.mark.parametrize('mapping', ['linear', 'relu', 'sigmoid', 'kernel'])
+def test_attri2vec(device, mapping):
+    edge_index = torch.tensor([[0, 1, 1, 2], [1, 0, 2, 1]], device=device)
+    x = torch.randn(3, 16, device=device)
+    model = Attri2Vec(edge_index,
+                      x,
+                      embedding_dim=32,
+                      walk_length=5,
+                      context_size=3,
+                      mapping=mapping).to(device)
+    assert str(model) == 'Attri2Vec(3, 32)'
+    assert model(torch.arange(3, device=device)).size() == (3, 32)
+
+    pos_rw, neg_rw = model.sample(torch.arange(3))
+    assert float(
+        model.loss(pos_rw.to(device), neg_rw.to(device)).detach()
+    ) >= 0
+
+    if has_package('sklearn'):
+        acc = model.test(torch.ones(20, 32), torch.randint(10, (20, )),
+                         torch.ones(20, 32), torch.randint(10, (20, )))
+        assert 0 <= acc <= 1
+
+    if is_full_test():
+        jit = torch.jit.script(model)
+        assert jit(torch.arange(3, device=device)).size() == (3, 32)
+        pos_rw, neg_rw = jit.sample(torch.arange(3))
+        assert float(
+            jit.loss(pos_rw.to(device), neg_rw.to(device)).detach()
+        ) >= 0
+
+
+@withPackage('pyg_lib')
+def test_attri2vec_kernel_odd_dim():
+    edge_index = torch.tensor([[0, 1, 1, 2], [1, 0, 2, 1]])
+    x = torch.randn(3, 16)
+    with pytest.raises(AssertionError):
+        Attri2Vec(edge_index, x, embedding_dim=33, walk_length=5,
+                  context_size=3, mapping='kernel')
+
+
+@withPackage('pyg_lib')
+def test_attri2vec_sparse():
+    edge_index = torch.tensor([[0, 1, 1, 2], [1, 0, 2, 1]])
+    x = torch.randn(3, 16)
+    model = Attri2Vec(edge_index, x, embedding_dim=32, walk_length=5,
+                      context_size=3, sparse=True)
+    assert model.embedding.sparse

--- a/test/nn/models/test_attri2vec.py
+++ b/test/nn/models/test_attri2vec.py
@@ -16,19 +16,14 @@ from torch_geometric.testing import (
 def test_attri2vec(device, mapping):
     edge_index = torch.tensor([[0, 1, 1, 2], [1, 0, 2, 1]], device=device)
     x = torch.randn(3, 16, device=device)
-    model = Attri2Vec(edge_index,
-                      x,
-                      embedding_dim=32,
-                      walk_length=5,
-                      context_size=3,
-                      mapping=mapping).to(device)
+    model = Attri2Vec(edge_index, x, embedding_dim=32, walk_length=5,
+                      context_size=3, mapping=mapping).to(device)
     assert str(model) == 'Attri2Vec(3, 32)'
     assert model(torch.arange(3, device=device)).size() == (3, 32)
 
     pos_rw, neg_rw = model.sample(torch.arange(3))
-    assert float(
-        model.loss(pos_rw.to(device), neg_rw.to(device)).detach()
-    ) >= 0
+    assert float(model.loss(pos_rw.to(device),
+                            neg_rw.to(device)).detach()) >= 0
 
     if has_package('sklearn'):
         acc = model.test(torch.ones(20, 32), torch.randint(10, (20, )),
@@ -39,9 +34,8 @@ def test_attri2vec(device, mapping):
         jit = torch.jit.script(model)
         assert jit(torch.arange(3, device=device)).size() == (3, 32)
         pos_rw, neg_rw = jit.sample(torch.arange(3))
-        assert float(
-            jit.loss(pos_rw.to(device), neg_rw.to(device)).detach()
-        ) >= 0
+        assert float(jit.loss(pos_rw.to(device),
+                              neg_rw.to(device)).detach()) >= 0
 
 
 @withPackage('pyg_lib')

--- a/torch_geometric/nn/models/__init__.py
+++ b/torch_geometric/nn/models/__init__.py
@@ -37,6 +37,7 @@ from .polynormer import Polynormer
 from torch_geometric.explain.algorithm.captum import (to_captum_input,
                                                       captum_output_to_dicts)
 from .attract_repel import ARLinkPredictor
+from .attri2vec import Attri2Vec
 
 __all__ = classes = [
     'MLP',
@@ -86,4 +87,5 @@ __all__ = classes = [
     'SGFormer',
     'Polynormer',
     'ARLinkPredictor',
+    'Attri2Vec',
 ]

--- a/torch_geometric/nn/models/attri2vec.py
+++ b/torch_geometric/nn/models/attri2vec.py
@@ -1,4 +1,5 @@
-from typing import Optional, Tuple, List, Union
+from typing import List, Optional, Tuple, Union
+
 import torch
 import torch.nn.functional as F
 from torch import Tensor
@@ -83,11 +84,8 @@ class Attri2Vec(torch.nn.Module):
         else:
             self.lin = Linear(num_features, embedding_dim, bias=False)
 
-        self.embedding = Embedding(
-            self.num_nodes,
-            embedding_dim,
-            sparse=sparse
-        )
+        self.embedding = Embedding(self.num_nodes, embedding_dim,
+                                   sparse=sparse)
 
         self.reset_parameters()
 
@@ -115,16 +113,14 @@ class Attri2Vec(torch.nn.Module):
             return torch.sigmoid(self.lin(x))
         elif self.mapping == 'kernel':
             z = self.lin(x)
-            scale = (self.embedding_dim / 2) ** -0.5
+            scale = (self.embedding_dim / 2)**-0.5
             return scale * torch.cat([torch.cos(z), torch.sin(z)], dim=-1)
         else:
             raise ValueError(f"Unknown mapping: {self.mapping!r}")
 
     def loader(self, **kwargs) -> DataLoader:
-        return DataLoader(range(self.num_nodes),
-                          collate_fn=self.sample,
-                          **kwargs
-                          )
+        return DataLoader(range(self.num_nodes), collate_fn=self.sample,
+                          **kwargs)
 
     @torch.jit.export
     def pos_sample(self, batch: Tensor) -> Tensor:
@@ -165,11 +161,9 @@ class Attri2Vec(torch.nn.Module):
         r"""Computes the loss given positive and negative random walks."""
         start, rest = pos_rw[:, 0], pos_rw[:, 1:].contiguous()
 
-        h_start = self._transform(self.x[start]).view(pos_rw.size(0),
-                                                      1,
+        h_start = self._transform(self.x[start]).view(pos_rw.size(0), 1,
                                                       self.embedding_dim)
-        h_rest = self.embedding(rest.view(-1)).view(pos_rw.size(0),
-                                                    -1,
+        h_rest = self.embedding(rest.view(-1)).view(pos_rw.size(0), -1,
                                                     self.embedding_dim)
 
         out = (h_start * h_rest).sum(dim=-1).view(-1)
@@ -178,11 +172,9 @@ class Attri2Vec(torch.nn.Module):
         # Negative loss.
         start, rest = neg_rw[:, 0], neg_rw[:, 1:].contiguous()
 
-        h_start = self._transform(self.x[start]).view(neg_rw.size(0),
-                                                      1,
+        h_start = self._transform(self.x[start]).view(neg_rw.size(0), 1,
                                                       self.embedding_dim)
-        h_rest = self.embedding(rest.view(-1)).view(neg_rw.size(0),
-                                                    -1,
+        h_rest = self.embedding(rest.view(-1)).view(neg_rw.size(0), -1,
                                                     self.embedding_dim)
 
         out = (h_start * h_rest).sum(dim=-1).view(-1)

--- a/torch_geometric/nn/models/attri2vec.py
+++ b/torch_geometric/nn/models/attri2vec.py
@@ -1,0 +1,216 @@
+from typing import Optional, Tuple, List, Union
+import torch
+import torch.nn.functional as F
+from torch import Tensor
+from torch.nn import Embedding, Linear
+from torch.utils.data import DataLoader
+
+from torch_geometric.index import index2ptr
+from torch_geometric.typing import WITH_PYG_LIB
+from torch_geometric.utils import sort_edge_index
+from torch_geometric.utils.num_nodes import maybe_num_nodes
+
+
+class Attri2Vec(torch.nn.Module):
+    r"""The attri2vec model from the `"Attributed Network Embedding
+    via Subspace Discovery" <https://arxiv.org/abs/1901.04095>`_ paper.
+
+    `attri2vec` learns node embeddings by mapping a node's features into a
+    structure-aware subspace using a linear or non-linear transformation.
+    It optimizes the embedding space by predicting context nodes collected
+    from random walks.
+
+    Args:
+        edge_index (torch.Tensor): The edge indices.
+        x (torch.Tensor): The node features.
+        embedding_dim (int): The size of each embedding vector.
+        walk_length (int): The walk length.
+        context_size (int): The actual context size considered for
+            positive samples.
+        walks_per_node (int, optional): The number of walks to sample for each
+            node. (default: :obj:`1`)
+        num_negative_samples (int, optional): The number of negative samples to
+            use for each positive sample. (default: :obj:`1`)
+        mapping (str, optional): The transformation function applied to node
+            features (:obj:`"linear"`, :obj:`"relu"`, :obj:`"kernel"`, or
+            :obj:`"sigmoid"`). (default: :obj:`"linear"`)
+        num_nodes (int, optional): The number of nodes. (default: :obj:`None`)
+        sparse (bool, optional): If set to :obj:`True`, gradients w.r.t. the
+            weight matrix will be sparse. (default: :obj:`False`)
+    """
+    def __init__(
+        self,
+        edge_index: Tensor,
+        x: Tensor,
+        embedding_dim: int,
+        walk_length: int,
+        context_size: int,
+        walks_per_node: int = 1,
+        num_negative_samples: int = 1,
+        mapping: str = 'linear',
+        num_nodes: Optional[int] = None,
+        sparse: bool = False,
+    ):
+        super().__init__()
+
+        if not WITH_PYG_LIB:
+            raise ImportError(f"'{self.__class__.__name__}' "
+                              f"requires 'pyg-lib>=0.6.0'")
+        self.random_walk_fn = torch.ops.pyg.random_walk
+        self.num_nodes = maybe_num_nodes(edge_index, num_nodes)
+
+        row, col = sort_edge_index(edge_index, num_nodes=self.num_nodes).cpu()
+        self.rowptr, self.col = index2ptr(row, self.num_nodes), col
+
+        self.EPS = 1e-15
+        assert walk_length >= context_size
+        assert mapping in ('linear', 'relu', 'sigmoid', 'kernel')
+
+        self.embedding_dim = embedding_dim
+        self.walk_length = walk_length - 1
+        self.context_size = context_size
+        self.walks_per_node = walks_per_node
+        self.num_negative_samples = num_negative_samples
+        self.mapping = mapping
+        self._x: Tensor
+        self.register_buffer('_x', x)
+
+        num_features = x.size(1)
+
+        if mapping == 'kernel':
+            assert embedding_dim % 2 == 0
+            self.lin = Linear(num_features, embedding_dim // 2, bias=False)
+        else:
+            self.lin = Linear(num_features, embedding_dim, bias=False)
+
+        self.embedding = Embedding(
+            self.num_nodes,
+            embedding_dim,
+            sparse=sparse
+        )
+
+        self.reset_parameters()
+
+    @property
+    def x(self) -> Tensor:
+        return self._x
+
+    def reset_parameters(self):
+        r"""Resets all learnable parameters of the module."""
+        torch.nn.init.xavier_uniform_(self.lin.weight)
+        self.embedding.reset_parameters()
+
+    def forward(self, batch: Optional[Tensor] = None) -> Tensor:
+        """Returns the embeddings for the nodes in :obj:`batch`."""
+        x = self.x if batch is None else self.x[batch]
+        return self._transform(x)
+
+    def _transform(self, x: Tensor) -> Tensor:
+        r"""Apply f(x): the attribute-to-embedding transformation."""
+        if self.mapping == 'linear':
+            return self.lin(x)
+        elif self.mapping == 'relu':
+            return F.relu(self.lin(x))
+        elif self.mapping == 'sigmoid':
+            return torch.sigmoid(self.lin(x))
+        elif self.mapping == 'kernel':
+            z = self.lin(x)
+            scale = (self.embedding_dim / 2) ** -0.5
+            return scale * torch.cat([torch.cos(z), torch.sin(z)], dim=-1)
+        else:
+            raise ValueError(f"Unknown mapping: {self.mapping!r}")
+
+    def loader(self, **kwargs) -> DataLoader:
+        return DataLoader(range(self.num_nodes),
+                          collate_fn=self.sample,
+                          **kwargs
+                          )
+
+    @torch.jit.export
+    def pos_sample(self, batch: Tensor) -> Tensor:
+        batch = batch.repeat(self.walks_per_node)
+        rw = self.random_walk_fn(self.rowptr, self.col, batch,
+                                 self.walk_length, 1.0, 1.0)
+        if not isinstance(rw, Tensor):
+            rw = rw[0]
+
+        walks = []
+        num_walks_per_rw = 1 + self.walk_length + 1 - self.context_size
+        for j in range(num_walks_per_rw):
+            walks.append(rw[:, j:j + self.context_size])
+        return torch.cat(walks, dim=0)
+
+    @torch.jit.export
+    def neg_sample(self, batch: Tensor) -> Tensor:
+        batch = batch.repeat(self.walks_per_node * self.num_negative_samples)
+
+        rw = torch.randint(self.num_nodes, (batch.size(0), self.walk_length),
+                           dtype=batch.dtype, device=batch.device)
+        rw = torch.cat([batch.view(-1, 1), rw], dim=-1)
+
+        walks = []
+        num_walks_per_rw = 1 + self.walk_length + 1 - self.context_size
+        for j in range(num_walks_per_rw):
+            walks.append(rw[:, j:j + self.context_size])
+        return torch.cat(walks, dim=0)
+
+    @torch.jit.export
+    def sample(self, batch: Union[List[int], Tensor]) -> Tuple[Tensor, Tensor]:
+        if not isinstance(batch, Tensor):
+            batch = torch.tensor(batch)
+        return self.pos_sample(batch), self.neg_sample(batch)
+
+    @torch.jit.export
+    def loss(self, pos_rw: Tensor, neg_rw: Tensor) -> Tensor:
+        r"""Computes the loss given positive and negative random walks."""
+        start, rest = pos_rw[:, 0], pos_rw[:, 1:].contiguous()
+
+        h_start = self._transform(self.x[start]).view(pos_rw.size(0),
+                                                      1,
+                                                      self.embedding_dim)
+        h_rest = self.embedding(rest.view(-1)).view(pos_rw.size(0),
+                                                    -1,
+                                                    self.embedding_dim)
+
+        out = (h_start * h_rest).sum(dim=-1).view(-1)
+        pos_loss = -torch.log(torch.sigmoid(out) + self.EPS).mean()
+
+        # Negative loss.
+        start, rest = neg_rw[:, 0], neg_rw[:, 1:].contiguous()
+
+        h_start = self._transform(self.x[start]).view(neg_rw.size(0),
+                                                      1,
+                                                      self.embedding_dim)
+        h_rest = self.embedding(rest.view(-1)).view(neg_rw.size(0),
+                                                    -1,
+                                                    self.embedding_dim)
+
+        out = (h_start * h_rest).sum(dim=-1).view(-1)
+        neg_loss = -torch.log(1 - torch.sigmoid(out) + self.EPS).mean()
+
+        return pos_loss + neg_loss
+
+    def test(
+        self,
+        train_z: Tensor,
+        train_y: Tensor,
+        test_z: Tensor,
+        test_y: Tensor,
+        solver: str = 'lbfgs',
+        *args,
+        **kwargs,
+    ) -> float:
+        r"""Evaluates latent space quality via a logistic regression downstream
+        task.
+        """
+        from sklearn.linear_model import LogisticRegression
+
+        clf = LogisticRegression(*args, solver=solver,
+                                 **kwargs).fit(train_z.detach().cpu().numpy(),
+                                               train_y.detach().cpu().numpy())
+        return clf.score(test_z.detach().cpu().numpy(),
+                         test_y.detach().cpu().numpy())
+
+    def __repr__(self) -> str:
+        return (f'{self.__class__.__name__}({self.embedding.weight.size(0)}, '
+                f'{self.embedding.weight.size(1)})')


### PR DESCRIPTION
Closes #9688

### Feature Summary:
- Adds the Attri2Vec model from the paper <https://arxiv.org/abs/1901.04095>. 
- Adds example
- Adds unit test

### Notes:
- Implementation extremely similar to that of Node2Vec. Model, examples, and tests bear resemblance
- The model does not implement any bias (p or q), as the paper implements a DeepWalk Strategy over a Node2Vec strategy. StellarGraphs, can perform biased random walks, and I'd be happy to implement the feature for the model if necessary!
- If the mapping is of type "kernel" then we map the embeddings to half of the embedding length. The paper states that that the kernel transformation doubles the size of the input. 

I tried to implement this as similarly to Node2Vec as I could for clarity. This is my first open source contribution, so I sincerely apologize if I made any significant/obvious mistakes!