### PR TITLE
Fix `negative_sampling` when no negative samples are requested

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- Fixed `negative_sampling` returning a float `edge_index` (and raising for `method="dense"`) when the number of requested samples rounds down to zero ([#10794](https://github.com/pyg-team/pytorch_geometric/pull/10794))
 - Fixed `config_store` on Python 3.14, where `typing.Union`/`typing.Optional` annotations could no longer be remapped in-place via the now read-only `__args__` attribute
 
 ### Security

--- a/test/utils/test_negative_sampling.py
+++ b/test/utils/test_negative_sampling.py
@@ -1,3 +1,4 @@
+import pytest
 import torch
 
 from torch_geometric.utils import (
@@ -11,6 +12,7 @@ from torch_geometric.utils import (
 )
 from torch_geometric.utils._negative_sampling import (
     edge_index_to_vector,
+    sample,
     vector_to_edge_index,
 )
 
@@ -186,3 +188,34 @@ def test_structured_negative_sampling_feasible():
     assert not structured_negative_sampling_feasible(edge_index, 3, False)
     assert structured_negative_sampling_feasible(edge_index, 3, True)
     assert structured_negative_sampling_feasible(edge_index, 4, False)
+
+
+def test_sample_dtype():
+    assert sample(population=10, k=3).dtype == torch.long
+    assert sample(population=10, k=0).dtype == torch.long
+    assert sample(population=0, k=0).dtype == torch.long
+
+
+@pytest.mark.parametrize('method', ['sparse', 'dense'])
+@pytest.mark.parametrize('num_neg_samples', [0, 0.2])
+def test_negative_sampling_without_samples(method, num_neg_samples):
+    edge_index = torch.tensor([[0, 1, 2], [1, 2, 0]])
+
+    neg_edge_index = negative_sampling(edge_index, num_nodes=4, method=method,
+                                       num_neg_samples=num_neg_samples)
+
+    assert neg_edge_index.size() == (2, 0)
+    assert neg_edge_index.dtype == edge_index.dtype
+
+
+@pytest.mark.parametrize('method', ['sparse', 'dense'])
+def test_negative_sampling_force_undirected_single_edge(method):
+    # `force_undirected` halves the number of requested samples, which rounds
+    # down to zero for a single edge:
+    edge_index = torch.tensor([[0], [1]])
+
+    neg_edge_index = negative_sampling(edge_index, num_nodes=4, method=method,
+                                       force_undirected=True)
+
+    assert neg_edge_index.size() == (2, 0)
+    assert neg_edge_index.dtype == edge_index.dtype

--- a/torch_geometric/utils/_negative_sampling.py
+++ b/torch_geometric/utils/_negative_sampling.py
@@ -326,7 +326,8 @@ def sample(
     if population <= k:
         return torch.arange(population, device=device)
     else:
-        return torch.tensor(random.sample(range(population), k), device=device)
+        return torch.tensor(random.sample(range(population), k),
+                            dtype=torch.long, device=device)
 
 
 def edge_index_to_vector(


### PR DESCRIPTION
## Problem

`sample()` in `torch_geometric/utils/_negative_sampling.py` builds its result with `torch.tensor(random.sample(...))`. When the requested sample size is `0`, `random.sample` returns `[]` and `torch.tensor([])` falls back to the default float dtype. The other branch returns `torch.arange(population)`, which is `int64`, so the two branches disagree as soon as `k == 0`.

Everything downstream assumes an integer index tensor, so whenever the number of requested negative samples rounds down to zero:

- `method="sparse"` silently returns a **float** edge index instead of an integer one
- `method="dense"` uses it to index a mask and raises `IndexError: tensors used as indices must be long, int, byte or bool tensors`
- `force_undirected=True` raises in both methods, since `vector_to_edge_index` does an in place `add_` of the float tensor into a long one (`RuntimeError: result type Float can't be cast to the desired output type Long`)

## Reproduction

```python
import torch
from torch_geometric.utils import negative_sampling

edge_index = torch.tensor([[0, 1, 2], [1, 2, 0]])

# 1. silently returns a float edge index
negative_sampling(edge_index, num_nodes=4, num_neg_samples=0).dtype
# torch.float32

# 2. a ratio that rounds down to zero, same thing
negative_sampling(edge_index, num_nodes=4, num_neg_samples=0.2).dtype
# torch.float32

# 3. dense raises
negative_sampling(edge_index, num_nodes=4, num_neg_samples=0, method="dense")
# IndexError: tensors used as indices must be long, int, byte or bool tensors

# 4. force_undirected halves the count, so a single edge rounds to zero
negative_sampling(torch.tensor([[0], [1]]), num_nodes=4, force_undirected=True)
# RuntimeError: result type Float can't be cast to the desired output type Long
```

Case 4 is the one I hit first: `force_undirected` does `num_neg_samples = num_neg_samples // 2`, so any graph with a single edge trips it.

## Fix

Pass `dtype=torch.long` explicitly in `sample()` so both branches return the same dtype.

## Tests

Added `test_sample_dtype`, `test_negative_sampling_without_samples` (parametrized over both methods and over `num_neg_samples` of `0` and `0.2`) and `test_negative_sampling_force_undirected_single_edge`. Seven of the new cases fail on `master` and pass with the fix. `test/utils/` is green (251 passed, 70 skipped).
