### PR TITLE
Make AddLaplacianEigenvectorPE deterministic for the sparse (ARPACK) solver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Removed
 
 ### Fixed
+- Made `AddLaplacianEigenvectorPE` deterministic for graphs that use the sparse (ARPACK) eigenvector solver by defaulting to a fixed starting vector `v0` ([#7499](https://github.com/pyg-team/pytorch_geometric/issues/7499))
 
 - Fixed `config_store` on Python 3.14, where `typing.Union`/`typing.Optional` annotations could no longer be remapped in-place via the now read-only `__args__` attribute
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Removed
 
 ### Fixed
+
 - Made `AddLaplacianEigenvectorPE` deterministic for graphs that use the sparse (ARPACK) eigenvector solver by defaulting to a fixed starting vector `v0` ([#7499](https://github.com/pyg-team/pytorch_geometric/issues/7499))
 
 - Fixed `config_store` on Python 3.14, where `typing.Union`/`typing.Optional` annotations could no longer be remapped in-place via the now read-only `__args__` attribute

--- a/test/transforms/test_add_positional_encoding.py
+++ b/test/transforms/test_add_positional_encoding.py
@@ -53,6 +53,34 @@ def test_add_laplacian_eigenvector_pe():
 
 
 @withPackage('scipy')
+def test_add_laplacian_eigenvector_pe_sparse_is_deterministic():
+    # Graphs with more nodes than `SPARSE_THRESHOLD` use ARPACK, whose
+    # starting vector `v0` is initialized randomly unless provided. This
+    # previously made the encoding non-reproducible even when all library
+    # seeds were set. With a deterministic `v0`, seeding now guarantees
+    # reproducible eigenvectors (see GitHub issue #7499).
+    num_nodes = AddLaplacianEigenvectorPE.SPARSE_THRESHOLD + 50
+    torch.manual_seed(0)
+    row = torch.randint(0, num_nodes, (500, ))
+    col = torch.randint(0, num_nodes, (500, ))
+    edge_index = torch.stack([torch.cat([row, col]), torch.cat([col, row])])
+    data = Data(edge_index=edge_index, num_nodes=num_nodes)
+
+    transform = AddLaplacianEigenvectorPE(k=3, attr_name='pe')
+
+    torch.manual_seed(12345)
+    pe1 = transform(data).pe
+    torch.manual_seed(12345)
+    pe2 = transform(data).pe
+    assert torch.allclose(pe1, pe2)
+
+    # The eigenvector magnitudes are reproducible regardless of the random
+    # sign flip, which is what the fixed ARPACK starting vector guarantees:
+    pe3 = transform(data).pe
+    assert torch.allclose(pe1.abs(), pe3.abs())
+
+
+@withPackage('scipy')
 def test_eigenvector_permutation_invariance():
     edge_index = torch.tensor([[0, 1, 0, 4, 1, 4, 2, 3, 3, 5],
                                [1, 0, 4, 0, 4, 1, 3, 2, 5, 3]])

--- a/torch_geometric/transforms/add_positional_encoding.py
+++ b/torch_geometric/transforms/add_positional_encoding.py
@@ -97,12 +97,22 @@ class AddLaplacianEigenvectorPE(BaseTransform):
             from scipy.sparse.linalg import eigs, eigsh
             eig_fn = eigs if not self.is_undirected else eigsh
 
+            # ARPACK (used by `eigs`/`eigsh`) initializes its starting vector
+            # `v0` randomly when it is not provided, which yields different
+            # eigenvectors across runs even when all library seeds are set.
+            # We default to a deterministic starting vector to make the
+            # positional encoding reproducible (see GitHub issue #7499). A
+            # local copy of `kwargs` is used so that a size-dependent `v0` is
+            # not cached on the (potentially reused) transform instance.
+            kwargs = dict(self.kwargs)
+            kwargs.setdefault('v0', np.ones(num_nodes))
+
             eig_vals, eig_vecs = eig_fn(
                 L,
                 k=self.k + 1,
                 which='SR' if not self.is_undirected else 'SA',
                 return_eigenvectors=True,
-                **self.kwargs,
+                **kwargs,
             )
 
         eig_vecs = np.real(eig_vecs[:, eig_vals.argsort()])


### PR DESCRIPTION
### Fixes #7499

`AddLaplacianEigenvectorPE` is non-deterministic for graphs above `SPARSE_THRESHOLD`, which take the sparse code path using SciPy ARPACK (`eigs`/`eigsh`). ARPACK initializes its starting vector `v0` **randomly** when it is not provided, so the returned eigenvectors — and thus the positional encoding — differ across runs *even when NumPy/PyTorch/Python seeds are all set*. This matches @rusty1s's diagnosis in the issue thread.

### Fix

Default to a deterministic ARPACK starting vector `v0 = np.ones(num_nodes)` in the sparse branch. A **local copy** of `kwargs` is used (via `setdefault`) so that:
- a user-supplied `v0` is still respected, and
- a size-dependent `v0` is never cached on a reused transform instance.

This keeps ARPACK's speed/memory benefits (no switch to dense `numpy.linalg.eig`) while making the encoding reproducible under seeding.

### Reproduction (before)

```python
import random, numpy as np, torch
from torch_geometric.datasets import Planetoid
from torch_geometric.transforms import AddLaplacianEigenvectorPE

def seed(s=42):
    random.seed(s); np.random.seed(s); torch.manual_seed(s)

data = Planetoid(root='/tmp/Cora', name='Cora')[0]  # 2708 nodes -> sparse path
t = AddLaplacianEigenvectorPE(k=4)
seed(); pe1 = t(data.clone()).laplacian_eigenvector_pe
seed(); pe2 = t(data.clone()).laplacian_eigenvector_pe
print(torch.allclose(pe1, pe2))  # False before, True after
```

Before: `max|pe1 - pe2| ~= 0.59`. After: `0.0`.

### Notes

- The dense path (`num_nodes < SPARSE_THRESHOLD`, `numpy.linalg.eig`/`eigh`) was already deterministic.
- Eigenvector **sign** ambiguity (the existing `torch.randint` sign flip) is unchanged; it already respects `torch.manual_seed`. The added test therefore checks (a) reproducibility under seeding and (b) reproducibility of eigenvector magnitudes regardless of the sign flip.

### Test

Added `test_add_laplacian_eigenvector_pe_sparse_is_deterministic`, which exercises the sparse (ARPACK) path (`SPARSE_THRESHOLD + 50` nodes). All tests in `test/transforms/test_add_positional_encoding.py` pass; `flake8` clean.
