### PR TITLE
Add BLISConv bi-Lipschitz geometric-scattering operator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- Added the `BLISConv` bi-Lipschitz geometric-scattering operator from the ["BLIS-Net: Classifying and Analyzing Signals on Graphs"](https://proceedings.mlr.press/v238/xu24c.html) paper, plus an example ([#10742](https://github.com/pyg-team/pytorch_geometric/pull/10742))
 - Added `torch_geometric.contrib.nn.models.MGNAN` (M-GNAN, an extension of `GNAN` to multivariate shape functions) model plus an example ([#10371](https://github.com/pyg-team/pytorch_geometric/pull/10371))
 
 ### Changed

--- a/examples/blis_net.py
+++ b/examples/blis_net.py
@@ -1,0 +1,111 @@
+"""BLIS-Net example on graph classification.
+
+BLIS-Net is primarily designed for signal-level classification tasks (i.e.
+predicting a label for each signal defined on a fixed graph). This example
+instead runs graph classification on MUTAG simply because it is a readily
+available dataset in PyG; the same :class:`~torch_geometric.nn.BLISConv`
+scattering layers apply directly to signal-level tasks.
+
+The model stacks :class:`~torch_geometric.nn.BLISConv` bi-Lipschitz
+geometric-scattering layers into a cascade, reads out a graph-level
+representation with a (first-order moment) mean pooling, and classifies with an
+MLP. This mirrors the BLIS-Net architecture from the `"BLIS-Net: Classifying
+and Analyzing Signals on Graphs"
+<https://proceedings.mlr.press/v238/xu24c.html>`_ paper: since the scattering
+layers preserve the full wavelet-frame energy, only the final layer's
+coefficients are pooled.
+"""
+import argparse
+import os.path as osp
+
+import torch
+import torch.nn.functional as F
+
+from torch_geometric.datasets import TUDataset
+from torch_geometric.loader import DataLoader
+from torch_geometric.nn import BLISConv, global_mean_pool
+
+parser = argparse.ArgumentParser()
+parser.add_argument('--dataset', type=str, default='MUTAG')
+parser.add_argument('--batch_size', type=int, default=64)
+parser.add_argument('--num_layers', type=int, default=2)
+parser.add_argument('--hidden_channels', type=int, default=64)
+parser.add_argument('--lr', type=float, default=0.001)
+parser.add_argument('--epochs', type=int, default=100)
+args = parser.parse_args()
+
+device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
+
+path = osp.join(osp.dirname(osp.realpath(__file__)), '..', 'data', 'TU')
+dataset = TUDataset(path, name=args.dataset).shuffle()
+
+n = (len(dataset) + 9) // 10
+test_dataset = dataset[:n]
+train_dataset = dataset[n:]
+train_loader = DataLoader(train_dataset, args.batch_size, shuffle=True)
+test_loader = DataLoader(test_dataset, args.batch_size)
+
+
+class BLISNet(torch.nn.Module):
+    def __init__(self, in_channels, num_classes, num_layers, hidden_channels):
+        super().__init__()
+        self.convs = torch.nn.ModuleList()
+        channels = in_channels
+        for _ in range(num_layers):
+            conv = BLISConv(channels)
+            self.convs.append(conv)
+            channels = conv.out_channels
+
+        self.mlp = torch.nn.Sequential(
+            torch.nn.Linear(channels, hidden_channels),
+            torch.nn.ReLU(),
+            torch.nn.Linear(hidden_channels, num_classes),
+        )
+
+    def forward(self, x, edge_index, batch):
+        for conv in self.convs:
+            x = conv(x, edge_index)  # Final-layer readout (energy preserving).
+        x = global_mean_pool(x, batch)  # First-order moment aggregation.
+        return self.mlp(x)
+
+
+model = BLISNet(
+    dataset.num_features,
+    dataset.num_classes,
+    args.num_layers,
+    args.hidden_channels,
+).to(device)
+optimizer = torch.optim.Adam(model.parameters(), lr=args.lr, weight_decay=0.01)
+
+
+def train():
+    model.train()
+    total_loss = 0.0
+    for data in train_loader:
+        data = data.to(device)
+        optimizer.zero_grad()
+        out = model(data.x, data.edge_index, data.batch)
+        loss = F.cross_entropy(out, data.y)
+        loss.backward()
+        optimizer.step()
+        total_loss += loss.item() * data.num_graphs
+    return total_loss / len(train_loader.dataset)
+
+
+@torch.no_grad()
+def test(loader):
+    model.eval()
+    correct = 0
+    for data in loader:
+        data = data.to(device)
+        pred = model(data.x, data.edge_index, data.batch).argmax(dim=-1)
+        correct += int((pred == data.y).sum())
+    return correct / len(loader.dataset)
+
+
+for epoch in range(1, args.epochs + 1):
+    loss = train()
+    train_acc = test(train_loader)
+    test_acc = test(test_loader)
+    print(f'Epoch: {epoch:03d}, Loss: {loss:.4f}, '
+          f'Train: {train_acc:.4f}, Test: {test_acc:.4f}')

--- a/test/nn/conv/test_blis_conv.py
+++ b/test/nn/conv/test_blis_conv.py
@@ -1,0 +1,110 @@
+import torch
+
+import torch_geometric.typing
+from torch_geometric.nn import BLISConv
+from torch_geometric.testing import is_full_test
+from torch_geometric.typing import SparseTensor
+from torch_geometric.utils import to_torch_csc_tensor
+
+
+def test_blis_conv():
+    x = torch.randn(4, 16)
+    edge_index = torch.tensor([[0, 0, 0, 1, 2, 3], [1, 2, 3, 0, 0, 0]])
+    value = torch.rand(edge_index.size(1))
+    adj1 = to_torch_csc_tensor(edge_index, size=(4, 4))
+    adj2 = to_torch_csc_tensor(edge_index, value, size=(4, 4))
+
+    conv = BLISConv(16)
+    assert str(conv) == 'BLISConv(16, out_channels=192, K=4, activation=blis)'
+    # (K + 2) filters * 2 activations * 16 channels = 6 * 2 * 16 = 192.
+    assert conv.out_channels == 192
+
+    out1 = conv(x, edge_index)
+    assert out1.size() == (4, 192)
+    assert torch.allclose(conv(x, adj1.t()), out1, atol=1e-6)
+
+    out2 = conv(x, edge_index, value)
+    assert out2.size() == (4, 192)
+    assert torch.allclose(conv(x, adj2.t()), out2, atol=1e-6)
+
+    if torch_geometric.typing.WITH_TORCH_SPARSE:
+        adj3 = SparseTensor.from_edge_index(edge_index, sparse_sizes=(4, 4))
+        adj4 = SparseTensor.from_edge_index(edge_index, value, (4, 4))
+        assert torch.allclose(conv(x, adj3.t()), out1, atol=1e-6)
+        assert torch.allclose(conv(x, adj4.t()), out2, atol=1e-6)
+
+    if is_full_test():
+        jit = torch.jit.script(conv)
+        assert torch.allclose(jit(x, edge_index), out1, atol=1e-6)
+        assert torch.allclose(jit(x, edge_index, value), out2, atol=1e-6)
+
+        if torch_geometric.typing.WITH_TORCH_SPARSE:
+            assert torch.allclose(jit(x, adj3.t()), out1, atol=1e-6)
+            assert torch.allclose(jit(x, adj4.t()), out2, atol=1e-6)
+
+
+def test_blis_conv_scalar_signal():
+    x = torch.randn(4)
+    edge_index = torch.tensor([[0, 0, 0, 1, 2, 3], [1, 2, 3, 0, 0, 0]])
+
+    conv = BLISConv(1)
+    out = conv(x, edge_index)
+    assert out.size() == (4, conv.out_channels) == (4, 12)
+
+
+def test_blis_conv_identity_activation():
+    x = torch.randn(4, 8)
+    edge_index = torch.tensor([[0, 0, 0, 1, 2, 3], [1, 2, 3, 0, 0, 0]])
+
+    conv = BLISConv(8, activation='identity')
+    out = conv(x, edge_index)
+    # No bi-Lipschitz doubling: 6 filters * 8 channels = 48.
+    assert conv.out_channels == 48
+    assert out.size() == (4, 48)
+
+
+def test_blis_conv_invalid_activation():
+    with_error = False
+    try:
+        BLISConv(8, activation='relu')
+    except ValueError:
+        with_error = True
+    assert with_error
+
+
+def test_blis_conv_matches_dense_reference():
+    # BLISConv (identity) must equal the dense W2 wavelet transform built from
+    # the lazy random walk P = 1/2 (I + A D^-1).
+    torch.manual_seed(12345)
+    n, f = 7, 3
+    adj = (torch.rand(n, n) < 0.4).float()
+    adj = ((adj + adj.t()) > 0).float()
+    adj.fill_diagonal_(0)
+    edge_index = adj.nonzero().t().contiguous()
+    x = torch.randn(n, f)
+
+    deg = adj.sum(0)
+    p = 0.5 * (torch.eye(n) + adj @ torch.diag(1.0 / deg))
+
+    conv = BLISConv(f, activation='identity')
+    powers = [torch.eye(n)]
+    for _ in range(conv.num_diffusion):
+        powers.append(p @ powers[-1])
+    levels = torch.stack(
+        [powers[k] @ x for k in range(conv.num_diffusion + 1)])
+    ref = torch.einsum('ij,jnf->inf', conv.wavelet_constructor, levels)
+    ref = ref.permute(1, 0, 2).reshape(n, -1)
+
+    assert torch.allclose(conv(x, edge_index), ref, atol=1e-5)
+
+
+def test_blis_conv_trainable():
+    x = torch.randn(4, 8)
+    edge_index = torch.tensor([[0, 0, 0, 1, 2, 3], [1, 2, 3, 0, 0, 0]])
+
+    conv = BLISConv(8, trainable_laziness=True, trainable_scales=True)
+    conv(x, edge_index).sum().backward()
+
+    grads = [p.grad for p in conv.parameters() if p.requires_grad]
+    assert len(grads) > 0
+    assert any(g is not None and g.abs().sum() > 0 for g in grads)

--- a/torch_geometric/nn/conv/__init__.py
+++ b/torch_geometric/nn/conv/__init__.py
@@ -15,6 +15,7 @@ from .gatv2_conv import GATv2Conv
 from .transformer_conv import TransformerConv
 from .agnn_conv import AGNNConv
 from .tag_conv import TAGConv
+from .blis_conv import BLISConv
 from .gin_conv import GINConv, GINEConv
 from .arma_conv import ARMAConv
 from .sg_conv import SGConv
@@ -83,6 +84,7 @@ __all__ = [
     'TransformerConv',
     'AGNNConv',
     'TAGConv',
+    'BLISConv',
     'GINConv',
     'GINEConv',
     'ARMAConv',

--- a/torch_geometric/nn/conv/blis_conv.py
+++ b/torch_geometric/nn/conv/blis_conv.py
@@ -1,0 +1,207 @@
+from typing import List
+
+import torch
+from torch import Tensor
+from torch.nn import Parameter
+
+from torch_geometric.nn.conv import MessagePassing
+from torch_geometric.typing import Adj, OptTensor
+from torch_geometric.utils import spmm
+
+
+class LazyLayer(torch.nn.Module):
+    r"""A learnable, per-channel convex combination of a signal and its
+    diffused version (a "laziness" parameter passed through a softmax).
+    """
+    def __init__(self, n: int) -> None:
+        super().__init__()
+        self.n = n
+        self.weights = Parameter(torch.empty(2, n))
+        self.reset_parameters()
+
+    def forward(self, x: Tensor, propagated: Tensor) -> Tensor:
+        s_weights = torch.softmax(self.weights, dim=0)
+        inp = torch.stack((x, propagated), dim=0)
+        return torch.sum(inp * s_weights.view(2, 1, self.n), dim=0)
+
+    def reset_parameters(self) -> None:
+        torch.nn.init.ones_(self.weights)
+
+
+def _build_wavelet_constructor(max_scale_power: int) -> Tensor:
+    r"""Builds the dyadic ``W2`` wavelet-difference matrix.
+
+    Given ``max_scale_power`` :math:`= K`, the diffusion scales are
+    :math:`\{0, 2^0, 2^1, \ldots, 2^K\}`. Each band-pass wavelet is the
+    difference of diffusion operators at consecutive dyadic scales,
+    :math:`\mathbf{P}^{2^k} - \mathbf{P}^{2^{k+1}}`, and a final low-pass
+    filter :math:`\mathbf{P}^{2^K}` is appended. Returns the
+    ``[num_filters, num_diffusion + 1]`` selection matrix.
+    """
+    dyadic = [0] + [2**k for k in range(max_scale_power + 1)]
+    num_diffusion = dyadic[-1]
+    num_filters = len(dyadic)  # (len(dyadic) - 1) band-pass + 1 low-pass.
+
+    weight = torch.zeros(num_filters, num_diffusion + 1)
+    for i in range(len(dyadic) - 1):
+        weight[i, dyadic[i]] = 1.0
+        weight[i, dyadic[i + 1]] = -1.0
+    weight[-1, dyadic[-1]] = 1.0  # low-pass filter.
+    return weight
+
+
+class BLISConv(MessagePassing):
+    r"""The bi-Lipschitz geometric-scattering operator from the `"BLIS-Net:
+    Classifying and Analyzing Signals on Graphs"
+    <https://proceedings.mlr.press/v238/xu24c.html>`_ paper.
+
+    For an input node signal, the layer computes diffusion-wavelet coefficients
+    on every node using the dyadic ``W2`` wavelet bank derived from the lazy
+    random walk
+    :math:`\mathbf{P} = \frac{1}{2}(\mathbf{I} + \mathbf{A}\mathbf{D}^{-1})`,
+
+    .. math::
+        \mathbf{W}_k = \mathbf{P}^{2^{k-1}} - \mathbf{P}^{2^k}, \quad
+        \mathbf{W}_{\text{low}} = \mathbf{P}^{2^K},
+
+    followed by the bi-Lipschitz activation
+    :math:`[\textrm{ReLU}(x), \textrm{ReLU}(-x)]`. Because the full wavelet
+    frame is applied at every layer, the energy of the input signal is
+    preserved; stacking :math:`m` layers therefore realizes an :math:`m`-th
+    order scattering cascade whose informative output is simply the final
+    layer's coefficients (no skip connections required).
+
+    With :math:`K =` :obj:`max_scale_power`, the bank contains :math:`K + 2`
+    filters. For an input with :math:`F` channels, the output has
+    :math:`(K + 2) \cdot A \cdot F` channels per node, where :math:`A` is the
+    number of activations (:obj:`2` for :obj:`"blis"`), available as
+    :obj:`out_channels`.
+
+    .. note::
+        The layer assumes an undirected graph (as in the paper); edge
+        directions are treated symmetrically by the random-walk normalization.
+
+    Args:
+        in_channels (int): Size of each input sample :math:`F`.
+        max_scale_power (int, optional): The largest dyadic diffusion scale is
+            :math:`2^{\texttt{max\_scale\_power}}` (:math:`K`).
+            (default: :obj:`4`)
+        activation (str, optional): The pointwise nonlinearity, either
+            :obj:`"blis"` for the bi-Lipschitz :math:`[\textrm{ReLU}(x),
+            \textrm{ReLU}(-x)]` map, or :obj:`"identity"` for the linear
+            scattering transform. (default: :obj:`"blis"`)
+        trainable_laziness (bool, optional): If set to :obj:`True`, uses a
+            learnable laziness parameter in the diffusion.
+            (default: :obj:`False`)
+        trainable_scales (bool, optional): If set to :obj:`True`, the
+            wavelet-difference matrix becomes a learnable parameter.
+            (default: :obj:`False`)
+        **kwargs (optional): Additional arguments of
+            :class:`torch_geometric.nn.conv.MessagePassing`.
+
+    Shapes:
+        - **input:**
+          node features :math:`(|\mathcal{V}|, F)` (or :math:`(|\mathcal{V}|)`
+          for a scalar signal),
+          edge indices :math:`(2, |\mathcal{E}|)`,
+          edge weights :math:`(|\mathcal{E}|)` *(optional)*
+        - **output:** node features :math:`(|\mathcal{V}|,` :obj:`out_channels`
+          :math:`)`
+    """
+    def __init__(
+        self,
+        in_channels: int,
+        max_scale_power: int = 4,
+        activation: str = 'blis',
+        trainable_laziness: bool = False,
+        trainable_scales: bool = False,
+        **kwargs,
+    ) -> None:
+        kwargs.setdefault('aggr', 'add')
+        super().__init__(**kwargs)
+
+        if activation not in ('blis', 'identity'):
+            raise ValueError(f"Invalid activation '{activation}' "
+                             f"(expected 'blis' or 'identity')")
+
+        self.in_channels = in_channels
+        self.max_scale_power = max_scale_power
+        self.activation = activation
+        self.trainable_laziness = trainable_laziness
+        self.trainable_scales = trainable_scales
+
+        weight = _build_wavelet_constructor(max_scale_power)
+        self.num_diffusion = weight.size(1) - 1
+        self.num_filters = weight.size(0)
+        self.num_activations = 2 if activation == 'blis' else 1
+        self.out_channels = (self.num_filters * self.num_activations *
+                             in_channels)
+
+        if trainable_scales:
+            self.wavelet_constructor = Parameter(weight)
+        else:
+            self.register_buffer('wavelet_constructor', weight)
+
+        self.lazy_layer = LazyLayer(
+            in_channels) if trainable_laziness else None
+
+        self.reset_parameters()
+
+    def reset_parameters(self) -> None:
+        super().reset_parameters()
+        if self.lazy_layer is not None:
+            self.lazy_layer.reset_parameters()
+        if isinstance(self.wavelet_constructor, Parameter):
+            with torch.no_grad():
+                weight = _build_wavelet_constructor(self.max_scale_power)
+                self.wavelet_constructor.copy_(
+                    weight.to(self.wavelet_constructor.device))
+
+    def forward(self, x: Tensor, edge_index: Adj,
+                edge_weight: OptTensor = None) -> Tensor:
+        if x.dim() == 1:
+            x = x.view(-1, 1)
+
+        # T = A D^-1 acts as T x = A (x / deg), so a single unnormalized
+        # aggregation of an all-ones signal yields the (weighted) degrees. This
+        # keeps the layer agnostic to the `edge_index` / `SparseTensor` format.
+        ones = x.new_ones((x.size(self.node_dim), 1))
+        # propagate_type: (x: Tensor, edge_weight: OptTensor)
+        deg = self.propagate(edge_index, x=ones, edge_weight=edge_weight)
+        deg_inv = deg.pow(-1)
+        deg_inv.masked_fill_(deg_inv == float('inf'), 0)
+
+        avgs: List[Tensor] = [x]
+        cur = x
+        for _ in range(self.num_diffusion):
+            propagated = self.propagate(edge_index, x=cur * deg_inv,
+                                        edge_weight=edge_weight)
+            if self.lazy_layer is not None:
+                cur = self.lazy_layer(cur, propagated)
+            else:
+                cur = 0.5 * (cur + propagated)
+            avgs.append(cur)
+
+        # Select dyadic differences: [num_filters, num_nodes, F].
+        levels = torch.stack(avgs, dim=0)
+        coeffs = torch.einsum('ij,jnf->inf', self.wavelet_constructor, levels)
+
+        if self.activation == 'blis':
+            coeffs = torch.stack([coeffs.relu(), (-coeffs).relu()], dim=0)
+        else:
+            coeffs = coeffs.unsqueeze(0)
+
+        # [A, num_filters, num_nodes, F] -> [num_nodes, out_channels].
+        num_nodes = coeffs.size(2)
+        return coeffs.permute(2, 0, 1, 3).reshape(num_nodes, -1)
+
+    def message(self, x_j: Tensor, edge_weight: OptTensor) -> Tensor:
+        return x_j if edge_weight is None else edge_weight.view(-1, 1) * x_j
+
+    def message_and_aggregate(self, adj_t: Adj, x: Tensor) -> Tensor:
+        return spmm(adj_t, x, reduce=self.aggr)
+
+    def __repr__(self) -> str:
+        return (f'{self.__class__.__name__}({self.in_channels}, '
+                f'out_channels={self.out_channels}, '
+                f'K={self.max_scale_power}, activation={self.activation})')


### PR DESCRIPTION
This PR adds `BLISConv`, the bi-Lipschitz geometric-scattering operator from the paper ["BLIS-Net: Classifying and Analyzing Signals on Graphs" (Xu et al., AISTATS 2024)](https://proceedings.mlr.press/v238/xu24c.html).

### Motivation

BLIS-Net is a graph-scattering architecture designed primarily for **signal-level classification** — predicting labels for signals defined on a fixed graph — a setting current PyG conv layers don't directly target. Its core building block is a diffusion-wavelet scattering transform: for the lazy random walk $\mathbf{P} = \tfrac{1}{2}(\mathbf{I} + \mathbf{A}\mathbf{D}^{-1})$, it computes a dyadic wavelet bank

```math
\mathbf{W}_k = \mathbf{P}^{2^{k-1}} - \mathbf{P}^{2^k}, \qquad \mathbf{W}_{\mathrm{low}} = \mathbf{P}^{2^K}
```

followed by the bi-Lipschitz activation $[\mathrm{ReLU}(x), \mathrm{ReLU}(-x)]$. The transform is energy-preserving, so stacking layers yields a multi-order scattering cascade whose informative output is simply the final layer's coefficients (no skip connections needed).

### What's included

- `torch_geometric/nn/conv/blis_conv.py` — `BLISConv`, implemented as a `MessagePassing` subclass.
- Registered in `torch_geometric.nn.conv` (import + `__all__`), so it's available as `torch_geometric.nn.BLISConv` and appears in the API docs/cheatsheet.
- `test/nn/conv/test_blis_conv.py` — tests following PyG conv-test conventions.
- `examples/blis_net.py` — a BLIS-Net graph-classification example on MUTAG.
- `CHANGELOG.md` entry.

### Usage

```python
from torch_geometric.nn import BLISConv

conv = BLISConv(in_channels=16)   # K=4, "blis" activation
out = conv(x, edge_index)         # -> [num_nodes, conv.out_channels] == [num_nodes, 192]
```

### Design decisions

- **`MessagePassing` subclass.** Since $\mathbf{T}x = \mathbf{A}(x \oslash \deg)$, degree is computed once via a plain ones-aggregation and reused through standard `propagate`/`spmm`. As a result `Tensor`, `SparseTensor`, and `torch-sparse` inputs all flow through the same path, and the layer is `torch.jit.script`-able.
- **`out_channels` is derived** as $(K{+}2)\cdot A \cdot F$ (filters × activations × input channels), e.g. `BLISConv(16)` → `192`.
- **Undirected graphs** are assumed, as in the paper (documented in a `.. note::`).

### Scope / future work

- Moment aggregation is handled by existing `torch_geometric.nn.aggr`, so it's not re-implemented here.

### Test plan

- [x] `FULL_TEST=1 pytest test/nn/conv/test_blis_conv.py` passes, covering the `edge_index`, CSC (`to_torch_csc_tensor`), and `torch-sparse` paths, `torch.jit.script` compatibility, and a dense-reference equivalence check against $\mathbf{P} = \tfrac{1}{2}(\mathbf{I} + \mathbf{A}\mathbf{D}^{-1})$.
- [x] `examples/blis_net.py` trains on MUTAG.
- [x] `pre-commit run` passes on all changed files.