### PR TITLE
Geometric scattering convolution layer

### DIFF
--- a/examples/geo_scat.py
+++ b/examples/geo_scat.py
@@ -1,0 +1,160 @@
+import argparse
+import os.path as osp
+import time
+from typing import Tuple
+
+import torch
+import torch.nn.functional as F
+
+import torch_geometric
+from torch_geometric.datasets import TUDataset
+from torch_geometric.loader import DataLoader
+from torch_geometric.logging import init_wandb, log
+from torch_geometric.nn import MLP, GeoScatConv
+from torch_geometric.seed import seed_everything
+
+parser = argparse.ArgumentParser()
+parser.add_argument('--dataset', type=str, default='MUTAG')
+parser.add_argument('--batch_size', type=int, default=16)
+parser.add_argument('--hidden_channels', type=int, default=64)
+parser.add_argument('--dropout', type=float, default=0.5,
+                    help='Dropout rate of the prediction head')
+parser.add_argument('--lr', type=float, default=0.005)
+parser.add_argument('--epochs', type=int, default=256)
+parser.add_argument('--seed', type=int, default=0)
+parser.add_argument('--legs', action='store_true',
+                    help='Use learnable LEGS diffusion scales')
+parser.add_argument('--legs_J', type=int, default=4,
+                    help='LEGS diffusion depth J (ignored unless --legs)')
+parser.add_argument('--scattering_orders', type=int, nargs='+', default=[0, 1],
+                    choices=[0, 1, 2], help='Scattering orders to include')
+parser.add_argument('--pool', type=str, nargs='+',
+                    default=['mean', 'var', 'max'],
+                    choices=['mean', 'max', 'min', 'median', 'var'],
+                    help='Graph-level pooling ops applied by GeoScatConv')
+parser.add_argument('--wandb', action='store_true', help='Track experiment')
+args = parser.parse_args()
+
+seed_everything(args.seed)
+device = torch_geometric.device('auto')
+
+init_wandb(
+    name=f'GeoScat-{args.dataset}',
+    batch_size=args.batch_size,
+    hidden_channels=args.hidden_channels,
+    dropout=args.dropout,
+    lr=args.lr,
+    epochs=args.epochs,
+    seed=args.seed,
+    legs=args.legs,
+    legs_J=args.legs_J,
+    scattering_orders=args.scattering_orders,
+    pool=args.pool,
+    device=device,
+)
+
+path = osp.join(osp.dirname(osp.realpath(__file__)), '..', 'data', 'TU')
+dataset = TUDataset(path, name=args.dataset).shuffle()
+
+train_loader = DataLoader(dataset[:0.8], args.batch_size, shuffle=True)
+test_loader = DataLoader(dataset[0.8:], args.batch_size)
+
+
+class GeoScat(torch.nn.Module):
+    def __init__(
+        self,
+        in_channels: int,
+        hidden_channels: int,
+        out_channels: int,
+        scattering_orders: Tuple[int, ...],
+        pool: Tuple[str, ...],
+        use_legs: bool,
+        legs_J: int,
+        dropout: float,
+    ):
+        super().__init__()
+        diffusion_scales = 'legs' if use_legs else (0, 1, 2, 4, 8, 16)
+        legs_kwargs = {'legs_J': legs_J} if use_legs else None
+        self.conv = GeoScatConv(
+            in_channels,
+            scattering_orders=scattering_orders,
+            diffusion_scales=diffusion_scales,
+            legs_kwargs=legs_kwargs,
+            include_lowpass=True,
+            pool=pool,
+        )
+        # DeepSets head over feature channels: ρ(∑_f φ(h_f)).
+        self.phi = MLP(
+            [self.conv.out_channels, hidden_channels, hidden_channels],
+            norm=None)
+        self.rho = MLP([hidden_channels, hidden_channels, out_channels],
+                       norm=None, dropout=dropout)
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        edge_index: torch.Tensor,
+        batch: torch.Tensor,
+    ) -> torch.Tensor:
+        # h: (batch_size, num_features, num_scattering_filters * |pool|)
+        h = self.conv(x, edge_index, batch=batch)
+        h = self.phi(h).sum(dim=1)
+        return self.rho(h)
+
+
+model = GeoScat(
+    in_channels=dataset.num_features,
+    hidden_channels=args.hidden_channels,
+    out_channels=dataset.num_classes,
+    scattering_orders=tuple(args.scattering_orders),
+    pool=tuple(args.pool),
+    use_legs=args.legs,
+    legs_J=args.legs_J,
+    dropout=args.dropout,
+).to(device)
+optimizer = torch.optim.Adam(model.parameters(), lr=args.lr)
+
+
+def train() -> float:
+    model.train()
+
+    total_loss = 0.0
+    for data in train_loader:
+        data = data.to(device)
+        optimizer.zero_grad()
+        out = model(data.x, data.edge_index, data.batch)
+        loss = F.cross_entropy(out, data.y)
+        loss.backward()
+        optimizer.step()
+        total_loss += float(loss.detach()) * data.num_graphs
+    return total_loss / len(train_loader.dataset)
+
+
+@torch.no_grad()
+def test(loader: DataLoader) -> float:
+    model.eval()
+
+    total_correct = 0
+    for data in loader:
+        data = data.to(device)
+        out = model(data.x, data.edge_index, data.batch)
+        pred = out.argmax(dim=-1)
+        total_correct += int((pred == data.y).sum())
+    return total_correct / len(loader.dataset)
+
+
+times = []
+best_test_acc = 0.0
+best_epoch = 0
+for epoch in range(1, args.epochs + 1):
+    start = time.time()
+    loss = train()
+    train_acc = test(train_loader)
+    test_acc = test(test_loader)
+    if test_acc > best_test_acc:
+        best_test_acc = test_acc
+        best_epoch = epoch
+    log(Epoch=epoch, Loss=loss, Train=train_acc, Test=test_acc)
+    times.append(time.time() - start)
+print(f'Median time per epoch: {torch.tensor(times).median():.4f}s')
+print(f'Best test accuracy: {best_test_acc:.4f} (epoch {best_epoch})')

--- a/test/nn/conv/test_geo_scat_conv.py
+++ b/test/nn/conv/test_geo_scat_conv.py
@@ -1,0 +1,458 @@
+import warnings
+
+import pytest
+import torch
+
+from torch_geometric.data import Batch, Data
+from torch_geometric.nn import GeoScatConv
+from torch_geometric.nn.conv.geo_scat_conv import (
+    get_sparse_lrw_diffusion_operator,
+    multiorder_scatter,
+)
+
+
+def test_geo_scat_conv_node_level():
+    in_channels = 4
+    edge_index = torch.tensor([[0, 0, 0, 1, 2, 3], [1, 2, 3, 0, 0, 0]])
+    num_nodes = edge_index.max().item() + 1
+    edge_weight = torch.rand(edge_index.size(1))
+    x = torch.randn((num_nodes, in_channels))
+
+    conv = GeoScatConv(in_channels, pool=None)
+    assert conv.num_wavelet_filters == 6
+    assert conv.num_scattering_filters == 7
+    assert str(conv).startswith('GeoScatConv(')
+
+    out = conv(x, edge_index)
+    assert out.size() == (num_nodes, in_channels, 7)
+
+    out_weighted = conv(x, edge_index, edge_weight)
+    assert out_weighted.size() == (num_nodes, in_channels, 7)
+
+
+def test_geo_scat_conv_second_order():
+    in_channels = 3
+    edge_index = torch.tensor([[0, 1, 1, 2], [1, 0, 2, 1]])
+    num_nodes = edge_index.max().item() + 1
+    x = torch.randn((num_nodes, in_channels))
+
+    conv = GeoScatConv(
+        in_channels,
+        scattering_orders=[0, 1, 2],
+        pool=None,
+    )
+    assert conv.num_scattering_filters == 22
+
+    out = conv(x, edge_index)
+    assert out.size() == (num_nodes, in_channels, 22)
+
+
+def test_geo_scat_conv_graph_level_pooling():
+    in_channels = 2
+    batch = torch.tensor([0, 0, 1, 1])
+    edge_index = torch.tensor([[0, 1, 2, 3], [1, 0, 3, 2]])
+    num_nodes = edge_index.max().item() + 1
+    x = torch.randn((num_nodes, in_channels))
+
+    conv = GeoScatConv(
+        in_channels,
+        scattering_orders=[0, 1, 2],
+        pool=['mean', 'max'],
+    )
+    assert conv.out_channels == 44
+
+    out = conv(x, edge_index, batch=batch)
+    assert out.size() == (2, in_channels, 44)
+
+
+def test_geo_scat_conv_all_pooling_ops():
+    in_channels = 2
+    edge_index = torch.tensor([[0, 1, 1, 2], [1, 0, 2, 1]])
+    num_nodes = edge_index.max().item() + 1
+    x = torch.randn((num_nodes, in_channels))
+
+    conv = GeoScatConv(
+        in_channels,
+        pool=['min', 'median', 'mean', 'max', 'var'],
+    )
+    assert conv.out_channels == 7 * 5
+
+    out = conv(x, edge_index)
+    assert out.size() == (1, in_channels, 35)
+
+
+def test_geo_scat_conv_vector_features():
+    vector_dim = 3
+    edge_index = torch.tensor([[0, 1, 1, 2], [1, 0, 2, 1]])
+    num_nodes = edge_index.max().item() + 1
+    x = torch.randn((num_nodes, vector_dim))
+
+    P_node = get_sparse_lrw_diffusion_operator(
+        edge_index,
+        None,
+        num_nodes,
+        'row',
+        x.dtype,
+        x.device,
+    ).to_dense()
+    P = torch.kron(
+        P_node,
+        torch.eye(vector_dim, device=x.device, dtype=x.dtype),
+    )
+
+    conv = GeoScatConv(
+        vector_dim,
+        is_vector_feature=True,
+        pool=None,
+    )
+    with warnings.catch_warnings():
+        warnings.simplefilter('ignore', UserWarning)
+        out = conv(
+            x,
+            diffusion_op=P,
+            diffusion_op_key='diffusion_adj',
+        )
+    assert out.size() == (num_nodes, vector_dim, 7)
+
+
+def test_geo_scat_conv_vector_features_require_diffusion_op():
+    vector_dim = 3
+    edge_index = torch.tensor([[0, 1, 1, 2], [1, 0, 2, 1]])
+    num_nodes = edge_index.max().item() + 1
+    x = torch.randn((num_nodes, vector_dim))
+
+    conv = GeoScatConv(
+        vector_dim,
+        is_vector_feature=True,
+        pool=None,
+    )
+
+    with pytest.raises(ValueError, match='require a precomputed diffusion_op'):
+        conv(x, edge_index)
+
+
+def test_geo_scat_conv_activation():
+    in_channels = 2
+    edge_index = torch.tensor([[0, 1, 1, 2], [1, 0, 2, 1]])
+    num_nodes = edge_index.max().item() + 1
+    x = torch.randn((num_nodes, in_channels))
+
+    conv = GeoScatConv(
+        in_channels,
+        scattering_orders=[1],
+        activation=torch.abs,
+        pool=None,
+    )
+    out = conv(x, edge_index)
+    assert out.size() == (num_nodes, in_channels, 6)
+    assert (out >= 0).all()
+
+
+def test_geo_scat_conv_wavelet_only():
+    in_channels = 2
+    edge_index = torch.tensor([[0, 1, 1, 2], [1, 0, 2, 1]])
+    num_nodes = edge_index.max().item() + 1
+    x = torch.randn((num_nodes, in_channels))
+
+    conv = GeoScatConv(
+        in_channels,
+        scattering_orders=[1],
+        pool=None,
+    )
+    assert conv.num_scattering_filters == 6
+
+    out = conv(x, edge_index)
+    assert out.size() == (num_nodes, in_channels, 6)
+
+
+def test_geo_scat_conv_batch_consistency():
+    in_channels = 3
+    x1 = torch.randn(4, in_channels)
+    edge_index1 = torch.tensor([[0, 1, 1, 2, 2, 3], [1, 0, 2, 1, 3, 2]])
+    data1 = Data(x=x1, edge_index=edge_index1)
+
+    x2 = torch.randn(3, in_channels)
+    edge_index2 = torch.tensor([[0, 1, 1, 2], [1, 0, 2, 1]])
+    data2 = Data(x=x2, edge_index=edge_index2)
+
+    conv = GeoScatConv(in_channels, pool=None)
+
+    out1 = conv(x1, edge_index1)
+    out2 = conv(x2, edge_index2)
+
+    batch = Batch.from_data_list([data1, data2])
+    out = conv(batch.x, batch.edge_index, batch=batch.batch)
+
+    assert out.size() == (7, in_channels, 7)
+    assert torch.allclose(out1, out[:4], atol=1e-6)
+    assert torch.allclose(out2, out[4:], atol=1e-6)
+
+
+def test_geo_scat_conv_removes_self_loops():
+    in_channels = 2
+    edge_index = torch.tensor([[0, 1, 1, 2], [1, 0, 2, 1]])
+    edge_index_with_loops = torch.tensor([
+        [0, 1, 1, 2, 0, 1, 2],
+        [1, 0, 2, 1, 0, 1, 2],
+    ])
+    num_nodes = edge_index.max().item() + 1
+    x = torch.randn((num_nodes, in_channels))
+    edge_weight = torch.tensor([1.0, 1.0, 1.0, 1.0, 2.0, 3.0, 4.0])
+
+    conv = GeoScatConv(in_channels, pool=None)
+
+    with torch.no_grad():
+        out = conv(x, edge_index)
+        out_with_loops = conv(x, edge_index_with_loops, edge_weight)
+
+    assert torch.allclose(out, out_with_loops, atol=1e-6)
+
+
+def test_geo_scat_conv_custom_scales():
+    in_channels = 2
+    edge_index = torch.tensor([[0, 1, 1, 2], [1, 0, 2, 1]])
+    num_nodes = edge_index.max().item() + 1
+    x = torch.randn((num_nodes, in_channels))
+
+    conv = GeoScatConv(
+        in_channels,
+        diffusion_scales=[0, 1, 2],
+        include_lowpass=False,
+        scattering_orders=[1],
+        pool=None,
+    )
+    assert conv.num_wavelet_filters == 2
+    assert conv.num_scattering_filters == 2
+
+    out = conv(x, edge_index)
+    assert out.size() == (num_nodes, in_channels, 2)
+
+
+def test_geo_scat_conv_precomputed_diffusion_op():
+    in_channels = 2
+    edge_index = torch.tensor([[0, 1, 1, 2], [1, 0, 2, 1]])
+    num_nodes = edge_index.max().item() + 1
+    x = torch.randn((num_nodes, in_channels))
+
+    conv = GeoScatConv(in_channels, pool=None)
+
+    P = get_sparse_lrw_diffusion_operator(
+        edge_index,
+        None,
+        num_nodes,
+        'row',
+        x.dtype,
+        x.device,
+    )
+
+    with torch.no_grad():
+        out_edge = conv(x, edge_index)
+        out_P = conv(
+            x,
+            diffusion_op=P,
+            diffusion_op_key='diffusion_adj',
+        )
+
+    assert torch.allclose(out_edge, out_P, atol=1e-6)
+
+
+def test_geo_scat_conv_diffusion_op_batching_warning():
+    in_channels = 2
+    num_nodes = 3
+    x = torch.randn((num_nodes, in_channels))
+
+    conv = GeoScatConv(in_channels, pool=None)
+
+    row = torch.tensor([0, 1, 2, 0, 1, 2])
+    col = torch.tensor([0, 1, 2, 1, 0, 1])
+    val = torch.tensor([0.5, 0.5, 0.5, 0.25, 0.25, 0.25])
+    P_sparse = torch.sparse_coo_tensor(
+        torch.stack([row, col]),
+        val,
+        (num_nodes, num_nodes),
+    ).coalesce()
+    P_dense = P_sparse.to_dense()
+
+    with pytest.warns(UserWarning, match='Dense diffusion_op'):
+        conv(x, diffusion_op=P_dense)
+
+    with pytest.warns(UserWarning, match="diffusion_op_key='P'"):
+        conv(x, diffusion_op=P_sparse, diffusion_op_key='P')
+
+    with pytest.warns(UserWarning, match='without diffusion_op_key'):
+        conv(x, diffusion_op=P_sparse)
+
+    with warnings.catch_warnings():
+        warnings.simplefilter('error')
+        conv(
+            x,
+            diffusion_op=P_sparse,
+            diffusion_op_key='diffusion_adj',
+        )
+
+
+@pytest.mark.parametrize('normalization', ['row', 'column', 'symmetric'])
+def test_geo_scat_conv_normalization(normalization):
+    in_channels = 2
+    edge_index = torch.tensor([[0, 1, 1, 2], [1, 0, 2, 1]])
+    num_nodes = edge_index.max().item() + 1
+    x = torch.randn((num_nodes, in_channels))
+
+    conv = GeoScatConv(in_channels, normalization=normalization, pool=None)
+    out = conv(x, edge_index)
+
+    assert out.size() == (num_nodes, in_channels, 7)
+    assert torch.isfinite(out).all()
+
+
+def test_geo_scat_conv_scattering_order_zero_only():
+    in_channels = 2
+    edge_index = torch.tensor([[0, 1, 1, 2], [1, 0, 2, 1]])
+    num_nodes = edge_index.max().item() + 1
+    x = torch.randn((num_nodes, in_channels))
+
+    conv = GeoScatConv(in_channels, scattering_orders=[0], pool=None)
+    assert conv.num_scattering_filters == 1
+
+    out = conv(x, edge_index)
+    assert out.size() == (num_nodes, in_channels, 1)
+    assert torch.allclose(out.squeeze(-1), x)
+
+
+def test_geo_scat_conv_second_order_activation():
+    in_channels = 2
+    edge_index = torch.tensor([[0, 1, 1, 2], [1, 0, 2, 1]])
+    num_nodes = edge_index.max().item() + 1
+    x = torch.randn((num_nodes, in_channels))
+
+    conv = GeoScatConv(
+        in_channels,
+        scattering_orders=[0, 1, 2],
+        activation=torch.abs,
+        pool=None,
+    )
+    out = conv(x, edge_index)
+
+    assert out.size() == (num_nodes, in_channels, 22)
+    assert (out[:, :, 1:] >= 0).all()
+
+
+def test_geo_scat_conv_multiorder_scatter_consistency():
+    in_channels = 2
+    edge_index = torch.tensor([[0, 1, 1, 2], [1, 0, 2, 1]])
+    num_nodes = edge_index.max().item() + 1
+    x = torch.randn((num_nodes, in_channels))
+
+    conv = GeoScatConv(
+        in_channels,
+        scattering_orders=[0, 1, 2],
+        pool=None,
+    )
+    P = get_sparse_lrw_diffusion_operator(
+        edge_index,
+        None,
+        num_nodes,
+        conv.normalization,
+        x.dtype,
+        x.device,
+    )
+
+    with torch.no_grad():
+        out_conv = conv(x, edge_index)
+        out_scatter = multiorder_scatter(
+            x,
+            P,
+            diffusion_scales=torch.tensor(conv.diffusion_scales),
+            include_lowpass=conv.include_lowpass,
+            scattering_orders=conv.scattering_orders,
+            is_vector_feature=conv.is_vector_feature,
+        )
+
+    assert torch.allclose(out_conv, out_scatter, atol=1e-6)
+
+
+def test_geo_scat_conv_check_nonfinite():
+    in_channels = 2
+    edge_index = torch.tensor([[0, 1, 1, 2], [1, 0, 2, 1]])
+    num_nodes = edge_index.max().item() + 1
+    x = torch.randn((num_nodes, in_channels))
+    x[0, 0] = float('nan')
+
+    conv = GeoScatConv(in_channels, check_nonfinite=True, pool=None)
+
+    with pytest.raises(RuntimeError, match='Non-finite value detected'):
+        conv(x, edge_index)
+
+
+def test_geo_scat_conv_diffusion_op_shape_mismatch():
+    in_channels = 2
+    edge_index = torch.tensor([[0, 1, 1, 2], [1, 0, 2, 1]])
+    num_nodes = edge_index.max().item() + 1
+    x = torch.randn((num_nodes + 1, in_channels))
+
+    conv = GeoScatConv(in_channels, pool=None)
+    P = get_sparse_lrw_diffusion_operator(
+        edge_index,
+        None,
+        num_nodes,
+        'row',
+        x.dtype,
+        x.device,
+    )
+
+    with pytest.raises(ValueError, match='does not match expected size'):
+        conv(x, diffusion_op=P)
+
+
+@pytest.mark.parametrize(
+    'kwargs,match',
+    [
+        ({
+            'scattering_orders': []
+        }, 'must be a non-empty tuple'),
+        ({
+            'scattering_orders': [0, 0, 1]
+        }, 'must not contain duplicates'),
+        ({
+            'scattering_orders': [0, 2]
+        }, 'must also contain 1'),
+        ({
+            'scattering_orders': [1, 0]
+        }, 'must be strictly increasing'),
+        ({
+            'diffusion_scales': [0]
+        }, 'at least two entries'),
+        ({
+            'diffusion_scales': [0, 2, 1]
+        }, 'strictly increasing'),
+        ({
+            'pool': []
+        }, 'non-empty tuple'),
+        ({
+            'pool': ['invalid']
+        }, 'Invalid pooling operations'),
+        ({
+            'normalization': 'invalid'
+        }, "must be one of {'row', 'column'"),
+    ],
+)
+def test_geo_scat_conv_constructor_validation(kwargs, match):
+    with pytest.raises(ValueError, match=match):
+        GeoScatConv(2, **kwargs)
+
+
+def test_geo_scat_conv_forward_validation():
+    in_channels = 2
+    edge_index = torch.tensor([[0, 1, 1, 2], [1, 0, 2, 1]])
+    num_nodes = edge_index.max().item() + 1
+    x = torch.randn((num_nodes, in_channels))
+    conv = GeoScatConv(in_channels, pool=None)
+
+    with pytest.raises(ValueError, match='Exactly one of edge_index'):
+        conv(x)
+
+    with pytest.raises(ValueError, match='Exactly one of edge_index'):
+        conv(x, edge_index, diffusion_op=torch.eye(num_nodes))
+
+    with pytest.raises(ValueError, match='Expected input with 2 channels'):
+        conv(torch.randn(num_nodes, in_channels + 1), edge_index)

