### PR TITLE
Fix TorchScript support of `GATConv` and `GATv2Conv`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- Fixed TorchScript support of `GATConv` and `GATv2Conv` after the `return_attention_weights` change ([#10796](https://github.com/pyg-team/pytorch_geometric/pull/10796))
 - Fixed `config_store` on Python 3.14, where `typing.Union`/`typing.Optional` annotations could no longer be remapped in-place via the now read-only `__args__` attribute
 
 ### Security

--- a/test/nn/conv/test_gat_conv.py
+++ b/test/nn/conv/test_gat_conv.py
@@ -58,6 +58,10 @@ def test_gat_conv(residual):
     assert result[1][1].size() == (7, 2)
     assert result[1][1].min() >= 0 and result[1][1].max() <= 1
 
+    result = conv(x1, edge_index, return_attention_weights=False)
+    assert isinstance(result, Tensor)
+    assert torch.allclose(result, out)
+
     result = conv(x1, adj1.t(), return_attention_weights=True)
     assert torch.allclose(result[0], out, atol=1e-6)
     assert result[1][0].size() == torch.Size([4, 4, 2])

--- a/test/nn/conv/test_gatv2_conv.py
+++ b/test/nn/conv/test_gatv2_conv.py
@@ -56,6 +56,10 @@ def test_gatv2_conv(residual):
     assert result[1][1].size() == (7, 2)
     assert result[1][1].min() >= 0 and result[1][1].max() <= 1
 
+    result = conv(x1, edge_index, return_attention_weights=False)
+    assert isinstance(result, Tensor)
+    assert torch.allclose(result, out)
+
     result = conv(x1, adj1.t(), return_attention_weights=True)
     assert torch.allclose(result[0], out, atol=1e-6)
     assert result[1][0].size() == torch.Size([4, 4, 2])

--- a/torch_geometric/nn/conv/gat_conv.py
+++ b/torch_geometric/nn/conv/gat_conv.py
@@ -273,13 +273,12 @@ class GATConv(MessagePassing):
                 (default: :obj:`None`)
             size ((int, int), optional): The shape of the adjacency matrix.
                 (default: :obj:`None`)
-            return_attention_weights (bool, optional):
-                Will additionally return the tuple
-                :obj:`(edge_index, attention_weights)` whenever it is set to
-                a value, regardless of its actual value
-                (might be `True` or `False`), holding the computed attention
-                weights for each edge.
-                (default: :obj:`None`)
+            return_attention_weights (bool, optional): If set to :obj:`True`,
+                will additionally return the tuple
+                :obj:`(edge_index, attention_weights)`, holding the computed
+                attention weights for each edge. Under TorchScript, passing
+                :obj:`False` still returns the tuple, since scripting cannot
+                branch on the value. (default: :obj:`None`)
         """
         H, C = self.heads, self.out_channels
 
@@ -371,7 +370,9 @@ class GATConv(MessagePassing):
         if self.bias is not None:
             out = out + self.bias
 
-        if return_attention_weights:
+        if isinstance(return_attention_weights, bool):
+            if not torch.jit.is_scripting() and not return_attention_weights:
+                return out
             if isinstance(edge_index, Tensor):
                 if is_torch_sparse_tensor(edge_index):
                     # TODO TorchScript requires to return a tuple

--- a/torch_geometric/nn/conv/gatv2_conv.py
+++ b/torch_geometric/nn/conv/gatv2_conv.py
@@ -266,13 +266,12 @@ class GATv2Conv(MessagePassing):
             edge_index (torch.Tensor or SparseTensor): The edge indices.
             edge_attr (torch.Tensor, optional): The edge features.
                 (default: :obj:`None`)
-            return_attention_weights (bool, optional):
-                Will additionally return the tuple
-                :obj:`(edge_index, attention_weights)` whenever it is set to
-                a value, regardless of its actual value
-                (might be `True` or `False`), holding the computed attention
-                weights for each edge.
-                (default: :obj:`None`)
+            return_attention_weights (bool, optional): If set to :obj:`True`,
+                will additionally return the tuple
+                :obj:`(edge_index, attention_weights)`, holding the computed
+                attention weights for each edge. Under TorchScript, passing
+                :obj:`False` still returns the tuple, since scripting cannot
+                branch on the value. (default: :obj:`None`)
         """
         H, C = self.heads, self.out_channels
 
@@ -342,7 +341,9 @@ class GATv2Conv(MessagePassing):
         if self.bias is not None:
             out = out + self.bias
 
-        if return_attention_weights:
+        if isinstance(return_attention_weights, bool):
+            if not torch.jit.is_scripting() and not return_attention_weights:
+                return out
             if isinstance(edge_index, Tensor):
                 if is_torch_sparse_tensor(edge_index):
                     # TODO TorchScript requires to return a tuple


### PR DESCRIPTION
Reworked from the test-deletion version. #10596 fixed `return_attention_weights=False` to return a plain tensor, but the resulting `if return_attention_weights:` doesn't script on the `bool` overload, so the FULL TorchScript tests for `GATConv`/`GATv2Conv` (and `AttentiveFP`/`SAGPooling` on top of them) have been red on master since. This guards on `isinstance(return_attention_weights, bool)` and only takes the early tensor return outside of scripting, so eager keeps the fixed semantics and TorchScript keeps its static tuple overload. One limitation, now in the docstring: under TorchScript passing `False` still returns the tuple, since scripting can't branch on the value. I kept the TorchScript tests instead of deleting them, same call as #10747. This is the same `isinstance(return_attention_weights, bool)` guard as akihironitta's draft #10728, plus the early return so eager `False` keeps returning a plain tensor per #10596; the eager `False -> Tensor` asserts stay as the regression guard. `FULL_TEST=1` on the six GAT-related test files: master 6 failed / 73 passed, this branch 79 passed; `torch.compile(fullgraph=True)` allclose on both convs.
