### PR TITLE
Defer optional LLM dataset imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Changed
 
 - Improved error handling in `txt2kg` multi-process execution. ([#10771](https://github.com/pyg-team/pytorch_geometric/pull/10771))
+- Deferred importing LLM dataset dependencies until the corresponding datasets are used.
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Changed
 
 - Improved error handling in `txt2kg` multi-process execution. ([#10771](https://github.com/pyg-team/pytorch_geometric/pull/10771))
-- Deferred importing LLM dataset dependencies until the corresponding datasets are used.
+- Deferred importing LLM dataset dependencies until the corresponding datasets are used. ([#10782](https://github.com/pyg-team/pytorch_geometric/pull/10782))
 
 ### Deprecated
 

--- a/test/datasets/test_web_qsp_dataset.py
+++ b/test/datasets/test_web_qsp_dataset.py
@@ -157,9 +157,9 @@ def test_kgqa_base_dataset(tmp_path, monkeypatch):
     monkeypatch.setattr(datasets, "load_dataset", mock_load_dataset_func)
 
     # Mock the SentenceTransformer
-    import torch_geometric.datasets.web_qsp_dataset
-    monkeypatch.setattr(torch_geometric.datasets.web_qsp_dataset,
-                        "SentenceTransformer", MockSentenceTransformer)
+    import torch_geometric.llm.models
+    monkeypatch.setattr(torch_geometric.llm.models, "SentenceTransformer",
+                        MockSentenceTransformer)
 
     dataset_train = KGQABaseDataset(root=tmp_path, dataset_name="TestDataset",
                                     split="train", use_pcst=False)

--- a/test/test_import.py
+++ b/test/test_import.py
@@ -1,0 +1,24 @@
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_import_does_not_load_llm_dependencies():
+    code = """
+import sys
+
+import torch_geometric
+from torch_geometric.datasets import (MoleculeGPTDataset, TAGDataset,
+                                      WebQSPDataset)
+
+assert 'torch_geometric.llm' not in sys.modules
+assert 'pandas' not in sys.modules
+assert MoleculeGPTDataset.__name__ == 'MoleculeGPTDataset'
+assert TAGDataset.__name__ == 'TAGDataset'
+assert WebQSPDataset.__name__ == 'WebQSPDataset'
+"""
+    subprocess.run(
+        [sys.executable, '-c', code],
+        cwd=Path(__file__).resolve().parents[1],
+        check=True,
+    )

--- a/torch_geometric/datasets/molecule_gpt_dataset.py
+++ b/torch_geometric/datasets/molecule_gpt_dataset.py
@@ -14,7 +14,6 @@ from tqdm import tqdm
 
 from torch_geometric.data import Data, InMemoryDataset, download_url
 from torch_geometric.io import fs
-from torch_geometric.llm.models import LLM
 from torch_geometric.utils import one_hot
 
 
@@ -340,6 +339,8 @@ class MoleculeGPTDataset(InMemoryDataset):
 
             self.save(data_list, self.processed_paths[0])
             return
+
+        from torch_geometric.llm.models import LLM
 
         # Step 03. Filter out SDF
         step2_folder = f"{self.raw_dir}/step_02_PubChemSTM_SDF"

--- a/torch_geometric/datasets/tag_dataset.py
+++ b/torch_geometric/datasets/tag_dataset.py
@@ -20,13 +20,15 @@ except ImportError:  # pragma: no cover
     PreTrainedTokenizerBase = None
     WITH_TRANSFORMERS = False
 
-try:
-    from pandas import DataFrame, read_csv
-    WITH_PANDAS = True
-except ImportError:
-    WITH_PANDAS = False
-
 IndexType = Union[slice, Tensor, np.ndarray, Sequence]
+
+
+def _import_pandas():
+    try:
+        import pandas as pd
+    except ImportError as e:
+        raise ImportError('`pip install pandas` to use this dataset.') from e
+    return pd
 
 
 def _safe_auto_tokenizer(model_name: str) -> PreTrainedTokenizerBase:
@@ -103,6 +105,7 @@ class TAGDataset(InMemoryDataset):
         text_on_disk: bool = False,
         force_reload: bool = False,
     ) -> None:
+        _import_pandas()
         # list the vars you want to pass in before run download & process
         self.name = dataset.name
         self.text = text
@@ -116,13 +119,6 @@ class TAGDataset(InMemoryDataset):
 
         self.dir_name = '_'.join(dataset.name.split('-'))
         self.root = osp.join(root, self.dir_name)
-        missing_str_list = []
-        if not WITH_PANDAS:
-            missing_str_list.append('pandas')
-        if len(missing_str_list) > 0:
-            missing_str = ' '.join(missing_str_list)
-            error_out = f"`pip install {missing_str}` to use this dataset."
-            raise ImportError(error_out)
         if hasattr(dataset, 'get_idx_split'):
             self.split_idx = dataset.get_idx_split()
         elif split_idx is not None:
@@ -251,26 +247,32 @@ class TAGDataset(InMemoryDataset):
         return self.split_idx
 
     def download(self) -> None:
+        pd = _import_pandas()
+
         print('downloading raw text')
         raw_text_path = download_google_url(id=self.raw_text_id[self.name],
                                             folder=f'{self.root}/raw',
                                             filename='node-text.csv.gz',
                                             log=True)
-        self.text = list(read_csv(raw_text_path)['text'])
+        self.text = list(pd.read_csv(raw_text_path)['text'])
         if self.name in self.llm_explanation_id:
             print('downloading llm explanations')
             llm_explanation_path = download_google_url(
                 id=self.llm_explanation_id[self.name],
                 folder=f'{self.root}/raw', filename='node-gpt-response.csv.gz',
                 log=True)
-            self.llm_explanation = list(read_csv(llm_explanation_path)['text'])
+            self.llm_explanation = list(
+                pd.read_csv(llm_explanation_path)['text'])
             print('downloading llm predictions')
             fs.cp(f'{self.llm_prediction_url}/{self.name}.csv', self.raw_dir)
 
     def process(self) -> None:
+        pd = _import_pandas()
+
         # process Title and Abstraction
         if osp.exists(osp.join(self.root, 'raw', 'node-text.csv.gz')):
-            text_df = read_csv(osp.join(self.root, 'raw', 'node-text.csv.gz'))
+            text_df = pd.read_csv(
+                osp.join(self.root, 'raw', 'node-text.csv.gz'))
             self.text = list(text_df['text'])
         elif self.name in self.raw_text_id:
             self.download()
@@ -289,7 +291,8 @@ class TAGDataset(InMemoryDataset):
         if osp.exists(llm_explanation_path) and osp.exists(
                 llm_prediction_path):
             # load LLM explanation
-            self.llm_explanation = list(read_csv(llm_explanation_path)['text'])
+            self.llm_explanation = list(
+                pd.read_csv(llm_explanation_path)['text'])
             # load LLM prediction
             preds = []
             with open(llm_prediction_path) as file:
@@ -322,13 +325,15 @@ class TAGDataset(InMemoryDataset):
                 'and llm prediction list to `llm_prediction`')
 
     def save_node_text(self, text: List[str]) -> None:
+        pd = _import_pandas()
+
         node_text_path = osp.join(self.root, 'raw', 'node-text.csv.gz')
         if osp.exists(node_text_path):
             print(f'The raw text is existed at {node_text_path}')
         else:
             print(f'Saving raw text file at {node_text_path}')
             os.makedirs(f'{self.root}/raw', exist_ok=True)
-            text_df = DataFrame(text, columns=['text'])
+            text_df = pd.DataFrame(text, columns=['text'])
             text_df.to_csv(osp.join(node_text_path), compression='gzip',
                            index=False)
 

--- a/torch_geometric/datasets/web_qsp_dataset.py
+++ b/torch_geometric/datasets/web_qsp_dataset.py
@@ -2,23 +2,12 @@
 import gc
 import os
 from itertools import chain
-from typing import Any, Dict, Iterator, List, Optional
+from typing import Any, Dict, Iterator, List, Optional, Tuple
 
 import torch
 from tqdm import tqdm
 
 from torch_geometric.data import InMemoryDataset
-from torch_geometric.llm.large_graph_indexer import (
-    EDGE_RELATION,
-    LargeGraphIndexer,
-    TripletLike,
-    get_features_for_triplets_groups,
-)
-from torch_geometric.llm.models import SentenceTransformer
-from torch_geometric.llm.utils.backend_utils import (
-    preprocess_triplet,
-    retrieval_via_pcst,
-)
 
 
 class KGQABaseDataset(InMemoryDataset):
@@ -115,7 +104,7 @@ class KGQABaseDataset(InMemoryDataset):
 
         raw_dataset.save_to_disk(self.raw_paths[0])
 
-    def _get_trips(self) -> Iterator[TripletLike]:
+    def _get_trips(self) -> Iterator[Tuple[str, str, str]]:
         # Iterate over each element's graph in each split of the dataset
         # Using chain to lazily iterate without storing all trips in memory
         split_iterators = []
@@ -130,6 +119,12 @@ class KGQABaseDataset(InMemoryDataset):
         return chain.from_iterable(split_iterators)
 
     def _build_graph(self) -> None:
+        from torch_geometric.llm.large_graph_indexer import (
+            EDGE_RELATION,
+            LargeGraphIndexer,
+        )
+        from torch_geometric.llm.utils.backend_utils import preprocess_triplet
+
         print("Encoding graph...")
         trips = self._get_trips()
         self.indexer: LargeGraphIndexer = LargeGraphIndexer.from_triplets(
@@ -157,6 +152,12 @@ class KGQABaseDataset(InMemoryDataset):
         self.indexer.save(self.indexer_path)
 
     def _retrieve_subgraphs(self) -> None:
+        import torch_geometric.llm.large_graph_indexer as large_graph_indexer
+        from torch_geometric.llm.utils.backend_utils import (
+            preprocess_triplet,
+            retrieval_via_pcst,
+        )
+
         raw_splits = [
             self.raw_dataset[split] for split in self.required_splits
         ]
@@ -182,7 +183,7 @@ class KGQABaseDataset(InMemoryDataset):
                     'verbose': self.verbose,
                 }
             }
-            graph_gen = get_features_for_triplets_groups(
+            graph_gen = large_graph_indexer.get_features_for_triplets_groups(
                 self.indexer, (element['graph'] for element in dataset),
                 **retrieval_kwargs)
 
@@ -221,6 +222,10 @@ class KGQABaseDataset(InMemoryDataset):
     def process(self) -> None:
         import datasets
         from pandas import DataFrame
+
+        from torch_geometric.llm.large_graph_indexer import LargeGraphIndexer
+        from torch_geometric.llm.models import SentenceTransformer
+
         self.raw_dataset = datasets.load_from_disk(self.raw_paths[0])
 
         device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')


### PR DESCRIPTION
## Summary

- Defer the LLM imports used by `MoleculeGPTDataset` and `KGQABaseDataset` until their processing paths execute.
- Defer pandas loading in `TAGDataset` while preserving its actionable missing-dependency error.
- Add an import regression test and update the KGQA mock to patch the lazy import location.

Fixes #10772

## Validation

- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 py -3.13 -m pytest test/test_import.py -q` (1 passed)
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 py -3.13 -m pytest test/datasets/test_web_qsp_dataset.py -k test_kgqa_base_dataset -m rag -q` (1 passed, 1 deselected)
- `pre-commit run --files CHANGELOG.md test/test_import.py test/datasets/test_web_qsp_dataset.py torch_geometric/datasets/molecule_gpt_dataset.py torch_geometric/datasets/tag_dataset.py torch_geometric/datasets/web_qsp_dataset.py` (all hooks passed)
- The same import assertions fail on pristine upstream with `torch_geometric.llm` already loaded and pass on this branch.

AI assistance disclosure: AI-assisted development tools were used during investigation and implementation. The reported tests were run against the final diff.