### PR TITLE
Use `out_v` for the node message in the ProteinMPNN encoder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- Fixed `ProteinMPNN` encoder applying the edge head to the node message, leaving `out_v` untrained ([#10781](https://github.com/pyg-team/pytorch_geometric/pull/10781))
 - Fixed `config_store` on Python 3.14, where `typing.Union`/`typing.Optional` annotations could no longer be remapped in-place via the now read-only `__args__` attribute
 
 ### Security

--- a/test/llm/models/test_protein_mpnn.py
+++ b/test/llm/models/test_protein_mpnn.py
@@ -1,6 +1,7 @@
 import torch
 
 from torch_geometric.llm.models import ProteinMPNN
+from torch_geometric.llm.models.protein_mpnn import Encoder
 from torch_geometric.testing import withPackage
 
 
@@ -21,3 +22,25 @@ def test_protein_mpnn():
     logits = model(x, chain_seq_label, mask, chain_mask_all, residue_idx,
                    chain_encoding_all, batch)
     assert logits.size() == (num_nodes, vocab_size)
+
+
+def test_protein_mpnn_encoder_uses_out_v_for_messages():
+    # The encoder keeps separate heads for the node message (`out_v`) and the
+    # edge update (`out_e`); both must be trained.
+    hidden_channels = 16
+    encoder = Encoder(in_channels=3 * hidden_channels,
+                      hidden_channels=hidden_channels)
+
+    num_nodes, num_edges = 6, 12
+    x = torch.randn(num_nodes, hidden_channels)
+    edge_attr = torch.randn(num_edges, hidden_channels)
+    edge_index = torch.stack([
+        torch.randint(0, num_nodes, (num_edges, )),
+        torch.randint(0, num_nodes, (num_edges, )),
+    ])
+
+    x_out, edge_attr_out = encoder(x, edge_index, edge_attr)
+    (x_out.sum() + edge_attr_out.sum()).backward()
+
+    assert all(param.grad is not None for param in encoder.out_v.parameters())
+    assert all(param.grad is not None for param in encoder.out_e.parameters())

--- a/torch_geometric/llm/models/protein_mpnn.py
+++ b/torch_geometric/llm/models/protein_mpnn.py
@@ -97,7 +97,7 @@ class Encoder(MessagePassing):
     def message(self, x_i: torch.Tensor, x_j: torch.Tensor,
                 edge_attr: torch.Tensor) -> torch.Tensor:
         h = torch.cat([x_i, x_j, edge_attr], dim=-1)  # [E, 2*d_v + d_e]
-        h = self.out_e(h)  # [E, d_e]
+        h = self.out_v(h)  # [E, d_v]
         return h
 
 


### PR DESCRIPTION
`Encoder` builds two separate heads — `out_v` for the node message and `out_e` for the edge update — but `message()` applies `out_e`:

```python
def message(self, x_i, x_j, edge_attr):
    h = torch.cat([x_i, x_j, edge_attr], dim=-1)   # [E, 2*d_v + d_e]
    h = self.out_e(h)                              # [E, d_e]
    return h
```

`forward()` also applies `out_e` for the edge update, so `out_v` is never called anywhere and the node and edge updates are driven by the same learned transform. Both heads are built with identical shapes, which is why this doesn't raise.

The consequence is that `out_v` gets no gradient. For a single encoder layer with `hidden_channels=128`:

```
before:  submodules receiving NO gradient: ['out_v']
         dead params: 82304 of 297088  (27.7%)

after:   submodules receiving NO gradient: []
         dead params: 0 of 297088  (0.0%)
```

Two things point the same way. The `Decoder` in this file already applies `out_v` in its own `message()` — it has no `out_e` to confuse it with. And the reference implementation keeps the two heads separate: the node message goes through `W1/W2/W3` and the edge update through `W11/W12/W13`, which are `out_v` and `out_e` here.

Scope:

- `state_dict` keys are unchanged, since both modules already exist under those names, so existing checkpoints still load.
- This does change what the model computes during training, so runs from the current code will not reproduce. Flagging that explicitly — the counterweight is that roughly 28% of every encoder layer is untrained noise today.

The existing test asserts the output shape, which is unaffected either way, and requires `pyg_lib`. The added test builds an `Encoder` directly, runs a backward pass and checks that both heads receive gradients; it needs no optional dependencies, fails on `master` and passes here.
