### PR TITLE
Fix device/dtype propagation and reset_parameters in MeshCNNConv

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
-- Fixed `MeshCNNConv` ignoring the device and dtype of its input, and added a `reset_parameters` method
+- Fixed `MeshCNNConv` ignoring the device and dtype of its input, and added a `reset_parameters` method ([#10741](https://github.com/pyg-team/pytorch_geometric/pull/10741))
 - Fixed `config_store` on Python 3.14, where `typing.Union`/`typing.Optional` annotations could no longer be remapped in-place via the now read-only `__args__` attribute
 
 ### Security

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
-- Fixed `MeshCNNConv` ignoring the device and dtype of its input, and added a `reset_parameters` method ([#10741](https://github.com/pyg-team/pytorch_geometric/pull/10741))
+- Fixed `MeshCNNConv.message()` ignoring the device and dtype of its input, and `reset_parameters()` not resetting the layer's kernels ([#10741](https://github.com/pyg-team/pytorch_geometric/pull/10741))
 - Fixed `config_store` on Python 3.14, where `typing.Union`/`typing.Optional` annotations could no longer be remapped in-place via the now read-only `__args__` attribute
 
 ### Security

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- Fixed `MeshCNNConv` ignoring the device and dtype of its input, and added a `reset_parameters` method
 - Fixed `config_store` on Python 3.14, where `typing.Union`/`typing.Optional` annotations could no longer be remapped in-place via the now read-only `__args__` attribute
 
 ### Security

--- a/test/nn/conv/test_meshcnn_conv.py
+++ b/test/nn/conv/test_meshcnn_conv.py
@@ -3,6 +3,12 @@ import torch
 from torch.nn import Linear, ModuleList, Sequential, Sigmoid
 
 from torch_geometric.nn import MeshCNNConv
+from torch_geometric.testing import withDevice
+
+TETRAHEDRON_EDGE_INDEX = torch.tensor(
+    [[0, 0, 0, 0, 1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3, 4, 4, 4, 4, 5, 5, 5, 5],
+     [1, 2, 3, 4, 2, 0, 4, 5, 5, 3, 0, 1, 2, 5, 4, 0, 0, 3, 5, 1, 1, 4, 3, 2]],
+    dtype=torch.int64)
 
 
 @pytest.mark.parametrize('in_channels, out_channels', [
@@ -50,3 +56,43 @@ def test_meshcnn_conv(in_channels: int, out_channels: int):
     assert str(conv) == f"MeshCNNConv({in_channels}, {out_channels})"
     x1 = conv(x0, edge_index)
     assert x1.size() == (E_cardinality, out_channels)
+
+
+def test_meshcnn_conv_message_preserves_dtype():
+    # `message()` used to allocate its output buffer via a bare
+    # `torch.empty(E4, out_channels)`, which always defaults to float32.
+    # Assigning float64 kernel outputs into that buffer silently downcasts
+    # them, losing precision. This is invisible from `forward()`'s final
+    # output because `update()`'s `kernel(x) + inputs` addition promotes
+    # float32 + float64 back to float64, masking the loss -- so this test
+    # calls `message()` directly, where the bug actually lives.
+    conv = MeshCNNConv(in_channels=8, out_channels=3).double()
+    x_j = torch.randn(TETRAHEDRON_EDGE_INDEX.size(1), 8, dtype=torch.float64)
+
+    out = conv.message(x_j)
+    assert out.dtype == torch.float64
+
+
+@withDevice
+def test_meshcnn_conv_device_propagation(device):
+    # `message()`'s bare `torch.empty(...)` also always allocates on CPU,
+    # ignoring `x_j.device`. On any non-CPU device this crashes `forward()`
+    # with a device-mismatch error.
+    x = torch.randn(6, 8, device=device)
+    edge_index = TETRAHEDRON_EDGE_INDEX.to(device)
+    conv = MeshCNNConv(in_channels=8, out_channels=3).to(device)
+
+    out = conv(x, edge_index)
+    assert out.device == x.device
+    assert out.size() == (6, 3)
+
+
+def test_meshcnn_conv_reset_parameters():
+    torch.manual_seed(0)
+    conv = MeshCNNConv(in_channels=4, out_channels=4)
+    before = [kernel.weight.clone() for kernel in conv.kernels]
+
+    conv.reset_parameters()
+
+    for kernel, weight_before in zip(conv.kernels, before):
+        assert not torch.allclose(kernel.weight, weight_before)

--- a/torch_geometric/nn/conv/meshcnn_conv.py
+++ b/torch_geometric/nn/conv/meshcnn_conv.py
@@ -7,6 +7,7 @@ import torch
 from torch.nn import Linear, Module, ModuleList
 
 from torch_geometric.nn.conv import MessagePassing
+from torch_geometric.nn.inits import reset
 from torch_geometric.typing import Tensor
 
 
@@ -285,6 +286,17 @@ class MeshCNNConv(MessagePassing):
             self._assert_kernels(kernels)
             self.kernels = kernels
 
+        self.reset_parameters()
+
+    def reset_parameters(self):
+        r"""Resets all learnable parameters of the module, including each
+        of the 5 :obj:`kernels`. Kernels that do not implement
+        :meth:`reset_parameters` (directly or via a child module) are left
+        untouched.
+        """
+        super().reset_parameters()
+        reset(self.kernels)
+
     def forward(self, x: Tensor, edge_index: Tensor):
         r"""Forward pass.
 
@@ -391,7 +403,7 @@ class MeshCNNConv(MessagePassing):
         n_b = x_j[1::4]  # shape: |E| x in_channels
         n_c = x_j[2::4]  # shape: |E| x in_channels
         n_d = x_j[3::4]  # shape: |E| x in_channels
-        m = torch.empty(E4, self.out_channels)
+        m = x_j.new_empty(E4, self.out_channels)
         m[0::4] = self.kernels[1].forward(torch.abs(n_a - n_c))
         m[1::4] = self.kernels[2].forward(n_a + n_c)
         m[2::4] = self.kernels[3].forward(torch.abs(n_b - n_d))


### PR DESCRIPTION
> ## What
>
> Two independent defects in `MeshCNNConv`:
>
> **1. `message()` ignores input device and dtype.** The intermediate buffer is allocated with `torch.empty(E4, self.out_channels)`, using the default device and dtype instead of inheriting from the input. On non-CPU devices this crashes (reproduced locally on MPS: `RuntimeError: Placeholder storage has not been allocated on MPS device`; `SGConv` runs fine on the same MPS device, confirming the issue is layer-specific, not environmental. CUDA was not tested locally and is left to CI). The dtype half is silent: end-to-end output dtype looks correct because `update()` computes `kernels[0](x) + inputs`, and float64+float32 auto-promotes, masking the leak. Calling `message()` directly shows it returns float32 even for a fully-float64 module and input.
>
> **2. `reset_parameters()` does not reset the layer's kernels.** `MeshCNNConv` inherits `reset_parameters()` from `MessagePassing`, which only resets `aggr_module`. The five learnable `kernels` are never re-initialized, so `hasattr(conv, "reset_parameters")` is `True` but calling it leaves `kernels[i].weight` unchanged.
>
> ## Fix
>
> - `message()`: `torch.empty(...)` → `x_j.new_empty(...)`, inheriting device and dtype (standard PyG idiom).
> - Add `reset_parameters()` that resets each kernel via PyG's `reset()` helper, following the pattern `GINConv` uses for user-supplied modules (guarded by `hasattr(kernel, "reset_parameters")`, since custom kernels may not define it). Called from `__init__`, consistent with 50 of the 54 conv layers that define `reset_parameters()`; the 4 that don't (`gen_conv`, `gps_conv`, `hetero_conv`, `wl_conv`) are composite/wrapper/parameter-free layers structurally unlike `MeshCNNConv`.
>
> For the default `Linear` kernels, the added `__init__` call is effectively a no-op (it re-runs the same initialization `Linear` already performs); for user-supplied kernels it invokes their own `reset_parameters` only if defined. No change to output for existing correct usage.
>
> ## Tests
>
> Added to `test/nn/conv/test_meshcnn_conv.py`: `message()` dtype preservation, device propagation (parametrized to run on CPU always, plus CUDA/MPS/XPU when available), and a kernel-reset assertion. All three fail on clean master and pass with the fix.
>
> **Before** (clean master, `1f0661c`):
> ```
> test_meshcnn_conv_message_preserves_dtype FAILED
>   assert torch.float32 == torch.float64
> test_meshcnn_conv_device_propagation[mps] FAILED
>   RuntimeError: Placeholder storage has not been allocated on MPS device!
> test_meshcnn_conv_reset_parameters FAILED
>   assert not True
>    +  where True = torch.allclose(kernel.weight, weight_before)
> 3 failed, 6 passed in 0.83s
> ```
>
> **After:**
> ```
> 9 passed in 0.38s
> ```
