### PR TITLE
Make EdgeConv TorchScript-compatible

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -45,4 +45,7 @@ jobs:
 
       - name: Check type hints
         run: |
-          mypy -v --cache-dir=/dev/null torch_geometric
+          mypy -v --cache-dir=/dev/null  \
+      		--ignore-missing-imports \
+      		--skip-stubs \
+		torch_geometric

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -45,4 +45,4 @@ jobs:
 
       - name: Check type hints
         run: |
-          mypy -v --cache-dir=/dev/null
+          mypy -v --cache-dir=/dev/null torch_geometric

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -38,17 +38,11 @@ jobs:
 
       - name: Setup packages
         uses: ./.github/actions/setup
-        with:
-          full_install: false
 
       - name: Install main package
         run: |
           uv pip install -e ".[test]" mypy types-requests
 
-      - name: Remove problematic rdkit-stubs
-        run: |
-          uv pip uninstall -y rdkit-stubs || true
-
       - name: Check type hints
         run: |
-          mypy -v --cache-dir=/dev/null --ignore-missing-imports --exclude 'site-packages/rdkit-stubs' torch_geometric
+          mypy -v --cache-dir=/dev/null --ignore-missing-imports torch_geometric

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -45,4 +45,4 @@ jobs:
 
       - name: Check type hints
         run: |
-          mypy -v --cache-dir=/dev/null --ignore-missing-imports --skip-stubs torch_geometric
+          mypy -v --cache-dir=/dev/null --ignore-missing-imports torch_geometric

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -45,7 +45,4 @@ jobs:
 
       - name: Check type hints
         run: |
-          mypy -v --cache-dir=/dev/null  \
-      		--ignore-missing-imports \
-      		--skip-stubs \
-		torch_geometric
+          mypy -v --cache-dir=/dev/null --ignore-missing-imports --skip-stubs torch_geometric

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -38,11 +38,17 @@ jobs:
 
       - name: Setup packages
         uses: ./.github/actions/setup
+        with:
+          full_install: false
 
       - name: Install main package
         run: |
-          uv pip install -e ".[full,test]" mypy types-requests
+          uv pip install -e ".[test]" mypy types-requests
+
+      - name: Remove problematic rdkit-stubs
+        run: |
+          uv pip uninstall -y rdkit-stubs || true
 
       - name: Check type hints
         run: |
