### PR TITLE
Fix `HGTConv` to accept the `aggr` argument

### DIFF
--- a/test/nn/conv/test_hgt_conv.py
+++ b/test/nn/conv/test_hgt_conv.py
@@ -59,6 +59,24 @@ def test_hgt_conv_same_dimensions():
     # allows indexing `ParameterDict` mappings :(
 
 
+def test_hgt_conv_with_custom_aggr():
+    x_dict = {
+        'author': torch.randn(4, 16),
+        'paper': torch.randn(6, 16),
+    }
+    edge_index_dict = {
+        ('author', 'writes', 'paper'): get_random_edge_index(4, 6, 20),
+    }
+    metadata = (list(x_dict.keys()), list(edge_index_dict.keys()))
+
+    conv = HGTConv(16, 16, metadata, heads=2, aggr='sum')
+    assert conv.aggr == 'sum'
+
+    out_dict = conv(x_dict, edge_index_dict)
+    assert len(out_dict) == 1
+    assert out_dict['paper'].size() == (6, 16)
+
+
 def test_hgt_conv_different_dimensions():
     x_dict = {
         'author': torch.randn(4, 16),

--- a/torch_geometric/nn/conv/hgt_conv.py
+++ b/torch_geometric/nn/conv/hgt_conv.py
@@ -37,6 +37,8 @@ class HGTConv(MessagePassing):
             information.
         heads (int, optional): Number of multi-head-attentions.
             (default: :obj:`1`)
+        aggr (str, optional): The aggregation scheme to use for message
+            aggregation. (default: :obj:`"add"`)
         **kwargs (optional): Additional arguments of
             :class:`torch_geometric.nn.conv.MessagePassing`.
     """
@@ -46,9 +48,10 @@ class HGTConv(MessagePassing):
         out_channels: int,
         metadata: Metadata,
         heads: int = 1,
+        aggr: str = 'add',
         **kwargs,
     ):
-        super().__init__(aggr='add', node_dim=0, **kwargs)
+        super().__init__(aggr=aggr, node_dim=0, **kwargs)
 
         if out_channels % heads != 0:
             raise ValueError(f"'out_channels' (got {out_channels}) must be "


### PR DESCRIPTION
Fixes #10664.

This PR makes `HGTConv` accept a custom `aggr` argument without passing duplicate `aggr` values to `MessagePassing`.

Previously, `HGTConv(..., aggr='sum')` failed because `HGTConv` always called `super().__init__(aggr='add', ..., **kwargs)`, so `aggr` could be passed twice.

Changes:
- Adds explicit `aggr: str = 'add'` argument to `HGTConv`.
- Forwards it via `super().__init__(aggr=aggr, node_dim=0, **kwargs)`.
- Documents the argument in the class docstring.
- Adds a regression test for `HGTConv(..., aggr='sum')`.

Test:
`pytest test/nn/conv/test_hgt_conv.py -q`

Result:
`8 passed`