### PR TITLE
Fix timing methodology for GCN compile benchmark

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- Fixed timing methodology for GCN compile benchmark ([#10773](https://github.com/pyg-team/pytorch_geometric/pull/10773))
 - Fixed `config_store` on Python 3.14, where `typing.Union`/`typing.Optional` annotations could no longer be remapped in-place via the now read-only `__args__` attribute
 
 ### Security

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
-- Fixed timing methodology for GCN compile benchmark ([#10773](https://github.com/pyg-team/pytorch_geometric/pull/10773))
 - Fixed `config_store` on Python 3.14, where `typing.Union`/`typing.Optional` annotations could no longer be remapped in-place via the now read-only `__args__` attribute
 
 ### Security

--- a/examples/compile/gcn.py
+++ b/examples/compile/gcn.py
@@ -75,6 +75,7 @@ def test():
         accs.append(int((pred[mask] == data.y[mask]).sum()) / int(mask.sum()))
     return accs
 
+
 # Warm-up
 for i in range(0, 10):
     train()

--- a/examples/compile/gcn.py
+++ b/examples/compile/gcn.py
@@ -76,20 +76,14 @@ def test():
     return accs
 
 
-# Warm-up
-for _i in range(0, 10):
-    train()
-    test()
-    torch.cuda.synchronize()
-
 times = []
 for epoch in range(1, 201):
     start = time.time()
     loss = train()
-    torch.cuda.synchronize()
-    times.append(time.time() - start)
+    torch.cuda.synchronize() 
+    if epoch >= 10:  # We treat the first 10 iterations as a warm-up
+        times.append(time.time() - start)
     train_acc, val_acc, test_acc = test()
-    torch.cuda.synchronize()
     print(f'Epoch: {epoch:03d}, Loss: {loss:.4f}, Train: {train_acc:.4f}, '
           f'Val: {val_acc:.4f}, Test: {test_acc:.4f}')
 print(f'Median time per epoch: {torch.tensor(times).median():.4f}s')

--- a/examples/compile/gcn.py
+++ b/examples/compile/gcn.py
@@ -75,13 +75,20 @@ def test():
         accs.append(int((pred[mask] == data.y[mask]).sum()) / int(mask.sum()))
     return accs
 
+# Warm-up
+for i in range(0, 10):
+    train()
+    test()
+    torch.cuda.synchronize()
 
 times = []
 for epoch in range(1, 201):
     start = time.time()
     loss = train()
-    train_acc, val_acc, test_acc = test()
+    torch.cuda.synchronize()
     times.append(time.time() - start)
+    train_acc, val_acc, test_acc = test()
+    torch.cuda.synchronize()
     print(f'Epoch: {epoch:03d}, Loss: {loss:.4f}, Train: {train_acc:.4f}, '
           f'Val: {val_acc:.4f}, Test: {test_acc:.4f}')
 print(f'Median time per epoch: {torch.tensor(times).median():.4f}s')

--- a/examples/compile/gcn.py
+++ b/examples/compile/gcn.py
@@ -80,7 +80,7 @@ times = []
 for epoch in range(1, 201):
     start = time.time()
     loss = train()
-    torch.cuda.synchronize() 
+    torch.cuda.synchronize()
     if epoch >= 10:  # We treat the first 10 iterations as a warm-up
         times.append(time.time() - start)
     train_acc, val_acc, test_acc = test()

--- a/examples/compile/gcn.py
+++ b/examples/compile/gcn.py
@@ -77,7 +77,7 @@ def test():
 
 
 # Warm-up
-for i in range(0, 10):
+for _i in range(0, 10):
     train()
     test()
     torch.cuda.synchronize()

--- a/examples/compile/gcn.py
+++ b/examples/compile/gcn.py
@@ -80,7 +80,6 @@ times = []
 for epoch in range(1, 201):
     start = time.time()
     loss = train()
-    torch.cuda.synchronize()
     if epoch >= 10:  # We treat the first 10 iterations as a warm-up
         times.append(time.time() - start)
     train_acc, val_acc, test_acc = test()

--- a/examples/gcn.py
+++ b/examples/gcn.py
@@ -94,22 +94,15 @@ def test():
         accs.append(int((pred[mask] == data.y[mask]).sum()) / int(mask.sum()))
     return accs
 
-
-# Warm-up
-for _i in range(0, 10):
-    train()
-    test()
-    torch.cuda.synchronize()
-
 best_val_acc = test_acc = 0
 times = []
 for epoch in range(1, args.epochs + 1):
     start = time.time()
     loss = train()
-    torch.cuda.synchronize()
-    times.append(time.time() - start)
+    if epoch >= 10:  # We treat the first 10 iterations as a warm-up
+        times.append(time.time() - start)
+
     train_acc, val_acc, tmp_test_acc = test()
-    torch.cuda.synchronize()
     if val_acc > best_val_acc:
         best_val_acc = val_acc
         test_acc = tmp_test_acc

--- a/examples/gcn.py
+++ b/examples/gcn.py
@@ -95,15 +95,23 @@ def test():
     return accs
 
 
+# Warm-up
+for i in range(0, 10):
+    train()
+    test()
+    torch.cuda.synchronize()
+
 best_val_acc = test_acc = 0
 times = []
 for epoch in range(1, args.epochs + 1):
     start = time.time()
     loss = train()
+    torch.cuda.synchronize()
+    times.append(time.time() - start)
     train_acc, val_acc, tmp_test_acc = test()
+    torch.cuda.synchronize()
     if val_acc > best_val_acc:
         best_val_acc = val_acc
         test_acc = tmp_test_acc
     log(Epoch=epoch, Loss=loss, Train=train_acc, Val=val_acc, Test=test_acc)
-    times.append(time.time() - start)
 print(f'Median time per epoch: {torch.tensor(times).median():.4f}s')

--- a/examples/gcn.py
+++ b/examples/gcn.py
@@ -96,7 +96,7 @@ def test():
 
 
 # Warm-up
-for i in range(0, 10):
+for _i in range(0, 10):
     train()
     test()
     torch.cuda.synchronize()

--- a/examples/gcn.py
+++ b/examples/gcn.py
@@ -94,6 +94,7 @@ def test():
         accs.append(int((pred[mask] == data.y[mask]).sum()) / int(mask.sum()))
     return accs
 
+
 best_val_acc = test_acc = 0
 times = []
 for epoch in range(1, args.epochs + 1):


### PR DESCRIPTION
**Motivation**

The GCN compile performance test was intermittently failing on some machines because of variability in the measured execution times. I investigated the failures and found that the benchmark timing was affected by compilation warm-up and timing of the evaluation phase.

This PR fixes the timing methodology to provide more stable and reliable training-time measurements.

**Changes**

- treat first 10 iterations as a warm-up before collecting timing measurements.
- Measure training time separately from evaluation time.

**Result**

- Timing variance for different epochs is now negligible.
- `torch.compile` shows approximately 2× speedup over the regular implementation.