### PR TITLE
Fix normalize being ignored when average=True

### DIFF
--- a/test/utils/test_total_influence.py
+++ b/test/utils/test_total_influence.py
@@ -17,15 +17,16 @@ class GNN(torch.nn.Module):
         return x2
 
 
-def test_total_influence_smoke():
+def get_data():
     x = torch.randn(6, 5)
     edge_index = torch.tensor([[0, 1, 2, 3, 4], [1, 2, 3, 4, 5]])
+    return Data(x=x, edge_index=edge_index)
+
+
+def test_total_influence_smoke():
     max_hops = 2
     num_samples = 4
-    data = Data(
-        x=x,
-        edge_index=edge_index,
-    )
+    data = get_data()
     model = GNN()
     I, R = total_influence(
         model,
@@ -45,3 +46,46 @@ def test_total_influence_smoke():
         average=False,
     )
     assert I.shape == torch.Size([num_samples, max_hops + 1])
+
+
+def test_total_influence_normalize_average():
+    max_hops = 2
+    data = get_data()
+    model = GNN()
+
+    # Sampling all nodes makes the hop-wise mean invariant to the order in
+    # which seed nodes are drawn:
+    I_norm, _ = total_influence(model, data, max_hops=max_hops, average=True,
+                                normalize=True)
+    I_raw, _ = total_influence(model, data, max_hops=max_hops, average=True,
+                               normalize=False)
+
+    # Normalization is relative to the hop-0 influence:
+    assert torch.isclose(I_norm[0], torch.ones(1))
+    assert torch.allclose(I_norm, I_raw / I_raw[0])
+    assert not torch.allclose(I_norm, I_raw)
+
+
+def test_total_influence_normalize_no_average():
+    max_hops = 2
+    num_samples = 4
+    data = get_data()
+    model = GNN()
+
+    def run(normalize):
+        # Seed so that both calls draw the same set of seed nodes:
+        torch.manual_seed(12345)
+        return total_influence(model, data, max_hops=max_hops,
+                               num_samples=num_samples, average=False,
+                               normalize=normalize)[0]
+
+    I_norm = run(normalize=True)
+    I_raw = run(normalize=False)
+
+    assert I_norm.shape == torch.Size([num_samples, max_hops + 1])
+
+    # `normalize` must be respected in non-averaged mode as well, normalizing
+    # every row by its own hop-0 influence:
+    assert torch.allclose(I_norm[:, 0], torch.ones(num_samples))
+    assert torch.allclose(I_norm, I_raw / I_raw[:, 0:1])
+    assert not torch.allclose(I_norm, I_raw)

