### PR TITLE
Specify MetaPath2Vec sampling in docstring

### DIFF
--- a/torch_geometric/nn/models/metapath2vec.py
+++ b/torch_geometric/nn/models/metapath2vec.py
@@ -18,7 +18,10 @@ class MetaPath2Vec(torch.nn.Module):
     <https://ericdongyx.github.io/papers/
     KDD17-dong-chawla-swami-metapath2vec.pdf>`_ paper where random walks based
     on a given :obj:`metapath` are sampled in a heterogeneous graph, and node
-    embeddings are learned via negative sampling optimization.
+    embeddings are learned via negative sampling optimization. Positive random
+    walks follow edges along the :obj:`metapath`, while negative random walks
+    sample each node after the starting node independently and uniformly from
+    all nodes of the node type at the corresponding :obj:`metapath` position.
 
     .. note::
 


### PR DESCRIPTION
## Summary

- Clarify that positive random walks follow edges along the metapath.
- Clarify that negative random walks keep the starting node and independently sample each subsequent node uniformly from all nodes of the node type at the corresponding metapath position.

Fixes #10287

## Tests

- `PYTHONPATH=. ../pyg-venv/bin/python -m pytest test/nn/models/test_metapath2vec.py` (2 passed)
- `../pyg-venv/bin/ruff check torch_geometric/nn/models/metapath2vec.py` (All checks passed)
- `../pyg-venv/bin/python -m compileall -q torch_geometric/nn/models/metapath2vec.py` (passed)
- `git diff --check` (passed)