-          mypy -v --cache-dir=/dev/null --ignore-missing-imports torch_geometric
+          mypy -v --cache-dir=/dev/null --ignore-missing-imports --exclude 'site-packages/rdkit-stubs' torch_geometric

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- Fixed issues with the `index2ptr` input parameters ([#10745](https://github.com/pyg-team/pytorch_geometric/pull/10745))
 - Fixed `config_store` on Python 3.14, where `typing.Union`/`typing.Optional` annotations could no longer be remapped in-place via the now read-only `__args__` attribute
 
 ### Security

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,9 @@
+[mypy]
+python_version = 3.10
+install_types = False
+# keep normal import handling so we still check our code; don't use global ignore_missing_imports
+follow_imports = normal
+
+# Ignore errors coming from rdkit / rdkit-stubs (third-party stubs that cause parse errors)
+[mypy-rdkit.*]
+ignore_errors = True

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,9 +1,5 @@
 [mypy]
-python_version = 3.10
-install_types = False
-# keep normal import handling so we still check our code; don't use global ignore_missing_imports
-follow_imports = normal
+ignore_missing_imports = True
 
-# Ignore errors coming from rdkit / rdkit-stubs (third-party stubs that cause parse errors)
 [mypy-rdkit.*]
 ignore_errors = True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -143,7 +143,6 @@ warn_unused_configs = true
 warn_unused_ignores = true
 disallow_untyped_defs = true
 disallow_incomplete_defs = true
-cache_dir = "/dev/null"
 
 [[tool.mypy.overrides]]
 ignore_errors = true
@@ -158,6 +157,12 @@ module = [
     "torch_geometric.graphgym.*",
     "torch_geometric.distributed.*",
     "torch_geometric.llm.*",
+]
+
+[[tool.mypy.overrides]]
+ignore_errors = true
+module = [
+    "rdkit",
     "rdkit.*",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -143,6 +143,7 @@ warn_unused_configs = true
 warn_unused_ignores = true
 disallow_untyped_defs = true
 disallow_incomplete_defs = true
+cache_dir = "/dev/null"
 
 [[tool.mypy.overrides]]
 ignore_errors = true
@@ -157,6 +158,7 @@ module = [
     "torch_geometric.graphgym.*",
     "torch_geometric.distributed.*",
     "torch_geometric.llm.*",
+    "rdkit.*",
 ]
 
 [tool.isort]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,7 +84,6 @@ dev=[
     "ipython",
     "matplotlib-inline",
     "pre-commit",
-    "rdkit-stubs>=2024.01.0",
     "torch_geometric[test]",
 ]
 full = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,6 +84,7 @@ dev=[
     "ipython",
     "matplotlib-inline",
     "pre-commit",
+    "rdkit-stubs>=2024.01.0",
     "torch_geometric[test]",
 ]
 full = [

--- a/torch_geometric/nn/conv/edge_conv.py
+++ b/torch_geometric/nn/conv/edge_conv.py
@@ -130,8 +130,11 @@ class DynamicEdgeConv(MessagePassing):
             assert batch is not None
             b = (batch[0], batch[1])
 
-        ptr_l = None if b[0] is None else index2ptr(b[0])
-        ptr_r = None if b[1] is None else index2ptr(b[1])
+        batch_l = b[0]
+        batch_r = b[1]
+
+        ptr_l = None if batch_l is None else index2ptr(batch_l)
+        ptr_r = None if batch_r is None else index2ptr(batch_r)
         edge_index = torch.ops.pyg.knn(x[0], x[1], ptr_l, ptr_r, self.k, False,
                                        1).flip([0])
 

--- a/torch_geometric/nn/conv/gravnet_conv.py
+++ b/torch_geometric/nn/conv/gravnet_conv.py
@@ -107,8 +107,11 @@ class GravNetConv(MessagePassing):
         s_l: Tensor = self.lin_s(x[0])
         s_r: Tensor = self.lin_s(x[1]) if is_bipartite else s_l
 
-        ptr_l = None if b[0] is None else index2ptr(b[0])
-        ptr_r = None if b[1] is None else index2ptr(b[1])
+        batch_l = b[0]
+        batch_r = b[1]
+
+        ptr_l = None if batch_l is None else index2ptr(batch_l)
+        ptr_r = None if batch_r is None else index2ptr(batch_r)
         edge_index = torch.ops.pyg.knn(s_l, s_r, ptr_l, ptr_r, self.k, False,
                                        1).flip([0])
 


### PR DESCRIPTION
This PR fixes a `TorchScript` scripting failure in `EdgeConv` by replacing tuple-based `Optional[Tensor]` handling with TorchScript-friendly type refinement using local variables and explicit conditional checks. 

This failures occurs in 
```
test/nn/conv/test_edge_conv.py::test_dynamic_edge_conv
test/nn/conv/test_gravnet_conv.py::test_gravnet_conv
```
and the error is:
```
E       RuntimeError: 
E       
E       index2ptr(Tensor index, int? size=None) -> Tensor:
E       Expected a value of type 'Tensor' for argument 'index' but instead found type 'Optional[Tensor]'.
E       :
E         File "/usr/local/lib/python3.12/dist-packages/torch_geometric/nn/conv/edge_conv.py", line 133
E                   b = (batch[0], batch[1])
E           
E               ptr_l = None if b[0] is None else index2ptr(b[0])
E                                                 ~~~~~~~~~ <--- HERE
E               ptr_r = None if b[1] is None else index2ptr(b[1])
E               edge_index = torch.ops.pyg.knn(x[0], x[1], ptr_l, ptr_r, self.k, False,
```
