### PR TITLE
ci: add name to test trigger check step for readability

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -23,7 +23,8 @@ jobs:
       - uses: actions/checkout@v7
         with:
           fetch-depth: 2
-      - id: check
+      - name: Decide whether to run tests
+        id: check
         run: |
           if [ "${{ github.event_name }}" = "schedule" ]; then
             echo "triggered=true" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Problem

In `.github/workflows/testing.yml`, the `check` step is an unnamed `run` block longer than **300 characters**. In the GitHub Actions UI that collapses into a generic label, which hurts readability when deciding whether the test suite should run.

## Changes

Semantics are unchanged: same `id: check`, same `triggered` output, and the same job output wiring used by downstream jobs.

- Add `name: Decide whether to run tests` to the existing `check` step

## Test plan
- [ ] Confirm `trigger.outputs.triggered` still comes from `steps.check.outputs.triggered`
- [ ] Confirm the path-filter / schedule logic is unchanged