--- a/test/nn/conv/test_geo_scat_conv.py
+++ b/test/nn/conv/test_geo_scat_conv.py
@@ -6,6 +6,7 @@ import torch
 from torch_geometric.data import Batch, Data
 from torch_geometric.nn import GeoScatConv
 from torch_geometric.nn.conv.geo_scat_conv import (
+    _initialize_legs_parameters,
     get_sparse_lrw_diffusion_operator,
     multiorder_scatter,
 )
@@ -348,17 +349,12 @@ def test_geo_scat_conv_multiorder_scatter_consistency():
         scattering_orders=[0, 1, 2],
         pool=None,
     )
-    P = get_sparse_lrw_diffusion_operator(
-        edge_index,
-        None,
-        num_nodes,
-        conv.normalization,
-        x.dtype,
-        x.device,
-    )
+    P = _make_dense_lrw_diffusion_operator(edge_index, num_nodes)
 
     with torch.no_grad():
-        out_conv = conv(x, edge_index)
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore', UserWarning)
+            out_conv = conv(x, diffusion_op=P)
         out_scatter = multiorder_scatter(
             x,
             P,
@@ -456,3 +452,220 @@ def test_geo_scat_conv_forward_validation():
 
     with pytest.raises(ValueError, match='Expected input with 2 channels'):
         conv(torch.randn(num_nodes, in_channels + 1), edge_index)
+
+
+def _make_dense_lrw_diffusion_operator(
+    edge_index: torch.Tensor,
+    num_nodes: int,
+) -> torch.Tensor:
+    adj = torch.zeros(num_nodes, num_nodes)
+    for src, dst in edge_index.t():
+        adj[src, dst] += 1.0
+    degree = adj.sum(dim=1)
+    adj_norm = adj / degree.unsqueeze(1).clamp(min=1.0)
+    return 0.5 * (torch.eye(num_nodes) + adj_norm)
+
+
+def test_geo_scat_conv_legs_construction():
+    in_channels = 2
+    edge_index = torch.tensor([[0, 1, 1, 2], [1, 0, 2, 1]])
+    num_nodes = edge_index.max().item() + 1
+    x = torch.randn((num_nodes, in_channels))
+
+    conv = GeoScatConv(in_channels, diffusion_scales='legs', pool=None)
+    assert conv.use_legs is True
+    assert conv.legs_kwargs == {'legs_J': 4}
+    assert conv.F.shape == (4, 17)
+    assert conv.num_wavelet_filters == 5
+    assert conv.num_scattering_filters == 12
+    assert "diffusion_scales='legs'" in str(conv)
+
+    P = _make_dense_lrw_diffusion_operator(edge_index, num_nodes)
+    with warnings.catch_warnings():
+        warnings.simplefilter('ignore', UserWarning)
+        out = conv(x, diffusion_op=P)
+    assert out.size() == (num_nodes, in_channels, 12)
+
+
+def test_geo_scat_conv_legs_init_row_zero():
+    conv = GeoScatConv(2, diffusion_scales='legs', pool=None)
+    F = conv.F
+    assert F[0, 0].item() == 1.0
+    assert F[0, 1].item() == -1.0
+    assert F[0, 2:].abs().sum().item() == 0.0
+
+
+def test_geo_scat_conv_legs_reset_parameters():
+    conv = GeoScatConv(
+        2,
+        diffusion_scales='LEGS',
+        legs_kwargs={'legs_J': 4},
+        pool=None,
+    )
+    expected = _initialize_legs_parameters(4)
+    conv.F.data.fill_(0.0)
+    conv.reset_parameters()
+    assert torch.allclose(conv.F, expected)
+
+
+def test_geo_scat_conv_legs_gradient_flow():
+    in_channels = 2
+    edge_index = torch.tensor([[0, 1, 1, 2], [1, 0, 2, 1]])
+    num_nodes = edge_index.max().item() + 1
+    x = torch.randn((num_nodes, in_channels))
+    P = _make_dense_lrw_diffusion_operator(edge_index, num_nodes)
+
+    conv = GeoScatConv(
+        in_channels,
+        diffusion_scales='legs',
+        scattering_orders=[1],
+        pool=None,
+    )
+    with warnings.catch_warnings():
+        warnings.simplefilter('ignore', UserWarning)
+        out = conv(x, diffusion_op=P)
+    out.sum().backward()
+    assert conv.F.grad is not None
+    assert torch.isfinite(conv.F.grad).all()
+
+
+def test_geo_scat_conv_legs_lowpass_before_activation():
+    in_channels = 2
+    edge_index = torch.tensor([[0, 1, 1, 2], [1, 0, 2, 1]])
+    num_nodes = edge_index.max().item() + 1
+    x = torch.randn((num_nodes, in_channels))
+    P = _make_dense_lrw_diffusion_operator(edge_index, num_nodes)
+
+    conv = GeoScatConv(
+        in_channels,
+        diffusion_scales='legs',
+        scattering_orders=[1],
+        activation=torch.abs,
+        include_lowpass=True,
+        pool=None,
+    )
+    with warnings.catch_warnings():
+        warnings.simplefilter('ignore', UserWarning)
+        out = conv(x, diffusion_op=P)
+    assert out.size() == (num_nodes, in_channels, 5)
+    assert (out >= 0).all()
+
+
+def test_geo_scat_conv_legs_partial_equivalence_at_init():
+    in_channels = 2
+    edge_index = torch.tensor([[0, 1, 1, 2], [1, 0, 2, 1]])
+    num_nodes = edge_index.max().item() + 1
+    x = torch.randn((num_nodes, in_channels))
+    P = _make_dense_lrw_diffusion_operator(edge_index, num_nodes)
+
+    conv_legs = GeoScatConv(
+        in_channels,
+        diffusion_scales='legs',
+        legs_kwargs={'legs_J': 4},
+        include_lowpass=False,
+        scattering_orders=[1],
+        pool=None,
+    )
+    conv_fixed = GeoScatConv(
+        in_channels,
+        diffusion_scales=(0, 1, 2, 4, 8, 16),
+        include_lowpass=False,
+        scattering_orders=[1],
+        pool=None,
+    )
+
+    with warnings.catch_warnings():
+        warnings.simplefilter('ignore', UserWarning)
+        with torch.no_grad():
+            out_legs = conv_legs(x, diffusion_op=P)
+            out_fixed = conv_fixed(x, diffusion_op=P)
+
+    assert torch.allclose(out_legs[..., 0], out_fixed[..., 0], atol=1e-6)
+    assert torch.allclose(out_legs[..., 1], out_fixed[..., 2], atol=1e-6)
+    assert torch.allclose(out_legs[..., 2], out_fixed[..., 3], atol=1e-6)
+    assert torch.allclose(out_legs[..., 3], out_fixed[..., 4], atol=1e-6)
+
+
+def test_geo_scat_conv_legs_second_order():
+    in_channels = 2
+    edge_index = torch.tensor([[0, 1, 1, 2], [1, 0, 2, 1]])
+    num_nodes = edge_index.max().item() + 1
+    x = torch.randn((num_nodes, in_channels))
+    P = _make_dense_lrw_diffusion_operator(edge_index, num_nodes)
+
+    conv = GeoScatConv(
+        in_channels,
+        diffusion_scales='legs',
+        legs_kwargs={'legs_J': 4},
+        scattering_orders=[0, 1, 2],
+        pool=None,
+    )
+    assert conv.num_scattering_filters == 12
+
+    with warnings.catch_warnings():
+        warnings.simplefilter('ignore', UserWarning)
+        out = conv(x, diffusion_op=P)
+    assert out.size() == (num_nodes, in_channels, 12)
+
+
+def test_geo_scat_conv_legs_multiorder_scatter_consistency():
+    in_channels = 2
+    edge_index = torch.tensor([[0, 1, 1, 2], [1, 0, 2, 1]])
+    num_nodes = edge_index.max().item() + 1
+    x = torch.randn((num_nodes, in_channels))
+    P = _make_dense_lrw_diffusion_operator(edge_index, num_nodes)
+
+    conv = GeoScatConv(
+        in_channels,
+        diffusion_scales='legs',
+        scattering_orders=[0, 1, 2],
+        pool=None,
+    )
+
+    with torch.no_grad():
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore', UserWarning)
+            out_conv = conv(x, diffusion_op=P)
+        out_scatter = multiorder_scatter(
+            x,
+            P,
+            F=conv.F,
+            include_lowpass=conv.include_lowpass,
+            scattering_orders=conv.scattering_orders,
+            is_vector_feature=conv.is_vector_feature,
+        )
+
+    assert torch.allclose(out_conv, out_scatter, atol=1e-6)
+
+
+@pytest.mark.parametrize(
+    'kwargs,match',
+    [
+        ({
+            'diffusion_scales': 'legs',
+            'legs_kwargs': {
+                'legs_J': 0
+            }
+        }, 'legs_J must be at least 1'),
+        ({
+            'diffusion_scales': 'legs',
+            'legs_kwargs': {
+                'legs_J': 1
+            },
+            'scattering_orders': [0, 1, 2],
+        }, 'requires legs_J >= 2'),
+        ({
+            'diffusion_scales': 'legs',
+            'legs_kwargs': {
+                'unknown': 1
+            }
+        }, 'Unknown legs_kwargs keys'),
+        ({
+            'diffusion_scales': 'legs',
+            'legs_kwargs': {}
+        }, "must contain 'legs_J'"),
+    ],
+)
+def test_geo_scat_conv_legs_validation(kwargs, match):
+    with pytest.raises(ValueError, match=match):
+        GeoScatConv(2, **kwargs)

--- a/test/nn/conv/test_geo_scat_conv.py
+++ b/test/nn/conv/test_geo_scat_conv.py
@@ -31,6 +31,24 @@ def test_geo_scat_conv_node_level():
     assert out_weighted.size() == (num_nodes, in_channels, 7)
 
 
+def test_lazy_geo_scat_conv():
+    in_channels = 4
+    num_nodes = 3
+    x = torch.randn((num_nodes, in_channels))
+    diffusion_op = torch.eye(num_nodes)
+
+    conv = GeoScatConv(pool=None)
+    assert conv.in_channels == -1
+
+    out = conv(x, diffusion_op=diffusion_op)
+    assert conv.in_channels == in_channels
+    assert out.size() == (num_nodes, in_channels, conv.num_scattering_filters)
+
+    with pytest.raises(ValueError, match='Expected input with 4 channels'):
+        conv(torch.randn(num_nodes, in_channels + 1),
+             diffusion_op=diffusion_op)
+
+
 def test_geo_scat_conv_second_order():
     in_channels = 3
     edge_index = torch.tensor([[0, 1, 1, 2], [1, 0, 2, 1]])

--- a/test/nn/conv/test_geo_scat_conv.py
+++ b/test/nn/conv/test_geo_scat_conv.py
@@ -475,24 +475,28 @@ def test_geo_scat_conv_legs_construction():
     conv = GeoScatConv(in_channels, diffusion_scales='legs', pool=None)
     assert conv.use_legs is True
     assert conv.legs_kwargs == {'legs_J': 4}
-    assert conv.F.shape == (4, 17)
-    assert conv.num_wavelet_filters == 5
-    assert conv.num_scattering_filters == 12
+    assert conv.F.shape == (5, 17)
+    assert conv.num_wavelet_filters == 6
+    assert conv.num_scattering_filters == 22
     assert "diffusion_scales='legs'" in str(conv)
 
     P = _make_dense_lrw_diffusion_operator(edge_index, num_nodes)
     with warnings.catch_warnings():
         warnings.simplefilter('ignore', UserWarning)
         out = conv(x, diffusion_op=P)
-    assert out.size() == (num_nodes, in_channels, 12)
+    assert out.size() == (num_nodes, in_channels, 22)
 
 
-def test_geo_scat_conv_legs_init_row_zero():
+def test_geo_scat_conv_legs_init_rows():
     conv = GeoScatConv(2, diffusion_scales='legs', pool=None)
     F = conv.F
+    assert F.shape == (5, 17)
     assert F[0, 0].item() == 1.0
     assert F[0, 1].item() == -1.0
-    assert F[0, 2:].abs().sum().item() == 0.0
+    assert F[1, 1].item() == 1.0
+    assert F[1, 2].item() == -1.0
+    assert F[4, 8].item() == 1.0
+    assert F[4, 16].item() == -1.0
 
 
 def test_geo_scat_conv_legs_reset_parameters():
@@ -547,7 +551,7 @@ def test_geo_scat_conv_legs_lowpass_before_activation():
     with warnings.catch_warnings():
         warnings.simplefilter('ignore', UserWarning)
         out = conv(x, diffusion_op=P)
-    assert out.size() == (num_nodes, in_channels, 5)
+    assert out.size() == (num_nodes, in_channels, 6)
     assert (out >= 0).all()
 
 
@@ -581,9 +585,41 @@ def test_geo_scat_conv_legs_partial_equivalence_at_init():
             out_fixed = conv_fixed(x, diffusion_op=P)
 
     assert torch.allclose(out_legs[..., 0], out_fixed[..., 0], atol=1e-6)
-    assert torch.allclose(out_legs[..., 1], out_fixed[..., 2], atol=1e-6)
-    assert torch.allclose(out_legs[..., 2], out_fixed[..., 3], atol=1e-6)
-    assert torch.allclose(out_legs[..., 3], out_fixed[..., 4], atol=1e-6)
+    assert torch.allclose(out_legs[..., 1], out_fixed[..., 1], atol=1e-6)
+    assert torch.allclose(out_legs[..., 2], out_fixed[..., 2], atol=1e-6)
+    assert torch.allclose(out_legs[..., 3], out_fixed[..., 3], atol=1e-6)
+    assert torch.allclose(out_legs[..., 4], out_fixed[..., 4], atol=1e-6)
+
+
+def test_geo_scat_conv_legs_full_equivalence_at_init():
+    in_channels = 2
+    edge_index = torch.tensor([[0, 1, 1, 2], [1, 0, 2, 1]])
+    num_nodes = edge_index.max().item() + 1
+    x = torch.randn((num_nodes, in_channels))
+    P = _make_dense_lrw_diffusion_operator(edge_index, num_nodes)
+
+    conv_legs = GeoScatConv(
+        in_channels,
+        diffusion_scales='legs',
+        legs_kwargs={'legs_J': 4},
+        scattering_orders=[0, 1, 2],
+        pool=None,
+    )
+    conv_fixed = GeoScatConv(
+        in_channels,
+        diffusion_scales=(0, 1, 2, 4, 8, 16),
+        scattering_orders=[0, 1, 2],
+        pool=None,
+    )
+
+    with warnings.catch_warnings():
+        warnings.simplefilter('ignore', UserWarning)
+        with torch.no_grad():
+            out_legs = conv_legs(x, diffusion_op=P)
+            out_fixed = conv_fixed(x, diffusion_op=P)
+
+    assert out_legs.shape == out_fixed.shape
+    assert torch.allclose(out_legs, out_fixed, atol=1e-6)
 
 
 def test_geo_scat_conv_legs_second_order():
@@ -600,12 +636,12 @@ def test_geo_scat_conv_legs_second_order():
         scattering_orders=[0, 1, 2],
         pool=None,
     )
