### PR TITLE
Fix cumulative edge dropout in APPNP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Fixed
 
 - Fixed `config_store` on Python 3.14, where `typing.Union`/`typing.Optional` annotations could no longer be remapped in-place via the now read-only `__args__` attribute
-- Fixed APPNP edge dropout being applied cumulatively across propagation steps ([#10783](https://github.com/pyg-team/pytorch_geometric/issues/10783))
+- Fixed APPNP edge dropout being applied cumulatively across propagation steps ([#10784](https://github.com/pyg-team/pytorch_geometric/pull/10784))
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Fixed
 
 - Fixed `config_store` on Python 3.14, where `typing.Union`/`typing.Optional` annotations could no longer be remapped in-place via the now read-only `__args__` attribute
+- Fixed APPNP edge dropout being applied cumulatively across propagation steps ([#10783](https://github.com/pyg-team/pytorch_geometric/issues/10783))
 
 ### Security
 

--- a/test/nn/conv/test_appnp.py
+++ b/test/nn/conv/test_appnp.py
@@ -1,5 +1,7 @@
+import pytest
 import torch
 
+import torch_geometric.nn.conv.appnp as appnp_module
 import torch_geometric.typing
 from torch_geometric.nn import APPNP
 from torch_geometric.testing import is_full_test
@@ -55,3 +57,41 @@ def test_appnp_dropout():
     if torch_geometric.typing.WITH_TORCH_SPARSE:
         adj2 = SparseTensor.from_edge_index(edge_index, sparse_sizes=(4, 4))
         assert torch.allclose(0.1 * x, conv(x, adj2.t()), rtol=1e-5, atol=1e-6)
+
+
+@pytest.mark.parametrize('adjacency_type', [
+    'edge_index',
+    'torch_sparse',
+    'torch_sparse_tensor',
+])
+def test_appnp_dropout_uses_original_edge_weight(monkeypatch, adjacency_type):
+    x = torch.ones(2, 1)
+    edge_index = torch.tensor([[0, 1], [1, 0]])
+    edge_weight = torch.tensor([1.0, 3.0])
+    dropout_inputs = []
+
+    def fake_dropout(input, p):
+        dropout_inputs.append(input.clone())
+        return input * 0.5
+
+    monkeypatch.setattr(appnp_module.F, 'dropout', fake_dropout)
+
+    if adjacency_type == 'edge_index':
+        adjacency = edge_index
+        conv = APPNP(K=3, alpha=0.1, dropout=0.5, normalize=False)
+        conv(x, adjacency, edge_weight)
+    elif adjacency_type == 'torch_sparse':
+        adjacency = torch.sparse_coo_tensor(edge_index, edge_weight,
+                                            size=(2, 2)).coalesce()
+        conv = APPNP(K=3, alpha=0.1, dropout=0.5, normalize=False)
+        conv(x, adjacency)
+    else:
+        if not torch_geometric.typing.WITH_TORCH_SPARSE:
+            pytest.skip('torch_sparse is not installed')
+        adjacency = SparseTensor.from_edge_index(edge_index, edge_weight,
+                                                 sparse_sizes=(2, 2)).t()
+        conv = APPNP(K=3, alpha=0.1, dropout=0.5, normalize=False)
+        conv(x, adjacency)
+
+    assert len(dropout_inputs) == 3
+    assert all(torch.equal(input, edge_weight) for input in dropout_inputs)

--- a/test/nn/conv/test_appnp.py
+++ b/test/nn/conv/test_appnp.py
@@ -78,11 +78,13 @@ def test_appnp_dropout_uses_original_edge_weight(monkeypatch, adjacency_type):
 
     if adjacency_type == 'edge_index':
         adjacency = edge_index
+        expected_edge_weight = edge_weight
         conv = APPNP(K=3, alpha=0.1, dropout=0.5, normalize=False)
         conv(x, adjacency, edge_weight)
     elif adjacency_type == 'torch_sparse':
         adjacency = torch.sparse_coo_tensor(edge_index, edge_weight,
                                             size=(2, 2)).coalesce()
+        expected_edge_weight = adjacency.values()
         conv = APPNP(K=3, alpha=0.1, dropout=0.5, normalize=False)
         conv(x, adjacency)
     else:
@@ -90,8 +92,10 @@ def test_appnp_dropout_uses_original_edge_weight(monkeypatch, adjacency_type):
             pytest.skip('torch_sparse is not installed')
         adjacency = SparseTensor.from_edge_index(edge_index, edge_weight,
                                                  sparse_sizes=(2, 2)).t()
+        expected_edge_weight = adjacency.storage.value()
         conv = APPNP(K=3, alpha=0.1, dropout=0.5, normalize=False)
         conv(x, adjacency)
 
     assert len(dropout_inputs) == 3
-    assert all(torch.equal(input, edge_weight) for input in dropout_inputs)
+    assert all(
+        torch.equal(input, expected_edge_weight) for input in dropout_inputs)

--- a/torch_geometric/nn/conv/appnp.py
+++ b/torch_geometric/nn/conv/appnp.py
@@ -109,20 +109,28 @@ class APPNP(MessagePassing):
                     edge_index = cache
 
         h = x
+        original_edge_weight = edge_weight
+        if isinstance(edge_index, Tensor):
+            if is_torch_sparse_tensor(edge_index):
+                _, original_edge_weight = to_edge_index(edge_index)
+        else:
+            original_edge_weight = edge_index.storage.value()
+
         for _ in range(self.K):
             if self.dropout > 0 and self.training:
                 if isinstance(edge_index, Tensor):
                     if is_torch_sparse_tensor(edge_index):
-                        _, edge_weight = to_edge_index(edge_index)
-                        edge_weight = F.dropout(edge_weight, p=self.dropout)
+                        assert original_edge_weight is not None
+                        edge_weight = F.dropout(original_edge_weight,
+                                                p=self.dropout)
                         edge_index = set_sparse_value(edge_index, edge_weight)
                     else:
-                        assert edge_weight is not None
-                        edge_weight = F.dropout(edge_weight, p=self.dropout)
+                        assert original_edge_weight is not None
+                        edge_weight = F.dropout(original_edge_weight,
+                                                p=self.dropout)
                 else:
-                    value = edge_index.storage.value()
-                    assert value is not None
-                    value = F.dropout(value, p=self.dropout)
+                    assert original_edge_weight is not None
+                    value = F.dropout(original_edge_weight, p=self.dropout)
                     edge_index = edge_index.set_value(value, layout='coo')
 
             # propagate_type: (x: Tensor, edge_weight: OptTensor)


### PR DESCRIPTION
## Summary

`APPNP` now samples edge dropout from the original normalized edge weights on every propagation step. This prevents dropout masks and inverted-dropout scaling from accumulating across the `K` iterations.

Fixes #10783

## Implementation

The original edge weights are retained once per forward pass for dense edge indices, PyTorch sparse tensors, and `torch_sparse.SparseTensor` inputs. Each iteration still receives a fresh dropout result, while the adjacency structure and existing propagation behavior remain unchanged.

## Validation

- Added a deterministic regression test that verifies all three propagation steps receive the original weights for dense and PyTorch sparse inputs, with an optional test path for `torch_sparse.SparseTensor`.
- `$env:FULL_TEST='1'; $env:PYTEST_DISABLE_PLUGIN_AUTOLOAD='1'; py -3.13 -m pytest test/nn/conv/test_appnp.py -q`: 4 passed, 1 skipped (`torch_sparse` unavailable). This also exercises TorchScript compilation.
- `py -3.13 -m pytest test/nn/conv -q`: 278 passed, 381 skipped.
- `py -3.13 -m pre_commit run --files CHANGELOG.md torch_geometric/nn/conv/appnp.py test/nn/conv/test_appnp.py`: passed.
- The regression assertion fails on pristine `master` because the second and third dropout calls receive already-dropped weights.
- The author of #10803 independently applied this change and confirmed that separate dense and PyTorch sparse resampling tests pass, then closed #10803 as a duplicate in favor of this PR.

AI assistance disclosure: AI-assisted development tools were used during investigation and implementation. The reported tests were run against the final diff.
