### PR TITLE
Clarify radius/radius_graph docs: CPU uses k-d tree, GPU is brute-force

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
+- Clarified in the `radius` and `radius_graph` docstrings that the CPU implementation uses a `k`-d tree while the GPU implementation performs a brute-force `O(N * M)` search ([#PLACEHOLDER](https://github.com/pyg-team/pytorch_geometric/pull/PLACEHOLDER))
+
 ### Deprecated
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Changed
 
 - Improved error handling in `txt2kg` multi-process execution. ([#10771](https://github.com/pyg-team/pytorch_geometric/pull/10771))
+- Clarified in the `radius` and `radius_graph` docstrings that the CPU implementation uses a `k`-d tree while the GPU implementation performs a brute-force `O(N * M)` search ([#10757](https://github.com/pyg-team/pytorch_geometric/pull/10757))
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
-- Clarified in the `radius` and `radius_graph` docstrings that the CPU implementation uses a `k`-d tree while the GPU implementation performs a brute-force `O(N * M)` search ([#PLACEHOLDER](https://github.com/pyg-team/pytorch_geometric/pull/PLACEHOLDER))
+- Clarified in the `radius` and `radius_graph` docstrings that the CPU implementation uses a `k`-d tree while the GPU implementation performs a brute-force `O(N * M)` search ([#10757](https://github.com/pyg-team/pytorch_geometric/pull/10757))
 
 ### Deprecated
 

--- a/torch_geometric/nn/pool/__init__.py
+++ b/torch_geometric/nn/pool/__init__.py
@@ -256,6 +256,14 @@ def radius(
         is biased towards certain quadrants.
         Consider setting :obj:`max_num_neighbors` to :obj:`None` or moving
         inputs to GPU before proceeding.
+
+    .. note::
+
+        The CPU implementation of :meth:`radius` builds a :obj:`k`-d tree
+        (via :obj:`nanoflann`) to avoid comparing every pair of points, while
+        the GPU implementation performs a brute-force :math:`O(N \cdot M)`
+        search. For large point sets, this means the CPU path can scale
+        better than moving the computation to GPU.
     """
     if not torch_geometric.typing.WITH_RADIUS:
         raise ImportError("'radius' requires 'pyg-lib>=0.6.0'")
@@ -315,6 +323,14 @@ def radius_graph(
         :obj:`max_num_neighbors` is biased towards certain quadrants.
         Consider setting :obj:`max_num_neighbors` to :obj:`None` or moving
         inputs to GPU before proceeding.
+
+    .. note::
+
+        The CPU implementation of :meth:`radius_graph` builds a :obj:`k`-d
+        tree (via :obj:`nanoflann`) to avoid comparing every pair of points,
+        while the GPU implementation performs a brute-force
+        :math:`O(N \cdot M)` search. For large point sets, this means the
+        CPU path can scale better than moving the computation to GPU.
     """
     if not torch_geometric.typing.WITH_RADIUS:
         raise ImportError("'radius_graph' requires 'pyg-lib>=0.6.0'")


### PR DESCRIPTION
## Summary
Closes #10567.

`radius`/`radius_graph` warn that the CPU path is biased towards certain quadrants when `max_num_neighbors` is set, and suggest moving to GPU as a workaround — but don't mention that the two backends use fundamentally different search strategies. This led to the linked issue: a user assumed the GPU path also uses a k-d tree, when in fact it's a brute-force `O(N * M)` kernel (verified in `pyg-lib`'s `radius_kernel.cu`, vs. the CPU path in `radius_kernel.cpp` which builds a `nanoflann` k-d tree).

Added a `.. note::` to both docstrings stating this explicitly, so the GPU suggestion in the existing warning isn't read as a strictly faster option for large point sets.

## Test plan
- [x] Docs-only change, no code path touched
- [x] Verified the complexity claim against `pyg-lib`'s CPU (`nanoflann` KD-tree) and CUDA (brute-force) kernels directly