### PR TITLE
Remove obsolete RGAT TorchScript test

### DIFF
--- a/test/nn/conv/test_rgat_conv.py
+++ b/test/nn/conv/test_rgat_conv.py
@@ -1,11 +1,7 @@
 import pytest
 import torch
 
-import torch_geometric.typing
 from torch_geometric.nn import RGATConv
-from torch_geometric.testing import is_full_test
-from torch_geometric.typing import SparseTensor
-from torch_geometric.utils import to_torch_coo_tensor
 
 
 @pytest.mark.parametrize('mod', [

--- a/test/nn/conv/test_rgat_conv.py
+++ b/test/nn/conv/test_rgat_conv.py
@@ -96,31 +96,3 @@ def test_rgat_conv(mod, attention_mechanism, attention_mode, concat, edge_dim):
         assert out.size() == (4, 16 * (2 if concat else 1))
         assert adj.size() == edge_index.size()
         assert alpha.size() == (4, 2)
-
-
-def test_rgat_conv_jit():
-    x = torch.randn(4, 8)
-    edge_index = torch.tensor([[0, 1, 2, 3], [0, 0, 1, 1]])
-    edge_attr = torch.randn((edge_index.size(1), 8))
-    edge_type = torch.tensor([0, 2, 1, 2])
-    adj1 = to_torch_coo_tensor(edge_index, edge_attr, size=(4, 4))
-
-    conv = RGATConv(8, 20, num_relations=4, num_bases=4, mod='additive',
-                    attention_mechanism='across-relation',
-                    attention_mode='additive-self-attention', heads=2, dim=1,
-                    edge_dim=8, bias=False)
-
-    out = conv(x, edge_index, edge_type, edge_attr)
-    assert out.size() == (4, 40)
-    # t() expects a tensor with <= 2 sparse and 0 dense dimensions
-    adj1_t = adj1.transpose(0, 1).coalesce()
-    assert torch.allclose(conv(x, adj1_t, edge_type), out, atol=1e-6)
-
-    if torch_geometric.typing.WITH_TORCH_SPARSE:
-        adj2 = SparseTensor.from_edge_index(edge_index, edge_attr, (4, 4))
-        assert torch.allclose(conv(x, adj2.t(), edge_type), out, atol=1e-6)
-
-    if is_full_test():
-        jit = torch.jit.script(conv)
-        assert torch.allclose(jit(x, edge_index, edge_type),
-                              conv(x, edge_index, edge_type))


### PR DESCRIPTION
**Cause:** `test_rgat_conv_jit` fails (see below) because PyG's legacy HashTensor TorchScript support is incompatible with the current PyTorch version. As far as I can see, PyG plans to drop support for TorchScript - the file `test/nn/conv/test_rgat_conv.py` is already missing from the [drop_torchscript](https://github.com/pyg-team/pytorch_geometric/tree/drop-torchscript/test/nn) branch.

**Fix:** Remove the obsolete test_rgat_conv_jit test, following upstream PyG commit e42ec6804 (Drop TorchScript support).


Just in case: here is what we see when running `test_rgat_conv_jit`:
``` 
______________________________ test_rgat_conv_jit ______________________________
    def test_rgat_conv_jit():
        x = torch.randn(4, 8)
        edge_index = torch.tensor([[0, 1, 2, 3], [0, 0, 1, 1]])
        edge_attr = torch.randn((edge_index.size(1), 8))
        edge_type = torch.tensor([0, 2, 1, 2])
        adj1 = to_torch_coo_tensor(edge_index, edge_attr, size=(4, 4))
    
        conv = RGATConv(8, 20, num_relations=4, num_bases=4, mod='additive',
                        attention_mechanism='across-relation',
                        attention_mode='additive-self-attention', heads=2, dim=1,
                        edge_dim=8, bias=False)
    
        out = conv(x, edge_index, edge_type, edge_attr)
        assert out.size() == (4, 40)
        # t() expects a tensor with <= 2 sparse and 0 dense dimensions
        adj1_t = adj1.transpose(0, 1).coalesce()
        assert torch.allclose(conv(x, adj1_t, edge_type), out, atol=1e-6)
    
        if torch_geometric.typing.WITH_TORCH_SPARSE:
            adj2 = SparseTensor.from_edge_index(edge_index, edge_attr, (4, 4))
            assert torch.allclose(conv(x, adj2.t(), edge_type), out, atol=1e-6)
    
        if is_full_test():
>           jit = torch.jit.script(conv)
                  ^^^^^^^^^^^^^^^^^^^^^^
. . . . . 
            ast = get_jit_def(obj, obj.__name__)
            if _rcb is None:
                _rcb = _jit_internal.createResolutionCallbackFromClosure(obj)
>           fn = torch._C._jit_script_compile(
                qualified_name, ast, _rcb, get_default_args(obj)
            )
E           RuntimeError:                  
E           Arguments for call are not valid.
E           The following variants are available:
E             
E             aten::index_select(Tensor self, int dim, Tensor index) -> Tensor:
E             Expected a value of type 'int' for argument 'dim' but instead found type 'str'.
E             
E             aten::index_select.out(Tensor self, int dim, Tensor index, *, Tensor(a!) out) -> Tensor(a!):
E             Expected a value of type 'int' for argument 'dim' but instead found type 'str'.
E           
E           The original call is:
E             File "/usr/local/lib/python3.12/dist-packages/torch_geometric/hash_tensor.py", line 693
E               else:
E                   if out is None:
E                       return _old_index_select(input, dim, index)
E                              ~~~~~~~~~~~~~~~~~ <--- HERE
E                   else:
E                       return _old_index_select(input, dim, index, out=out)
E           '_new_index_select' is being compiled since it was called from 'RGATConv.message'
E             File "/usr/local/lib/python3.12/dist-packages/torch_geometric/nn/conv/rgat_conv.py", line 397
E                       if self.num_bases is None:
E                           w = self.weight
E                       w = torch.index_select(w, 0, edge_type)
E                       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ <--- HERE
E                       outi = torch.bmm(x_i.unsqueeze(1), w).squeeze(-2)
E                       outj = torch.bmm(x_j.unsqueeze(1), w).squeeze(-2)
E           'RGATConv.message' is being compiled since it was called from 'RGATConv.propagate'
E             File "/tmp/torch_geometric.nn.conv.rgat_conv_RGATConv_propagate_naywld0q.py", line 218
E                   # End Message Forward Pre Hook #########################################
E           
E                   out = self.message(
E                   ~~~~~~~~~~~~~~~~~~~
E                       x_i=kwargs.x_i,
E                       ~~~~~~~~~~~~~~~
E                       x_j=kwargs.x_j,
E                       ~~~~~~~~~~~~~~~
E                       edge_type=kwargs.edge_type,
E                       ~~~~~~~~~~~~~~~~~~~~~~~~~~~
E                       edge_attr=kwargs.edge_attr,
E                       ~~~~~~~~~~~~~~~~~~~~~~~~~~~
E                       index=kwargs.index,
E                       ~~~~~~~~~~~~~~~~~~~
E                       ptr=kwargs.ptr,
E                       ~~~~~~~~~~~~~~~
E                       size_i=kwargs.size_i,
E                       ~~~~~~~~~~~~~~~~~~~~ <--- HERE
E                   )
E           'RGATConv.propagate' is being compiled since it was called from 'RGATConv.forward'
E             File "/usr/local/lib/python3.12/dist-packages/torch_geometric/nn/conv/rgat_conv.py", line 353
E                   # propagate_type: (x: Tensor, edge_type: OptTensor,
E                   #                  edge_attr: OptTensor)
E                   out = self.propagate(edge_index=edge_index, edge_type=edge_type, x=x,
E                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
E                                        size=size, edge_attr=edge_attr)
E                                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ <--- HERE
E               
E                   alpha = self._alpha
/usr/local/lib/python3.12/dist-packages/torch/jit/_script.py:1261: RuntimeError
```