### PR TITLE
ci: Mark MedShapeNet test as requiring dataset download

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
-- The test_medshapenet, which requires loading the MedShapeNet dataset, will not be run in full testing mode ([#10788](https://github.com/pyg-team/pytorch_geometric/pull/10788))
 - Improved error handling in `txt2kg` multi-process execution. ([#10771](https://github.com/pyg-team/pytorch_geometric/pull/10771))
 
 ### Deprecated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
+- The test_medshapenet, which requires loading the MedShapeNet dataset, will not be run in full testing mode ([#10788](https://github.com/pyg-team/pytorch_geometric/pull/10788))
 - Improved error handling in `txt2kg` multi-process execution. ([#10771](https://github.com/pyg-team/pytorch_geometric/pull/10771))
 
 ### Deprecated

--- a/test/datasets/test_medshapenet.py
+++ b/test/datasets/test_medshapenet.py
@@ -1,3 +1,4 @@
+import pytest
 import torch
 
 from torch_geometric.data import Data
@@ -5,6 +6,7 @@ from torch_geometric.datasets import MedShapeNet
 from torch_geometric.testing import withPackage
 
 
+@pytest.mark.dataset
 @withPackage('MedShapeNet')
 def test_medshapenet():
     dataset = MedShapeNet(root="./data/MedShapeNet", size=1)


### PR DESCRIPTION
**Summary**

Mark `test_medshapenet` with `pytest.mark.datase` since the test downloads data from the external `MedShapeNe` service.

**Details**

`test_medshapenet` instantiates `MedShapeNet`, which triggers dataset discovery and downloads data from the remote `MedShapeNe` server:
```
dataset = MedShapeNet(root="./data/MedShapeNet", size=1)
```
As a result, the test requires external network access and should be classified as a dataset-download test.

This change adds the dataset marker to `test_medshapene` so that it is handled consistently with the dataset tests excluded from the regular/full test suite by the CI changes in PR #10710.

Testing

Verified that the test is correctly recognized with the dataset marker and that the test itself requires access to the external `MedShapeNet` service.

Related to [#10710](https://github.com/pyg-team/pytorch_geometric/pull/10710/): **ci: Don't run tests that require dataset downloads in full test**
