### PR TITLE
Verify TLS certificates when downloading datasets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Security
 
-- `download_url` now verifies TLS certificates instead of always using an unverified SSL context. Set `PYG_INSECURE_DOWNLOADS=1` to restore the previous behavior ([#10754](https://github.com/pyg-team/pytorch_geometric/pull/10754))
+- `download_url` now verifies TLS certificates instead of always using an unverified SSL context. Set `PYG_INSECURE_DOWNLOADS=1` to restore the previous behavior ([#10756](https://github.com/pyg-team/pytorch_geometric/pull/10756))
 
 ## [2.8.0] - 2026-06-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Security
 
+- `download_url` now verifies TLS certificates instead of always using an unverified SSL context. Set `PYG_INSECURE_DOWNLOADS=1` to restore the previous behavior ([#10754](https://github.com/pyg-team/pytorch_geometric/pull/10754))
+
 ## [2.8.0] - 2026-06-05
 
 ### Added

--- a/test/data/test_download.py
+++ b/test/data/test_download.py
@@ -1,0 +1,34 @@
+import ssl
+
+import pytest
+
+from torch_geometric.data.download import INSECURE_ENV_VAR, get_ssl_context
+
+
+def test_ssl_context_verifies_certificates_by_default(monkeypatch):
+    monkeypatch.delenv(INSECURE_ENV_VAR, raising=False)
+
+    context = get_ssl_context()
+
+    assert context.verify_mode == ssl.CERT_REQUIRED
+    assert context.check_hostname
+
+
+def test_ssl_context_can_be_opted_out_of(monkeypatch):
+    monkeypatch.setenv(INSECURE_ENV_VAR, '1')
+
+    with pytest.warns(UserWarning, match='verification disabled'):
+        context = get_ssl_context()
+
+    assert context.verify_mode == ssl.CERT_NONE
+    assert not context.check_hostname
+
+
+@pytest.mark.parametrize('value', ['0', 'true', 'yes', ''])
+def test_ssl_context_only_opts_out_on_exactly_one(monkeypatch, value):
+    monkeypatch.setenv(INSECURE_ENV_VAR, value)
+
+    context = get_ssl_context()
+
+    assert context.verify_mode == ssl.CERT_REQUIRED
+    assert context.check_hostname

--- a/torch_geometric/data/download.py
+++ b/torch_geometric/data/download.py
@@ -3,11 +3,41 @@ import os.path as osp
 import ssl
 import sys
 import urllib
+import warnings
 from typing import Optional
 
 import fsspec
 
 from torch_geometric.io import fs
+
+INSECURE_ENV_VAR = 'PYG_INSECURE_DOWNLOADS'
+
+
+def get_ssl_context() -> ssl.SSLContext:
+    r"""Returns the :class:`ssl.SSLContext` used to download datasets.
+
+    Server certificates are verified by default. Set the environment variable
+    :obj:`PYG_INSECURE_DOWNLOADS=1` to skip verification, e.g., for a dataset
+    host with a misconfigured certificate chain. Note that doing so leaves
+    downloads open to tampering by anyone able to intercept the connection.
+    """
+    if os.getenv(INSECURE_ENV_VAR, '0') == '1':
+        warnings.warn(
+            f'Downloading with TLS certificate verification disabled '
+            f"('{INSECURE_ENV_VAR}=1'). Downloaded files cannot be trusted to "
+            f'originate from the expected host.',
+            stacklevel=2,
+        )
+        return ssl._create_unverified_context()
+
+    # `certifi` is installed alongside the `requests` dependency, and its CA
+    # bundle is more reliable than the system trust store on some platforms:
+    try:
+        import certifi
+
+        return ssl.create_default_context(cafile=certifi.where())
+    except ImportError:
+        return ssl.create_default_context()
 
 
 def download_url(
@@ -43,8 +73,7 @@ def download_url(
 
     os.makedirs(folder, exist_ok=True)
 
-    context = ssl._create_unverified_context()
-    data = urllib.request.urlopen(url, context=context)
+    data = urllib.request.urlopen(url, context=get_ssl_context())
 
     with fsspec.open(path, 'wb') as f:
         # workaround for https://bugs.python.org/issue42853


### PR DESCRIPTION
## What this fixes

`download_url` built its SSL context like this:

```python
context = ssl._create_unverified_context()
data = urllib.request.urlopen(url, context=context)
```

Unconditional, with no way to opt back in. Every dataset download accepts any certificate, and nothing hashes or verifies the file afterwards, so anyone able to intercept the connection can substitute their own payload — it gets written to disk and loaded as a dataset. This is on the path taken by essentially every built-in dataset, plus `download_google_url`.

## The change

- `get_ssl_context()` returns a verifying context by default.
- It prefers `certifi`'s CA bundle when importable, falling back to the system trust store. `certifi` already ships with the existing `requests` dependency, so this is available in practice, and it is more reliable than the system store on some platforms — which matters, because a bad default here is what makes people reach for the unverified context in the first place.
- `PYG_INSECURE_DOWNLOADS=1` restores the old behaviour for hosts with a broken certificate chain, and emits a `UserWarning` when it does.

I kept the escape hatch deliberately: some dataset hosts do have misconfigured chains, and I would rather those users set one environment variable than have the library disable verification for everyone. Happy to drop it, make it a `download_url(..., verify=False)` keyword argument, or gate it per-URL instead if you'd prefer a different shape.

## Verification

End-to-end against a local HTTPS server with a self-signed certificate serving a poisoned payload:

```
# before (current main)
clean main         -> ACCEPTED poisoned payload: b'POISONED_GRAPH_DATAS'...

# after
default (verify)   -> REJECTED: URLError: [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: self-signed cert
opt-out            -> ACCEPTED poisoned payload  (with UserWarning)
```

## Tests

Added `test/data/test_download.py` (6 tests, no network):

- default context has `verify_mode == CERT_REQUIRED` and `check_hostname`
- `PYG_INSECURE_DOWNLOADS=1` yields `CERT_NONE`, no hostname check, and warns
- parametrized over `'0'`, `'true'`, `'yes'`, `''` to pin that only the exact value `'1'` opts out, so a stray truthy-looking value cannot silently disable verification

`ruff check` and `ruff format` are clean on both files. CHANGELOG entry added under `### Security`.

Fixes #10732.
