### PR TITLE
Add Shapes docstrings to TransformerConv and SplineConv

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Changed
 
 - Improved error handling in `txt2kg` multi-process execution. ([#10771](https://github.com/pyg-team/pytorch_geometric/pull/10771))
+- Added `Shapes` sections to the `TransformerConv` and `SplineConv` docstrings ([#10761](https://github.com/pyg-team/pytorch_geometric/pull/10761))
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
+- Added `Shapes` sections to the `TransformerConv` and `SplineConv` docstrings
+
 ### Deprecated
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
-- Added `Shapes` sections to the `TransformerConv` and `SplineConv` docstrings
+- Added `Shapes` sections to the `TransformerConv` and `SplineConv` docstrings ([#10761](https://github.com/pyg-team/pytorch_geometric/pull/10761))
 
 ### Deprecated
 

--- a/torch_geometric/nn/conv/spline_conv.py
+++ b/torch_geometric/nn/conv/spline_conv.py
@@ -58,6 +58,16 @@ class SplineConv(MessagePassing):
             an additive bias. (default: :obj:`True`)
         **kwargs (optional): Additional arguments of
             :class:`torch_geometric.nn.conv.MessagePassing`.
+
+    Shapes:
+        - **input:**
+          node features :math:`(|\mathcal{V}|, F_{in})` or
+          :math:`((|\mathcal{V_s}|, F_{s}), (|\mathcal{V_t}|, F_{t}))`
+          if bipartite,
+          edge indices :math:`(2, |\mathcal{E}|)`,
+          edge pseudo-coordinates :math:`(|\mathcal{E}|, D)`
+        - **output:** node features :math:`(|\mathcal{V}|, F_{out})` or
+          :math:`(|\mathcal{V_t}|, F_{out})` if bipartite
     """
     def __init__(
         self,

--- a/torch_geometric/nn/conv/transformer_conv.py
+++ b/torch_geometric/nn/conv/transformer_conv.py
@@ -94,6 +94,21 @@ class TransformerConv(MessagePassing):
             option  :attr:`beta` is set to :obj:`False`. (default: :obj:`True`)
         **kwargs (optional): Additional arguments of
             :class:`torch_geometric.nn.conv.MessagePassing`.
+
+    Shapes:
+        - **input:**
+          node features :math:`(|\mathcal{V}|, F_{in})` or
+          :math:`((|\mathcal{V_s}|, F_{s}), (|\mathcal{V_t}|, F_{t}))`
+          if bipartite,
+          edge indices :math:`(2, |\mathcal{E}|)`,
+          edge features :math:`(|\mathcal{E}|, D)` *(optional)*
+        - **output:** node features :math:`(|\mathcal{V}|, H * F_{out})` or
+          :math:`(|\mathcal{V_t}|, H * F_{out})` if bipartite.
+          If :obj:`return_attention_weights=True`, then
+          :math:`((|\mathcal{V}|, H * F_{out}),
+          ((2, |\mathcal{E}|), (|\mathcal{E}|, H)))`
+          or :math:`((|\mathcal{V_t}|, H * F_{out}), ((2, |\mathcal{E}|),
+          (|\mathcal{E}|, H)))` if bipartite
     """
     _alpha: OptTensor
 


### PR DESCRIPTION
## Summary
- Adds a `Shapes:` section to `TransformerConv` and `SplineConv`, following the format already established in layers like `TAGConv`, `ARMAConv`, `SGConv`, and `GATConv`.
- Part of the ongoing docs effort tracked in #3573.

## Details
- `TransformerConv`: documents the (optionally bipartite) node/edge input shapes and the `H * F_out` output, including the `return_attention_weights=True` case, mirroring the existing `GATConv`/`GATv2Conv` shape blocks since the layer has the same multi-head attention + bipartite structure.
- `SplineConv`: documents node features, edge indices, and edge pseudo-coordinates as input, and node features as output, with the bipartite variant noted.

## Test plan
- [x] `flake8` clean on both changed files
- [x] Docstring-only change; no behavioral code touched
- [x] Verified no other open PR currently touches these two files or this docs effort