### PR TITLE
Fix `mypy --install-types` in CI

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -45,4 +45,4 @@ jobs:
 
       - name: Check type hints
         run: |
-          mypy -v --cache-dir="${RUNNER_TEMP}/mypy_cache"
+          mypy --cache-dir="${RUNNER_TEMP}/mypy_cache"

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -45,4 +45,4 @@ jobs:
 
       - name: Check type hints
         run: |
-          mypy -v --cache-dir=/dev/null
+          mypy -v --cache-dir="${RUNNER_TEMP}/mypy_cache"

--- a/torch_geometric/__init__.py
+++ b/torch_geometric/__init__.py
@@ -80,4 +80,3 @@ if torch_geometric.typing.WITH_PT24:
         torch_geometric.edge_index.CatMetadata,
         HashTensor,
     ])
-# asdf

--- a/torch_geometric/__init__.py
+++ b/torch_geometric/__init__.py
@@ -80,3 +80,4 @@ if torch_geometric.typing.WITH_PT24:
         torch_geometric.edge_index.CatMetadata,
         HashTensor,
     ])
+# asdf


### PR DESCRIPTION
Fixes a mypy issue in CI on the main branch:

```
mypy -v --cache-dir=/dev/null
...
error: --install-types failed (an error blocked analysis of which types to install)
```
https://github.com/pyg-team/pytorch_geometric/actions/runs/30565177033/job/90947787376?pr=10763