### PR TITLE
Fix ToUndirected crash on self-relations with edge_label_index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- Fixed `ToUndirected` raising an `IndexError` on heterogeneous self-relations carrying `edge_label_index` / `edge_label` attributes
 - Fixed `config_store` on Python 3.14, where `typing.Union`/`typing.Optional` annotations could no longer be remapped in-place via the now read-only `__args__` attribute
 
 ### Security

--- a/test/transforms/test_to_undirected.py
+++ b/test/transforms/test_to_undirected.py
@@ -67,3 +67,25 @@ def test_hetero_to_undirected():
     assert data['w', 'v'].edge_index.tolist() == [[3, 1], [2, 0]]
     assert data['w', 'v'].edge_weight.tolist() == edge_weight.tolist()
     assert data['w', 'v'].edge_attr.tolist() == edge_attr.tolist()
+
+
+def test_hetero_to_undirected_self_relation_with_edge_label():
+    edge_index = torch.tensor([[0, 1, 2], [3, 4, 5]])
+    edge_label_index = edge_index.clone()
+    edge_label = torch.tensor([1, 0, 1])
+
+    data = HeteroData()
+    data['v'].num_nodes = 6
+    data['v', 'v'].edge_index = edge_index
+    data['v', 'v'].edge_label_index = edge_label_index
+    data['v', 'v'].edge_label = edge_label
+
+    data = ToUndirected()(data)
+
+    # `edge_index` is made undirected (E -> 2 * E):
+    assert data['v', 'v'].edge_index.size(1) == 6
+    # Link-prediction supervision attributes are preserved unchanged on the
+    # forward relation:
+    assert data['v',
+                'v'].edge_label_index.tolist() == edge_label_index.tolist()
+    assert data['v', 'v'].edge_label.tolist() == edge_label.tolist()

--- a/torch_geometric/transforms/to_undirected.py
+++ b/torch_geometric/transforms/to_undirected.py
@@ -61,6 +61,18 @@ class ToUndirected(BaseTransform):
                         inv_store[key] = value
 
             else:
+                # Link-prediction supervision attributes are not per-edge
+                # features and must not be passed through `to_undirected()` /
+                # `coalesce()`, which would index them with a `2 * E`
+                # permutation. Detach them before the call and reattach them on
+                # the forward store afterwards -- supervision semantics never
+                # apply to the added reverse edges.
+                supervision_keys = ('edge_label_index', 'edge_label')
+                detached = {
+                    key: store.pop(key)
+                    for key in supervision_keys if key in store
+                }
+
                 keys, values = [], []
                 for key, value in store.items():
                     if key == 'edge_index':
@@ -74,6 +86,9 @@ class ToUndirected(BaseTransform):
                     store.edge_index, values, reduce=self.reduce)
 
                 for key, value in zip(keys, values):
+                    store[key] = value
+
+                for key, value in detached.items():
                     store[key] = value
 
         return data


### PR DESCRIPTION
While working on a link-prediction project I ran into a crash that I think is worth fixing. I have a heterogeneous graph with supervision edges on a relation whose source and destination are the same node type (e.g. `user → user`),
and those edges are tagged for supervision via `edge_label_index`. Calling `ToUndirected()` on that graph raises an `IndexError`:

```python
data = HeteroData()
data['user'].num_nodes = 6
edges = torch.tensor([[0, 1, 2], [3, 4, 5]])
data['user', 'HAS_FRIEND', 'user'].edge_index = edges
data['user', 'HAS_FRIEND', 'user'].edge_label_index = edges.clone()

T.ToUndirected()(data)  # IndexError: index 4 is out of bounds for dimension 0 with size 4
```

As far as I can tell, for non-bipartite stores `ToUndirected` passes every `is_edge_attr` tensor through `to_undirected()` → `coalesce()`. The trouble is that `edge_label_index` (and its companion `edge_label`, which `RandomLinkSplit` adds
alongside it) aren't really per-edge features — they carry supervision for link prediction. `coalesce()` builds a 2 * E permutation and uses it to index these E-sized tensors, which ends up out of bounds.

The fix I'm proposing detaches those two attributes before the call and reattaches them on the forward relation afterwards — the added reverse edges shouldn't carry supervision labels anyway. 