### PR TITLE
Add `DenseGATv2Conv`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- Added `DenseGATv2Conv`, the dense counterpart of `GATv2Conv` ([#10755](https://github.com/pyg-team/pytorch_geometric/pull/10755))
 - Added `torch_geometric.contrib.nn.models.MGNAN` (M-GNAN, an extension of `GNAN` to multivariate shape functions) model plus an example ([#10371](https://github.com/pyg-team/pytorch_geometric/pull/10371))
 
 ### Changed

--- a/test/nn/dense/test_dense_gatv2_conv.py
+++ b/test/nn/dense/test_dense_gatv2_conv.py
@@ -1,0 +1,75 @@
+import pytest
+import torch
+
+from torch_geometric.nn import DenseGATv2Conv, GATv2Conv
+from torch_geometric.testing import is_full_test
+
+
+@pytest.mark.parametrize('heads', [1, 4])
+@pytest.mark.parametrize('concat', [True, False])
+@pytest.mark.parametrize('share_weights', [False, True])
+def test_dense_gatv2_conv(heads, concat, share_weights):
+    channels = 16
+    sparse_conv = GATv2Conv(channels, channels, heads=heads, concat=concat,
+                            share_weights=share_weights)
+    dense_conv = DenseGATv2Conv(channels, channels, heads=heads, concat=concat,
+                                share_weights=share_weights)
+    assert str(dense_conv) == f'DenseGATv2Conv(16, 16, heads={heads})'
+
+    # Ensure same weights and bias:
+    dense_conv.lin_l = sparse_conv.lin_l
+    dense_conv.lin_r = sparse_conv.lin_r
+    dense_conv.att = sparse_conv.att
+    dense_conv.bias = sparse_conv.bias
+
+    x = torch.randn((5, channels))
+    edge_index = torch.tensor([[0, 1, 1, 2, 3, 4], [1, 0, 2, 1, 4, 3]])
+
+    sparse_out = sparse_conv(x, edge_index)
+
+    x = torch.cat([x, x.new_zeros(1, channels)], dim=0).view(2, 3, channels)
+    adj = torch.tensor([
+        [
+            [0.0, 1.0, 0.0],
+            [1.0, 0.0, 1.0],
+            [0.0, 1.0, 0.0],
+        ],
+        [
+            [0.0, 1.0, 0.0],
+            [1.0, 0.0, 0.0],
+            [0.0, 0.0, 0.0],
+        ],
+    ])
+    mask = torch.tensor([[1, 1, 1], [1, 1, 0]], dtype=torch.bool)
+
+    dense_out = dense_conv(x, adj, mask)
+
+    if is_full_test():
+        jit = torch.jit.script(dense_conv)
+        assert torch.allclose(jit(x, adj, mask), dense_out)
+
+    assert dense_out[1, 2].abs().sum() == 0
+    dense_out = dense_out.view(6, dense_out.size(-1))[:-1]
+    assert torch.allclose(sparse_out, dense_out, atol=1e-4)
+
+
+def test_dense_gatv2_conv_with_broadcasting():
+    batch_size, num_nodes, channels = 8, 3, 16
+    conv = DenseGATv2Conv(channels, channels, heads=4)
+
+    x = torch.randn(batch_size, num_nodes, channels)
+    adj = torch.tensor([
+        [0.0, 1.0, 1.0],
+        [1.0, 0.0, 1.0],
+        [1.0, 1.0, 0.0],
+    ])
+
+    assert conv(x, adj).size() == (batch_size, num_nodes, 64)
+    mask = torch.tensor([1, 1, 1], dtype=torch.bool)
+    assert conv(x, adj, mask).size() == (batch_size, num_nodes, 64)
+
+
+def test_dense_gatv2_conv_share_weights():
+    channels = 16
+    conv = DenseGATv2Conv(channels, channels, heads=2, share_weights=True)
+    assert conv.lin_l is conv.lin_r

--- a/torch_geometric/nn/dense/__init__.py
+++ b/torch_geometric/nn/dense/__init__.py
@@ -6,6 +6,7 @@ representations.
 
 from .linear import Linear, HeteroLinear, HeteroDictLinear
 from .dense_gat_conv import DenseGATConv
+from .dense_gatv2_conv import DenseGATv2Conv
 from .dense_sage_conv import DenseSAGEConv
 from .dense_gcn_conv import DenseGCNConv
 from .dense_graph_conv import DenseGraphConv
@@ -23,11 +24,12 @@ __all__ = [
     'DenseGraphConv',
     'DenseSAGEConv',
     'DenseGATConv',
+    'DenseGATv2Conv',
     'dense_diff_pool',
     'dense_mincut_pool',
     'DMoNPooling',
 ]
 
 lin_classes = __all__[:3]
-conv_classes = __all__[3:8]
-pool_classes = __all__[8:]
+conv_classes = __all__[3:9]
+pool_classes = __all__[9:]

--- a/torch_geometric/nn/dense/dense_gatv2_conv.py
+++ b/torch_geometric/nn/dense/dense_gatv2_conv.py
@@ -1,0 +1,134 @@
+from typing import Optional
+
+import torch
+import torch.nn.functional as F
+from torch import Tensor
+from torch.nn import Parameter
+
+from torch_geometric.nn.dense.linear import Linear
+from torch_geometric.nn.inits import glorot, zeros
+
+
+class DenseGATv2Conv(torch.nn.Module):
+    r"""See :class:`torch_geometric.nn.conv.GATv2Conv`.
+
+    .. note::
+        In contrast to :class:`~torch_geometric.nn.dense.DenseGATConv`, the
+        attention coefficients of :class:`GATv2Conv` are computed by applying
+        the non-linearity *before* projecting onto the attention vector.
+        This requires materializing an intermediate tensor of shape
+        :obj:`[B, N, N, heads, out_channels]`, and therefore uses
+        :obj:`out_channels` times more memory than
+        :class:`~torch_geometric.nn.dense.DenseGATConv`.
+    """
+    def __init__(
+        self,
+        in_channels: int,
+        out_channels: int,
+        heads: int = 1,
+        concat: bool = True,
+        negative_slope: float = 0.2,
+        dropout: float = 0.0,
+        bias: bool = True,
+        share_weights: bool = False,
+    ):
+        # TODO Add support for edge features.
+        super().__init__()
+
+        self.in_channels = in_channels
+        self.out_channels = out_channels
+        self.heads = heads
+        self.concat = concat
+        self.negative_slope = negative_slope
+        self.dropout = dropout
+        self.share_weights = share_weights
+
+        self.lin_l = Linear(in_channels, heads * out_channels, bias=bias,
+                            weight_initializer='glorot')
+        if share_weights:
+            self.lin_r = self.lin_l
+        else:
+            self.lin_r = Linear(in_channels, heads * out_channels, bias=bias,
+                                weight_initializer='glorot')
+
+        self.att = Parameter(torch.empty(1, heads, out_channels))
+
+        if bias and concat:
+            self.bias = Parameter(torch.empty(heads * out_channels))
+        elif bias and not concat:
+            self.bias = Parameter(torch.empty(out_channels))
+        else:
+            self.register_parameter('bias', None)
+
+        self.reset_parameters()
+
+    def reset_parameters(self):
+        self.lin_l.reset_parameters()
+        self.lin_r.reset_parameters()
+        glorot(self.att)
+        zeros(self.bias)
+
+    def forward(self, x: Tensor, adj: Tensor, mask: Optional[Tensor] = None,
+                add_loop: bool = True):
+        r"""Forward pass.
+
+        Args:
+            x (torch.Tensor): Node feature tensor
+                :math:`\mathbf{X} \in \mathbb{R}^{B \times N \times F}`, with
+                batch-size :math:`B`, (maximum) number of nodes :math:`N` for
+                each graph, and feature dimension :math:`F`.
+            adj (torch.Tensor): Adjacency tensor
+                :math:`\mathbf{A} \in \mathbb{R}^{B \times N \times N}`.
+                The adjacency tensor is broadcastable in the batch dimension,
+                resulting in a shared adjacency matrix for the complete batch.
+            mask (torch.Tensor, optional): Mask matrix
+                :math:`\mathbf{M} \in {\{ 0, 1 \}}^{B \times N}` indicating
+                the valid nodes for each graph. (default: :obj:`None`)
+            add_loop (bool, optional): If set to :obj:`False`, the layer will
+                not automatically add self-loops to the adjacency matrices.
+                (default: :obj:`True`)
+        """
+        x = x.unsqueeze(0) if x.dim() == 2 else x  # [B, N, F]
+        adj = adj.unsqueeze(0) if adj.dim() == 2 else adj  # [B, N, N]
+
+        H, C = self.heads, self.out_channels
+        B, N, _ = x.size()
+
+        if add_loop:
+            adj = adj.clone()
+            idx = torch.arange(N, dtype=torch.long, device=adj.device)
+            adj[:, idx, idx] = 1.0
+
+        x_l = self.lin_l(x).view(B, N, H, C)  # [B, N, H, C]
+        x_r = self.lin_r(x).view(B, N, H, C)  # [B, N, H, C]
+
+        # In contrast to `DenseGATConv`, the non-linearity is applied before
+        # projecting onto `att`, which requires a [B, N, N, H, C] tensor:
+        alpha = x_r.unsqueeze(2) + x_l.unsqueeze(1)  # [B, N, N, H, C]
+        alpha = F.leaky_relu(alpha, self.negative_slope)
+        alpha = (alpha * self.att).sum(dim=-1)  # [B, N, N, H]
+
+        # Weighted and masked softmax:
+        alpha = alpha.masked_fill(adj.unsqueeze(-1) == 0, float('-inf'))
+        alpha = alpha.softmax(dim=2)
+        alpha = F.dropout(alpha, p=self.dropout, training=self.training)
+
+        out = torch.matmul(alpha.movedim(3, 1), x_l.movedim(2, 1))
+        out = out.movedim(1, 2)  # [B, N, H, C]
+
+        if self.concat:
+            out = out.reshape(B, N, H * C)
+        else:
+            out = out.mean(dim=2)
+
+        if self.bias is not None:
+            out = out + self.bias
+
+        if mask is not None:
+            out = out * mask.view(-1, N, 1).to(x.dtype)
+
+        return out
+
+    def __repr__(self) -> str:
+        return (f'{self.__class__.__name__}({self.in_channels}, '
+                f'{self.out_channels}, heads={self.heads})')


### PR DESCRIPTION
Closes #10722.

`DenseGATConv` exists but has no v2 counterpart, so there is currently no dense equivalent of `GATv2Conv`. This adds one, mirroring the relationship between `DenseGATConv` and `GATConv`.

### Implementation

GAT computes attention as `LeakyReLU(a_src · Wx_i + a_dst · Wx_j)` — the projection onto the attention vector happens before the non-linearity, which is the source of its static attention. GATv2 applies the non-linearity first:

```
alpha = a^T · LeakyReLU(W_l x_i + W_r x_j)
```

So the dense version uses two linear maps (`lin_l`, `lin_r`, optionally tied via `share_weights`) and a single `att` parameter, rather than one `lin` and two `att_*` vectors.

### Memory note

`DenseGATConv` can reduce to `[B, N, N, heads]` before the softmax. GATv2 cannot — the non-linearity applies to the full feature vector, so the intermediate is `[B, N, N, heads, out_channels]`, i.e. `out_channels`× more memory than `DenseGATConv`.

This is inherent to the GATv2 formulation rather than an artifact of this implementation, but since it matters on an already-`O(N^2)` dense layer, it's called out explicitly in the class docstring rather than left to be discovered.

### Scope

The parameter surface mirrors `DenseGATConv`, plus `share_weights` (GATv2-specific).

`edge_dim` and `residual` are deliberately not included: `DenseGATConv` carries a `# TODO Add support for edge features` and no dense conv implements `residual`, so supporting them here would make this layer inconsistent with the rest of the dense family. Happy to add either if you'd prefer.

### Tests

`test/nn/dense/test_dense_gatv2_conv.py` follows the existing `test_dense_gat_conv.py` pattern: weights are shared with the sparse `GATv2Conv` and the outputs are asserted equal, parametrized over `heads=[1, 4]`, `concat=[True, False]` and `share_weights=[False, True]` (8 combinations), plus masked-node zeroing, batch broadcasting, and the `is_full_test()` TorchScript check. All pass, including under `FULL_TEST=1`.

### Note on `nn/dense/__init__.py`

`conv_classes` / `pool_classes` are positional slices of `__all__`, and `docs/source/modules/nn.rst` iterates them to generate documentation. The slice bounds are updated so the new layer lands in `conv_classes` and the pooling group is unchanged — verified.
