### PR TITLE
Fix NormalizeScale for degenerate point clouds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Fixed
 
 - Fixed `config_store` on Python 3.14, where `typing.Union`/`typing.Optional` annotations could no longer be remapped in-place via the now read-only `__args__` attribute
+- Fixed `NormalizeScale` producing non-finite coordinates for degenerate point clouds
 
 ### Security
 

--- a/test/transforms/test_normalize_scale.py
+++ b/test/transforms/test_normalize_scale.py
@@ -15,3 +15,21 @@ def test_normalize_scale():
     assert len(data) == 1
     assert data.pos.min().item() > -1
     assert data.pos.max().item() < 1
+
+
+def test_normalize_scale_degenerate_positions():
+    transform = NormalizeScale()
+    pos = torch.full((4, 3), 7.0)
+
+    data = transform(Data(pos=pos))
+
+    assert torch.equal(data.pos, torch.zeros_like(pos))
+
+
+def test_normalize_scale_empty_positions():
+    transform = NormalizeScale()
+    pos = torch.empty((0, 3))
+
+    data = transform(Data(pos=pos))
+
+    assert torch.equal(data.pos, pos)

--- a/torch_geometric/transforms/normalize_scale.py
+++ b/torch_geometric/transforms/normalize_scale.py
@@ -1,3 +1,5 @@
+import torch
+
 from torch_geometric.data import Data
 from torch_geometric.data.datapipes import functional_transform
 from torch_geometric.transforms import BaseTransform, Center
@@ -15,7 +17,10 @@ class NormalizeScale(BaseTransform):
         data = self.center(data)
 
         assert data.pos is not None
-        scale = (1.0 / data.pos.abs().max()) * 0.999999
-        data.pos = data.pos * scale
+        if data.pos.numel() > 0:
+            max_abs = data.pos.abs().max()
+            max_abs = torch.where(max_abs > 0, max_abs,
+                                  torch.ones_like(max_abs))
+            data.pos = data.pos * ((1.0 / max_abs) * 0.999999)
 
         return data


### PR DESCRIPTION
## Summary

- keep empty point clouds unchanged in `NormalizeScale`
- use a finite unit denominator when centering produces a zero-extent point cloud
- add regression tests for empty and fully coincident positions and document the fix in the changelog

## Problem

`NormalizeScale` centers positions and then multiplies them by the reciprocal of their maximum absolute coordinate. When all positions are identical, centering produces all zeros, so the reciprocal is infinite and the final `0 * inf` operation turns every coordinate into `NaN`. Empty position tensors fail earlier because `max()` has no reduction identity.

This can feed non-finite coordinates into downstream point-cloud models even though both inputs are valid degenerate graphs.

## Fix

Skip the reduction for empty position tensors. For non-empty tensors, replace a zero maximum absolute coordinate with a scalar one before computing the existing scale factor. The regular non-degenerate formula and output range remain unchanged, while coincident points stay centered at finite zeros. The tensor-only denominator selection also avoids a device synchronization.

## Testing

- `python -m pytest test/transforms/test_normalize_scale.py -q` (3 passed)
- `python -m pytest test/transforms -q` (151 passed, 14 skipped, 2 deselected)
- full test suite on PyTorch 2.12 with MPS fallback (5902 passed, 1166 skipped, 169 deselected)
- CPU and MPS forward/backward finite-value checks for coincident positions
- `pre-commit run --files torch_geometric/transforms/normalize_scale.py test/transforms/test_normalize_scale.py CHANGELOG.md`
