### PR TITLE
fix: adapt rdl example to RelBench 3.0 dataset API

### DIFF
--- a/examples/rdl.py
+++ b/examples/rdl.py
@@ -14,8 +14,10 @@ from typing import Any, Dict, List, NamedTuple, Optional, Tuple
 
 import numpy as np
 import pandas as pd
+import sklearn.metrics as skm
 import torch
 import torch_frame
+from numpy.typing import NDArray
 from relbench import load_dataset
 from relbench.base import EntityTask, Table, TaskType
 from relbench.modeling.graph import make_pkey_fkey_graph
@@ -38,9 +40,6 @@ from torch_geometric.nn import (
 )
 from torch_geometric.seed import seed_everything
 from torch_geometric.typing import EdgeType, NodeType
-
-import sklearn.metrics as skm
-from numpy.typing import NDArray
 
 
 def mae(true: NDArray[np.float64], pred: NDArray[np.float64]) -> float:

--- a/examples/rdl.py
+++ b/examples/rdl.py
@@ -16,11 +16,10 @@ import numpy as np
 import pandas as pd
 import torch
 import torch_frame
+from relbench import load_dataset
 from relbench.base import EntityTask, Table, TaskType
-from relbench.datasets import get_dataset, get_dataset_names
 from relbench.modeling.graph import make_pkey_fkey_graph
 from relbench.modeling.utils import get_stype_proposal
-from relbench.tasks import get_task, get_task_names
 from sentence_transformers import SentenceTransformer
 from torch import Tensor
 from torch_frame.config.text_embedder import TextEmbedderConfig
@@ -39,6 +38,13 @@ from torch_geometric.nn import (
 )
 from torch_geometric.seed import seed_everything
 from torch_geometric.typing import EdgeType, NodeType
+
+import sklearn.metrics as skm
+from numpy.typing import NDArray
+
+
+def mae(true: NDArray[np.float64], pred: NDArray[np.float64]) -> float:
+    return skm.mean_absolute_error(true, pred)
 
 
 class GloveTextEmbedding:
@@ -442,13 +448,12 @@ def get_task_type_params(
         - tune_metric: Metric to optimize
         - higher_is_better: Whether higher metric values are better
     """
+    out_channels = 1
     if task.task_type == TaskType.REGRESSION:
-        out_channels = 1
         loss_fn = torch.nn.L1Loss()
         tune_metric = "mae"
         higher_is_better = False
     elif task.task_type == TaskType.BINARY_CLASSIFICATION:
-        out_channels = 1
         loss_fn = torch.nn.BCEWithLogitsLoss()
         tune_metric = "roc_auc"
         higher_is_better = True
@@ -572,10 +577,20 @@ def test(
 def main():
     seed_everything(42)
 
+    REL_BENCH_DATASETS = [
+        "rel-amazon",
+        "rel-avito",
+        "rel-event",
+        "rel-f1",
+        "rel-hm",
+        "rel-stack",
+        "rel-trial",
+    ]
+
     parser = argparse.ArgumentParser(
         formatter_class=argparse.ArgumentDefaultsHelpFormatter)
     parser.add_argument("--dataset", type=str, default="rel-f1",
-                        choices=get_dataset_names())
+                        choices=REL_BENCH_DATASETS)
     parser.add_argument(
         "--task", type=str, default=None,
         help="See available tasks at https://relbench.stanford.edu/")
@@ -594,15 +609,13 @@ def main():
     print("Using device:", device)
 
     print("Loading dataset and task...")
-    assert args.task in get_task_names(args.dataset), (
+    dataset = load_dataset(args.dataset)
+    task_names = dataset.get_task_names()
+    assert args.task in task_names, (
         f"Invalid --task '{args.task}' for --dataset '{args.dataset}'. "
-        f"Available tasks: {get_task_names(args.dataset)}")
-    dataset = get_dataset(name=args.dataset, download=True)
-    task = get_task(
-        dataset_name=args.dataset,
-        task_name=args.task,
-        download=True,
-    )
+        f"Available tasks: {task_names}")
+
+    task = dataset.load_task(args.task)
     print(f"Task type: {task.task_type}")
     print(f"Target column: '{task.target_col}'")
     print(f"Entity table: '{task.entity_table}'")
@@ -690,6 +703,8 @@ def main():
 
     print("Training the model...")
     best_val_metric = -math.inf if higher_is_better else math.inf
+    is_better_op = operator.gt if higher_is_better else operator.lt
+    val = task.get_table("val")
     for epoch in range(1, args.epochs + 1):
         train_loss = train(
             model=model,
@@ -705,14 +720,13 @@ def main():
             task=task,
             device=device,
         )
-        val_metrics = task.evaluate(val_pred, task.get_table("val"))
+        val_metrics = task.evaluate(val_pred, val, [mae])
         print(
             f"Epoch: {epoch:02d}, "
             f"train_loss: {train_loss:.4f}, "
             f"{', '.join([f'val_{k}: {v:.4f}' for k, v in val_metrics.items()])}"  # noqa: E501
         )
 
-        is_better_op = operator.gt if higher_is_better else operator.lt
         if is_better_op(val_metrics[tune_metric], best_val_metric):
             best_val_metric = val_metrics[tune_metric]
             torch.save(model.state_dict(), "best_model.pt")


### PR DESCRIPTION
**Summary**

Update `examples/rdl.py` to work with RelBench 3.0.

RelBench 3.0 changed the dataset loading API, so the example is updated to use the new API.

Without this fix, this test fails on NVidia version 26.09 when building with relbench 3.0:
```
Traceback (most recent call last):
  File "/workspace/examples/rdl.py", line 20, in <module>
    from relbench.datasets import get_dataset, get_dataset_names
ModuleNotFoundError: No module named 'relbench.datasets'
```

This is a replacement for [PR#10790](https://github.com/pyg-team/pytorch_geometric/pull/10790): **fix: make examples/rdl.py compatible with RelBench 2.x and 3.x**