### PR TITLE
Fix txt2kg handling of non-retryable NIM API errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
+- Improved error handling in `txt2kg` multi-process execution. ([#10771](https://github.com/pyg-team/pytorch_geometric/pull/10771))
+
 ### Deprecated
 
 ### Removed

--- a/test/llm/models/test_txt2kg.py
+++ b/test/llm/models/test_txt2kg.py
@@ -330,22 +330,12 @@ def test_add_doc_nonempty_text_placeholder(kg_cpu, monkeypatch):
 
 
 def test_is_retryable_exception_status_codes():
-    assert txt2kg._is_retryable_exception(
-        RuntimeError(), 429
-    )
-    assert txt2kg._is_retryable_exception(
-        RuntimeError(), 500
-    )
-    assert txt2kg._is_retryable_exception(
-        RuntimeError(), 503
-    )
+    assert txt2kg._is_retryable_exception(RuntimeError(), 429)
+    assert txt2kg._is_retryable_exception(RuntimeError(), 500)
+    assert txt2kg._is_retryable_exception(RuntimeError(), 503)
 
-    assert not txt2kg._is_retryable_exception(
-        RuntimeError(), 400
-    )
-    assert not txt2kg._is_retryable_exception(
-        RuntimeError(), 403
-    )
+    assert not txt2kg._is_retryable_exception(RuntimeError(), 400)
+    assert not txt2kg._is_retryable_exception(RuntimeError(), 403)
 
 
 def test_is_retryable_exception_network_errors():
@@ -447,8 +437,8 @@ def test_extract_relevant_triples_cloud_non_retryable(monkeypatch):
     )
 
     with pytest.raises(
-        RuntimeError,
-        match="Authorization failed",
+            RuntimeError,
+            match="Authorization failed",
     ):
         model._extract_relevant_triples("Some text")
 
@@ -482,4 +472,3 @@ def test_extract_relevant_triples_cloud(monkeypatch):
     triples = model._extract_relevant_triples("Some text")
 
     assert ("A", "rel", "B") in triples
-

--- a/test/llm/models/test_txt2kg.py
+++ b/test/llm/models/test_txt2kg.py
@@ -185,7 +185,10 @@ def dummy_multiproc_helper(
     max_retries=3,
     base_delay=0,
 ):
-    return [("A", "rel", "B")]
+    return {
+        "success": True,
+        "result": [("A", "rel", "B")],
+    }
 
 
 def test_extract_relevant_triples_cloud(monkeypatch):
@@ -227,7 +230,8 @@ def test_multiproc_helper_success(monkeypatch):
         base_delay=0.01  # keep backoff small in tests
     )
 
-    assert result == ["PARSED:['chunk0', 'chunk1']"]
+    assert result["success"] is True
+    assert result["result"] == ["PARSED:['chunk0', 'chunk1']"]
 
 
 def test_multiproc_helper_retry(monkeypatch):
@@ -255,7 +259,8 @@ def test_multiproc_helper_retry(monkeypatch):
         base_delay=0  # instant retries for test
     )
 
-    assert result == ["SUCCESS"]
+    assert result["success"] is True
+    assert result["result"] == ["SUCCESS"]
     assert len(attempts) == 3  # retried twice, succeeded on 3rd
 
 

--- a/test/llm/models/test_txt2kg.py
+++ b/test/llm/models/test_txt2kg.py
@@ -237,10 +237,13 @@ def test_multiproc_helper_success(monkeypatch):
 def test_multiproc_helper_retry(monkeypatch):
     attempts = []
 
+    class RetryableError(RuntimeError):
+        status_code = 500
+
     def failing_parse(chunks, py_fn, llm_fn, **kwargs):
         attempts.append(1)
         if len(attempts) < 3:
-            raise RuntimeError("fail")
+            raise RetryableError("fail")
         return ["SUCCESS"]
 
     monkeypatch.setattr(

--- a/test/llm/models/test_txt2kg.py
+++ b/test/llm/models/test_txt2kg.py
@@ -458,33 +458,3 @@ def test_extract_relevant_triples_cloud_non_retryable(monkeypatch):
 
     assert len(calls) == 1
 
-
-def dummy_multiproc_helper(
-    rank,
-    chunks,
-    py_fn,
-    llm_fn,
-    NIM_KEY,
-    NIM_MODEL,
-    ENDPOINT_URL,
-    max_retries=3,
-    base_delay=0,
-):
-    return {
-        "success": True,
-        "result": [("A", "rel", "B")],
-    }
-
-
-def test_extract_relevant_triples_cloud(monkeypatch):
-    model = TXT2KG(local_LM=False, chunk_size=10)
-
-    monkeypatch.setattr(
-        txt2kg,
-        "_multiproc_helper",
-        dummy_multiproc_helper,
-    )
-
-    triples = model._extract_relevant_triples("Some text")
-
-    assert ("A", "rel", "B") in triples

--- a/test/llm/models/test_txt2kg.py
+++ b/test/llm/models/test_txt2kg.py
@@ -416,31 +416,47 @@ def test_multiproc_helper_retry_exhausted(monkeypatch):
 
     assert result["success"] is False
     assert result["retryable"] is True
-    assert "Server error" in result["error"]
+    assert result["error"] == "Worker 0: exhausted 3 retries"
     assert len(attempts) == 3
 
 
 def test_extract_relevant_triples_cloud_non_retryable(monkeypatch):
     model = TXT2KG(local_LM=False, chunk_size=10)
 
-    def dummy_helper(*args, **kwargs):
-        return {
-            "success": False,
-            "retryable": False,
-            "error": "Authorization failed",
-        }
+    calls = []
+
+    class DummyPool:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            pass
+
+        def starmap(self, func, args):
+            calls.append(1)
+            return [{
+                "success": False,
+                "retryable": False,
+                "error": "Authorization failed",
+            }]
+
+    class DummyContext:
+        def Pool(self, num_procs):
+            return DummyPool()
 
     monkeypatch.setattr(
-        txt2kg,
-        "_multiproc_helper",
-        dummy_helper,
+        txt2kg.mp,
+        "get_context",
+        lambda method: DummyContext(),
     )
 
     with pytest.raises(
-            RuntimeError,
-            match="Authorization failed",
+        RuntimeError,
+        match="Authorization failed",
     ):
         model._extract_relevant_triples("Some text")
+
+    assert len(calls) == 1
 
 
 def dummy_multiproc_helper(

--- a/test/llm/models/test_txt2kg.py
+++ b/test/llm/models/test_txt2kg.py
@@ -451,8 +451,8 @@ def test_extract_relevant_triples_cloud_non_retryable(monkeypatch):
     )
 
     with pytest.raises(
-        RuntimeError,
-        match="Authorization failed",
+            RuntimeError,
+            match="Authorization failed",
     ):
         model._extract_relevant_triples("Some text")
 

--- a/test/llm/models/test_txt2kg.py
+++ b/test/llm/models/test_txt2kg.py
@@ -327,3 +327,159 @@ def test_add_doc_nonempty_text_placeholder(kg_cpu, monkeypatch):
     # Ensure doc_id_counter incremented and key exists
     key = kg_cpu.doc_id_counter - 1
     assert key in kg_cpu.relevant_triples
+
+
+def test_is_retryable_exception_status_codes():
+    assert txt2kg._is_retryable_exception(
+        RuntimeError(), 429
+    )
+    assert txt2kg._is_retryable_exception(
+        RuntimeError(), 500
+    )
+    assert txt2kg._is_retryable_exception(
+        RuntimeError(), 503
+    )
+
+    assert not txt2kg._is_retryable_exception(
+        RuntimeError(), 400
+    )
+    assert not txt2kg._is_retryable_exception(
+        RuntimeError(), 403
+    )
+
+
+def test_is_retryable_exception_network_errors():
+    from openai import APIConnectionError, APITimeoutError
+
+    assert txt2kg._is_retryable_exception(
+        APIConnectionError(request=None),
+        None,
+    )
+
+    assert txt2kg._is_retryable_exception(
+        APITimeoutError(request=None),
+        None,
+    )
+
+
+def test_multiproc_helper_non_retryable(monkeypatch):
+    attempts = []
+
+    class ForbiddenError(RuntimeError):
+        status_code = 403
+
+    def failing_parse(chunks, py_fn, llm_fn, **kwargs):
+        attempts.append(1)
+        raise ForbiddenError("Authorization failed")
+
+    monkeypatch.setattr(
+        txt2kg,
+        "_llm_then_python_parse",
+        failing_parse,
+    )
+
+    result = _multiproc_helper(
+        rank=0,
+        chunks_for_rank=["chunk"],
+        py_fn=lambda x: x,
+        llm_fn=lambda x: x,
+        NIM_KEY="dummy",
+        NIM_MODEL="dummy",
+        ENDPOINT_URL="dummy",
+        max_retries=5,
+        base_delay=0,
+    )
+
+    assert result["success"] is False
+    assert result["retryable"] is False
+    assert "Authorization failed" in result["error"]
+    assert len(attempts) == 1
+
+
+def test_multiproc_helper_retry_exhausted(monkeypatch):
+    attempts = []
+
+    class RetryableError(RuntimeError):
+        status_code = 500
+
+    def failing_parse(chunks, py_fn, llm_fn, **kwargs):
+        attempts.append(1)
+        raise RetryableError("Server error")
+
+    monkeypatch.setattr(
+        txt2kg,
+        "_llm_then_python_parse",
+        failing_parse,
+    )
+
+    result = _multiproc_helper(
+        rank=0,
+        chunks_for_rank=["chunk"],
+        py_fn=lambda x: x,
+        llm_fn=lambda x: x,
+        NIM_KEY="dummy",
+        NIM_MODEL="dummy",
+        ENDPOINT_URL="dummy",
+        max_retries=3,
+        base_delay=0,
+    )
+
+    assert result["success"] is False
+    assert result["retryable"] is True
+    assert "Server error" in result["error"]
+    assert len(attempts) == 3
+
+
+def test_extract_relevant_triples_cloud_non_retryable(monkeypatch):
+    model = TXT2KG(local_LM=False, chunk_size=10)
+
+    def dummy_helper(*args, **kwargs):
+        return {
+            "success": False,
+            "retryable": False,
+            "error": "Authorization failed",
+        }
+
+    monkeypatch.setattr(
+        txt2kg,
+        "_multiproc_helper",
+        dummy_helper,
+    )
+
+    with pytest.raises(
+        RuntimeError,
+        match="Authorization failed",
+    ):
+        model._extract_relevant_triples("Some text")
+
+
+def dummy_multiproc_helper(
+    rank,
+    chunks,
+    py_fn,
+    llm_fn,
+    NIM_KEY,
+    NIM_MODEL,
+    ENDPOINT_URL,
+    max_retries=3,
+    base_delay=0,
+):
+    return {
+        "success": True,
+        "result": [("A", "rel", "B")],
+    }
+
+
+def test_extract_relevant_triples_cloud(monkeypatch):
+    model = TXT2KG(local_LM=False, chunk_size=10)
+
+    monkeypatch.setattr(
+        txt2kg,
+        "_multiproc_helper",
+        dummy_multiproc_helper,
+    )
+
+    triples = model._extract_relevant_triples("Some text")
+
+    assert ("A", "rel", "B") in triples
+

--- a/test/llm/models/test_txt2kg.py
+++ b/test/llm/models/test_txt2kg.py
@@ -457,4 +457,3 @@ def test_extract_relevant_triples_cloud_non_retryable(monkeypatch):
         model._extract_relevant_triples("Some text")
 
     assert len(calls) == 1
-

--- a/torch_geometric/llm/models/txt2kg.py
+++ b/torch_geometric/llm/models/txt2kg.py
@@ -194,9 +194,9 @@ class TXT2KG():
 
             # Check whether any worker failed.
             failed_result = next(
-        	    (result for result in worker_results if not result["success"]),
-        	    None,
-    	    )
+                (result for result in worker_results if not result["success"]),
+                None,
+            )
 
             if failed_result is None:
                 # All workers succeeded.
