### PR TITLE
Pass the `bias` argument through in `SignedGCN`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- Fixed `SignedGCN` not forwarding its `bias` argument to the layers it creates ([#10777](https://github.com/pyg-team/pytorch_geometric/pull/10777))
 - Fixed `config_store` on Python 3.14, where `typing.Union`/`typing.Optional` annotations could no longer be remapped in-place via the now read-only `__args__` attribute
 
 ### Security

--- a/test/nn/models/test_signed_gcn.py
+++ b/test/nn/models/test_signed_gcn.py
@@ -44,3 +44,15 @@ def test_signed_gcn():
     if is_full_test():
         jit = torch.jit.export(model)
         assert torch.allclose(jit(x, train_pos_index, train_neg_index), z)
+
+
+def test_signed_gcn_bias():
+    model = SignedGCN(8, 16, num_layers=2, bias=True)
+    assert model.conv1.lin_pos_r.bias is not None
+    assert model.convs[0].lin_pos_r.bias is not None
+    assert model.lin.bias is not None
+
+    model = SignedGCN(8, 16, num_layers=2, bias=False)
+    assert model.conv1.lin_pos_r.bias is None
+    assert model.convs[0].lin_pos_r.bias is None
+    assert model.lin.bias is None

--- a/torch_geometric/nn/models/signed_gcn.py
+++ b/torch_geometric/nn/models/signed_gcn.py
@@ -43,14 +43,14 @@ class SignedGCN(torch.nn.Module):
         self.lamb = lamb
 
         self.conv1 = SignedConv(in_channels, hidden_channels // 2,
-                                first_aggr=True)
+                                first_aggr=True, bias=bias)
         self.convs = torch.nn.ModuleList()
         for _ in range(num_layers - 1):
             self.convs.append(
                 SignedConv(hidden_channels // 2, hidden_channels // 2,
-                           first_aggr=False))
+                           first_aggr=False, bias=bias))
 
-        self.lin = torch.nn.Linear(2 * hidden_channels, 3)
+        self.lin = torch.nn.Linear(2 * hidden_channels, 3, bias=bias)
 
         self.reset_parameters()
 


### PR DESCRIPTION
`SignedGCN` documents a `bias` argument:

> **bias** (bool, optional): If set to `False`, all layers will not learn an additive bias. (default: `True`)

It is accepted in `__init__`, but it is never forwarded to any of the layers the model builds, so it currently has no effect.

```python
import torch
from torch_geometric.nn import SignedGCN

model = SignedGCN(16, 32, num_layers=2, bias=False)
print([name for name, _ in model.named_parameters() if name.endswith('bias')])
```

On `master`:

```
['conv1.lin_pos_r.bias', 'conv1.lin_neg_r.bias',
 'convs.0.lin_pos_r.bias', 'convs.0.lin_neg_r.bias', 'lin.bias']
```

With this PR:

```
[]
```

The `SignedConv` layers that `SignedGCN` wraps already accept and honour `bias` themselves, so the flag simply never reaches them. This forwards it to `conv1`, to the `SignedConv` layers in `convs`, and to the final `lin` layer, which matches the documented "all layers" and follows the same pattern as `RENet`, which passes `bias=bias` into its `Linear` layers.

Only users who explicitly pass `bias=False` are affected, and for them the argument is currently ignored without any warning. The default (`bias=True`) is unchanged, and the forward pass is unaffected in both cases.

Added `test_signed_gcn_bias`, which fails on `master` and passes with this change.
