### PR TITLE
fix(hetero_data): support non-zero cat_dim in HeteroData.subgraph (#10768)

### DIFF
--- a/test/data/test_hetero_data.py
+++ b/test/data/test_hetero_data.py
@@ -333,6 +333,30 @@ def test_hetero_data_subgraph():
     assert out['paper', 'paper'].edge_attr.size() == (4, 8)
 
 
+def test_hetero_data_subgraph_edge_attr_with_nonzero_cat_dim():
+    data = HeteroData()
+    data['paper'].num_nodes = 3
+    data['paper', 'cites', 'paper'].edge_index = torch.tensor([
+        [0, 1, 2],
+        [1, 2, 0],
+    ])
+    data['paper', 'cites', 'paper'].pair_index = torch.tensor([
+        [10, 11, 12],
+        [20, 21, 22],
+    ])
+
+    out = data.subgraph({'paper': torch.tensor([0, 1])})
+
+    assert torch.equal(
+        out['paper', 'cites', 'paper'].edge_index,
+        torch.tensor([[0], [1]]),
+    )
+    assert torch.equal(
+        out['paper', 'cites', 'paper'].pair_index,
+        torch.tensor([[10], [20]]),
+    )
+
+
 def test_hetero_data_empty_subgraph():
     data = HeteroData()
     data.num_node_types = 3

--- a/torch_geometric/data/hetero_data.py
+++ b/torch_geometric/data/hetero_data.py
@@ -806,7 +806,8 @@ class HeteroData(BaseData, FeatureStore, GraphStore):
                 if key == 'edge_index':
                     data[edge_type].edge_index = edge_index
                 elif self[edge_type].is_edge_attr(key):
-                    data[edge_type][key] = value[edge_mask]
+                    dim = self.__cat_dim__(key, value, self[edge_type])
+                    data[edge_type][key] = mask_select(value, dim, edge_mask)
                 else:
                     data[edge_type][key] = value
 


### PR DESCRIPTION
## Summary\n\n- apply edge masks along each edge attribute's configured concatenation dimension\n- add regression coverage for [2, num_edges] pair_index attributes\n\n## Verification\n\n- PYTHONPATH=. pytest -q test/data/test_hetero_data.py test/data/test_data.py test/utils/test_mask.py\n- 45 passed, 4 skipped on CPU\n\nFixes #10768