### PR TITLE
Fix `dense_to_sparse` backward pass for three-dimensional input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- Fixed `dense_to_sparse` breaking the backward pass for three-dimensional input by shifting the column indices in-place ([#10758](https://github.com/pyg-team/pytorch_geometric/pull/10758))
 - Fixed `config_store` on Python 3.14, where `typing.Union`/`typing.Optional` annotations could no longer be remapped in-place via the now read-only `__args__` attribute
 
 ### Security

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
-- Fixed `dense_to_sparse` breaking the backward pass for three-dimensional input by shifting the column indices in-place ([#10758](https://github.com/pyg-team/pytorch_geometric/pull/10758))
+- Fixed `dense_to_sparse` breaking the backward pass for three-dimensional input ([#10758](https://github.com/pyg-team/pytorch_geometric/pull/10758))
 - Fixed `config_store` on Python 3.14, where `typing.Union`/`typing.Optional` annotations could no longer be remapped in-place via the now read-only `__args__` attribute
 
 ### Security

--- a/test/utils/test_sparse.py
+++ b/test/utils/test_sparse.py
@@ -87,6 +87,17 @@ def test_dense_to_sparse_bipartite():
     assert edge_index[1].max() == 9
 
 
+@pytest.mark.parametrize('mask', [None, torch.tensor([[True, True, False]])])
+def test_dense_to_sparse_backward(mask):
+    adj = torch.rand(1, 3, 3).requires_grad_()
+
+    _, edge_attr = dense_to_sparse(adj, mask)
+    edge_attr.sum().backward()
+
+    assert adj.grad is not None
+    assert adj.grad.shape == adj.shape
+
+
 def test_is_torch_sparse_tensor():
     x = torch.randn(5, 5)
 

--- a/torch_geometric/utils/sparse.py
+++ b/torch_geometric/utils/sparse.py
@@ -107,7 +107,10 @@ def dense_to_sparse(
             offset = cumsum(count)[:-1]
             offset = offset.repeat_interleave(count)
 
-        edge_index[1] += offset[edge_index[0]]
+        # The indexing above saves `edge_index` for the backward pass, so shift
+        # the column indices out-of-place to leave its version counter alone:
+        row, col = edge_index[0], edge_index[1]
+        edge_index = torch.stack([row, col + offset[row]], dim=0)
 
         return edge_index, edge_attr
 


### PR DESCRIPTION
Fixes #10318.

### Problem

`dense_to_sparse` breaks autograd when the adjacency matrix is three-dimensional:

```python
adj = torch.rand(1, 5, 5, requires_grad=True)
edge_index, edge_attr = dense_to_sparse(adj)
edge_attr.sum().backward()
# RuntimeError: one of the variables needed for gradient computation has been
# modified by an inplace operation: [torch.LongTensor [25]] is at version 2;
# expected version 0 instead.
```

The equivalent 2D call works fine, which is the clue.

### Cause

In the 3D branch of `torch_geometric/utils/sparse.py`:

```python
edge_index = flatten_adj.nonzero().t()
edge_attr = flatten_adj[edge_index[0], edge_index[1]]   # saves the index tensors
...
edge_index[1] += offset[edge_index[0]]                  # mutates them in place
```

The advanced indexing on the second line saves `edge_index[0]` and
`edge_index[1]` for the index backward. The in-place `+=` then bumps their
version counter, so autograd refuses to run backward. The 2D branch never
mutates `edge_index`, which is exactly why only the 3D path is affected.

### Fix

Build the shifted `edge_index` out-of-place. One line, no API change, no
behavioural change.

I checked that the forward output is unchanged rather than assuming it: for a
seeded `3 x 4 x 4` input, both `edge_index` and `edge_attr` are identical to
`main` on the unmasked path and on the `mask=` path.

### Test plan

- New `test_dense_to_sparse_backward` in `test/utils/test_sparse.py`,
  parametrised over `mask=None` and a real mask. Both cases fail on `main` with
  the `RuntimeError` above and pass with this change.
- `pytest test/utils/test_sparse.py`: 20 passed.
- `flake8`, `isort --check-only` and `yapf --diff` are clean on both changed
  files.
