### PR TITLE
Prepare for `2.8.0.post1`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [2.8.0.post1] - 2026-07-20
+
+### Fixed
+
+- Added the missing source distribution to the PyPI release.
+
 ## [2.8.0] - 2026-06-05
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend="flit_core.buildapi"
 
 [project]
 name="torch-geometric"
-version="2.8.0"
+version="2.8.0.post1"
 authors=[
     {name="Matthias Fey", email="matthias@pyg.org"},
 ]

--- a/torch_geometric/__init__.py
+++ b/torch_geometric/__init__.py
@@ -31,7 +31,7 @@ from .lazy_loader import LazyLoader
 contrib = LazyLoader('contrib', globals(), 'torch_geometric.contrib')
 graphgym = LazyLoader('graphgym', globals(), 'torch_geometric.graphgym')
 
-__version__ = '2.8.0'
+__version__ = '2.8.0.post1'
 
 __all__ = [
     'Index',


### PR DESCRIPTION
Fixes https://github.com/pyg-team/pytorch_geometric/issues/10748.

Prepares a new post release due to missing source distribution for `2.8.0`. PyPI doesn't allow updating a release after 14 days of the release:

> 400 Uploading new files to releases older than 14 days is not
allowed.

ref: https://github.com/pypa/packaging-problems/issues/718