@@ -210,10 +210,8 @@ class TXT2KG():
             if attempt == max_retries - 1:
                 raise RuntimeError(failed_result["error"])
 
-            print(
-                f"[Retry {attempt + 1}/{max_retries}] "
-                f"Multiprocessing failed: {failed_result['error']}"
-            )
+            print(f"[Retry {attempt + 1}/{max_retries}] "
+                  f"Multiprocessing failed: {failed_result['error']}")
 
             time.sleep(retry_delay)
 
@@ -338,13 +336,16 @@ def _multiproc_helper(
         if attempt > 0:
             # exponential backoff with jitter
             from random import uniform
-            sleep_time = base_delay * (2**min(attempt-1, 6)) + uniform(0, 0.1)
+            sleep_time = base_delay * (2**min(attempt - 1, 6)) + uniform(
+                0, 0.1)
             time.sleep(sleep_time)
 
         try:
             return {
-                "success": True,
-                "result": _llm_then_python_parse(
+                "success":
+                True,
+                "result":
+                _llm_then_python_parse(
                     chunks_for_rank,
                     py_fn,
                     llm_fn,
@@ -365,12 +366,11 @@ def _multiproc_helper(
             )
 
             if status_code == FORBIDDEN:
-                print("\n ***** Please, check your NV_NIM_KEY. *****\n"
+                print(
+                    "\n ***** Please, check your NV_NIM_KEY. *****\n"
                     "The key may be expired, invalid or not authorized "
-                    "to access the dataset you are using.\n",
-                    flush=True
-                )
-                
+                    "to access the dataset you are using.\n", flush=True)
+
             if not retryable:
                 return {
                     "success": False,

--- a/torch_geometric/llm/models/txt2kg.py
+++ b/torch_geometric/llm/models/txt2kg.py
@@ -1,6 +1,6 @@
 import os
 import time
-from typing import List, Optional, Tuple, Union
+from typing import List, Optional, Tuple, Union, TypedDict
 
 import torch
 import torch.multiprocessing as mp
@@ -322,6 +322,13 @@ def _is_retryable_exception(exc: Exception, status_code) -> bool:
     return isinstance(exc, (APIConnectionError, APITimeoutError))
 
 
+class WorkerResult(TypedDict, total=False):
+    success: bool
+    result: list
+    retryable: bool
+    error: str
+
+
 def _multiproc_helper(
     rank,
     chunks_for_rank,
@@ -332,7 +339,7 @@ def _multiproc_helper(
     ENDPOINT_URL,
     max_retries=MAX_NIM_RETRIES,
     base_delay=BASE_DELAY,
-):
+) -> WorkerResult:
 
     for attempt in range(max_retries):
         if attempt > 0:

--- a/torch_geometric/llm/models/txt2kg.py
+++ b/torch_geometric/llm/models/txt2kg.py
@@ -15,6 +15,8 @@ RETRY_DELAY = 5  # Fixed sleep time (in seconds) between outer retries.
 MAX_NIM_RETRIES = 200  # Maximum number of attempts to call the NIM API inside one worker.  # noqa
 BASE_DELAY = 0.5  # Initial wait time before retrying a failed network call.
 
+FORBIDDEN = 403
+
 
 class TXT2KG():
     """A class to convert text data into a Knowledge Graph (KG) format.
@@ -187,17 +189,32 @@ class TXT2KG():
         ) for rank in range(num_procs)]
 
         for attempt in range(max_retries):
-            try:
-                with mp.get_context("spawn").Pool(num_procs) as pool:
-                    results = pool.starmap(_multiproc_helper, worker_args)
-                break  # success
+            with mp.get_context("spawn").Pool(num_procs) as pool:
+                worker_results = pool.starmap(_multiproc_helper, worker_args)
 
-            except Exception as e:
-                if attempt == max_retries - 1:
-                    raise  # re-raise on final failure
+            # Check whether any worker failed.
+            failed_result = next(
+        	    (result for result in worker_results if not result["success"]),
+        	    None,
+    	    )
 
-                print(f"[Retry {attempt+1}/{max_retries}] "
-                      f"Multiprocessing failed: {e}")
+            if failed_result is None:
+                # All workers succeeded.
+                results = [result["result"] for result in worker_results]
+                break
+
+            # A worker failed with a non-retryable error.
+            if not failed_result["retryable"]:
+                raise RuntimeError(failed_result["error"])
+
+            if attempt == max_retries - 1:
+                raise RuntimeError(failed_result["error"])
+
+            print(
+                f"[Retry {attempt + 1}/{max_retries}] "
+                f"Multiprocessing failed: {failed_result['error']}"
+            )
+
             time.sleep(retry_delay)
 
         return _merge_triples_deterministically(results)
@@ -291,6 +308,20 @@ def _llm_then_python_parse(chunks, py_fn, llm_fn, **kwargs):
     return relevant_triples
 
 
+def _is_retryable_exception(exc: Exception, status_code) -> bool:
+    """Return True if an exception is likely to succeed when retried."""
+    if status_code is not None:
+        return status_code == 429 or status_code >= 500
+
+    # Network/transport exceptions.
+    try:
+        from openai import APIConnectionError, APITimeoutError
+    except ImportError:
+        return False
+
+    return isinstance(exc, (APIConnectionError, APITimeoutError))
+
+
 def _multiproc_helper(
     rank,
     chunks_for_rank,
@@ -304,26 +335,54 @@ def _multiproc_helper(
 ):
 
     for attempt in range(max_retries):
-        try:
-            return _llm_then_python_parse(
-                chunks_for_rank,
-                py_fn,
-                llm_fn,
-                GLOBAL_NIM_KEY=NIM_KEY,
-                NIM_MODEL=NIM_MODEL,
-                ENDPOINT_URL=ENDPOINT_URL,
-            )
-
-        except Exception:
-            # Optional: restrict to network-related exceptions only
-            if attempt == max_retries - 1:
-                raise
-
+        if attempt > 0:
             # exponential backoff with jitter
             from random import uniform
-            sleep_time = base_delay * (2**min(attempt, 6))
-            sleep_time += uniform(0, 0.1)
+            sleep_time = base_delay * (2**min(attempt-1, 6)) + uniform(0, 0.1)
             time.sleep(sleep_time)
+
+        try:
+            return {
+                "success": True,
+                "result": _llm_then_python_parse(
+                    chunks_for_rank,
+                    py_fn,
+                    llm_fn,
+                    GLOBAL_NIM_KEY=NIM_KEY,
+                    NIM_MODEL=NIM_MODEL,
+                    ENDPOINT_URL=ENDPOINT_URL,
+                )
+            }
+
+        except Exception as e:
+            # OpenAI-compatible API exceptions generally expose `status_code`.
+            status_code = getattr(e, "status_code", None)
+            retryable = _is_retryable_exception(e, status_code)
+            print(
+                f"[Worker {rank}] attempt {attempt + 1}/{max_retries}: "
+                f"{type(e).__name__}: {e}. Retryable={retryable}",
+                flush=True,
+            )
+
+            if status_code == FORBIDDEN:
+                print("\n ***** Please, check your NV_NIM_KEY. *****\n"
+                    "The key may be expired, invalid or not authorized "
+                    "to access the dataset you are using.\n",
+                    flush=True
+                )
+                
+            if not retryable:
+                return {
+                    "success": False,
+                    "retryable": False,
+                    "error": str(e),
+                }
+
+    return {
+        "success": False,
+        "retryable": True,
+        "error": f"Worker {rank}: exhausted {max_retries} retries",
+    }
 
 
 def _get_num_procs():

--- a/torch_geometric/llm/models/txt2kg.py
+++ b/torch_geometric/llm/models/txt2kg.py
@@ -1,6 +1,6 @@
 import os
 import time
-from typing import List, Optional, Tuple, Union, TypedDict
+from typing import List, Optional, Tuple, TypedDict, Union
 
 import torch
 import torch.multiprocessing as mp


### PR DESCRIPTION
After running `test_txt2kg_rag.py` for more than two hours, we encountered the following error:
```Note that if the TXT2KG process is too slow for you're liking using the public NIM, consider deploying yourself using local_lm flag of TXT2KG or using https://build.nvidia.com/nvidia/llama-3_1-nemotron-70b-instruct to deploy to a private endpoint, which you can pass to this script w/ --ENDPOINT_URL flag.
Guide for deploying NIM: https://developer.nvidia.com/blog/a-simple-guide-to-deploying-generative-ai-with-nvidia-nim/
Extracting KG triples:   0%|                                                                                                                       | 0/4 [00:00<?, ?it/s]Exception in thread Thread-3 (_handle_results):
Traceback (most recent call last):
  File "/usr/lib/python3.12/threading.py", line 1073, in _bootstrap_inner
    self.run()
  File "/usr/lib/python3.12/threading.py", line 1010, in run
    self._target(*self._args, **self._kwargs)
  File "/usr/lib/python3.12/multiprocessing/pool.py", line 579, in _handle_results
    task = get()
           ^^^^^
  File "/usr/lib/python3.12/multiprocessing/connection.py", line 251, in recv
    return _ForkingPickler.loads(buf.getbuffer())
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: APIStatusError.__init__() missing 2 required keyword-only arguments: 'response' and 'body'
```

Following a thorough investigation, we determined that the issue was caused by the expiration of the **`NV_NIM_KEY`**, while the program's prolonged operation was due to numerous attempts to restart the workers. 

Since the call stack captured at the time of the failure did not point to the root cause—which could have been identified during the initial worker startup attempt—we decided to improve the error-handling mechanism for NIM errors where operation retries are not applicable.

This PR adjusts the error handling and retry logic for `txt2kg`'s multi-process execution:

*   Disables retries for API errors that do not support retrying (e.g., HTTP 403).
*   Passes error information from workers in a `pickle`-compatible format instead of passing OpenAI exceptions across processes.
*   Prevents `multiprocessing.RemoteTraceback` errors and associated hangs when handling worker failures.
*   Reports potential issues with the **`NV_NIM_KEY`** used for the test.


Errors are reported in the following format:
```
[Worker 0] attempt 1/200: PermissionDeniedError: Error code: 403 - {'status': 403, 'title': 'Forbidden', 'detail': 'Authorization failed'}. Retryable=False

 ***** Please, check your NV_NIM_KEY. *****
The key may be expired, invalid or not authorized to access the dataset you are using.

[Worker 1] attempt 1/200: PermissionDeniedError: Error code: 403 - {'status': 403, 'title': 'Forbidden', 'detail': 'Authorization failed'}. Retryable=False

 ***** Please, check your NV_NIM_KEY. *****
The key may be expired, invalid or not authorized to access the dataset you are using.
```


