### PR TITLE
Fix `to_dataclass` for pydantic-v2 (and any generic-`__init__`) dataclasses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- Fixed `to_dataclass` for dataclasses (*e.g.*, `pydantic.dataclasses.dataclass`) whose `__init__` is a generic validator that hides the real fields, by enumerating `dataclasses.fields` instead of the `__init__` signature
 - Fixed `config_store` on Python 3.14, where `typing.Union`/`typing.Optional` annotations could no longer be remapped in-place via the now read-only `__args__` attribute
 
 ### Security

--- a/test/test_config_store.py
+++ b/test/test_config_store.py
@@ -1,3 +1,4 @@
+import dataclasses
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 from torch_geometric.config_store import (
@@ -16,6 +17,68 @@ from torch_geometric.transforms import AddSelfLoops
 
 def teardown_function():
     clear_config_store()
+
+
+def test_to_dataclass_for_dataclass():
+    # Dataclasses must enumerate their real fields rather than the
+    # `__init__` signature. This matters for dataclass implementations whose
+    # `__init__` is a generic validator that hides the fields (*e.g.*,
+    # `pydantic.dataclasses.dataclass`). We simulate that here by replacing
+    # `__init__` with a generic one after class creation:
+    @dataclasses.dataclass
+    class MyConfig:
+        x: int = 3
+        name: str = 'pyg'
+        tags: List[str] = dataclasses.field(default_factory=lambda: ['a'])
+
+    def generic_init(self, *args, **kwargs):  # Hide the real fields.
+        pass
+
+    MyConfig.__init__ = generic_init
+
+    Config = to_dataclass(MyConfig, with_target=True)
+    fields = Config.__dataclass_fields__
+
+    # The real fields are recovered (the generic `__init__` would otherwise
+    # only expose `args`/`kwargs`, all of which are excluded):
+    assert set(fields) == {'x', 'name', 'tags', '_target_'}
+
+    assert fields['x'].type == int
+    assert fields['x'].default == 3
+    assert fields['name'].type == str
+    assert fields['name'].default == 'pyg'
+    # `default_factory` fields are materialized and re-wrapped so that the
+    # default is shared safely rather than left as a raw factory sentinel:
+    assert fields['tags'].default_factory() == ['a']
+
+    cfg = Config()
+    assert cfg.x == 3
+    assert cfg.name == 'pyg'
+    assert cfg.tags == ['a']
+
+
+@withPackage('pydantic')
+def test_to_dataclass_for_pydantic_dataclass():
+    # `pydantic.dataclasses.dataclass` replaces `__init__` with a generic
+    # validating `__init__(self, *args, **kwargs)`, so field discovery must
+    # not rely on the `__init__` signature:
+    from pydantic.dataclasses import dataclass as pydantic_dataclass
+
+    @pydantic_dataclass
+    class PydanticConfig:
+        x: int = 3
+        name: str = 'pyg'
+
+    Config = to_dataclass(PydanticConfig, with_target=True)
+    fields = Config.__dataclass_fields__
+
+    assert set(fields) == {'x', 'name', '_target_'}
+    assert fields['x'].default == 3
+    assert fields['name'].default == 'pyg'
+
+    cfg = Config()
+    assert cfg.x == 3
+    assert cfg.name == 'pyg'
 
 
 def test_to_dataclass():

--- a/torch_geometric/config_store.py
+++ b/torch_geometric/config_store.py
@@ -1,3 +1,4 @@
+import dataclasses
 import inspect
 import typing
 from collections import defaultdict
@@ -193,6 +194,46 @@ def map_annotation(
     return annotation
 
 
+def _get_init_args(cls: Any) -> Dict[str, Tuple[Any, Any]]:
+    r"""Returns the constructor arguments of :obj:`cls` as a mapping from
+    argument name to a :obj:`(annotation, default)` tuple.
+
+    For regular callables, arguments are read from the signature of
+    :meth:`cls.__init__`. For :obj:`dataclasses`, arguments are read from
+    :func:`dataclasses.fields` instead. This is required because some
+    dataclass implementations (*e.g.*, ``pydantic.dataclasses.dataclass``)
+    replace ``__init__`` with a generic ``__init__(self, *args, **kwargs)``
+    validator that does not expose the real fields via its signature.
+
+    Annotations and defaults use :obj:`inspect.Parameter.empty` as the
+    "missing" sentinel so that both code paths feed the same downstream
+    handling in :func:`to_dataclass`.
+    """
+    if dataclasses.is_dataclass(cls):
+        out: Dict[str, Tuple[Any, Any]] = {}
+        for f in dataclasses.fields(cls):
+            if not f.init:  # Skip fields excluded from the constructor.
+                continue
+            empty = inspect.Parameter.empty
+            annotation = f.type if f.type is not None else empty
+            if f.default is not dataclasses.MISSING:
+                default = f.default
+            elif f.default_factory is not dataclasses.MISSING:
+                # Materialize the factory value so that the (list/dict)
+                # default receives the same late-binding-safe wrapping as the
+                # signature-based path below:
+                default = f.default_factory()
+            else:
+                default = inspect.Parameter.empty
+            out[f.name] = (annotation, default)
+        return out
+
+    return {
+        name: (param.annotation, param.default)
+        for name, param in inspect.signature(cls.__init__).parameters.items()
+    }
+
+
 def to_dataclass(
     cls: Any,
     base_cls: Optional[Any] = None,
@@ -239,7 +280,11 @@ def to_dataclass(
     """
     fields = []
 
-    params = inspect.signature(cls.__init__).parameters
+    # Discover the constructor arguments of `cls`. For dataclasses (including
+    # `pydantic.dataclasses.dataclass`, whose `__init__` is a generic
+    # validator that hides the real fields), this reads `dataclasses.fields`;
+    # otherwise it falls back to the `__init__` signature:
+    params = _get_init_args(cls)
 
     if strict:  # Check that keys in map_args or exclude_args are present.
         keys = set() if map_args is None else set(map_args.keys())
@@ -250,7 +295,7 @@ def to_dataclass(
             raise ValueError(f"Expected input argument(s) {diff} in "
                              f"'{cls.__name__}'")
 
-    for i, (name, arg) in enumerate(params.items()):
+    for i, (name, (annotation, default)) in enumerate(params.items()):
         if name in EXCLUDE:
             continue
         if exclude_args is not None:
@@ -264,7 +309,6 @@ def to_dataclass(
             fields.append((name, ) + map_args[name])
             continue
 
-        annotation, default = arg.annotation, arg.default
         annotation = map_annotation(annotation, mapping=MAPPING)
 
         if annotation != inspect.Parameter.empty:


### PR DESCRIPTION
### Problem

`torch_geometric.config_store.to_dataclass` discovers a class's fields via
`inspect.signature(cls.__init__).parameters`. This breaks for dataclasses whose
`__init__` is a generic validator that does not expose the real fields — most
notably `pydantic.dataclasses.dataclass`, whose `__init__` is
`(__dataclass_self__, *args, **kwargs)`. PyG then sees no fields and produces an
empty/broken config dataclass.

Minimal repro (PyG master):

```python
from pydantic.dataclasses import dataclass
from torch_geometric.config_store import to_dataclass

@dataclass
class Foo:
    x: int = 3
    y: str = "hi"

print(list(to_dataclass(Foo).__dataclass_fields__))
# master:  ['__dataclass_self__']      <- broken
# fixed:   ['x', 'y']                   <- correct
```

### Fix

When `cls` is a dataclass, derive fields from `dataclasses.fields(cls)`
(name / type / default / default_factory) instead of the `__init__` signature.
Non-dataclass callables keep the existing signature-based path, so their
behavior is unchanged. Both paths feed the same downstream handling
(`map_args` / `exclude_args` / `strict` / annotation + default mapping) through
shared `inspect.Parameter.empty` sentinels.

This is equivalent to today for normal dataclasses and additionally correct for
`pydantic`-v2 dataclasses. It also fixes a latent case where a dataclass
`default_factory` left a raw `<factory>` sentinel as the default.

### Tests

Adds `test_to_dataclass_for_dataclass` (a dataclass with a generic `__init__`)
and `test_to_dataclass_for_pydantic_dataclass` (a real
`pydantic.dataclasses.dataclass`, guarded by `@withPackage('pydantic')`).
Existing `config_store` tests still pass.
