### PR TITLE
fix: avoid tensor fill values in ONNX scatter path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- Fixed ONNX export for `scatter(reduce="min"/"max")` with older PyTorch versions
 - Fixed `config_store` on Python 3.14, where `typing.Union`/`typing.Optional` annotations could no longer be remapped in-place via the now read-only `__args__` attribute
 
 ### Security

--- a/test/utils/test_scatter.py
+++ b/test/utils/test_scatter.py
@@ -90,7 +90,7 @@ def test_scatter_onnx_export(reduce, expected):
 
     with patch('torch_geometric.utils._scatter.is_in_onnx_export',
                return_value=True), patch('torch.full',
-                                          side_effect=full_scalar_only):
+                                         side_effect=full_scalar_only):
         out = scatter(src, index, dim=0, dim_size=3, reduce=reduce)
 
     assert torch.equal(out, torch.tensor(expected))

--- a/test/utils/test_scatter.py
+++ b/test/utils/test_scatter.py
@@ -1,4 +1,5 @@
 from itertools import product
+from unittest.mock import patch
 
 import pytest
 import torch
@@ -70,6 +71,29 @@ def test_scatter_backward(reduce, device):
     assert src.grad is None
     out.mean().backward()
     assert src.grad is not None
+
+
+@pytest.mark.parametrize('reduce,expected', [
+    ('min', [0., 0., 0.]),
+    ('max', [3., 4., 2.]),
+])
+def test_scatter_onnx_export(reduce, expected):
+    src = torch.tensor([1., 4., 3., 2.])
+    index = torch.tensor([0, 1, 0, 2])
+
+    original_full = torch.full
+
+    def full_scalar_only(size, fill_value, *args, **kwargs):
+        if torch.is_tensor(fill_value):
+            raise TypeError('fill_value must be a scalar')
+        return original_full(size, fill_value, *args, **kwargs)
+
+    with patch('torch_geometric.utils._scatter.is_in_onnx_export',
+               return_value=True), patch('torch.full',
+                                          side_effect=full_scalar_only):
+        out = scatter(src, index, dim=0, dim_size=3, reduce=reduce)
+
+    assert torch.equal(out, torch.tensor(expected))
 
 
 @withDevice

--- a/torch_geometric/utils/_scatter.py
+++ b/torch_geometric/utils/_scatter.py
@@ -99,12 +99,8 @@ def scatter(
                     dim, index, src, reduce=f'a{reduce[-3:]}',
                     include_self=False)
 
-            fill = torch.full(  # type: ignore
-                size=(1, ),
-                fill_value=src.min() if 'max' in reduce else src.max(),
-                dtype=src.dtype,
-                device=src.device,
-            ).expand_as(src)
+            fill_value = src.min() if 'max' in reduce else src.max()
+            fill = fill_value.reshape(1).expand_as(src)
             out = src.new_zeros(size).scatter_reduce_(dim, index, fill,
                                                       reduce=f'a{reduce[-3:]}',
                                                       include_self=True)


### PR DESCRIPTION
Fixes #10327

### Summary

The ONNX-specific min/max scatter path passed src.min() or src.max() (a zero-dimensional Tensor) as the fill_value to torch.full. Older PyTorch versions reject Tensor-valued fill arguments during ONNX export.

This change creates the same dynamically computed fill tensor with reshape(1).expand_as(src), preserving the source dtype and device without converting the value to a Python scalar.

### Tests

- pytest test/utils/test_scatter.py -k onnx_export -q
- pytest test/utils/test_scatter.py -q
- pytest test/metrics/test_link_pred_metric.py -q
- ruff check torch_geometric/utils/_scatter.py test/utils/test_scatter.py
- git diff --check

The local scatter test suite reports 23 passed and 10 skipped because the optional torch-scatter package is not installed.