### PR TITLE
fix(data): ensure deepcopy isolates Batch metadata dictionaries (#10364)

### DIFF
--- a/test/data/test_batch.py
+++ b/test/data/test_batch.py
@@ -1,3 +1,4 @@
+import copy
 import os.path as osp
 
 import numpy as np
@@ -106,6 +107,24 @@ def test_batch_basic():
     assert data_list[2].num_nodes == 4
 
     torch_geometric.set_debug(True)
+
+
+def test_batch_deepcopy_isolates_metadata():
+    batch = Batch.from_data_list([
+        Data(x=torch.randn(2, 1)),
+        Data(x=torch.randn(3, 1)),
+    ])
+    out = copy.deepcopy(batch)
+
+    assert id(out._slice_dict) != id(batch._slice_dict)
+    assert id(out._inc_dict) != id(batch._inc_dict)
+    assert id(out._slice_dict['x']) != id(batch._slice_dict['x'])
+
+    out._slice_dict['x'][0] = 123
+    out._inc_dict['x'][0] = 456
+    assert batch._slice_dict['x'][0] == 0
+    assert batch._inc_dict['x'][0] == 0
+    assert torch.equal(out.get_example(1).x, batch.get_example(1).x)
 
 
 def test_index():

--- a/torch_geometric/data/storage.py
+++ b/torch_geometric/data/storage.py
@@ -143,8 +143,13 @@ class BaseStorage(MutableMapping):
     def __deepcopy__(self, memo: Optional[Dict[int, Any]]) -> Self:
         out = self.__class__.__new__(self.__class__)
         for key, value in self.__dict__.items():
-            out.__dict__[key] = value
-        out._mapping = copy.deepcopy(out._mapping, memo)
+            if key == '_mapping':
+                continue
+            # Keep the parent weak reference intact; owning data objects
+            # rebind it after copying their stores.
+            out.__dict__[key] = (value if key == '_parent' else copy.deepcopy(
+                value, memo))
+        out._mapping = copy.deepcopy(self._mapping, memo)
         return out
 
     def __getstate__(self) -> Dict[str, Any]:


### PR DESCRIPTION
## Summary\n\n- deep-copy BaseStorage metadata instead of sharing internal dictionaries\n- preserve parent weak-reference handling while copying stores\n- add regression coverage for Batch _slice_dict and _inc_dict isolation\n\n## Verification\n\n- PYTHONPATH=. pytest -q test/data/test_batch.py\n- 17 passed, 1 skipped on CPU\n\nFixes #10364