-    assert conv.num_scattering_filters == 12
+    assert conv.num_scattering_filters == 22
 
     with warnings.catch_warnings():
         warnings.simplefilter('ignore', UserWarning)
         out = conv(x, diffusion_op=P)
-    assert out.size() == (num_nodes, in_channels, 12)
+    assert out.size() == (num_nodes, in_channels, 22)
 
 
 def test_geo_scat_conv_legs_multiorder_scatter_consistency():

--- a/torch_geometric/nn/conv/__init__.py
+++ b/torch_geometric/nn/conv/__init__.py
@@ -62,6 +62,7 @@ from .antisymmetric_conv import AntiSymmetricConv
 from .dir_gnn_conv import DirGNNConv
 from .mixhop_conv import MixHopConv
 from .meshcnn_conv import MeshCNNConv
+from .geo_scat_conv import GeoScatConv
 
 import torch_geometric.nn.conv.utils  # noqa
 
@@ -133,6 +134,7 @@ __all__ = [
     'DirGNNConv',
     'MixHopConv',
     'MeshCNNConv',
+    'GeoScatConv',
 ]
 
 classes = __all__

--- a/torch_geometric/nn/conv/geo_scat_conv.py
+++ b/torch_geometric/nn/conv/geo_scat_conv.py
@@ -471,21 +471,26 @@ def diffusion_wavelet_transform(
     return torch.stack(wjxs, dim=filter_stack_dim).to(x.device)
 
 
+def _legs_max_power(F: Tensor) -> int:
+    """Return ``T = 2^J`` from a LEGS matrix with ``J + 1`` filter rows."""
+    return 2**(int(F.size(0)) - 1)
+
+
 def _initialize_legs_parameters(J: int = 4) -> Tensor:
     r"""Initialize the LEGS selector matrix :math:`F` with dyadic scales.
 
-    For ``J = 4``, the matrix has shape ``(4, 17)`` since powers
-    :math:`t = 0, \ldots, 2^J` are indexed along the last dimension.
+    For ``J = 4``, ``F`` has shape ``(5, 17)``: ``J + 1`` learnable wavelet
+    rows matching ``(P^{t_{j-1}} - P^{t_j})`` for scales
+    ``(0, 1, 2, 4, 8, 16)``, and ``2^J + 1`` diffusion-power columns.
     """
-    m = torch.zeros((J, 2**J + 1))
-    # We want to subtract greater powers of P when adding rows of
-    # the selector matrix, so -1s are at greater indices than +1s
-    # cf. Eq 4 in LEGS paper
-    m[0, 0] = 1.0
-    m[0, 1] = -1.0
-    for j in range(1, J):
-        m[j, 2**j] = 1.0
-        m[j, 2**(j + 1)] = -1.0
+    num_rows = J + 1
+    T = 2**J
+    m = torch.zeros((num_rows, T + 1))
+    for r in range(num_rows):
+        lower = 0 if r == 0 else 2**(r - 1)
+        upper = 2**r
+        m[r, lower] = 1.0
+        m[r, upper] = -1.0
     return m.to(torch.float)
 
 
@@ -504,8 +509,7 @@ def legs_wavelet_transform(
     At initialization, each row is a dyadic difference; during training ``F``
     can learn a continuous approximation to discrete wavelet scales.
     """
-    J = int(F.size(0))
-    T = 2**J
+    T = _legs_max_power(F)
     pt_xs = _compute_pt_xs(
         x,
         P,
@@ -520,29 +524,6 @@ def legs_wavelet_transform(
     if filter_stack_dim != -1:
         w1 = w1.movedim(-1, filter_stack_dim)
     return w1
-
-
-def _apply_legs_filters(
-    x: Tensor,
-    P: Union[Tensor, SparseTensor],
-    F: Tensor,
-    max_power: int,
-    *,
-    check_nonfinite: bool = False,
-) -> Tensor:
-    """Apply all LEGS wavelet rows of ``F`` to a single graph signal ``x``.
-
-    Returns shape ``(num_nodes, num_features, J)`` where entry ``[..., k]`` is
-    the k-th LEGS filter applied to ``x``.
-    """
-    pt_xs = _compute_pt_xs(
-        x,
-        P,
-        max_power,
-        check_nonfinite=check_nonfinite,
-    )
-    # Same einsum as first order, but over output filter index k.
-    return torch.einsum('kt,tnf->nfk', F, pt_xs)
 
 
 def _prepare_scatter_inputs(
@@ -584,25 +565,60 @@ def _compute_second_order_scattering(
             'wavelet filters.', )
 
     if F is not None:
-        J = int(F.size(0))
-        T = 2**J
-        # Apply every LEGS filter (k) to each learnable first-order coeff (j).
-        # Only the J learnable rows of W1 participate; lowpass is excluded.
-        w2_parts = [
-            _apply_legs_filters(
+        num_f_rows = int(F.size(0))
+        T = _legs_max_power(F)
+        w2_parts: List[Tensor] = []
+        lowpass_parts: List[Tensor] = []
+        for j in range(num_f_rows):
+            # One power stack per first-order channel;
+            # reuse for einsum and lowpass.
+            pt_xs = _compute_pt_xs(
                 W1[..., j],
                 diffusion_op,
-                F,
                 T,
                 check_nonfinite=check_nonfinite,
-            ).unsqueeze(-2) for j in range(J)
-        ]
-        W2raw = torch.cat(w2_parts, dim=-2)  # (..., J, K) before masking
-        if is_vector_feature:
-            W2raw = W2raw.view(W1.shape[0], J, J)
+            )
+            w2_parts.append(
+                torch.einsum('kt,tnf->nfk', F, pt_xs).unsqueeze(-2))
+            if include_lowpass:
+                lowpass_parts.append(pt_xs[T])
+
+        w2_learnable = torch.cat(w2_parts, dim=-2)
+
+        if include_lowpass:
+            num_wavelets = num_f_rows + 1
+            # Lowpass second-order: P^T applied to W_j x (from pt_xs[T] above).
+            lowpass_on_j = torch.stack(lowpass_parts, dim=-1)
+            if is_vector_feature:
+                nd = W1.shape[0]
+                w2_full = w2_learnable.new_zeros(nd, num_wavelets,
+                                                 num_wavelets)
+                w2_full[:, :num_f_rows, :num_f_rows] = w2_learnable.view(
+                    nd, num_f_rows, num_f_rows)
+                w2_full[:, :num_f_rows, num_f_rows] = lowpass_on_j.squeeze(1)
+                W2raw = w2_full
+            else:
+                num_channels = int(W1.shape[1])
+                w2_full = w2_learnable.new_zeros(
+                    num_nodes,
+                    num_channels,
+                    num_wavelets,
+                    num_wavelets,
+                )
+                w2_full[:, :, :num_f_rows, :num_f_rows] = w2_learnable.view(
+                    num_nodes, num_channels, num_f_rows, num_f_rows)
+                w2_full[:, :, :num_f_rows, num_f_rows] = lowpass_on_j
+                W2raw = w2_full
+        elif is_vector_feature:
+            W2raw = w2_learnable.view(W1.shape[0], num_f_rows, num_f_rows)
         else:
             num_channels = int(W1.shape[1])
-            W2raw = W2raw.view(num_nodes, num_channels, J, J)
+            W2raw = w2_learnable.view(
+                num_nodes,
+                num_channels,
+                num_f_rows,
+                num_f_rows,
+            )
     else:
         # Fixed scales: batch all first-order channels through the wavelet
         # transform again, producing (W_prev, W_next) pairs for every channel.
@@ -818,9 +834,10 @@ class GeoScatConv(Module):
     <https://arxiv.org/abs/2504.08802>`_.
 
     Alternatively, set :obj:`diffusion_scales='legs'` to use a learnable
-    LEGS-style selector matrix :math:`F \in \mathbb{R}^{J \times (2^J + 1)}`
-    initialized to dyadic scales. The number of learnable wavelet filters
-    :math:`J` is set via :obj:`legs_kwargs['legs_J']` (default: :obj:`4`).
+    LEGS selector matrix :math:`F \in \mathbb{R}^{(J+1) \times (2^J + 1)}`
+    initialized to dyadic scales matching the default filter bank. The
+    diffusion depth :math:`J` is set via :obj:`legs_kwargs['legs_J']`
+    (default: :obj:`4`, giving ``5`` learnable wavelet rows and ``T = 16``).
     Note that :math:`J` sets the max diffusion scale to :math:`2^J`;
     given its dyadic initialization, :math:`J=4` or :math:`J=5` is
     recommended.
@@ -908,8 +925,8 @@ class GeoScatConv(Module):
             dyadic scales. (default: :obj:`(0, 1, 2, 4, 8, 16)`)
         legs_kwargs (Dict[str, Any], optional): Keyword arguments for LEGS
             mode. Currently supports :obj:`'legs_J'`, the number of learnable
-            wavelet filters (default: :obj:`4`). Ignored unless
-            :obj:`diffusion_scales='legs'`.
+            wavelet filters (default: :obj:`4`, yielding ``J + 1`` rows in
+            :obj:`F` and maximum diffusion power ``2^J``).
         include_lowpass (bool, optional): If set to :obj:`True`, append the
             low-pass filter :math:`\mathbf{P}^{t_J} \mathbf{x}` before the
             optional activation at first order.
@@ -1057,7 +1074,7 @@ class GeoScatConv(Module):
     @property
     def num_wavelet_filters(self) -> int:
         if self.use_legs:
-            return self.legs_kwargs['legs_J'] + int(self.include_lowpass)
+            return (self.legs_kwargs['legs_J'] + 1) + int(self.include_lowpass)
         return _compute_num_wavelet_filters(
             self.diffusion_scales,
             self.include_lowpass,
@@ -1065,16 +1082,6 @@ class GeoScatConv(Module):
 
     @property
     def num_scattering_filters(self) -> int:
-        if self.use_legs:
-            legs_J = self.legs_kwargs['legs_J']
-            total = 0
-            if 0 in self.scattering_orders:
-                total += 1
-            if 1 in self.scattering_orders:
-                total += legs_J + int(self.include_lowpass)
-            if 2 in self.scattering_orders:
-                total += legs_J * (legs_J - 1) // 2
-            return total
         return _compute_num_scattering_filters(
             self.num_wavelet_filters,
             self.scattering_orders,

--- a/torch_geometric/nn/conv/geo_scat_conv.py
+++ b/torch_geometric/nn/conv/geo_scat_conv.py
@@ -802,8 +802,7 @@ class GeoScatConv(Module):
     Analysis" <https://arxiv.org/abs/1810.03068>`_ and `"Diffusion
     Scattering Transforms on Graphs" <https://arxiv.org/abs/1806.08829>`_.
     It has been utilized and extended further in, for example,
-    `"Learnable Filters for Geometric Scattering Modules"
-    (LEGS) <https://ieeexplore.ieee.org/document/10473218>`_,
+    `LEGS <https://ieeexplore.ieee.org/document/10473218>`_,
     `BLIS-Net <https://proceedings.mlr.press/v238/xu24c.html>`_,
     `HiPoNet <https://arxiv.org/abs/2502.07746>`_, and
     `VDW-GNNs <https://arxiv.org/abs/2510.01022>`_.
@@ -841,9 +840,7 @@ class GeoScatConv(Module):
     scales are initialized to dyadic scales matching the default filter bank.
     The diffusion depth :math:`J` is set via :obj:`legs_kwargs['legs_J']`
     (default: :obj:`4`, giving ``5`` learnable wavelet rows and ``T = 16``).
-    Note that :math:`J` sets the max diffusion scale to :math:`2^J`;
-    given its dyadic initialization, :math:`J \in {3, 4, 5}` is
-    recommended.
+    Note that :math:`J` sets the max diffusion scale to :math:`2^J`.
 
     This layer returns concatenated zeroeth and first-order scattering
     coefficients by default. The zeroeth-order scattering coefficient

--- a/torch_geometric/nn/conv/geo_scat_conv.py
+++ b/torch_geometric/nn/conv/geo_scat_conv.py
@@ -800,9 +800,10 @@ class GeoScatConv(Module):
     r"""Implements the geometric scattering transform
     introduced in the papers `"Geometric Scattering for Graph Data
     Analysis" <https://arxiv.org/abs/1810.03068>`_ and `"Diffusion
-    Scattering Transforms on Graphs"
-    <https://arxiv.org/abs/1806.08829>`_. It
-    has been utilized and extended further in, for example,
+    Scattering Transforms on Graphs" <https://arxiv.org/abs/1806.08829>`_.
+    It has been utilized and extended further in, for example,
+    `"Learnable Filters for Geometric Scattering Modules"
+    (LEGS) <https://ieeexplore.ieee.org/document/10473218>`_,
     `BLIS-Net <https://proceedings.mlr.press/v238/xu24c.html>`_,
     `HiPoNet <https://arxiv.org/abs/2502.07746>`_, and
     `VDW-GNNs <https://arxiv.org/abs/2510.01022>`_.
@@ -834,12 +835,14 @@ class GeoScatConv(Module):
     <https://arxiv.org/abs/2504.08802>`_.
 
     Alternatively, set :obj:`diffusion_scales='legs'` to use a learnable
-    LEGS selector matrix :math:`F \in \mathbb{R}^{(J+1) \times (2^J + 1)}`
-    initialized to dyadic scales matching the default filter bank. The
-    diffusion depth :math:`J` is set via :obj:`legs_kwargs['legs_J']`
+    diffusion scales selector matrix
+    :math:`F \in \mathbb{R}^{(J+1) \times (2^J + 1)}`, as detailed in
+    the LEGS paper. Learnable
+    scales are initialized to dyadic scales matching the default filter bank.
+    The diffusion depth :math:`J` is set via :obj:`legs_kwargs['legs_J']`
     (default: :obj:`4`, giving ``5`` learnable wavelet rows and ``T = 16``).
     Note that :math:`J` sets the max diffusion scale to :math:`2^J`;
-    given its dyadic initialization, :math:`J=4` or :math:`J=5` is
+    given its dyadic initialization, :math:`J \in {3, 4, 5}` is
     recommended.
 
     This layer returns concatenated zeroeth and first-order scattering
@@ -875,8 +878,8 @@ class GeoScatConv(Module):
     scattering coefficients, and apply other pooling operations downstream
     of this layer.
 
-    Vector-valued graph signals (as explored in the `VDW-GNNs paper
-    <https://arxiv.org/abs/2510.01022>`_) are supported by
+    Vector-valued graph signals (as explored in the `VDW-GNNs
+    <https://arxiv.org/abs/2510.01022>`_ paper) are supported by
     setting :obj:`is_vector_feature` to :obj:`True`. In this mode, node
     features :math:`\mathbf{x} \in \mathbb{R}^{n \times d}` are flattened
     internally and a user-supplied diffusion operator
@@ -1097,8 +1100,7 @@ class GeoScatConv(Module):
     def reset_parameters(self) -> None:
         r"""Resets learnable parameters.
 
-        In LEGS mode, reinitializes :obj:`F` to dyadic scales via
-        :func:`_initialize_legs_parameters`.
+        In LEGS mode, reinitializes :obj:`F` to dyadic scales.
         """
         if self.use_legs:
             with torch.no_grad():

--- a/torch_geometric/nn/conv/geo_scat_conv.py
+++ b/torch_geometric/nn/conv/geo_scat_conv.py
@@ -807,9 +807,9 @@ class GeoScatConv(Module):
     `HiPoNet <https://arxiv.org/abs/2502.07746>`_, and
     `VDW-GNNs <https://arxiv.org/abs/2510.01022>`_.
 
-    In particular, this layer computes diffusion wavelet scattering
-    coefficients on graph node features. A diffusion wavelet
-    convolution of a graph signal :math:`\mathbf{x}` has the
+    In particular, this layer computes diffusion-wavelet scattering
+    coefficients on graph node features. A diffusion wavelet convolution
+    of a graph signal :math:`\mathbf{x} \in \mathbb{R}^n` has the
     general form
 
     .. math::
@@ -819,10 +819,10 @@ class GeoScatConv(Module):
     where :math:`\mathbf{P}` is a lazy random walk operator
     (row-normalized by default), and :math:`t_j` are the diffusion
     scales.
-    A low-pass filter :math:`\mathbf{A}_J = \mathbf{P}^{t_J} \mathbf{x}`
-    is also included by default, such that the full filter bank is
-    :math:`\{\mathbf{W}_j\}_{j=0}^{J} \cup \{\mathbf{A}_J\}`. The low-pass
-    filter can be excluded by setting :obj:`include_lowpass`
+    A low-pass filter :math:`\bar{\mathbf{A}}_J = \mathbf{P}^{t_J} \mathbf{x}`
+    is also included by default, so that the full filter bank is
+    :math:`\{\mathbf{W}_j\}_{j=0}^{J} \cup \{\bar{\mathbf{A}}_J\}`. The
+    low-pass filter can be excluded by setting :obj:`include_lowpass`
     to :obj:`False`.
 
     By default, the :math:`t_j` are set to be dyadic integers
@@ -836,18 +836,18 @@ class GeoScatConv(Module):
     Alternatively, set :obj:`diffusion_scales='legs'` to use a learnable
     diffusion scales selector matrix
     :math:`F \in \mathbb{R}^{(J+1) \times (2^J + 1)}`, as detailed in
-    the LEGS paper. Learnable
-    scales are initialized to dyadic scales matching the default filter bank.
-    The diffusion depth :math:`J` is set via :obj:`legs_kwargs['legs_J']`
-    (default: :obj:`4`, giving ``5`` learnable wavelet rows and ``T = 16``).
-    Note that :math:`J` sets the max diffusion scale to :math:`2^J`.
+    the `LEGS <https://ieeexplore.ieee.org/document/10473218>`_ paper.
+    Learnable scales are initialized to dyadic scales matching the default
+    filter bank. The diffusion depth :math:`J` is set via
+    :obj:`legs_kwargs['legs_J']` (default: :obj:`4`, which gives
+    :math:`t_J = 2^J = 16`).
 
-    This layer returns concatenated zeroeth and first-order scattering
-    coefficients by default. The zeroeth-order scattering coefficient
-    is the unfiltered input feature vector, and can be excluded by
+    This layer returns concatenated zeroth and first-order scattering
+    coefficients by default. The zeroth-order scattering coefficient
+    is the unfiltered input feature vector and can be excluded by
     excluding :obj:`0` from :obj:`scattering_orders`. Second-order
     scattering coefficients can be included by including :obj:`2` in
-    the :obj:`scattering_orders` tuple. These are defined as:
+    the :obj:`scattering_orders` tuple. These are defined as
 
     .. math::
         \sigma(\mathbf{W}_{j^{\,\prime}} \, \sigma (\mathbf{W}_j \,
@@ -856,11 +856,11 @@ class GeoScatConv(Module):
     where :math:`\sigma` is an optional activation (e.g. the modulus
     operator via :obj:`torch.abs`), disabled by default.
 
-    Note there is not an :obj:`out_channels` property for this layer,
+    Note there is not an :obj:`out_channels` parameter for this layer,
     as the number of output channels is deterministic via the
-    parameterization of the scattering transform. Including 0th-order
+    parameterization of the scattering transform. Including zeroth-order
     scattering coefficients increases the number of output channels by
-    1; including first-order scattering coefficients increases the number
+    one; including first-order scattering coefficients increases the number
     of output channels by the number of filters :math:`w`; including
     second-order scattering coefficients increases the number of output
     channels by :math:`w \cdot (w - 1) / 2`.
@@ -883,7 +883,7 @@ class GeoScatConv(Module):
     :math:`\mathbf{P} \in \mathbb{R}^{nd \times nd}` must be passed via
     :obj:`diffusion_op` (for example, stored on
     :class:`~torch_geometric.data.Data` under an attribute such as
-    :obj:`diffusion_adj`). Lazy random walk operators built from
+    :obj:`P_adj`). Lazy random walk operators built from
     :obj:`edge_index` are not supported for vector features.
 
     .. note::
@@ -909,13 +909,16 @@ class GeoScatConv(Module):
         <https://pytorch-geometric.readthedocs.io/en/latest/advanced/batching.html>`_.
 
     Args:
-        in_channels (int): Size of each input sample. For vector features,
-            this is the vector dimension :math:`d`.
+        in_channels (int, optional): Size of each input sample, or :obj:`-1`
+            to derive the size from the first input(s) to the forward method.
+            For vector features, this is the vector dimension :math:`d`.
+            Multiple vector features are not currently supported.
+            (default: :obj:`-1`)
         scattering_orders (Tuple[int, ...], optional): Scattering orders to
-            include in the output. Each entry must be :obj:`0` (unfiltered
-            input), :obj:`1` (first-order wavelets), or :obj:`2`
-            (second-order). Pass :obj:`(1,)` for a diffusion wavelet
-            transform only. (default: :obj:`(0, 1, 2)`)
+            include in the output. Each entry must be :obj:`0` (zeroth-order,
+            i.e., unfiltered input), :obj:`1` (first-order wavelets),
+            or :obj:`2` (second-order). Pass :obj:`(1,)` for a diffusion
+            wavelet transform only. (default: :obj:`(0, 1, 2)`)
         diffusion_scales (Tuple[int, ...] or str, optional): Monotonically
             increasing diffusion powers, i.e., :math:`t_j` in each
             :math:`\mathbf{P}^{t_j}`. Wavelet filters are consecutive
@@ -925,11 +928,11 @@ class GeoScatConv(Module):
             dyadic scales. (default: :obj:`(0, 1, 2, 4, 8, 16)`)
         legs_kwargs (Dict[str, Any], optional): Keyword arguments for LEGS
             mode. Currently supports :obj:`'legs_J'`, the number of learnable
-            wavelet filters (default: :obj:`4`, yielding ``J + 1`` rows in
-            :obj:`F` and maximum diffusion power ``2^J``).
+            wavelet filters (default: :obj:`4`, yielding :math:`J + 1` rows in
+            :obj:`F` and maximum diffusion power :math:`2^J`).
         include_lowpass (bool, optional): If set to :obj:`True`, append the
-            low-pass filter :math:`\mathbf{P}^{t_J} \mathbf{x}` before the
-            optional activation at first order.
+            low-pass filter :math:`\bar{\mathbf{A}}_J = \mathbf{P}^{t_J}`
+            before the optional activation at first order.
             (default: :obj:`True`)
         activation (torch.nn.Module or Callable, optional): Activation
             applied to first- and second-order scattering coefficients, e.g.
@@ -937,13 +940,18 @@ class GeoScatConv(Module):
         normalization (str, optional): Normalization scheme for the adjacency
             matrix before building the lazy random walk operator
             :math:`\mathbf{P}`. Ignored when :obj:`diffusion_op` is provided.
-            Options: :obj:`"row"`, :obj:`"column"`, :obj:`"symmetric"`.
+            Options: :obj:`"row"` (:math:`\mathbf{P} = \frac{1}{2}(\mathbf{I}
+            + \mathbf{D}^{-1} \mathbf{A})`; rows of :math:`\mathbf{P}` sum to
+            one), :obj:`"column"` (:math:`\mathbf{P} = \frac{1}{2}(\mathbf{I}
+            + \mathbf{A} \mathbf{D}^{-1})`; columns of :math:`\mathbf{P}` sum
+            to one), :obj:`"symmetric"` (:math:`\mathbf{P} = \frac{1}{2}
+            (\mathbf{I} + \mathbf{D}^{-1/2} \mathbf{A} \mathbf{D}^{-1/2})`).
             (default: :obj:`"row"`)
         is_vector_feature (bool, optional): If set to :obj:`True`, treat each
             node feature as a vector signal of dimension :obj:`in_channels`
             and require a precomputed :obj:`diffusion_op` of shape
-            :math:`(n \cdot d, n \cdot d)`.
-            (default: :obj:`False`)
+            :math:`(n \cdot d, n \cdot d)`. Note that multiple vector features
+            are not currently supported. (default: :obj:`False`)
         pool (Tuple[str, ...], optional): Graph-level pooling operations to
             apply across nodes. Multiple pooling operations can be applied by
             passing a tuple of strings, the results of which are concatenated.
@@ -974,7 +982,7 @@ class GeoScatConv(Module):
     """
     def __init__(
         self,
-        in_channels: int,
+        in_channels: int = -1,
         scattering_orders: Optional[Tuple[int, ...]] = (0, 1, 2),
         diffusion_scales: Optional[DiffusionScalesArg] = (
             0,
@@ -1135,7 +1143,9 @@ class GeoScatConv(Module):
             or :math:`(B, F_{\mathrm{in}}, F_{\mathrm{out}}
             \cdot |\mathrm{pool}|)` if :obj:`pool` is set.
         """
-        if x.size(-1) != self.in_channels:
+        if self.in_channels == -1:
+            self.in_channels = x.size(-1)
+        elif x.size(-1) != self.in_channels:
             raise ValueError(
                 f"Expected input with {self.in_channels} channels "
                 f"(got {x.size(-1)}).", )

--- a/torch_geometric/nn/conv/geo_scat_conv.py
+++ b/torch_geometric/nn/conv/geo_scat_conv.py
@@ -523,12 +523,11 @@ def _pool_scattering_coefficients(
 
 
 class GeoScatConv(Module):
-    r"""Implements the geometric scattering transform built from
-    graph diffusion wavelets, introduced in the `"Geometric
-    Scattering for Graph Data Analysis"
-    <https://arxiv.org/abs/1810.03068>`_ and `"Diffusion
+    r"""Implements the geometric scattering transform
+    introduced in the papers `"Geometric Scattering for Graph Data
+    Analysis" <https://arxiv.org/abs/1810.03068>`_ and `"Diffusion
     Scattering Transforms on Graphs"
-    <https://arxiv.org/abs/1806.08829>`_ papers. This technique
+    <https://arxiv.org/abs/1806.08829>`_. It
     has been utilized and extended further in, for example,
     `BLIS-Net <https://proceedings.mlr.press/v238/xu24c.html>`_,
     `HiPoNet <https://arxiv.org/abs/2502.07746>`_, and
@@ -546,9 +545,9 @@ class GeoScatConv(Module):
     where :math:`\mathbf{P}` is a lazy random walk operator
     (row-normalized by default), and :math:`t_j` are the diffusion
     scales.
-    A low-pass filter :math:`A_J = \mathbf{P}^{t_J} \mathbf{x}`
+    A low-pass filter :math:`\mathbf{A}_J = \mathbf{P}^{t_J} \mathbf{x}`
     is also included by default, such that the full filter bank is
-    :math:`\{\mathbf{W}_j\}_{j=0}^{J} \cup \{A_J\}`. The low-pass
+    :math:`\{\mathbf{W}_j\}_{j=0}^{J} \cup \{\mathbf{A}_J\}`. The low-pass
     filter can be excluded by setting :obj:`include_lowpass`
     to :obj:`False`.
 
@@ -563,7 +562,7 @@ class GeoScatConv(Module):
     This layer returns concatenated zeroeth and first-order scattering
     coefficients by default. The zeroeth-order scattering coefficient
     is the unfiltered input feature vector, and can be excluded by
-    setting :obj:`scattering_orders` to :obj:`(1,)`. Second-order
+    excluding :obj:`0` from :obj:`scattering_orders`. Second-order
     scattering coefficients can be included by including :obj:`2` in
     the :obj:`scattering_orders` tuple. These are defined as:
 
@@ -579,14 +578,14 @@ class GeoScatConv(Module):
     parameterization of the scattering transform. Including 0th-order
     scattering coefficients increases the number of output channels by
     1; including first-order scattering coefficients increases the number
-    of output channels by the number of wavelets :math:`w`; including
+    of output channels by the number of filters :math:`w`; including
     second-order scattering coefficients increases the number of output
     channels by :math:`w \cdot (w - 1) / 2`.
 
     For graph-level tasks, scattering coefficients can be pooled across
     nodes within each graph and feature channel, changing the output shape
-    from :math:`(|\mathcal{V}|, F_{\mathrm{in}}, W_{\mathrm{total}})` to
-    :math:`(B, F_{\mathrm{in}}, W_{\mathrm{total}} \cdot |\mathrm{pool}|)`.
+    from :math:`(|\mathcal{V}|, F_{\mathrm{in}}, F_{\mathrm{out}})` to
+    :math:`(B, F_{\mathrm{in}}, F_{\mathrm{out}} \cdot |\mathrm{pool}|)`.
     Currently, the built-in options for pooling are :obj:`"mean"`,
     :obj:`"max"`, :obj:`"min"`, :obj:`"median"`, and :obj:`"var"`.
     Alternatively, leave :obj:`pool` as :obj:`None` to return node-level
@@ -633,22 +632,22 @@ class GeoScatConv(Module):
             include in the output. Each entry must be :obj:`0` (unfiltered
             input), :obj:`1` (first-order wavelets), or :obj:`2`
             (second-order). Pass :obj:`(1,)` for a diffusion wavelet
-            transform only. (default: :obj:`(0, 1)`)
+            transform only. (default: :obj:`(0, 1, 2)`)
         diffusion_scales (Tuple[int, ...], optional): Monotonically increasing
-            diffusion powers, i.e., :math:`t_j` in each `:math:`P^{t_j}`.
-            Wavelet filters are consecutive differences between adjacent
-            :math:`t_{j-1}` and :math:`t_j`.
+            diffusion powers, i.e., :math:`t_j` in each :math:
+            `\mathbf{P}^{t_j}`. Wavelet filters are consecutive differences
+            between adjacent :math:`t_{j-1}` and :math:`t_j`.
             (default: :obj:`(0, 1, 2, 4, 8, 16)`)
         include_lowpass (bool, optional): If set to :obj:`True`, append the
-            low-pass filter :math:`P^{t_J} \mathbf{x}`.
+            low-pass filter :math:`\mathbf{P}^{t_J} \mathbf{x}`.
             (default: :obj:`True`)
         activation (torch.nn.Module or Callable, optional): Activation
             applied to first- and second-order scattering coefficients, e.g.
             :obj:`torch.abs` for the modulus. (default: :obj:`None`)
         normalization (str, optional): Normalization scheme for the adjacency
             matrix before building the lazy random walk operator
-            :math:`P`. Ignored when :obj:`diffusion_op` is provided. Options:
-            :obj:`"row"`, :obj:`"column"`, :obj:`"symmetric"`.
+            :math:`\mathbf{P}`. Ignored when :obj:`diffusion_op` is provided.
+            Options: :obj:`"row"`, :obj:`"column"`, :obj:`"symmetric"`.
             (default: :obj:`"row"`)
         is_vector_feature (bool, optional): If set to :obj:`True`, treat each
             node feature as a vector signal of dimension :obj:`in_channels`
@@ -678,15 +677,15 @@ class GeoScatConv(Module):
           graph-level pooling on batched graphs)*
         - **output (node-level,** :obj:`pool=None` **):**
           scattering coefficients
-          :math:`(|\mathcal{V}|, F_{in}, W_{\mathrm{total}})`
+          :math:`(|\mathcal{V}|, F_{in}, F_{\mathrm{out}})`
         - **output (graph-level,** :obj:`pool` **set):**
           pooled scattering coefficients
-          :math:`(B, F_{in}, W_{\mathrm{total}} \cdot |\texttt{pool}|)`
+          :math:`(B, F_{in}, F_{\mathrm{out}} \cdot |\texttt{pool}|)`
     """
     def __init__(
         self,
         in_channels: int,
-        scattering_orders: Optional[Tuple[int, ...]] = (0, 1),
+        scattering_orders: Optional[Tuple[int, ...]] = (0, 1, 2),
         diffusion_scales: Optional[Tuple[int, ...]] = (0, 1, 2, 4, 8, 16),
         include_lowpass: bool = True,
         activation: Optional[Union[Module, Callable[[Tensor], Tensor]]] = None,
@@ -793,8 +792,8 @@ class GeoScatConv(Module):
 
         Returns:
             Scattering coefficients of shape
-            :math:`(|\mathcal{V}|, F_{\mathrm{in}}, W_{\mathrm{total}})`,
-            or :math:`(B, F_{\mathrm{in}}, W_{\mathrm{total}}
+            :math:`(|\mathcal{V}|, F_{\mathrm{in}}, F_{\mathrm{out}})`,
+            or :math:`(B, F_{\mathrm{in}}, F_{\mathrm{out}}
             \cdot |\mathrm{pool}|)` if :obj:`pool` is set.
         """
         if x.size(-1) != self.in_channels:

--- a/torch_geometric/nn/conv/geo_scat_conv.py
+++ b/torch_geometric/nn/conv/geo_scat_conv.py
@@ -51,7 +51,7 @@ def _is_sparse_diffusion_op(diffusion_op: Union[Tensor, SparseTensor]) -> bool:
         return True
     if isinstance(diffusion_op, Tensor):
         return is_torch_sparse_tensor(diffusion_op)
-    raise TypeError("Expected torch.Tensor or SparseTensor, got "
+    raise TypeError(f"Expected torch.Tensor or SparseTensor, got "
                     f"type {type(diffusion_op)}.")
 
 
@@ -540,7 +540,7 @@ class GeoScatConv(Module):
     general form
 
     .. math::
-        \mathbf{W}_j \mathbf{x} = (\mathbf{P}^{t_j} -
+        \mathbf{W}_j \, \mathbf{x} = (\mathbf{P}^{t_j} -
         \mathbf{P}^{t_{j+1}}) \mathbf{x},
 
     where :math:`\mathbf{P}` is a lazy random walk operator
@@ -557,16 +557,16 @@ class GeoScatConv(Module):
     :math:`P^{t_{\max}} \mathbf{x}` is included by default, and may
     be excluded by setting :obj:`include_lowpass` to :obj:`False`.
 
-    This layer returns concatenated 0th and 1st-order scattering
-    coefficients by default. The 0th-order scattering coefficient is
-    the unfiltered input feature vector, and may be excluded by
+    This layer returns concatenated zeroeth and first-order scattering
+    coefficients by default. The zeroeth-order scattering coefficient
+    is the unfiltered input feature vector, and can be excluded by
     setting :obj:`scattering_orders` to :obj:`(1,)`. Second-order
     scattering coefficients can be included by including :obj:`2` in
     the :obj:`scattering_orders` tuple. These are defined as:
 
     .. math::
-        \mathbf{W}_{j^{\prime}} \sigma (\mathbf{W}_j \mathbf{x}),
-        j^{\prime} > j,
+        \mathbf{W}_{j^{\,\prime}} \, \sigma (\mathbf{W}_j \,
+        \mathbf{x}), \quad j^{\, \prime} > j,
 
     where :math:`\sigma` is an optional activation (e.g. the modulus
     operator via :obj:`torch.abs`), disabled by default.
@@ -575,10 +575,10 @@ class GeoScatConv(Module):
     as the number of output channels is deterministic via the
     parameterization of the scattering transform. Including 0th-order
     scattering coefficients increases the number of output channels by
-    1; including 1st-order scattering coefficients increases the number
-     of output channels by the number of wavelets :math:`w`; including
-    2nd-order scattering coefficients increases the number of output
-    channels by :math:`w \cdot (w - 1) // 2`.
+    1; including first-order scattering coefficients increases the number
+    of output channels by the number of wavelets :math:`w`; including
+    second-order scattering coefficients increases the number of output
+    channels by :math:`w \cdot (w - 1) / 2`.
 
     For graph-level tasks, scattering coefficients can be pooled across
     nodes within each graph and feature channel, changing the output shape
@@ -639,7 +639,7 @@ class GeoScatConv(Module):
             low-pass filter :math:`P^{t_{\max}} \mathbf{x}`.
             (default: :obj:`True`)
         activation (torch.nn.Module or Callable, optional): Activation
-            applied to 1st- and 2nd-order scattering coefficients, e.g.
+            applied to first- and second-order scattering coefficients, e.g.
             :obj:`torch.abs` for the modulus. (default: :obj:`None`)
         normalization (str, optional): Normalization scheme for the adjacency
             matrix before building the lazy random walk operator

--- a/torch_geometric/nn/conv/geo_scat_conv.py
+++ b/torch_geometric/nn/conv/geo_scat_conv.py
@@ -1,9 +1,9 @@
 import warnings
-from typing import Callable, List, Literal, Optional, Tuple, Union
+from typing import Any, Callable, Dict, List, Literal, Optional, Tuple, Union
 
 import torch
 from torch import Tensor
-from torch.nn import Module
+from torch.nn import Module, Parameter
 
 import torch_geometric.typing
 from torch_geometric.nn.aggr.basic import MinAggregation, VarAggregation
@@ -22,6 +22,10 @@ DEFAULT_DIFFUSION_SCALES = (0, 1, 2, 4, 8, 16)
 
 VALID_POOL_OPS = frozenset({'mean', 'max', 'min', 'median', 'var'})
 VALID_SCATTERING_ORDERS = frozenset({0, 1, 2})
+VALID_LEGS_KWARGS = frozenset({'legs_J'})
+DEFAULT_LEGS_KWARGS: Dict[str, Any] = {'legs_J': 4}
+
+DiffusionScalesArg = Union[Tuple[int, ...], Literal['legs', 'LEGS']]
 
 _BATCHING_DOC_URL = (
     'https://pytorch-geometric.readthedocs.io/en/latest/advanced/batching.html'
@@ -266,11 +270,126 @@ def get_sparse_lrw_diffusion_operator(
         return _as_adj(P_sparse.coalesce())
 
 
+def _is_legs_diffusion_scales(diffusion_scales: DiffusionScalesArg, ) -> bool:
+    return isinstance(diffusion_scales, str) \
+        and diffusion_scales.lower() == 'legs'
+
+
+def _validate_legs_kwargs(
+    legs_kwargs: Optional[Dict[str, Any]],
+    scattering_orders: Tuple[int, ...],
+) -> Dict[str, Any]:
+    if legs_kwargs is None:
+        legs_kwargs = dict(DEFAULT_LEGS_KWARGS)
+    else:
+        legs_kwargs = dict(legs_kwargs)
+
+    unknown = set(legs_kwargs) - VALID_LEGS_KWARGS
+    if unknown:
+        raise ValueError(
+            f"Unknown legs_kwargs keys {sorted(unknown)}. "
+            f"Valid options are {sorted(VALID_LEGS_KWARGS)}.", )
+
+    if 'legs_J' not in legs_kwargs:
+        raise ValueError("legs_kwargs must contain 'legs_J'.")
+
+    legs_J = legs_kwargs['legs_J']
+    if not isinstance(legs_J, int) or isinstance(legs_J, bool):
+        raise ValueError(
+            f"legs_J must be an integer (got {type(legs_J).__name__}).", )
+    if legs_J < 1:
+        raise ValueError('legs_J must be at least 1.')
+    if 2 in scattering_orders and legs_J < 2:
+        raise ValueError(
+            'Second-order scattering with LEGS requires legs_J >= 2.', )
+
+    return legs_kwargs
+
+
+def _prepare_diffusion_op(
+    P: Union[Tensor, SparseTensor],
+    x: Tensor,
+) -> Union[Tensor, SparseTensor]:
+    if isinstance(P, SparseTensor):
+        if P.dtype() != x.dtype:
+            return P.to(dtype=x.dtype)
+        return P
+    if _is_sparse_diffusion_op(P):
+        if P.dtype != x.dtype:
+            return P.to(dtype=x.dtype)
+        return P
+    if P.dtype != x.dtype:
+        return P.to(dtype=x.dtype)
+    return P
+
+
+def _check_diffusion_inputs_nonfinite(
+    P: Union[Tensor, SparseTensor],
+    x: Tensor,
+    *,
+    check_nonfinite: bool,
+) -> None:
+    if not check_nonfinite:
+        return
+    if isinstance(P, SparseTensor):
+        _raise_if_nonfinite(
+            P.storage.value(),
+            name='GeoScatConv: P values',
+        )
+    elif isinstance(P, Tensor):
+        if _is_sparse_diffusion_op(P):
+            _raise_if_nonfinite(
+                P.values(),
+                name='GeoScatConv: P values',
+            )
+        else:
+            _raise_if_nonfinite(P, name='GeoScatConv: P')
+    _raise_if_nonfinite(x, name='GeoScatConv: x')
+
+
+def _compute_pt_xs(
+    x: Tensor,
+    P: Union[Tensor, SparseTensor],
+    max_power: int,
+    *,
+    check_nonfinite: bool = False,
+) -> Tensor:
+    """Stack diffusion powers ``P^t x`` for ``t = 0, ..., max_power``.
+
+    Returns a tensor of shape ``(max_power + 1, num_nodes, num_features)``,
+    where row ``t`` holds ``P^t x``.
+    """
+    if x.ndim == 1:
+        x = x.unsqueeze(1)
+
+    P = _prepare_diffusion_op(P, x)
+    _check_diffusion_inputs_nonfinite(P, x, check_nonfinite=check_nonfinite)
+
+    device = x.device
+    pt_xs = [x.to(device)]
+    pt_x = x.to(device)
+
+    for t in range(1, max_power + 1):
+        pt_x = _diffusion_matmul(P, pt_x)
+        if check_nonfinite:
+            _raise_if_nonfinite(pt_x, name=f'GeoScatConv: P^t x (t={t})')
+        pt_xs.append(pt_x.to(device))
+
+    return torch.stack(pt_xs, dim=0)
+
+
 def _subset_second_order_wavelets(
     W2raw: Tensor,
     *,
     feature_type: Literal['scalar', 'vector'],
 ) -> Tensor:
+    """Keep only second-order terms where the outer filter is higher-pass.
+
+    ``W2raw`` holds all pairs ``(W_prev, W_next)`` of first- and second-order
+    wavelet indices. Scattering theory requires ``W_next`` to be applied to
+    the output of a lower-pass ``W_prev``, i.e. ``j' > j``. The upper-
+    triangular mask (excluding the diagonal) enforces that ordering.
+    """
     if feature_type not in ('scalar', 'vector'):
         raise ValueError(
             f"feature_type must be 'scalar' or 'vector', got {feature_type}.",
@@ -285,7 +404,7 @@ def _subset_second_order_wavelets(
 
     mask = torch.triu(
         torch.ones(n_prev, n_next, dtype=torch.bool, device=W2raw.device),
-        diagonal=1,
+        diagonal=1,  # keep pairs with second index > first index
     )
 
     if feature_type == 'scalar':
@@ -310,35 +429,12 @@ def diffusion_wavelet_transform(
     filter_stack_dim: int = -1,
     check_nonfinite: bool = False,
 ) -> Tensor:
-    if x.ndim == 1:
-        x = x.unsqueeze(1)
+    """Fixed-scale wavelet transform via consecutive diffusion differences.
 
-    if isinstance(P, SparseTensor):
-        if P.dtype() != x.dtype:
-            P = P.to(dtype=x.dtype)
-    elif isinstance(P, Tensor):
-        if _is_sparse_diffusion_op(P):
-            if P.dtype != x.dtype:
-                P = P.to(dtype=x.dtype)
-        elif P.dtype != x.dtype:
-            P = P.to(dtype=x.dtype)
-
-    if check_nonfinite:
-        if isinstance(P, SparseTensor):
-            _raise_if_nonfinite(
-                P.storage.value(),
-                name='GeoScatConv: P values',
-            )
-        elif isinstance(P, Tensor):
-            if _is_sparse_diffusion_op(P):
-                _raise_if_nonfinite(
-                    P.values(),
-                    name='GeoScatConv: P values',
-                )
-            else:
-                _raise_if_nonfinite(P, name='GeoScatConv: P')
-        _raise_if_nonfinite(x, name='GeoScatConv: x')
-
+    For scales ``(t_0, t_1, ..., t_J)``, filter ``j`` is
+    ``P^{t_{j-1}} x - P^{t_j} x``. Optionally appends the lowpass
+    ``P^{t_J} x`` (non-learnable).
+    """
     if not isinstance(diffusion_scales, Tensor):
         diffusion_scales = torch.as_tensor(
             diffusion_scales,
@@ -346,65 +442,228 @@ def diffusion_wavelet_transform(
             device=x.device,
         )
     else:
-        diffusion_scales = diffusion_scales.to(device=x.device,
-                                               dtype=torch.long)
+        diffusion_scales = diffusion_scales.to(
+            device=x.device,
+            dtype=torch.long,
+        )
 
     if diffusion_scales.dim() != 1:
         raise ValueError(
             f"diffusion_scales must be one-dimensional "
             f"(got {diffusion_scales.dim()} dimensions).", )
 
-    device = x.device
-    powers_to_save = diffusion_scales
-    range_upper_lim = int(diffusion_scales.numel())
+    max_power = int(diffusion_scales[-1].item())
+    pt_xs = _compute_pt_xs(
+        x,
+        P,
+        max_power,
+        check_nonfinite=check_nonfinite,
+    )
+    pt_at_scales = pt_xs[diffusion_scales]
+    num_scales = int(diffusion_scales.numel())
 
-    Ptxs = [x.to(device)]
-    Ptx = x.to(device)
-    max_power = int(powers_to_save[-1].item())
-
-    for j in range(1, max_power + 1):
-        Ptx = _diffusion_matmul(P, Ptx)
-        if check_nonfinite:
-            _raise_if_nonfinite(Ptx, name=f'GeoScatConv: P^t x (t={j})')
-        if j in powers_to_save:
-            j_ct = int((powers_to_save == j).sum().item())
-            for _ in range(j_ct):
-                Ptxs.append(Ptx.to(device))
-
-    Wjxs = [Ptxs[j - 1] - Ptxs[j] for j in range(1, range_upper_lim)]
+    # Wavelet j approximates (P^{t_{j-1}} - P^{t_j}) x via stored powers.
+    wjxs = [
+        pt_at_scales[j - 1] - pt_at_scales[j] for j in range(1, num_scales)
+    ]
     if include_lowpass:
-        Wjxs.append(Ptxs[-1])
-    return torch.stack(Wjxs, dim=filter_stack_dim).to(device)
+        wjxs.append(pt_at_scales[-1])  # append P^{t_J} x before activation
+    return torch.stack(wjxs, dim=filter_stack_dim).to(x.device)
+
+
+def _initialize_legs_parameters(J: int = 4) -> Tensor:
+    r"""Initialize the LEGS selector matrix :math:`F` with dyadic scales.
+
+    For ``J = 4``, the matrix has shape ``(4, 17)`` since powers
+    :math:`t = 0, \ldots, 2^J` are indexed along the last dimension.
+    """
+    m = torch.zeros((J, 2**J + 1))
+    # We want to subtract greater powers of P when adding rows of
+    # the selector matrix, so -1s are at greater indices than +1s
+    # cf. Eq 4 in LEGS paper
+    m[0, 0] = 1.0
+    m[0, 1] = -1.0
+    for j in range(1, J):
+        m[j, 2**j] = 1.0
+        m[j, 2**(j + 1)] = -1.0
+    return m.to(torch.float)
+
+
+def legs_wavelet_transform(
+    x: Tensor,
+    P: Union[Tensor, SparseTensor],
+    F: Tensor,
+    *,
+    include_lowpass: bool,
+    filter_stack_dim: int = -1,
+    check_nonfinite: bool = False,
+) -> Tensor:
+    """LEGS first-order transform: learnable linear combos of diffusion powers.
+
+    Row ``j`` of ``F`` selects which ``P^t x`` terms form wavelet ``j``.
+    At initialization, each row is a dyadic difference; during training ``F``
+    can learn a continuous approximation to discrete wavelet scales.
+    """
+    J = int(F.size(0))
+    T = 2**J
+    pt_xs = _compute_pt_xs(
+        x,
+        P,
+        T,
+        check_nonfinite=check_nonfinite,
+    )
+    # F[j, t] weights P^t x; sum over t gives the j-th first-order coefficient.
+    w1 = torch.einsum('jt,tnf->nfj', F, pt_xs)
+    if include_lowpass:
+        # Lowpass P^T x is fixed (not a row of F); concat before activation.
+        w1 = torch.cat([w1, pt_xs[T].unsqueeze(-1)], dim=-1)
+    if filter_stack_dim != -1:
+        w1 = w1.movedim(-1, filter_stack_dim)
+    return w1
+
+
+def _apply_legs_filters(
+    x: Tensor,
+    P: Union[Tensor, SparseTensor],
+    F: Tensor,
+    max_power: int,
+    *,
+    check_nonfinite: bool = False,
+) -> Tensor:
+    """Apply all LEGS wavelet rows of ``F`` to a single graph signal ``x``.
+
+    Returns shape ``(num_nodes, num_features, J)`` where entry ``[..., k]`` is
+    the k-th LEGS filter applied to ``x``.
+    """
+    pt_xs = _compute_pt_xs(
+        x,
+        P,
+        max_power,
+        check_nonfinite=check_nonfinite,
+    )
+    # Same einsum as first order, but over output filter index k.
+    return torch.einsum('kt,tnf->nfk', F, pt_xs)
+
+
+def _prepare_scatter_inputs(
+    x: Tensor,
+    is_vector_feature: bool,
+) -> Tuple[Tensor, int, int, Literal['scalar', 'vector']]:
+    if is_vector_feature:
+        num_nodes, vector_dim = x.shape
+        flat = x.reshape(num_nodes * vector_dim, 1)
+        return flat, num_nodes, vector_dim, 'vector'
+
+    num_nodes = x.shape[0]
+    return x, num_nodes, x.size(-1), 'scalar'
+
+
+def _compute_second_order_scattering(
+    W1: Tensor,
+    diffusion_op: Union[Tensor, SparseTensor],
+    *,
+    diffusion_scales: Optional[Tensor],
+    F: Optional[Tensor],
+    include_lowpass: bool,
+    is_vector_feature: bool,
+    num_nodes: int,
+    feature_type: Literal['scalar', 'vector'],
+    check_nonfinite: bool = False,
+) -> Tensor:
+    """Compute ``W_{j'}(W_j x)`` and retain only pairs with ``j' > j``.
+
+    ``W1`` must already include any activation from first order. The raw
+    second-order tensor ``W2raw[..., j, k]`` holds filter ``k`` applied to
+    first-order coefficient ``j``; ``_subset_second_order_wavelets`` then
+    drops invalid (lower-on-lower) pairs.
+    """
+    num_wavelets = int(W1.shape[-1])
+    if num_wavelets <= 1:
+        raise ValueError(
+            'Second-order scattering requires at least two first-order '
+            'wavelet filters.', )
+
+    if F is not None:
+        J = int(F.size(0))
+        T = 2**J
+        # Apply every LEGS filter (k) to each learnable first-order coeff (j).
+        # Only the J learnable rows of W1 participate; lowpass is excluded.
+        w2_parts = [
+            _apply_legs_filters(
+                W1[..., j],
+                diffusion_op,
+                F,
+                T,
+                check_nonfinite=check_nonfinite,
+            ).unsqueeze(-2) for j in range(J)
+        ]
+        W2raw = torch.cat(w2_parts, dim=-2)  # (..., J, K) before masking
+        if is_vector_feature:
+            W2raw = W2raw.view(W1.shape[0], J, J)
+        else:
+            num_channels = int(W1.shape[1])
+            W2raw = W2raw.view(num_nodes, num_channels, J, J)
+    else:
+        # Fixed scales: batch all first-order channels through the wavelet
+        # transform again, producing (W_prev, W_next) pairs for every channel.
+        scatter_kwargs = {
+            'diffusion_scales': diffusion_scales,
+            'include_lowpass': include_lowpass,
+            'check_nonfinite': check_nonfinite,
+        }
+        if is_vector_feature:
+            x_second = W1.squeeze(1)
+            W2raw = diffusion_wavelet_transform(
+                x=x_second,
+                P=diffusion_op,
+                **scatter_kwargs,
+            )
+            W2raw = W2raw.view(x_second.shape[0], num_wavelets, -1)
+        else:
+            num_channels = int(W1.shape[1])
+            x_second = W1.reshape(num_nodes, num_channels * num_wavelets)
+            W2raw = diffusion_wavelet_transform(
+                x=x_second,
+                P=diffusion_op,
+                **scatter_kwargs,
+            )
+            W2raw = W2raw.view(num_nodes, num_channels, num_wavelets, -1)
+
+    return _subset_second_order_wavelets(
+        W2raw,
+        feature_type=feature_type,
+    )
 
 
 def multiorder_scatter(
     x: Tensor,
     diffusion_op: Union[Tensor, SparseTensor],
     *,
-    diffusion_scales: Tensor,
     include_lowpass: bool,
     scattering_orders: Tuple[int, ...],
+    diffusion_scales: Optional[Tensor] = None,
+    F: Optional[Tensor] = None,
     is_vector_feature: bool = False,
     activation: Optional[Union[Module, Callable[[Tensor], Tensor]]] = None,
     check_nonfinite: bool = False,
 ) -> Tensor:
+    """Build scattering coefficients from zeroth, first, and second order.
+
+    Pass ``diffusion_scales`` for fixed dyadic/custom scales, or ``F`` for
+    LEGS learnable scales (exactly one must be set). First-order lowpass is
+    concatenated before activation; second order uses the activated ``W1``.
+    """
+    if (F is None) == (diffusion_scales is None):
+        raise ValueError(
+            'Exactly one of diffusion_scales or F must be provided.', )
+
     if x.dim() == 1:
         x = x.unsqueeze(1)
 
-    if is_vector_feature:
-        num_nodes, vector_dim = x.shape
-        flat = x.reshape(num_nodes * vector_dim, 1)
-        feature_type: Literal['scalar', 'vector'] = 'vector'
-    else:
-        num_nodes = x.shape[0]
-        flat = x
-        feature_type = 'scalar'
-
-    scatter_kwargs = {
-        'diffusion_scales': diffusion_scales,
-        'include_lowpass': include_lowpass,
-        'check_nonfinite': check_nonfinite,
-    }
+    flat, num_nodes, feature_dim, feature_type = _prepare_scatter_inputs(
+        x,
+        is_vector_feature,
+    )
 
     need_first_order = 1 in scattering_orders or 2 in scattering_orders
     coeffs: List[Tensor] = []
@@ -414,39 +673,38 @@ def multiorder_scatter(
 
     W1: Optional[Tensor] = None
     if need_first_order:
-        W1 = diffusion_wavelet_transform(
-            x=flat,
-            P=diffusion_op,
-            **scatter_kwargs,
-        )
+        if F is not None:
+            W1 = legs_wavelet_transform(
+                x=flat,
+                P=diffusion_op,
+                F=F,
+                include_lowpass=include_lowpass,
+                check_nonfinite=check_nonfinite,
+            )
+        else:
+            W1 = diffusion_wavelet_transform(
+                x=flat,
+                P=diffusion_op,
+                diffusion_scales=diffusion_scales,
+                include_lowpass=include_lowpass,
+                check_nonfinite=check_nonfinite,
+            )
         W1 = _apply_activation(W1, activation)
         if 1 in scattering_orders:
             coeffs.append(W1)
 
     if 2 in scattering_orders and W1 is not None:
-        num_wavelets = int(W1.shape[-1])
-        if num_wavelets > 1:
-            if is_vector_feature:
-                x_second = W1.squeeze(1)
-                W2raw = diffusion_wavelet_transform(
-                    x=x_second,
-                    P=diffusion_op,
-                    **scatter_kwargs,
-                )
-                nd = x_second.shape[0]
-                W2raw = W2raw.view(nd, num_wavelets, -1)
-            else:
-                num_channels = int(W1.shape[1])
-                x_second = W1.reshape(num_nodes, num_channels * num_wavelets)
-                W2raw = diffusion_wavelet_transform(
-                    x=x_second,
-                    P=diffusion_op,
-                    **scatter_kwargs,
-                )
-                W2raw = W2raw.view(num_nodes, num_channels, num_wavelets, -1)
-            W2 = _subset_second_order_wavelets(
-                W2raw,
+        if int(W1.shape[-1]) > 1:
+            W2 = _compute_second_order_scattering(
+                W1,
+                diffusion_op,
+                diffusion_scales=diffusion_scales,
+                F=F,
+                include_lowpass=include_lowpass,
+                is_vector_feature=is_vector_feature,
+                num_nodes=num_nodes,
                 feature_type=feature_type,
+                check_nonfinite=check_nonfinite,
             )
             W2 = _apply_activation(W2, activation)
             coeffs.append(W2)
@@ -456,7 +714,7 @@ def multiorder_scatter(
 
     W_tot = torch.cat(coeffs, dim=-1)
     if is_vector_feature:
-        return W_tot.view(num_nodes, vector_dim, -1)
+        return W_tot.view(num_nodes, feature_dim, -1)
     return W_tot
 
 
@@ -559,6 +817,14 @@ class GeoScatConv(Module):
     One option for generating custom scales is `InfoGain Wavelets
     <https://arxiv.org/abs/2504.08802>`_.
 
+    Alternatively, set :obj:`diffusion_scales='legs'` to use a learnable
+    LEGS-style selector matrix :math:`F \in \mathbb{R}^{J \times (2^J + 1)}`
+    initialized to dyadic scales. The number of learnable wavelet filters
+    :math:`J` is set via :obj:`legs_kwargs['legs_J']` (default: :obj:`4`).
+    Note that :math:`J` sets the max diffusion scale to :math:`2^J`;
+    given its dyadic initialization, :math:`J=4` or :math:`J=5` is
+    recommended.
+
     This layer returns concatenated zeroeth and first-order scattering
     coefficients by default. The zeroeth-order scattering coefficient
     is the unfiltered input feature vector, and can be excluded by
@@ -633,13 +899,20 @@ class GeoScatConv(Module):
             input), :obj:`1` (first-order wavelets), or :obj:`2`
             (second-order). Pass :obj:`(1,)` for a diffusion wavelet
             transform only. (default: :obj:`(0, 1, 2)`)
-        diffusion_scales (Tuple[int, ...], optional): Monotonically increasing
-            diffusion powers, i.e., :math:`t_j` in each :math:
-            `\mathbf{P}^{t_j}`. Wavelet filters are consecutive differences
-            between adjacent :math:`t_{j-1}` and :math:`t_j`.
-            (default: :obj:`(0, 1, 2, 4, 8, 16)`)
+        diffusion_scales (Tuple[int, ...] or str, optional): Monotonically
+            increasing diffusion powers, i.e., :math:`t_j` in each
+            :math:`\mathbf{P}^{t_j}`. Wavelet filters are consecutive
+            differences between adjacent :math:`t_{j-1}` and :math:`t_j`.
+            Alternatively, pass :obj:`'legs'` or :obj:`'LEGS'` to use a
+            learnable LEGS-style selector matrix :math:`F` initialized to
+            dyadic scales. (default: :obj:`(0, 1, 2, 4, 8, 16)`)
+        legs_kwargs (Dict[str, Any], optional): Keyword arguments for LEGS
+            mode. Currently supports :obj:`'legs_J'`, the number of learnable
+            wavelet filters (default: :obj:`4`). Ignored unless
+            :obj:`diffusion_scales='legs'`.
         include_lowpass (bool, optional): If set to :obj:`True`, append the
-            low-pass filter :math:`\mathbf{P}^{t_J} \mathbf{x}`.
+            low-pass filter :math:`\mathbf{P}^{t_J} \mathbf{x}` before the
+            optional activation at first order.
             (default: :obj:`True`)
         activation (torch.nn.Module or Callable, optional): Activation
             applied to first- and second-order scattering coefficients, e.g.
@@ -686,7 +959,15 @@ class GeoScatConv(Module):
         self,
         in_channels: int,
         scattering_orders: Optional[Tuple[int, ...]] = (0, 1, 2),
-        diffusion_scales: Optional[Tuple[int, ...]] = (0, 1, 2, 4, 8, 16),
+        diffusion_scales: Optional[DiffusionScalesArg] = (
+            0,
+            1,
+            2,
+            4,
+            8,
+            16,
+        ),
+        legs_kwargs: Optional[Dict[str, Any]] = None,
         include_lowpass: bool = True,
         activation: Optional[Union[Module, Callable[[Tensor], Tensor]]] = None,
         normalization: Literal['row', 'column', 'symmetric'] = 'row',
@@ -707,16 +988,52 @@ class GeoScatConv(Module):
                 "normalization must be one of {'row', 'column', 'symmetric'}, "
                 f"got '{normalization}'.", )
 
-        if diffusion_scales is None:
-            diffusion_scales = DEFAULT_DIFFUSION_SCALES
+        use_legs = (diffusion_scales is not None
+                    and _is_legs_diffusion_scales(diffusion_scales))
+
+        if use_legs:
+            if legs_kwargs is not None and not isinstance(legs_kwargs, dict):
+                raise ValueError('legs_kwargs must be a dict or None.')
+            self.legs_kwargs = _validate_legs_kwargs(
+                legs_kwargs,
+                scattering_orders,
+            )
+            legs_J = self.legs_kwargs['legs_J']
+            self.use_legs = True
+            self.diffusion_scales = 'legs'
+            self.max_diffusion_power = 2**legs_J
+            self.register_parameter(
+                'F',
+                Parameter(_initialize_legs_parameters(legs_J)),
+            )
         else:
-            diffusion_scales = tuple(diffusion_scales)
-        if len(diffusion_scales) < 2:
-            raise ValueError(
-                'diffusion_scales must contain at least two entries.', )
-        if any(diffusion_scales[i] >= diffusion_scales[i + 1]
-               for i in range(len(diffusion_scales) - 1)):
-            raise ValueError('diffusion_scales must be strictly increasing.')
+            if legs_kwargs is not None:
+                warnings.warn(
+                    'legs_kwargs was provided but diffusion_scales is not '
+                    "'legs'; ignoring legs_kwargs.",
+                    stacklevel=2,
+                )
+            self.use_legs = False
+            self.legs_kwargs = None
+            self.max_diffusion_power = None
+            self.F = None
+
+            if diffusion_scales is None:
+                diffusion_scales = DEFAULT_DIFFUSION_SCALES
+            elif isinstance(diffusion_scales, str):
+                raise ValueError(
+                    "diffusion_scales must be a tuple of integers or 'legs' "
+                    f"(got '{diffusion_scales}').", )
+            else:
+                diffusion_scales = tuple(diffusion_scales)
+            if len(diffusion_scales) < 2:
+                raise ValueError(
+                    'diffusion_scales must contain at least two entries.', )
+            if any(diffusion_scales[i] >= diffusion_scales[i + 1]
+                   for i in range(len(diffusion_scales) - 1)):
+                raise ValueError(
+                    'diffusion_scales must be strictly increasing.', )
+            self.diffusion_scales = diffusion_scales
 
         if pool is not None:
             pool = tuple(pool)
@@ -730,7 +1047,6 @@ class GeoScatConv(Module):
 
         self.in_channels = in_channels
         self.scattering_orders = scattering_orders
-        self.diffusion_scales = diffusion_scales
         self.include_lowpass = include_lowpass
         self.activation = activation
         self.normalization = normalization
@@ -740,6 +1056,8 @@ class GeoScatConv(Module):
 
     @property
     def num_wavelet_filters(self) -> int:
+        if self.use_legs:
+            return self.legs_kwargs['legs_J'] + int(self.include_lowpass)
         return _compute_num_wavelet_filters(
             self.diffusion_scales,
             self.include_lowpass,
@@ -747,6 +1065,16 @@ class GeoScatConv(Module):
 
     @property
     def num_scattering_filters(self) -> int:
+        if self.use_legs:
+            legs_J = self.legs_kwargs['legs_J']
+            total = 0
+            if 0 in self.scattering_orders:
+                total += 1
+            if 1 in self.scattering_orders:
+                total += legs_J + int(self.include_lowpass)
+            if 2 in self.scattering_orders:
+                total += legs_J * (legs_J - 1) // 2
+            return total
         return _compute_num_scattering_filters(
             self.num_wavelet_filters,
             self.scattering_orders,
@@ -760,10 +1088,15 @@ class GeoScatConv(Module):
         return num_filters * len(self.pool)
 
     def reset_parameters(self) -> None:
-        """This layer does not have any learnable parameters to reset.
-        It is intended as a multiscale feature extractor layer for graph
-        data, whose coefficients can be fed into learnable layers downstream.
+        r"""Resets learnable parameters.
+
+        In LEGS mode, reinitializes :obj:`F` to dyadic scales via
+        :func:`_initialize_legs_parameters`.
         """
+        if self.use_legs:
+            with torch.no_grad():
+                self.F.copy_(
+                    _initialize_legs_parameters(self.legs_kwargs['legs_J']), )
 
     def forward(
         self,
@@ -844,22 +1177,31 @@ class GeoScatConv(Module):
                 x.device,
             )
 
-        diffusion_scales = torch.as_tensor(
-            self.diffusion_scales,
-            dtype=torch.long,
-            device=x.device,
-        )
-
-        coeffs = multiorder_scatter(
-            x,
-            op,
-            diffusion_scales=diffusion_scales,
-            include_lowpass=self.include_lowpass,
-            scattering_orders=self.scattering_orders,
-            is_vector_feature=self.is_vector_feature,
-            activation=self.activation,
-            check_nonfinite=self.check_nonfinite,
-        )
+        scatter_kwargs = {
+            'include_lowpass': self.include_lowpass,
+            'scattering_orders': self.scattering_orders,
+            'is_vector_feature': self.is_vector_feature,
+            'activation': self.activation,
+            'check_nonfinite': self.check_nonfinite,
+        }
+        if self.use_legs:
+            coeffs = multiorder_scatter(
+                x,
+                op,
+                F=self.F,
+                **scatter_kwargs,
+            )
+        else:
+            coeffs = multiorder_scatter(
+                x,
+                op,
+                diffusion_scales=torch.as_tensor(
+                    self.diffusion_scales,
+                    dtype=torch.long,
+                    device=x.device,
+                ),
+                **scatter_kwargs,
+            )
 
         if self.pool is None:
             return coeffs
@@ -867,6 +1209,15 @@ class GeoScatConv(Module):
         return _pool_scattering_coefficients(coeffs, batch, self.pool)
 
     def __repr__(self) -> str:
+        if self.use_legs:
+            return (f'{self.__class__.__name__}('
+                    f'in_channels={self.in_channels}, '
+                    f'scattering_orders={self.scattering_orders}, '
+                    f"diffusion_scales='legs', "
+                    f'legs_kwargs={self.legs_kwargs}, '
+                    f'num_scattering_filters={self.num_scattering_filters}, '
+                    f'normalization={self.normalization}, '
+                    f'pool={self.pool})')
         return (f'{self.__class__.__name__}('
                 f'in_channels={self.in_channels}, '
                 f'scattering_orders={self.scattering_orders}, '

--- a/torch_geometric/nn/conv/geo_scat_conv.py
+++ b/torch_geometric/nn/conv/geo_scat_conv.py
@@ -536,26 +536,29 @@ class GeoScatConv(Module):
 
     In particular, this layer computes diffusion wavelet scattering
     coefficients on graph node features. A diffusion wavelet
-    convolution of a feature vector :math:`\mathbf{x}` has the
+    convolution of a graph signal :math:`\mathbf{x}` has the
     general form
 
     .. math::
-        \mathbf{W}_j \, \mathbf{x} = (\mathbf{P}^{t_j} -
-        \mathbf{P}^{t_{j+1}}) \mathbf{x},
+        \mathbf{W}_j \, \mathbf{x} = (\mathbf{P}^{t_{j-1}} -
+        \mathbf{P}^{t_{j}}) \mathbf{x}, \quad j = 1, \ldots, J,
 
     where :math:`\mathbf{P}` is a lazy random walk operator
-    (typically row-normalized), and :math:`t_j` and
-    :math:`t_{j+1} > t_j` are the diffusion scales, set to
-    consecutive powers of 2 (dyadic scale, up to 16) by default.
-    However, one can use custom diffusion scales by setting
-    :obj:`diffusion_scales` to a custom tuple of increasing integers
-    (or tuple of tuples, for different diffusion scales per feature
-    channel). Here, `InfoGain Wavelets
-    <https://arxiv.org/abs/2504.08802>`_ provide a principled,
-    data-driven way to select (potentially non-dyadic) wavelet
-    diffusion scales. A simple low-pass filter
-    :math:`P^{t_{\max}} \mathbf{x}` is included by default, and may
-    be excluded by setting :obj:`include_lowpass` to :obj:`False`.
+    (row-normalized by default), and :math:`t_j` are the diffusion
+    scales.
+    A low-pass filter :math:`A_J = \mathbf{P}^{t_J} \mathbf{x}`
+    is also included by default, such that the full filter bank is
+    :math:`\{\mathbf{W}_j\}_{j=0}^{J} \cup \{A_J\}`. The low-pass
+    filter can be excluded by setting :obj:`include_lowpass`
+    to :obj:`False`.
+
+    By default, the :math:`t_j` are set to be dyadic integers
+    :math:`0, 1, 2, \ldots, 16`. However, one may also specify a
+    custom set of scales using the :obj:`diffusion_scales`
+    argument (pass a tuple of integers, or a tuple of tuples,
+    for different diffusion scales for each feature channel).
+    One option for generating custom scales is `InfoGain Wavelets
+    <https://arxiv.org/abs/2504.08802>`_.
 
     This layer returns concatenated zeroeth and first-order scattering
     coefficients by default. The zeroeth-order scattering coefficient
@@ -565,8 +568,8 @@ class GeoScatConv(Module):
     the :obj:`scattering_orders` tuple. These are defined as:
 
     .. math::
-        \mathbf{W}_{j^{\,\prime}} \, \sigma (\mathbf{W}_j \,
-        \mathbf{x}), \quad j^{\, \prime} > j,
+        \sigma(\mathbf{W}_{j^{\,\prime}} \, \sigma (\mathbf{W}_j \,
+        \mathbf{x})), \quad j^{\, \prime} > j,
 
     where :math:`\sigma` is an optional activation (e.g. the modulus
     operator via :obj:`torch.abs`), disabled by default.
@@ -632,18 +635,20 @@ class GeoScatConv(Module):
             (second-order). Pass :obj:`(1,)` for a diffusion wavelet
             transform only. (default: :obj:`(0, 1)`)
         diffusion_scales (Tuple[int, ...], optional): Monotonically increasing
-            diffusion powers at which to save :math:`P^t \mathbf{x}`.
+            diffusion powers, i.e., :math:`t_j` in each `:math:`P^{t_j}`.
             Wavelet filters are consecutive differences between adjacent
-            saved powers. (default: :obj:`(0, 1, 2, 4, 8, 16)`)
+            :math:`t_{j-1}` and :math:`t_j`.
+            (default: :obj:`(0, 1, 2, 4, 8, 16)`)
         include_lowpass (bool, optional): If set to :obj:`True`, append the
-            low-pass filter :math:`P^{t_{\max}} \mathbf{x}`.
+            low-pass filter :math:`P^{t_J} \mathbf{x}`.
             (default: :obj:`True`)
         activation (torch.nn.Module or Callable, optional): Activation
             applied to first- and second-order scattering coefficients, e.g.
             :obj:`torch.abs` for the modulus. (default: :obj:`None`)
         normalization (str, optional): Normalization scheme for the adjacency
             matrix before building the lazy random walk operator
-            :math:`P`. Ignored when :obj:`diffusion_op` is provided.
+            :math:`P`. Ignored when :obj:`diffusion_op` is provided. Options:
+            :obj:`"row"`, :obj:`"column"`, :obj:`"symmetric"`.
             (default: :obj:`"row"`)
         is_vector_feature (bool, optional): If set to :obj:`True`, treat each
             node feature as a vector signal of dimension :obj:`in_channels`
@@ -651,9 +656,11 @@ class GeoScatConv(Module):
             :math:`(n \cdot d, n \cdot d)`.
             (default: :obj:`False`)
         pool (Tuple[str, ...], optional): Graph-level pooling operations to
-            apply across nodes. Each entry must be one of :obj:`"mean"`,
-            :obj:`"max"`, :obj:`"min"`, :obj:`"median"`, or :obj:`"var"`.
-            If :obj:`None`, node-level scattering coefficients are returned.
+            apply across nodes. Multiple pooling operations can be applied by
+            passing a tuple of strings, the results of which are concatenated.
+            Each entry must be one of :obj:`"mean"`, :obj:`"max"`,
+            :obj:`"min"`, :obj:`"median"`, or  :obj:`"var"`. If :obj:`None`,
+            node-level scattering coefficients are returned.
             (default: :obj:`None`)
         check_nonfinite (bool, optional): If set to :obj:`True`, raise an
             error when non-finite values are detected in inputs or

--- a/torch_geometric/nn/conv/geo_scat_conv.py
+++ b/torch_geometric/nn/conv/geo_scat_conv.py
@@ -1,0 +1,869 @@
+import warnings
+from typing import Callable, List, Literal, Optional, Tuple, Union
+
+import torch
+from torch import Tensor
+from torch.nn import Module
+
+import torch_geometric.typing
+from torch_geometric.nn.aggr.basic import MinAggregation, VarAggregation
+from torch_geometric.nn.aggr.quantile import MedianAggregation
+from torch_geometric.typing import Adj, OptTensor, SparseTensor
+from torch_geometric.utils import (
+    contains_self_loops,
+    is_torch_sparse_tensor,
+    remove_self_loops,
+    scatter,
+    spmm,
+    to_torch_coo_tensor,
+)
+
+DEFAULT_DIFFUSION_SCALES = (0, 1, 2, 4, 8, 16)
+
+VALID_POOL_OPS = frozenset({'mean', 'max', 'min', 'median', 'var'})
+VALID_SCATTERING_ORDERS = frozenset({0, 1, 2})
+
+_BATCHING_DOC_URL = (
+    'https://pytorch-geometric.readthedocs.io/en/latest/advanced/batching.html'
+)
+
+
+def _raise_if_nonfinite(
+    tensor: Tensor,
+    *,
+    name: str,
+) -> None:
+    if not torch.isfinite(tensor).all():
+        raise RuntimeError(f"Non-finite value detected in {name}.")
+
+
+def _apply_activation(
+    x: Tensor,
+    activation: Optional[Union[Module, Callable[[Tensor], Tensor]]],
+) -> Tensor:
+    if activation is None:
+        return x
+    return activation(x)
+
+
+def _is_sparse_diffusion_op(diffusion_op: Union[Tensor, SparseTensor]) -> bool:
+    if isinstance(diffusion_op, SparseTensor):
+        return True
+    if isinstance(diffusion_op, Tensor):
+        return is_torch_sparse_tensor(diffusion_op)
+    raise TypeError("Expected torch.Tensor or SparseTensor, got "
+                    f"type {type(diffusion_op)}.")
+
+
+def _diffusion_matmul(
+    diffusion_op: Union[Tensor, SparseTensor],
+    x: Tensor,
+) -> Tensor:
+    # reduce='sum' performs standard sparse-dense matrix multiplication.
+    if _is_sparse_diffusion_op(diffusion_op):
+        return spmm(_as_adj(diffusion_op), x, reduce='sum')
+    return diffusion_op @ x
+
+
+def _get_diffusion_op_size(diffusion_op: Union[Tensor, SparseTensor]) -> int:
+    if isinstance(diffusion_op, SparseTensor):
+        return int(diffusion_op.size(0))
+    return int(diffusion_op.size(0))
+
+
+def _validate_diffusion_op_shape(
+    diffusion_op: Union[Tensor, SparseTensor],
+    expected_size: int,
+) -> None:
+    size = _get_diffusion_op_size(diffusion_op)
+    if isinstance(diffusion_op, SparseTensor):
+        if diffusion_op.size(1) != size:
+            raise ValueError(
+                f"diffusion_op must be square (got shape "
+                f"{tuple(diffusion_op.size())}).", )
+    elif isinstance(diffusion_op, Tensor):
+        if diffusion_op.dim() != 2 or diffusion_op.size(1) != size:
+            raise ValueError(
+                f"diffusion_op must be a square matrix (got shape "
+                f"{tuple(diffusion_op.shape)}).", )
+    if size != expected_size:
+        raise ValueError(
+            f"diffusion_op size {size} does not match expected size "
+            f"{expected_size}.", )
+
+
+def _warn_if_diffusion_op_batching_unsafe(
+    diffusion_op: Union[Tensor, SparseTensor],
+    key: Optional[str],
+) -> None:
+    is_sparse = _is_sparse_diffusion_op(diffusion_op)
+    if is_sparse and key is not None and 'adj' in key:
+        return
+
+    if not is_sparse:
+        warnings.warn(
+            'Dense diffusion_op passed to GeoScatConv. For batched Data '
+            'objects, override Data.__cat_dim__ to return (0, 1) for the '
+            'operator attribute so collation block-diagonal-stacks P. '
+            f'See {_BATCHING_DOC_URL}.',
+            stacklevel=3,
+        )
+    elif key is None:
+        warnings.warn(
+            'Sparse diffusion_op passed without diffusion_op_key. Cannot '
+            'verify that Data batching will block-diagonal-stack P. Pass '
+            "diffusion_op_key with 'adj' in the name (e.g. 'diffusion_adj') "
+            f'if P was stored on Data objects, or see {_BATCHING_DOC_URL}.',
+            stacklevel=3,
+        )
+    else:
+        warnings.warn(
+            f"Sparse diffusion_op passed with diffusion_op_key='{key}' "
+            "which does not contain 'adj'. PyG will not block-diagonal-stack "
+            "this operator during batching by default. Rename the attribute "
+            "to include 'adj' (e.g. 'diffusion_adj') or override "
+            f'Data.__cat_dim__. See {_BATCHING_DOC_URL}.',
+            stacklevel=3,
+        )
+
+
+def _validate_scattering_orders(scattering_orders: Tuple[int, ...], ) -> None:
+    if not scattering_orders:
+        raise ValueError('scattering_orders must be a non-empty tuple.')
+    if len(scattering_orders) != len(set(scattering_orders)):
+        raise ValueError('scattering_orders must not contain duplicates.')
+    invalid = set(scattering_orders) - VALID_SCATTERING_ORDERS
+    if invalid:
+        raise ValueError(
+            f"scattering_orders entries must be in {{0, 1, 2}} "
+            f"(got invalid values {sorted(invalid)}).", )
+    if any(scattering_orders[i] >= scattering_orders[i + 1]
+           for i in range(len(scattering_orders) - 1)):
+        raise ValueError('scattering_orders must be strictly increasing.')
+    if 2 in scattering_orders and 1 not in scattering_orders:
+        raise ValueError(
+            'scattering_orders containing 2 must also contain 1.', )
+
+
+def _as_adj(matrix: Union[Tensor, SparseTensor]) -> Adj:
+    if isinstance(matrix, SparseTensor):
+        return matrix
+    if not isinstance(matrix, Tensor):
+        raise TypeError(
+            f"Expected torch.Tensor or SparseTensor, got type {type(matrix)}.",
+        )
+    if matrix.layout != torch.sparse_coo:
+        matrix = matrix.to_sparse()
+    matrix = matrix.coalesce()
+    if torch_geometric.typing.WITH_TORCH_SPARSE:
+        row, col = matrix.indices()
+        return SparseTensor(
+            row=row,
+            col=col,
+            value=matrix.values(),
+            sparse_sizes=matrix.size(),
+        ).coalesce()
+    return matrix
+
+
+def _sparse_identity(
+    size: int,
+    *,
+    dtype: torch.dtype,
+    device: torch.device,
+) -> Tensor:
+    indices = torch.arange(size, device=device).unsqueeze(0).repeat(2, 1)
+    values = torch.ones(size, dtype=dtype, device=device)
+    return torch.sparse_coo_tensor(indices, values, (size, size))
+
+
+def _get_sparse_normalized_A(
+    edge_index: Tensor,
+    edge_weight: OptTensor,
+    num_nodes: int,
+    normalization: Literal['row', 'column', 'symmetric'],
+    dtype: torch.dtype,
+    device: torch.device,
+) -> Tensor:
+    if normalization not in {'row', 'column', 'symmetric'}:
+        raise ValueError(
+            "normalization must be one of {'row', 'column', 'symmetric'}, "
+            f"got '{normalization}'.", )
+
+    edge_index = edge_index.to(device)
+    if edge_weight is None:
+        edge_weight = torch.ones(edge_index.size(1), dtype=dtype,
+                                 device=device)
+    else:
+        edge_weight = edge_weight.to(device=device, dtype=dtype)
+
+    row = edge_index[0]
+    col = edge_index[1]
+    degree = torch.zeros(num_nodes, dtype=dtype, device=device)
+
+    if normalization == 'row':
+        degree.index_add_(0, row, edge_weight)
+        norm = torch.where(degree > 0, 1.0 / degree, torch.zeros_like(degree))
+        normalized_weight = edge_weight * norm[row]
+    elif normalization == 'column':
+        degree.index_add_(0, col, edge_weight)
+        norm = torch.where(degree > 0, 1.0 / degree, torch.zeros_like(degree))
+        normalized_weight = edge_weight * norm[col]
+    else:
+        degree.index_add_(0, row, edge_weight)
+        norm = torch.where(
+            degree > 0,
+            torch.rsqrt(degree),
+            torch.zeros_like(degree),
+        )
+        normalized_weight = edge_weight * norm[row] * norm[col]
+
+    return to_torch_coo_tensor(
+        edge_index,
+        normalized_weight,
+        (num_nodes, num_nodes),
+    )
+
+
+def get_sparse_lrw_diffusion_operator(
+    edge_index: Tensor,
+    edge_weight: OptTensor,
+    num_nodes: int,
+    normalization: Literal['row', 'column', 'symmetric'],
+    dtype: torch.dtype,
+    device: torch.device,
+) -> Adj:
+    if contains_self_loops(edge_index):
+        warnings.warn(
+            'Self-loops detected in edge_index and will be removed before '
+            'building the diffusion operator. Lazy self-transitions are '
+            'already provided by the identity term in '
+            'P = 0.5 * (I + A_norm).',
+            stacklevel=3,
+        )
+        edge_index, edge_weight = remove_self_loops(edge_index, edge_weight)
+
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            'ignore',
+            message='Sparse CSR tensor support is in beta state.*',
+            category=UserWarning,
+        )
+        sparse_norm_A = _get_sparse_normalized_A(
+            edge_index,
+            edge_weight,
+            num_nodes,
+            normalization,
+            dtype,
+            device,
+        )
+        identity = _sparse_identity(
+            num_nodes,
+            dtype=dtype,
+            device=device,
+        )
+        P_sparse = 0.5 * (identity + sparse_norm_A)
+        return _as_adj(P_sparse.coalesce())
+
+
+def _subset_second_order_wavelets(
+    W2raw: Tensor,
+    *,
+    feature_type: Literal['scalar', 'vector'],
+) -> Tensor:
+    if feature_type not in ('scalar', 'vector'):
+        raise ValueError(
+            f"feature_type must be 'scalar' or 'vector', got {feature_type}.",
+        )
+
+    n_prev = int(W2raw.shape[-2])
+    n_next = int(W2raw.shape[-1])
+    if n_prev < 2:
+        raise ValueError(
+            'Second-order scattering requires at least two first-order '
+            'wavelet filters.', )
+
+    mask = torch.triu(
+        torch.ones(n_prev, n_next, dtype=torch.bool, device=W2raw.device),
+        diagonal=1,
+    )
+
+    if feature_type == 'scalar':
+        if W2raw.ndim != 4:
+            raise ValueError(
+                'Scalar 2nd-order tensors must have shape '
+                '(N, C, W_prev, W_next).', )
+        return W2raw[:, :, mask]
+
+    if W2raw.ndim != 3:
+        raise ValueError(
+            'Vector 2nd-order tensors must have shape (N*d, W_prev, W_next).',
+        )
+    return W2raw[:, mask].unsqueeze(1)
+
+
+def diffusion_wavelet_transform(
+    x: Tensor,
+    P: Union[Tensor, SparseTensor],
+    diffusion_scales: Tensor,
+    include_lowpass: bool = True,
+    filter_stack_dim: int = -1,
+    check_nonfinite: bool = False,
+) -> Tensor:
+    if x.ndim == 1:
+        x = x.unsqueeze(1)
+
+    if isinstance(P, SparseTensor):
+        if P.dtype() != x.dtype:
+            P = P.to(dtype=x.dtype)
+    elif isinstance(P, Tensor):
+        if _is_sparse_diffusion_op(P):
+            if P.dtype != x.dtype:
+                P = P.to(dtype=x.dtype)
+        elif P.dtype != x.dtype:
+            P = P.to(dtype=x.dtype)
+
+    if check_nonfinite:
+        if isinstance(P, SparseTensor):
+            _raise_if_nonfinite(
+                P.storage.value(),
+                name='GeoScatConv: P values',
+            )
+        elif isinstance(P, Tensor):
+            if _is_sparse_diffusion_op(P):
+                _raise_if_nonfinite(
+                    P.values(),
+                    name='GeoScatConv: P values',
+                )
+            else:
+                _raise_if_nonfinite(P, name='GeoScatConv: P')
+        _raise_if_nonfinite(x, name='GeoScatConv: x')
+
+    if not isinstance(diffusion_scales, Tensor):
+        diffusion_scales = torch.as_tensor(
+            diffusion_scales,
+            dtype=torch.long,
+            device=x.device,
+        )
+    else:
+        diffusion_scales = diffusion_scales.to(device=x.device,
+                                               dtype=torch.long)
+
+    if diffusion_scales.dim() != 1:
+        raise ValueError(
+            f"diffusion_scales must be one-dimensional "
+            f"(got {diffusion_scales.dim()} dimensions).", )
+
+    device = x.device
+    powers_to_save = diffusion_scales
+    range_upper_lim = int(diffusion_scales.numel())
+
+    Ptxs = [x.to(device)]
+    Ptx = x.to(device)
+    max_power = int(powers_to_save[-1].item())
+
+    for j in range(1, max_power + 1):
+        Ptx = _diffusion_matmul(P, Ptx)
+        if check_nonfinite:
+            _raise_if_nonfinite(Ptx, name=f'GeoScatConv: P^t x (t={j})')
+        if j in powers_to_save:
+            j_ct = int((powers_to_save == j).sum().item())
+            for _ in range(j_ct):
+                Ptxs.append(Ptx.to(device))
+
+    Wjxs = [Ptxs[j - 1] - Ptxs[j] for j in range(1, range_upper_lim)]
+    if include_lowpass:
+        Wjxs.append(Ptxs[-1])
+    return torch.stack(Wjxs, dim=filter_stack_dim).to(device)
+
+
+def multiorder_scatter(
+    x: Tensor,
+    diffusion_op: Union[Tensor, SparseTensor],
+    *,
+    diffusion_scales: Tensor,
+    include_lowpass: bool,
+    scattering_orders: Tuple[int, ...],
+    is_vector_feature: bool = False,
+    activation: Optional[Union[Module, Callable[[Tensor], Tensor]]] = None,
+    check_nonfinite: bool = False,
+) -> Tensor:
+    if x.dim() == 1:
+        x = x.unsqueeze(1)
+
+    if is_vector_feature:
+        num_nodes, vector_dim = x.shape
+        flat = x.reshape(num_nodes * vector_dim, 1)
+        feature_type: Literal['scalar', 'vector'] = 'vector'
+    else:
+        num_nodes = x.shape[0]
+        flat = x
+        feature_type = 'scalar'
+
+    scatter_kwargs = {
+        'diffusion_scales': diffusion_scales,
+        'include_lowpass': include_lowpass,
+        'check_nonfinite': check_nonfinite,
+    }
+
+    need_first_order = 1 in scattering_orders or 2 in scattering_orders
+    coeffs: List[Tensor] = []
+
+    if 0 in scattering_orders:
+        coeffs.append(flat.unsqueeze(-1))
+
+    W1: Optional[Tensor] = None
+    if need_first_order:
+        W1 = diffusion_wavelet_transform(
+            x=flat,
+            P=diffusion_op,
+            **scatter_kwargs,
+        )
+        W1 = _apply_activation(W1, activation)
+        if 1 in scattering_orders:
+            coeffs.append(W1)
+
+    if 2 in scattering_orders and W1 is not None:
+        num_wavelets = int(W1.shape[-1])
+        if num_wavelets > 1:
+            if is_vector_feature:
+                x_second = W1.squeeze(1)
+                W2raw = diffusion_wavelet_transform(
+                    x=x_second,
+                    P=diffusion_op,
+                    **scatter_kwargs,
+                )
+                nd = x_second.shape[0]
+                W2raw = W2raw.view(nd, num_wavelets, -1)
+            else:
+                num_channels = int(W1.shape[1])
+                x_second = W1.reshape(num_nodes, num_channels * num_wavelets)
+                W2raw = diffusion_wavelet_transform(
+                    x=x_second,
+                    P=diffusion_op,
+                    **scatter_kwargs,
+                )
+                W2raw = W2raw.view(num_nodes, num_channels, num_wavelets, -1)
+            W2 = _subset_second_order_wavelets(
+                W2raw,
+                feature_type=feature_type,
+            )
+            W2 = _apply_activation(W2, activation)
+            coeffs.append(W2)
+
+    if not coeffs:
+        raise ValueError('scattering_orders produced no output coefficients.')
+
+    W_tot = torch.cat(coeffs, dim=-1)
+    if is_vector_feature:
+        return W_tot.view(num_nodes, vector_dim, -1)
+    return W_tot
+
+
+def _compute_num_wavelet_filters(
+    diffusion_scales: Tuple[int, ...],
+    include_lowpass: bool,
+) -> int:
+    return (len(diffusion_scales) - 1) + int(include_lowpass)
+
+
+def _compute_num_scattering_filters(
+    num_wavelet_filters: int,
+    scattering_orders: Tuple[int, ...],
+) -> int:
+    total = 0
+    if 0 in scattering_orders:
+        total += 1
+    if 1 in scattering_orders:
+        total += num_wavelet_filters
+    if 2 in scattering_orders:
+        W = num_wavelet_filters
+        total += W * (W - 1) // 2
+    return total
+
+
+def _pool_scattering_coefficients(
+    coeffs: Tensor,
+    batch: OptTensor,
+    pool: Tuple[str, ...],
+) -> Tensor:
+    num_nodes, num_features, num_filters = coeffs.shape
+    x_flat = coeffs.reshape(num_nodes, num_features * num_filters)
+
+    if batch is None:
+        batch = coeffs.new_zeros(num_nodes, dtype=torch.long)
+
+    num_graphs = int(batch.max().item()) + 1 if batch.numel() > 0 else 1
+
+    min_aggr = MinAggregation()
+    median_aggr = MedianAggregation()
+    var_aggr = VarAggregation()
+
+    pooled: List[Tensor] = []
+    for op in pool:
+        if op == 'mean':
+            out = scatter(x_flat, batch, dim=0, dim_size=num_graphs,
+                          reduce='mean')
+        elif op == 'max':
+            out = scatter(x_flat, batch, dim=0, dim_size=num_graphs,
+                          reduce='max')
+        elif op == 'min':
+            out = min_aggr(x_flat, batch, dim_size=num_graphs)
+        elif op == 'median':
+            out = median_aggr(x_flat, batch, dim_size=num_graphs)
+        elif op == 'var':
+            out = var_aggr(x_flat, batch, dim_size=num_graphs)
+        else:
+            raise ValueError(
+                f"Unknown pooling operation '{op}'. "
+                f"Valid options are {sorted(VALID_POOL_OPS)}.", )
+        pooled.append(out.view(num_graphs, num_features, num_filters))
+
+    return torch.cat(pooled, dim=-1)
+
+
+class GeoScatConv(Module):
+    r"""Implements the geometric scattering transform built from
+    graph diffusion wavelets, introduced in the `"Geometric
+    Scattering for Graph Data Analysis"
+    <https://arxiv.org/abs/1810.03068>`_ and `"Diffusion
+    Scattering Transforms on Graphs"
+    <https://arxiv.org/abs/1806.08829>`_ papers. This technique
+    has been utilized and extended further in, for example,
+    `BLIS-Net <https://proceedings.mlr.press/v238/xu24c.html>`_,
+    `HiPoNet <https://arxiv.org/abs/2502.07746>`_, and
+    `VDW-GNNs <https://arxiv.org/abs/2510.01022>`_.
+
+    In particular, this layer computes diffusion wavelet scattering
+    coefficients on graph node features. A diffusion wavelet
+    convolution of a feature vector :math:`\mathbf{x}` has the
+    general form
+
+    .. math::
+        \mathbf{W}_j \mathbf{x} = (\mathbf{P}^{t_j} -
+        \mathbf{P}^{t_{j+1}}) \mathbf{x},
+
+    where :math:`\mathbf{P}` is a lazy random walk operator
+    (typically row-normalized), and :math:`t_j` and
+    :math:`t_{j+1} > t_j` are the diffusion scales, set to
+    consecutive powers of 2 (dyadic scale, up to 16) by default.
+    However, one can use custom diffusion scales by setting
+    :obj:`diffusion_scales` to a custom tuple of increasing integers
+    (or tuple of tuples, for different diffusion scales per feature
+    channel). Here, `InfoGain Wavelets
+    <https://arxiv.org/abs/2504.08802>`_ provide a principled,
+    data-driven way to select (potentially non-dyadic) wavelet
+    diffusion scales. A simple low-pass filter
+    :math:`P^{t_{\max}} \mathbf{x}` is included by default, and may
+    be excluded by setting :obj:`include_lowpass` to :obj:`False`.
+
+    This layer returns concatenated 0th and 1st-order scattering
+    coefficients by default. The 0th-order scattering coefficient is
+    the unfiltered input feature vector, and may be excluded by
+    setting :obj:`scattering_orders` to :obj:`(1,)`. Second-order
+    scattering coefficients can be included by including :obj:`2` in
+    the :obj:`scattering_orders` tuple. These are defined as:
+
+    .. math::
+        \mathbf{W}_{j^{\prime}} \sigma (\mathbf{W}_j \mathbf{x}),
+        j^{\prime} > j,
+
+    where :math:`\sigma` is an optional activation (e.g. the modulus
+    operator via :obj:`torch.abs`), disabled by default.
+
+    Note there is not an :obj:`out_channels` property for this layer,
+    as the number of output channels is deterministic via the
+    parameterization of the scattering transform. Including 0th-order
+    scattering coefficients increases the number of output channels by
+    1; including 1st-order scattering coefficients increases the number
+     of output channels by the number of wavelets :math:`w`; including
+    2nd-order scattering coefficients increases the number of output
+    channels by :math:`w \cdot (w - 1) // 2`.
+
+    For graph-level tasks, scattering coefficients can be pooled across
+    nodes within each graph and feature channel, changing the output shape
+    from :math:`(|\mathcal{V}|, F_{\mathrm{in}}, W_{\mathrm{total}})` to
+    :math:`(B, F_{\mathrm{in}}, W_{\mathrm{total}} \cdot |\mathrm{pool}|)`.
+    Currently, the built-in options for pooling are :obj:`"mean"`,
+    :obj:`"max"`, :obj:`"min"`, :obj:`"median"`, and :obj:`"var"`.
+    Alternatively, leave :obj:`pool` as :obj:`None` to return node-level
+    scattering coefficients, and apply other pooling operations downstream
+    of this layer.
+
+    Vector-valued graph signals (as explored in the `VDW-GNNs paper
+    <https://arxiv.org/abs/2510.01022>`_) are supported by
+    setting :obj:`is_vector_feature` to :obj:`True`. In this mode, node
+    features :math:`\mathbf{x} \in \mathbb{R}^{n \times d}` are flattened
+    internally and a user-supplied diffusion operator
+    :math:`\mathbf{P} \in \mathbb{R}^{nd \times nd}` must be passed via
+    :obj:`diffusion_op` (for example, stored on
+    :class:`~torch_geometric.data.Data` under an attribute such as
+    :obj:`diffusion_adj`). Lazy random walk operators built from
+    :obj:`edge_index` are not supported for vector features.
+
+    .. note::
+        Self-loops in :obj:`edge_index` are automatically removed before
+        normalization of the lazy random walk operator, which includes
+        self-transitions due to the laziness of the random walk (i.e.,
+        a nonzero probability of staying at the same node).
+
+    .. note::
+        A cached diffusion operator :obj:`P` may be passed via
+        :obj:`diffusion_op` instead of recomputed from the :obj:`edge_index`
+        in every forward pass. Store (sparse)
+        :obj:`P` under an attribute name containing :obj:`'adj'` (e.g.
+        :obj:`P_adj`) so that PyG block-diagonal-stacks operators
+        during collation, and pass this name to :obj:`diffusion_op_key`
+        accordingly. (Block-diagonal collation is required to ensure that,
+        in multi-graph settings, :obj:`P` is correctly block-diagonal-stacked
+        so it applies only to nodes within its own graph in a batched
+        :class:`~torch_geometric.data.Data` object.) Forcing block-diagonal
+        collation of operators keyed under arbitrary names requires overriding
+        :meth:`~torch_geometric.data.Data.__cat_dim__`; see `Advanced
+        Mini-Batching
+        <https://pytorch-geometric.readthedocs.io/en/latest/advanced/batching.html>`_.
+
+    Args:
+        in_channels (int): Size of each input sample. For vector features,
+            this is the vector dimension :math:`d`.
+        scattering_orders (Tuple[int, ...], optional): Scattering orders to
+            include in the output. Each entry must be :obj:`0` (unfiltered
+            input), :obj:`1` (first-order wavelets), or :obj:`2`
+            (second-order). Pass :obj:`(1,)` for a diffusion wavelet
+            transform only. (default: :obj:`(0, 1)`)
+        diffusion_scales (Tuple[int, ...], optional): Monotonically increasing
+            diffusion powers at which to save :math:`P^t \mathbf{x}`.
+            Wavelet filters are consecutive differences between adjacent
+            saved powers. (default: :obj:`(0, 1, 2, 4, 8, 16)`)
+        include_lowpass (bool, optional): If set to :obj:`True`, append the
+            low-pass filter :math:`P^{t_{\max}} \mathbf{x}`.
+            (default: :obj:`True`)
+        activation (torch.nn.Module or Callable, optional): Activation
+            applied to 1st- and 2nd-order scattering coefficients, e.g.
+            :obj:`torch.abs` for the modulus. (default: :obj:`None`)
+        normalization (str, optional): Normalization scheme for the adjacency
+            matrix before building the lazy random walk operator
+            :math:`P`. Ignored when :obj:`diffusion_op` is provided.
+            (default: :obj:`"row"`)
+        is_vector_feature (bool, optional): If set to :obj:`True`, treat each
+            node feature as a vector signal of dimension :obj:`in_channels`
+            and require a precomputed :obj:`diffusion_op` of shape
+            :math:`(n \cdot d, n \cdot d)`.
+            (default: :obj:`False`)
+        pool (Tuple[str, ...], optional): Graph-level pooling operations to
+            apply across nodes. Each entry must be one of :obj:`"mean"`,
+            :obj:`"max"`, :obj:`"min"`, :obj:`"median"`, or :obj:`"var"`.
+            If :obj:`None`, node-level scattering coefficients are returned.
+            (default: :obj:`None`)
+        check_nonfinite (bool, optional): If set to :obj:`True`, raise an
+            error when non-finite values are detected in inputs or
+            intermediate results. (default: :obj:`False`). Useful for
+            debugging.
+
+    Shapes:
+        - **input:**
+          node features :math:`(|\mathcal{V}|, F_{in})` or
+          :math:`(|\mathcal{V}|, d)` for vector features,
+          edge indices :math:`(2, |\mathcal{E}|)` *(optional if*
+          :obj:`diffusion_op` *is set)*,
+          edge weights :math:`(|\mathcal{E}|)` *(optional)*,
+          batch vector :math:`(|\mathcal{V}|)` *(optional, required for
+          graph-level pooling on batched graphs)*
+        - **output (node-level,** :obj:`pool=None` **):**
+          scattering coefficients
+          :math:`(|\mathcal{V}|, F_{in}, W_{\mathrm{total}})`
+        - **output (graph-level,** :obj:`pool` **set):**
+          pooled scattering coefficients
+          :math:`(B, F_{in}, W_{\mathrm{total}} \cdot |\texttt{pool}|)`
+    """
+    def __init__(
+        self,
+        in_channels: int,
+        scattering_orders: Optional[Tuple[int, ...]] = (0, 1),
+        diffusion_scales: Optional[Tuple[int, ...]] = (0, 1, 2, 4, 8, 16),
+        include_lowpass: bool = True,
+        activation: Optional[Union[Module, Callable[[Tensor], Tensor]]] = None,
+        normalization: Literal['row', 'column', 'symmetric'] = 'row',
+        is_vector_feature: bool = False,
+        pool: Optional[Tuple[str, ...]] = None,
+        check_nonfinite: bool = False,
+    ):
+        super().__init__()
+
+        if scattering_orders is None:
+            scattering_orders = (0, 1)
+        else:
+            scattering_orders = tuple(scattering_orders)
+        _validate_scattering_orders(scattering_orders)
+
+        if normalization not in {'row', 'column', 'symmetric'}:
+            raise ValueError(
+                "normalization must be one of {'row', 'column', 'symmetric'}, "
+                f"got '{normalization}'.", )
+
+        if diffusion_scales is None:
+            diffusion_scales = DEFAULT_DIFFUSION_SCALES
+        else:
+            diffusion_scales = tuple(diffusion_scales)
+        if len(diffusion_scales) < 2:
+            raise ValueError(
+                'diffusion_scales must contain at least two entries.', )
+        if any(diffusion_scales[i] >= diffusion_scales[i + 1]
+               for i in range(len(diffusion_scales) - 1)):
+            raise ValueError('diffusion_scales must be strictly increasing.')
+
+        if pool is not None:
+            pool = tuple(pool)
+            if len(pool) == 0:
+                raise ValueError('pool must be None or a non-empty tuple.')
+            invalid = set(pool) - VALID_POOL_OPS
+            if invalid:
+                raise ValueError(
+                    f"Invalid pooling operations {sorted(invalid)}. "
+                    f"Valid options are {sorted(VALID_POOL_OPS)}.", )
+
+        self.in_channels = in_channels
+        self.scattering_orders = scattering_orders
+        self.diffusion_scales = diffusion_scales
+        self.include_lowpass = include_lowpass
+        self.activation = activation
+        self.normalization = normalization
+        self.is_vector_feature = is_vector_feature
+        self.pool = pool
+        self.check_nonfinite = check_nonfinite
+
+    @property
+    def num_wavelet_filters(self) -> int:
+        return _compute_num_wavelet_filters(
+            self.diffusion_scales,
+            self.include_lowpass,
+        )
+
+    @property
+    def num_scattering_filters(self) -> int:
+        return _compute_num_scattering_filters(
+            self.num_wavelet_filters,
+            self.scattering_orders,
+        )
+
+    @property
+    def out_channels(self) -> int:
+        num_filters = self.num_scattering_filters
+        if self.pool is None:
+            return num_filters
+        return num_filters * len(self.pool)
+
+    def reset_parameters(self) -> None:
+        """This layer does not have any learnable parameters to reset.
+        It is intended as a multiscale feature extractor layer for graph
+        data, whose coefficients can be fed into learnable layers downstream.
+        """
+
+    def forward(
+        self,
+        x: Tensor,
+        edge_index: Optional[Tensor] = None,
+        edge_weight: OptTensor = None,
+        batch: OptTensor = None,
+        diffusion_op: Optional[Union[Tensor, SparseTensor]] = None,
+        diffusion_op_key: Optional[str] = None,
+    ) -> Tensor:
+        r"""Forward pass.
+
+        Args:
+            x: Node features of shape :math:`(|\mathcal{V}|, F_{\mathrm{in}})`,
+                or :math:`(|\mathcal{V}|, d)` for vector features.
+            edge_index: Edge indices of shape :math:`(2, |\mathcal{E}|)`.
+            edge_weight: Edge weights of shape :math:`(|\mathcal{E}|)`.
+            batch: Batch vector of shape :math:`(|\mathcal{V}|)`.
+            diffusion_op: Precomputed diffusion operator of shape
+                :math:`(n, n)` for scalar node features, or
+                :math:`(n \cdot d, n \cdot d)` for vector features.
+            diffusion_op_key: Key of the precomputed diffusion operator in the
+                Data object(s). Should contain the substring 'adj' for proper
+                block-diagonal collation; otherwise, the :obj:`__cat_dim__`
+                method of the :obj:`Data` object(s) will need to be overridden.
+
+        Returns:
+            Scattering coefficients of shape
+            :math:`(|\mathcal{V}|, F_{\mathrm{in}}, W_{\mathrm{total}})`,
+            or :math:`(B, F_{\mathrm{in}}, W_{\mathrm{total}}
+            \cdot |\mathrm{pool}|)` if :obj:`pool` is set.
+        """
+        if x.size(-1) != self.in_channels:
+            raise ValueError(
+                f"Expected input with {self.in_channels} channels "
+                f"(got {x.size(-1)}).", )
+
+        num_nodes = x.size(0)
+
+        if self.is_vector_feature:
+            if diffusion_op is None:
+                raise ValueError(
+                    'Vector features require a precomputed diffusion_op of '
+                    'shape (num_nodes * in_channels, num_nodes * '
+                    'in_channels). Store it on Data objects (e.g. as '
+                    "'diffusion_adj') and pass it to forward.", )
+            if edge_index is not None:
+                raise ValueError(
+                    'When is_vector_feature is True, pass diffusion_op only '
+                    '(not edge_index).', )
+            expected_size = num_nodes * self.in_channels
+            _validate_diffusion_op_shape(diffusion_op, expected_size)
+            _warn_if_diffusion_op_batching_unsafe(
+                diffusion_op,
+                diffusion_op_key,
+            )
+            op = diffusion_op
+        elif diffusion_op is not None:
+            if edge_index is not None:
+                raise ValueError(
+                    'Exactly one of edge_index or diffusion_op must be '
+                    'provided.', )
+            _validate_diffusion_op_shape(diffusion_op, num_nodes)
+            _warn_if_diffusion_op_batching_unsafe(diffusion_op,
+                                                  diffusion_op_key)
+            op = diffusion_op
+        else:
+            if edge_index is None:
+                raise ValueError(
+                    'Exactly one of edge_index or diffusion_op must be '
+                    'provided.', )
+            op = get_sparse_lrw_diffusion_operator(
+                edge_index,
+                edge_weight,
+                num_nodes,
+                self.normalization,
+                x.dtype,
+                x.device,
+            )
+
+        diffusion_scales = torch.as_tensor(
+            self.diffusion_scales,
+            dtype=torch.long,
+            device=x.device,
+        )
+
+        coeffs = multiorder_scatter(
+            x,
+            op,
+            diffusion_scales=diffusion_scales,
+            include_lowpass=self.include_lowpass,
+            scattering_orders=self.scattering_orders,
+            is_vector_feature=self.is_vector_feature,
+            activation=self.activation,
+            check_nonfinite=self.check_nonfinite,
+        )
+
+        if self.pool is None:
+            return coeffs
+
+        return _pool_scattering_coefficients(coeffs, batch, self.pool)
+
+    def __repr__(self) -> str:
+        return (f'{self.__class__.__name__}('
+                f'in_channels={self.in_channels}, '
+                f'scattering_orders={self.scattering_orders}, '
+                f'num_scattering_filters={self.num_scattering_filters}, '
+                f'normalization={self.normalization}, '
+                f'pool={self.pool})')


### PR DESCRIPTION
**Summary**

Adds `GeoScatConv` to `torch_geometric.nn.conv`, implementing the geometric scattering transform from "[Gao et al., Geometric Scattering for Graph Data Analysis](https://arxiv.org/abs/1810.03068)" and Gama et al., "[Diffusion Scattering Transforms on Graphs](https://arxiv.org/abs/1806.08829)". This layer builds multi-scale representations of graph node signals from cascades of [Diffusion Wavelets](https://www.sciencedirect.com/science/article/pii/S106352030600056X). It also implements Learnable Geometric Scattering ("[LEGS](https://ieeexplore.ieee.org/document/10473218)") as an option, in which Diffusion Wavelet scale combinations are learned via a differentiable selector matrix. Please see the docstring for `GeoScatConv` for more details on the method and its key hyperparameters.

This is a foundational layer that several subsequent architectures have used or extended, e.g., [BLIS-Net](https://proceedings.mlr.press/v238/xu24c.html), [HiPoNet](https://arxiv.org/abs/2502.07746), and [VDW-GNNs](https://arxiv.org/abs/2510.01022). Having a PyG core module aids in reproducibility and further extensions of these models by providing the GNN community a standard, efficient, and tested core implementation of geometric scattering.

**Files touched**

- Added `GeoScatConv` to `torch_geometric.nn.conv`.
- Added imports to `torch_geometric/nn/conv/__init__.py`.
- Unit tests are in `test_geo_scat_conv.py`.
- An example script `geo_scat.py` is in `examples/`, and covers both default and LEGS modes.