### PR TITLE
Fix HeteroData subgraph edge attribute selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- Fixed `HeteroData.subgraph()` for edge attributes with non-zero concatenation dimensions
 - Fixed `config_store` on Python 3.14, where `typing.Union`/`typing.Optional` annotations could no longer be remapped in-place via the now read-only `__args__` attribute
 
 ### Security

--- a/test/data/test_hetero_data.py
+++ b/test/data/test_hetero_data.py
@@ -353,6 +353,25 @@ def test_hetero_data_empty_subgraph():
     assert torch.equal(out['paper', 'author'].edge_weight, torch.arange(5))
 
 
+def test_hetero_data_subgraph_with_nonzero_cat_dim():
+    data = HeteroData()
+    data['paper'].num_nodes = 3
+    data['paper', 'cites', 'paper'].edge_index = torch.tensor([
+        [0, 1, 2],
+        [1, 2, 0],
+    ])
+    data['paper', 'cites', 'paper'].pair_index = torch.tensor([
+        [10, 11, 12],
+        [20, 21, 22],
+    ])
+    assert data['paper', 'cites', 'paper'].is_edge_attr('pair_index')
+
+    out = data.subgraph({'paper': torch.tensor([0, 1])})
+
+    assert out['paper', 'cites', 'paper'].edge_index.tolist() == [[0], [1]]
+    assert out['paper', 'cites', 'paper'].pair_index.tolist() == [[10], [20]]
+
+
 def test_copy_hetero_data():
     data = HeteroData()
     data['paper'].x = x_paper

--- a/torch_geometric/data/hetero_data.py
+++ b/torch_geometric/data/hetero_data.py
@@ -33,6 +33,7 @@ from torch_geometric.utils import (
     is_sparse,
     is_undirected,
     mask_select,
+    select,
 )
 
 NodeOrEdgeStorage = Union[NodeStorage, EdgeStorage]
@@ -806,7 +807,8 @@ class HeteroData(BaseData, FeatureStore, GraphStore):
                 if key == 'edge_index':
                     data[edge_type].edge_index = edge_index
                 elif self[edge_type].is_edge_attr(key):
-                    data[edge_type][key] = value[edge_mask]
+                    dim = self.__cat_dim__(key, value, self[edge_type])
+                    data[edge_type][key] = select(value, edge_mask, dim=dim)
                 else:
                     data[edge_type][key] = value
 


### PR DESCRIPTION
## Summary

- Select heterogeneous edge attributes along their configured concatenation dimension in `HeteroData.subgraph()`.
- Add a regression test for an edge attribute shaped `[2, num_edges]` with `cat_dim=-1`.
- Document the fix in the unreleased changelog.

Fixes #10768.

## Root cause and impact

`EdgeStorage.is_edge_attr()` uses `HeteroData.__cat_dim__()` when deciding whether an attribute is edge-level. As a result, an additional `*_index` tensor shaped `[2, num_edges]` is a valid edge attribute with concatenation dimension `-1`.

The node-induced `HeteroData.subgraph()` path nevertheless applied its one-dimensional edge mask as `value[edge_mask]`, which always indexes dimension `0`. This raised an `IndexError` for those valid attributes. The change uses the existing `select()` utility with the attribute's configured concatenation dimension, matching `Data.subgraph()` behavior.

## Validation

- `python -m pytest test/data/test_hetero_data.py::test_hetero_data_subgraph_with_nonzero_cat_dim -q` — 1 passed
- `python -m pytest test/data/test_hetero_data.py -q` — 22 passed, 2 skipped
- `python -m pytest test/data/test_data.py test/data/test_hetero_data.py test/data/test_storage.py -q` — 45 passed, 4 skipped
- `python -m flake8 torch_geometric/data/hetero_data.py test/data/test_hetero_data.py` — passed
- `python -m ruff check torch_geometric/data/hetero_data.py test/data/test_hetero_data.py` — passed
- YAPF 0.43.0 and isort 8.0.1 checks — passed
- `git diff --check` — passed

All tests used CPU tensor operations.

## AI assistance disclosure

OpenAI Codex assisted with repository auditing, reproducer minimization, implementation, test preparation, and PR drafting. I verified the defect and the complete change locally against the current upstream `master` base before submission.
