### PR TITLE
Apply pre_transform in FakeDataset and FakeHeteroDataset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- Fixed `FakeDataset` and `FakeHeteroDataset` ignoring the `pre_transform` argument ([#10789](https://github.com/pyg-team/pytorch_geometric/pull/10789))
 - Fixed `config_store` on Python 3.14, where `typing.Union`/`typing.Optional` annotations could no longer be remapped in-place via the now read-only `__args__` attribute
 
 ### Security

--- a/test/datasets/test_fake.py
+++ b/test/datasets/test_fake.py
@@ -82,3 +82,27 @@ def test_fake_hetero_dataset(num_graphs, edge_dim, task):
         assert data.y.size() == (1, )
 
     assert data.global_features.size() == (3, )
+
+
+def test_fake_dataset_pre_transform():
+    def add_marker(data):
+        data.marker = True
+        return data
+
+    dataset = FakeDataset(num_graphs=3, pre_transform=add_marker)
+
+    assert dataset.pre_transform is add_marker
+    for data in dataset:
+        assert data.marker
+
+
+def test_fake_hetero_dataset_pre_transform():
+    def add_marker(data):
+        data.marker = True
+        return data
+
+    dataset = FakeHeteroDataset(num_graphs=3, pre_transform=add_marker)
+
+    assert dataset.pre_transform is add_marker
+    for data in dataset:
+        assert data.marker

--- a/torch_geometric/datasets/fake.py
+++ b/torch_geometric/datasets/fake.py
@@ -37,6 +37,10 @@ class FakeDataset(InMemoryDataset):
             an :obj:`torch_geometric.data.Data` object and returns a
             transformed version. The data object will be transformed before
             every access. (default: :obj:`None`)
+        pre_transform (callable, optional): A function/transform that takes in
+            an :obj:`torch_geometric.data.Data` object and returns a
+            transformed version. The data object will be transformed once,
+            when the dataset is generated. (default: :obj:`None`)
         **kwargs (optional): Additional attributes and their shapes
             *e.g.* :obj:`global_features=5`.
     """
@@ -54,7 +58,7 @@ class FakeDataset(InMemoryDataset):
         pre_transform: Optional[Callable] = None,
         **kwargs: Union[int, Tuple[int, ...]],
     ) -> None:
-        super().__init__(None, transform)
+        super().__init__(None, transform, pre_transform)
 
         if task == 'auto':
             task = 'graph' if num_graphs > 1 else 'node'
@@ -70,6 +74,10 @@ class FakeDataset(InMemoryDataset):
         self.kwargs = kwargs
 
         data_list = [self.generate_data() for _ in range(max(num_graphs, 1))]
+
+        if self.pre_transform is not None:
+            data_list = [self.pre_transform(data) for data in data_list]
+
         self.data, self.slices = self.collate(data_list)
 
     def generate_data(self) -> Data:
@@ -137,6 +145,10 @@ class FakeHeteroDataset(InMemoryDataset):
             an :obj:`torch_geometric.data.HeteroData` object and returns a
             transformed version. The data object will be transformed before
             every access. (default: :obj:`None`)
+        pre_transform (callable, optional): A function/transform that takes in
+            an :obj:`torch_geometric.data.HeteroData` object and returns a
+            transformed version. The data object will be transformed once,
+            when the dataset is generated. (default: :obj:`None`)
         **kwargs (optional): Additional attributes and their shapes
             *e.g.* :obj:`global_features=5`.
     """
@@ -155,7 +167,7 @@ class FakeHeteroDataset(InMemoryDataset):
         pre_transform: Optional[Callable] = None,
         **kwargs: Union[int, Tuple[int, ...]],
     ) -> None:
-        super().__init__(None, transform)
+        super().__init__(None, transform, pre_transform)
 
         if task == 'auto':
             task = 'graph' if num_graphs > 1 else 'node'
@@ -187,6 +199,10 @@ class FakeHeteroDataset(InMemoryDataset):
         self.kwargs = kwargs
 
         data_list = [self.generate_data() for _ in range(max(num_graphs, 1))]
+
+        if self.pre_transform is not None:
+            data_list = [self.pre_transform(data) for data in data_list]
+
         self.data, self.slices = self.collate(data_list)
 
     def generate_data(self) -> HeteroData:


### PR DESCRIPTION
### What this fixes

`FakeDataset` and `FakeHeteroDataset` both accept `pre_transform` in their signature:

```python
transform: Optional[Callable] = None,
pre_transform: Optional[Callable] = None,
**kwargs: Union[int, Tuple[int, ...]],
) -> None:
    super().__init__(None, transform)
```

but it is dropped on the way to the base class, so `self.pre_transform` stays `None`. And because these datasets generate and collate their graphs directly in `__init__` rather than in a `process()` method, nothing applies it either. The argument is accepted and silently discarded — it was also missing from both docstrings.

### Evidence

```python
ds = FakeDataset(num_graphs=1, num_channels=4, pre_transform=T.Constant(value=7.0))
```

| | before | after |
|---|---|---|
| `ds.pre_transform is not None` | `False` | `True` |
| `T.Constant` applied — `x` columns | `4` (unchanged) | `5` |
| same for `FakeHeteroDataset` | not applied | applied |

### The change

The base class now receives it, and the generated graphs are passed through it before collating — mirroring what `process()` does for the on-disk datasets:

```python
data_list = [self.generate_data() for _ in range(max(num_graphs, 1))]

if self.pre_transform is not None:
    data_list = [self.pre_transform(data) for data in data_list]

self.data, self.slices = self.collate(data_list)
```

`pre_filter` is deliberately not touched — neither class accepts it.

Anyone who was already passing `pre_transform` was getting nothing from it, so the transform now taking effect is the documented behaviour they were asking for. Callers that never passed it are unaffected.

### Testing

Added `test_fake_dataset_pre_transform` and `test_fake_hetero_dataset_pre_transform`, asserting the callable is stored on the dataset and that every generated graph went through it.

- without the fix: both fail (`assert None is <function add_marker>`)
- with the fix: `test/datasets/test_fake.py` gives 38 passed
- flake8, isort, yapf and ruff are all clean on both files
