### PR TITLE
Fix `KeyError` in `separate()` for attribute-less heterogeneous node stores

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
-- Fixed `KeyError` in `separate()` for heterogeneous node/edge stores whose only attribute is `num_nodes` (e.g. a node type with no features)
+- Fixed `KeyError` in `separate()` for heterogeneous node/edge stores whose only attribute is `num_nodes` (e.g. a node type with no features) ([#10759](https://github.com/pyg-team/pytorch_geometric/pull/10759))
 - Fixed `config_store` on Python 3.14, where `typing.Union`/`typing.Optional` annotations could no longer be remapped in-place via the now read-only `__args__` attribute
 
 ### Security

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- Fixed `KeyError` in `separate()` for heterogeneous node/edge stores whose only attribute is `num_nodes` (e.g. a node type with no features)
 - Fixed `config_store` on Python 3.14, where `typing.Union`/`typing.Optional` annotations could no longer be remapped in-place via the now read-only `__args__` attribute
 
 ### Security

--- a/test/data/test_dataset.py
+++ b/test/data/test_dataset.py
@@ -122,6 +122,39 @@ def test_stored_hetero_in_memory_dataset(tmp_path):
     assert dataset[1]['paper'].num_nodes == 4
 
 
+def test_stored_hetero_in_memory_dataset_attribute_less_node_type(tmp_path):
+    # A node type whose only attribute is `num_nodes` (no `x` or other
+    # tensor features) must still be separable after collation.
+    # See: https://github.com/pyg-team/pytorch_geometric/issues/9537
+    data1 = HeteroData()
+    data1['subject'].num_nodes = 2
+    data1['object'].num_nodes = 3
+    data1['subject', 'to', 'object'].edge_index = torch.tensor([
+        [0, 1],
+        [0, 2],
+    ])
+
+    data2 = HeteroData()
+    data2['subject'].num_nodes = 1
+    data2['object'].num_nodes = 2
+    data2['subject', 'to', 'object'].edge_index = torch.tensor([
+        [0, 0],
+        [0, 1],
+    ])
+
+    dataset = MyStoredTestDataset(tmp_path, [data1, data2])
+
+    assert dataset[0]['subject'].num_nodes == 2
+    assert dataset[0]['object'].num_nodes == 3
+    assert torch.equal(dataset[0]['subject', 'to', 'object'].edge_index,
+                       data1['subject', 'to', 'object'].edge_index)
+
+    assert dataset[1]['subject'].num_nodes == 1
+    assert dataset[1]['object'].num_nodes == 2
+    assert torch.equal(dataset[1]['subject', 'to', 'object'].edge_index,
+                       data2['subject', 'to', 'object'].edge_index)
+
+
 def test_index(tmp_path):
     index1 = Index([0, 1, 1, 2], dim_size=3, is_sorted=True)
     index2 = Index([0, 1, 1, 2, 2, 3], dim_size=4, is_sorted=True)

--- a/torch_geometric/data/collate.py
+++ b/torch_geometric/data/collate.py
@@ -87,6 +87,15 @@ def collate(
     for out_store in out.stores:  # type: ignore
         key = out_store._key
         stores = key_to_stores[key]
+
+        if key is not None:  # Heterogeneous:
+            # Ensure every store has a `slice_dict`/`inc_dict` entry, even if
+            # it holds no attribute that goes through the loop below (e.g. a
+            # node store whose only attribute is `num_nodes`). Otherwise,
+            # `separate()` fails with a `KeyError` on such stores.
+            slice_dict.setdefault(key, {})
+            inc_dict.setdefault(key, {})
+
         for attr in stores[0].keys():
 
             if attr in exclude_keys:  # Do not include top-level attribute.


### PR DESCRIPTION
## Bug

Closes #9537.

A `HeteroData` node (or edge) store whose only attribute is `num_nodes` (no `x` or any other tensor feature — e.g. a node type that's purely structural) never gets an entry in `slice_dict`/`inc_dict` during `collate()`. The per-attribute loop in `collate()` hits `continue` for the `num_nodes` attribute *before* reaching the code that populates `slice_dict[key]`, so a store with no other attributes leaves that key entirely absent. `separate()` then does `slice_dict[key].keys()` unconditionally, which raises `KeyError` for any such store.

Repro (matches the issue):

```python
data = HeteroData()
data['subject'].num_nodes = 2   # no other attributes
data['object'].num_nodes = 3
data['subject', 'to', 'object'].edge_index = torch.tensor([[0, 1], [0, 2]])

dataset = MyInMemoryDataset(root, [data, data])
dataset[0]  # KeyError: 'subject'
```

## Fix

`collate()` now ensures every heterogeneous store gets a `slice_dict`/`inc_dict` entry (defaulting to `{}`) up front, rather than only lazily creating it inside the per-attribute loop. `separate()` already handles an empty `attrs` dict correctly (and separately special-cases `num_nodes` via `_num_nodes`), so no change was needed there.

## Testing

- Added `test_stored_hetero_in_memory_dataset_attribute_less_node_type` in `test/data/test_dataset.py`, adapted from the issue's repro. Verified it fails with the reported `KeyError` against unmodified `collate.py` and passes with the fix.
- `test/data/` (121 tests): all passing, no regressions.
- `yapf`, `isort`, `flake8` clean on the changed files, using the pinned versions from `.pre-commit-config.yaml`.