### PR TITLE
Fix HashTensor string keys with xxhash 4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- Fixex HashTensor string keys with xxhash 4.0. ([#10779](https://github.com/pyg-team/pytorch_geometric/pull/10779))
 - Fixed `config_store` on Python 3.14, where `typing.Union`/`typing.Optional` annotations could no longer be remapped in-place via the now read-only `__args__` attribute
 
 ### Security

--- a/torch_geometric/hash_tensor.py
+++ b/torch_geometric/hash_tensor.py
@@ -36,6 +36,12 @@ def implements(torch_function: Callable) -> Callable:
     return decorator
 
 
+def _hash_key(x):
+    if isinstance(x, str):
+        x = x.encode("utf-8")
+    return xxhash.xxh64(x).intdigest() & 0x7FFFFFFFFFFFFFFF
+
+
 def as_key_tensor(
     key: Any,
     *,
@@ -46,7 +52,7 @@ def as_key_tensor(
     except Exception:
         device = device or torch.get_default_device()
         key = torch.tensor(
-            [xxhash.xxh64(x).intdigest() & 0x7FFFFFFFFFFFFFFF for x in key],
+            [_hash_key(x) for x in key],
             dtype=torch.int64, device=device)
 
     if key.element_size() == 1:

--- a/torch_geometric/hash_tensor.py
+++ b/torch_geometric/hash_tensor.py
@@ -36,7 +36,7 @@ def implements(torch_function: Callable) -> Callable:
     return decorator
 
 
-def _hash_key(x):
+def _hash_key(x: Union[str, bytes]) -> int:
     if isinstance(x, str):
         x = x.encode("utf-8")
     return xxhash.xxh64(x).intdigest() & 0x7FFFFFFFFFFFFFFF

--- a/torch_geometric/hash_tensor.py
+++ b/torch_geometric/hash_tensor.py
@@ -51,9 +51,8 @@ def as_key_tensor(
         key = torch.as_tensor(key, device=device)
     except Exception:
         device = device or torch.get_default_device()
-        key = torch.tensor(
-            [_hash_key(x) for x in key],
-            dtype=torch.int64, device=device)
+        key = torch.tensor([_hash_key(x) for x in key], dtype=torch.int64,
+                           device=device)
 
     if key.element_size() == 1:
         key = key.view(torch.uint8)


### PR DESCRIPTION
The `xxhash` 4.0 no longer accepts str inputs for hashing. Encode string keys as UTF-8 before passing them to `xxhash.xxh64()`. This PR fixes HashTensor string-key support with `xxhash==4.0` while remaining compatible with `xxhash==3.7.1`.

Just in case, here is the error we see when running `test_string_key`:
```
______________________________________________________________________________________ test_string_key[cuda:0] _______________________________________________________________________________________

key = ['1', '2', '3'], device = device(type='cuda', index=0)

    def as_key_tensor(
        key: Any,
        *,
        device: Optional[torch.device] = None,
    ) -> Tensor:
        try:
>           key = torch.as_tensor(key, device=device)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
E           ValueError: too many dimensions 'str'

/usr/local/lib/python3.12/dist-packages/torch_geometric/hash_tensor.py:45: ValueError

During handling of the above exception, another exception occurred:

device = device(type='cuda', index=0)

    @withCUDA
    @withHashTensor
    def test_string_key(device):
>       tensor = HashTensor(['1', '2', '3'], device=device)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

../../pytorch_geometric/test/test_hash_tensor.py:94:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
/usr/local/lib/python3.12/dist-packages/torch_geometric/hash_tensor.py:165: in __new__
    key = as_key_tensor(key, device=device)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

key = ['1', '2', '3'], device = device(type='cuda', index=0)

    def as_key_tensor(
        key: Any,
        *,
        device: Optional[torch.device] = None,
    ) -> Tensor:
        try:
            key = torch.as_tensor(key, device=device)
        except Exception:
            device = device or torch.get_default_device()
            key = torch.tensor(
>               [xxhash.xxh64(x).intdigest() & 0x7FFFFFFFFFFFFFFF for x in key],
                 ^^^^^^^^^^^^^^^
                dtype=torch.int64, device=device)
E           TypeError: Strings must be encoded before hashing

/usr/local/lib/python3.12/dist-packages/torch_geometric/hash_tensor.py:49: TypeError
```
