### PR TITLE
fix(utils): handle empty edge index in sparse tensor conversion

### DIFF
--- a/test/utils/test_sparse.py
+++ b/test/utils/test_sparse.py
@@ -146,8 +146,8 @@ def test_to_torch_coo_tensor():
         assert torch.allclose(adj.values(), edge_attr)
 
 
-@pytest.mark.parametrize('layout', [torch.sparse_coo, torch.sparse_csr,
-                                    torch.sparse_csc])
+@pytest.mark.parametrize(
+    'layout', [torch.sparse_coo, torch.sparse_csr, torch.sparse_csc])
 def test_to_torch_sparse_tensor_empty_edge_index(layout):
     edge_index = torch.empty((2, 0), dtype=torch.long)
 

--- a/test/utils/test_sparse.py
+++ b/test/utils/test_sparse.py
@@ -146,6 +146,36 @@ def test_to_torch_coo_tensor():
         assert torch.allclose(adj.values(), edge_attr)
 
 
+@pytest.mark.parametrize('layout', [torch.sparse_coo, torch.sparse_csr,
+                                    torch.sparse_csc])
+def test_to_torch_sparse_tensor_empty_edge_index(layout):
+    edge_index = torch.empty((2, 0), dtype=torch.long)
+
+    adj = to_torch_sparse_tensor(edge_index, layout=layout)
+    assert adj.size() == (0, 0)
+    assert adj._nnz() == 0
+
+    # Explicit sizes preserve isolated nodes even when no edges are present.
+    adj = to_torch_sparse_tensor(edge_index, size=3, layout=layout)
+    assert adj.size() == (3, 3)
+    assert adj._nnz() == 0
+
+    coo = adj.to_sparse_coo().coalesce() if layout != torch.sparse_coo else adj
+    assert coo.indices().size() == (2, 0)
+
+    # Isolated nodes remain part of the explicitly sized graph.
+    edge_index = torch.tensor([[0], [1]])
+    adj = to_torch_sparse_tensor(edge_index, size=3, layout=layout)
+    assert adj.size() == (3, 3)
+    assert adj._nnz() == 1
+
+    # Non-empty graphs retain their inferred dimensions and entries.
+    edge_index = torch.tensor([[0, 1], [1, 0]])
+    adj = to_torch_sparse_tensor(edge_index, layout=layout)
+    assert adj.size() == (2, 2)
+    assert adj._nnz() == 2
+
+
 def test_to_torch_csr_tensor():
     edge_index = torch.tensor([
         [0, 1, 1, 2, 2, 3],

--- a/torch_geometric/utils/sparse.py
+++ b/torch_geometric/utils/sparse.py
@@ -181,11 +181,11 @@ def to_torch_coo_tensor(
     if isinstance(size, (tuple, list)):
         num_src_nodes, num_dst_nodes = size
         if num_src_nodes is None:
-            num_src_nodes = (int(edge_index[0].max()) + 1
-                             if edge_index[0].numel() > 0 else 0)
+            num_src_nodes = (int(edge_index[0].max()) +
+                             1 if edge_index[0].numel() > 0 else 0)
         if num_dst_nodes is None:
-            num_dst_nodes = (int(edge_index[1].max()) + 1
-                             if edge_index[1].numel() > 0 else 0)
+            num_dst_nodes = (int(edge_index[1].max()) +
+                             1 if edge_index[1].numel() > 0 else 0)
         size = (num_src_nodes, num_dst_nodes)
     else:
         size = (size, size)
@@ -259,11 +259,11 @@ def to_torch_csr_tensor(
     if isinstance(size, (tuple, list)):
         num_src_nodes, num_dst_nodes = size
         if num_src_nodes is None:
-            num_src_nodes = (int(edge_index[0].max()) + 1
-                             if edge_index[0].numel() > 0 else 0)
+            num_src_nodes = (int(edge_index[0].max()) +
+                             1 if edge_index[0].numel() > 0 else 0)
         if num_dst_nodes is None:
-            num_dst_nodes = (int(edge_index[1].max()) + 1
-                             if edge_index[1].numel() > 0 else 0)
+            num_dst_nodes = (int(edge_index[1].max()) +
+                             1 if edge_index[1].numel() > 0 else 0)
         size = (num_src_nodes, num_dst_nodes)
     else:
         size = (size, size)
@@ -329,11 +329,11 @@ def to_torch_csc_tensor(
     if isinstance(size, (tuple, list)):
         num_src_nodes, num_dst_nodes = size
         if num_src_nodes is None:
-            num_src_nodes = (int(edge_index[0].max()) + 1
-                             if edge_index[0].numel() > 0 else 0)
+            num_src_nodes = (int(edge_index[0].max()) +
+                             1 if edge_index[0].numel() > 0 else 0)
         if num_dst_nodes is None:
-            num_dst_nodes = (int(edge_index[1].max()) + 1
-                             if edge_index[1].numel() > 0 else 0)
+            num_dst_nodes = (int(edge_index[1].max()) +
+                             1 if edge_index[1].numel() > 0 else 0)
         size = (num_src_nodes, num_dst_nodes)
     else:
         size = (size, size)

--- a/torch_geometric/utils/sparse.py
+++ b/torch_geometric/utils/sparse.py
@@ -176,14 +176,16 @@ def to_torch_coo_tensor(
 
     """
     if size is None:
-        size = int(edge_index.max()) + 1
+        size = int(edge_index.max()) + 1 if edge_index.numel() > 0 else 0
 
     if isinstance(size, (tuple, list)):
         num_src_nodes, num_dst_nodes = size
         if num_src_nodes is None:
-            num_src_nodes = int(edge_index[0].max()) + 1
+            num_src_nodes = (int(edge_index[0].max()) + 1
+                             if edge_index[0].numel() > 0 else 0)
         if num_dst_nodes is None:
-            num_dst_nodes = int(edge_index[1].max()) + 1
+            num_dst_nodes = (int(edge_index[1].max()) + 1
+                             if edge_index[1].numel() > 0 else 0)
         size = (num_src_nodes, num_dst_nodes)
     else:
         size = (size, size)
@@ -252,14 +254,16 @@ def to_torch_csr_tensor(
 
     """
     if size is None:
-        size = int(edge_index.max()) + 1
+        size = int(edge_index.max()) + 1 if edge_index.numel() > 0 else 0
 
     if isinstance(size, (tuple, list)):
         num_src_nodes, num_dst_nodes = size
         if num_src_nodes is None:
-            num_src_nodes = int(edge_index[0].max()) + 1
+            num_src_nodes = (int(edge_index[0].max()) + 1
+                             if edge_index[0].numel() > 0 else 0)
         if num_dst_nodes is None:
-            num_dst_nodes = int(edge_index[1].max()) + 1
+            num_dst_nodes = (int(edge_index[1].max()) + 1
+                             if edge_index[1].numel() > 0 else 0)
         size = (num_src_nodes, num_dst_nodes)
     else:
         size = (size, size)
@@ -320,14 +324,16 @@ def to_torch_csc_tensor(
 
     """
     if size is None:
-        size = int(edge_index.max()) + 1
+        size = int(edge_index.max()) + 1 if edge_index.numel() > 0 else 0
 
     if isinstance(size, (tuple, list)):
         num_src_nodes, num_dst_nodes = size
         if num_src_nodes is None:
-            num_src_nodes = int(edge_index[0].max()) + 1
+            num_src_nodes = (int(edge_index[0].max()) + 1
+                             if edge_index[0].numel() > 0 else 0)
         if num_dst_nodes is None:
-            num_dst_nodes = int(edge_index[1].max()) + 1
+            num_dst_nodes = (int(edge_index[1].max()) + 1
+                             if edge_index[1].numel() > 0 else 0)
         size = (num_src_nodes, num_dst_nodes)
     else:
         size = (size, size)


### PR DESCRIPTION
## Summary
- Handle empty edge indices when inferring COO, CSR, and CSC sparse tensor sizes.
- Preserve explicit isolated-node dimensions and rectangular sizes.
- Add regression coverage for empty, isolated-node, and standard graph inputs.

## Testing
- python -m pytest -q test/utils/test_sparse.py (21 passed)
- python -m pytest -q test/utils/ (184 passed, 65 skipped)
- python -m pytest -q test/transforms/ (157 passed, 5 skipped, 2 deselected)

All tests were run on pure CPU.