--- a/torch_geometric/utils/influence.py
+++ b/torch_geometric/utils/influence.py
@@ -18,7 +18,7 @@ def k_hop_subsets_rough(
     r"""Return *rough* (possibly overlapping) *k*-hop node subsets.
 
     This is a thin wrapper around
-    :pyfunc:`torch_geometric.utils.k_hop_subgraph` that *additionally* returns
+    :func:`torch_geometric.utils.k_hop_subgraph` that *additionally* returns
     **all** intermediate hop subsets rather than the full union only.
 
     Parameters
@@ -66,7 +66,7 @@ def k_hop_subsets_exact(
 ) -> List[Tensor]:
     """Return **disjoint** *k*-hop subsets.
 
-    This function refines :pyfunc:`k_hop_subsets_rough` by removing nodes that
+    This function refines :func:`k_hop_subsets_rough` by removing nodes that
     have already appeared in previous hops, ensuring that each subset contains
     nodes *exactly* *i* hops away from the seed.
     """
@@ -167,7 +167,12 @@ def avg_total_influence(
     influence_all_nodes: Tensor,
     normalize: bool = True,
 ) -> Tensor:
-    """Compute the *influence‑weighted receptive field* ``R``."""
+    """Average the per-node influence vectors over all seed nodes.
+
+    Given an influence matrix of shape ``[N, k+1]`` (*i*-th row contains the
+    per-hop influences of node *i*), return the hop-wise mean of shape
+    ``[k+1]``, optionally normalized by the hop-0 influence.
+    """
     avg_total_influences = torch.mean(influence_all_nodes, dim=0)
     if normalize:  # normalize by hop_0 (jacobian of the center node feature)
         avg_total_influences = avg_total_influences / avg_total_influences[0]
@@ -228,7 +233,10 @@ def total_influence(
         num_samples (int, optional): Number of random seed nodes to evaluate.
             If :obj:`None`, all nodes are used. (default: :obj:`None`)
         normalize (bool, optional): If :obj:`True`, normalize each hop‑wise
-            influence by the influence of hop 0. (default: :obj:`True`)
+            influence by the influence of hop 0. If :obj:`average=True`,
+            the averaged vector is divided by its own hop 0 entry;
+            otherwise each row of the returned matrix is divided by its
+            own hop 0 entry. (default: :obj:`True`)
         average (bool, optional): If :obj:`True`, return the hop‑wise **mean**
             over all seed nodes (shape ``[k+1]``).
             If :obj:`False`, return the full influence matrix of shape
@@ -270,6 +278,8 @@ def total_influence(
     # Average total influence at each hop
     if average:
         avg_influence = avg_total_influence(allnodes, normalize=normalize)
+    elif normalize:  # normalize each row by its own hop-0 influence:
+        avg_influence = allnodes / allnodes[:, 0:1]
     else:
         avg_influence = allnodes
 


### PR DESCRIPTION
`torch_geometric.utils.total_influence` accepts a `normalize` argument that defaults to `True`, documented as:
> `normalize` (bool, optional): If `True`, normalize each hop-wise influence by
> the influence of hop 0.

However, it is only ever applied on the `average=True` path. Calling `total_influence(..., average=False)` silently returns **un-normalized** values, even though `normalize=True` by default and the docstring places no condition on it.

<details>
<summary> Reproduction: </summary>

```python
import torch
from torch_geometric.data import Data
from torch_geometric.nn import GCNConv
from torch_geometric.utils import total_influence

class GNN(torch.nn.Module):
    def __init__(self):
        super().__init__()
        self.conv1 = GCNConv(5, 6)
        self.conv2 = GCNConv(6, 7)
    def forward(self, x, edge_index):
        return self.conv2(self.conv1(x, edge_index), edge_index)

torch.manual_seed(0)
data = Data(x=torch.randn(6, 5),
            edge_index=torch.tensor([[0, 1, 2, 3, 4], [1, 2, 3, 4, 5]]))
model = GNN()

def run(**kw):
    torch.manual_seed(42)
    return total_influence(model=model, data=data, max_hops=2,
                           num_samples=4, **kw)[0]

print(torch.equal(run(average=False, normalize=True),
                  run(average=False, normalize=False)))
```
On `master` this prints `True`, meaning the flag has no effect whatsoever.

</details>

## Fix:
Apply the normalization on the non-averaged path too, dividing each row by its own hop-0 influence:

```python
if average:
    avg_influence = avg_total_influence(allnodes, normalize=normalize)
elif normalize:  # normalize each row by its own hop-0 influence:
    avg_influence = allnodes / allnodes[:, 0:1]
else:
    avg_influence = allnodes
```

Before / after, `average=False`:

```
normalize=True (before, == raw)     normalize=True (after)
[[12.6886,  0.0000,  0.0000],       [[1.0000, 0.0000, 0.0000],
 [ 3.1721,  6.3443,  4.4861],        [1.0000, 2.0000, 1.4142],
 [ 3.1721,  6.3443,  4.4861],        [1.0000, 2.0000, 1.4142],
 [ 3.1721,  6.3443,  4.4861]]        [1.0000, 2.0000, 1.4142]]
```
Added two tests to `test/utils/test_total_influence.py`:

- `test_total_influence_normalize_average` pins the existing averaged behaviour (guards against regressing the path that already worked).
- `test_total_influence_normalize_no_average` asserts every row's hop-0 entry is `1.0` and that the result equals `raw / raw[:, 0:1]`.

The second test fails on `master` (`assert torch.allclose(I_norm[:, 0], torch.ones(num_samples))`)
and passes with this change.

## Additionally:
- `avg_total_influence`'s docstring was a verbatim copy of `influence_weighted_receptive_field`'s and described the wrong function.
- `:pyfunc:` → `:func:` (`:pyfunc:` is not a Sphinx role, so those cross-references were dead).
- Expanded the `normalize` docstring to state its behaviour in each mode.