### PR TITLE
Fix `APPNP` applying edge dropout cumulatively across propagation steps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- Fixed `APPNP` applying edge dropout cumulatively across propagation steps instead of resampling it at each step ([#10803](https://github.com/pyg-team/pytorch_geometric/pull/10803))
 - Fixed `config_store` on Python 3.14, where `typing.Union`/`typing.Optional` annotations could no longer be remapped in-place via the now read-only `__args__` attribute
 
 ### Security

--- a/test/nn/conv/test_appnp.py
+++ b/test/nn/conv/test_appnp.py
@@ -1,10 +1,12 @@
+import pytest
 import torch
+from torch import Tensor
 
 import torch_geometric.typing
 from torch_geometric.nn import APPNP
 from torch_geometric.testing import is_full_test
 from torch_geometric.typing import SparseTensor
-from torch_geometric.utils import to_torch_csc_tensor
+from torch_geometric.utils import to_edge_index, to_torch_csc_tensor
 
 
 def test_appnp():
@@ -55,3 +57,89 @@ def test_appnp_dropout():
     if torch_geometric.typing.WITH_TORCH_SPARSE:
         adj2 = SparseTensor.from_edge_index(edge_index, sparse_sizes=(4, 4))
         assert torch.allclose(0.1 * x, conv(x, adj2.t()), rtol=1e-5, atol=1e-6)
+
+
+def _propagated_edge_weights(conv, x, edge_index):
+    """The edge weights APPNP actually propagates with, one tensor per step."""
+    per_step = []
+
+    def hook(module, inputs):
+        adj, kwargs = inputs[0], inputs[-1]
+        if isinstance(adj, Tensor) and adj.is_sparse_csr:
+            _, value = to_edge_index(adj)
+        elif isinstance(adj, SparseTensor):
+            value = adj.storage.value()
+        else:
+            value = kwargs['edge_weight']
+        per_step.append(value.detach().clone())
+
+    handle = conv.register_propagate_forward_pre_hook(hook)
+    try:
+        conv(x, edge_index)
+    finally:
+        handle.remove()
+
+    return per_step
+
+
+@pytest.mark.parametrize('adj_type', ['edge_index', 'torch_sparse', 'sparse'])
+def test_appnp_dropout_is_resampled_each_step(adj_type):
+    """Edge dropout must be drawn afresh at every propagation step.
+
+    Applying it to the previous step's already-thinned weights
+    compounds the mask, so an edge survives with probability
+    (1 - p) ** K instead of (1 - p), and the 1 / (1 - p) rescaling
+    stacks on the few survivors.
+    """
+    if adj_type == 'sparse' and not torch_geometric.typing.WITH_TORCH_SPARSE:
+        pytest.skip('torch-sparse not installed')
+
+    num_nodes, num_edges = 64, 512
+    torch.manual_seed(12345)
+    x = torch.randn(num_nodes, 8)
+    edge_index = torch.randint(0, num_nodes, (2, num_edges))
+
+    if adj_type == 'edge_index':
+        adj = edge_index
+    elif adj_type == 'torch_sparse':
+        adj = to_torch_csc_tensor(edge_index, size=(num_nodes, num_nodes)).t()
+    else:
+        adj = SparseTensor.from_edge_index(edge_index,
+                                           sparse_sizes=(num_nodes,
+                                                         num_nodes)).t()
+
+    conv = APPNP(K=4, alpha=0.1, dropout=0.5)
+    per_step = _propagated_edge_weights(conv, x, adj)
+    assert len(per_step) == 4
+
+    surviving = [w != 0 for w in per_step]
+
+    # Compounding shows up as strict nesting: every later step's
+    # survivors are a subset of the previous step's.
+    for step, (previous, current) in enumerate(zip(surviving, surviving[1:])):
+        revived = int((current & ~previous).sum())
+        assert revived > 0, (
+            f'step {step + 1} kept no edge that step {step} had '
+            f'dropped, so dropout was applied on top of the previous '
+            f'step rather than resampled')
+
+    # Each step keeps roughly half the edges, not 1 / 2 ** k of them.
+    for step, mask in enumerate(surviving):
+        kept = int(mask.sum())
+        assert 0.3 < kept / mask.numel() < 0.7, (
+            f'step {step} kept {kept}/{mask.numel()} edges')
+
+
+def test_appnp_dropout_leaves_input_untouched():
+    """A forward pass must not consume the weights it was handed."""
+    num_nodes, num_edges = 32, 256
+    torch.manual_seed(12345)
+    x = torch.randn(num_nodes, 8)
+    edge_index = torch.randint(0, num_nodes, (2, num_edges))
+    edge_weight = torch.rand(num_edges)
+    expected = edge_weight.clone()
+
+    conv = APPNP(K=4, alpha=0.1, dropout=0.5, normalize=False)
+    conv(x, edge_index, edge_weight)
+
+    assert torch.equal(edge_weight, expected)

--- a/torch_geometric/nn/conv/appnp.py
+++ b/torch_geometric/nn/conv/appnp.py
@@ -110,23 +110,33 @@ class APPNP(MessagePassing):
 
         h = x
         for _ in range(self.K):
+            # Dropout is drawn afresh from the normalized weights at
+            # every step. Writing it back into `edge_index`/`edge_weight`
+            # would compound the mask instead, so an edge would survive
+            # all `K` steps with probability `(1 - p) ** K` rather than
+            # `1 - p`, and the `1 / (1 - p)` rescaling would stack on
+            # the few survivors:
+            step_edge_index = edge_index
+            step_edge_weight = edge_weight
             if self.dropout > 0 and self.training:
                 if isinstance(edge_index, Tensor):
                     if is_torch_sparse_tensor(edge_index):
-                        _, edge_weight = to_edge_index(edge_index)
-                        edge_weight = F.dropout(edge_weight, p=self.dropout)
-                        edge_index = set_sparse_value(edge_index, edge_weight)
+                        _, value = to_edge_index(edge_index)
+                        value = F.dropout(value, p=self.dropout)
+                        step_edge_index = set_sparse_value(edge_index, value)
                     else:
                         assert edge_weight is not None
-                        edge_weight = F.dropout(edge_weight, p=self.dropout)
+                        step_edge_weight = F.dropout(edge_weight,
+                                                     p=self.dropout)
                 else:
                     value = edge_index.storage.value()
                     assert value is not None
                     value = F.dropout(value, p=self.dropout)
-                    edge_index = edge_index.set_value(value, layout='coo')
+                    step_edge_index = edge_index.set_value(value, layout='coo')
 
             # propagate_type: (x: Tensor, edge_weight: OptTensor)
-            x = self.propagate(edge_index, x=x, edge_weight=edge_weight)
+            x = self.propagate(step_edge_index, x=x,
+                               edge_weight=step_edge_weight)
             x = x * (1 - self.alpha)
             x = x + self.alpha * h
 


### PR DESCRIPTION
Closes #10783.

## Problem

`APPNP.forward` wrote each step's dropout result back into `edge_index` / `edge_weight`, so step `k+1` sampled from step `k`'s already-thinned weights rather than from the normalized ones. Two consequences, both as the reporter described:

- an edge survives all `K` steps with probability `(1 - p) ** K` instead of `1 - p`, so most edges are gone after a few iterations;
- the `1 / (1 - p)` rescaling stacks on the shrinking set of survivors, so their weights grow without bound — which is where the NaNs come from.

The issue reports the dense branch and says the fix for the others wasn't clear. **All three input paths had it**, for the same reason:

| path | how it compounded |
|---|---|
| dense `Tensor` | `edge_weight = F.dropout(edge_weight, ...)` rebinds the name each step |
| `is_torch_sparse_tensor` | reads values back out of the `edge_index` it overwrote via `set_sparse_value` on the previous step |
| `SparseTensor` | same, through `storage.value()` after `set_value` |

## Fix

Rather than carrying the reported patch's `original_edge_weight` (which fixes only the dense path), the loop simply stops rebinding its inputs. Each step derives a local `step_edge_index` / `step_edge_weight` from the pristine normalized values and propagates with those, so dropout is drawn afresh every step on every path. `edge_index` and `edge_weight` are now read-only inside the loop, which is what makes all three branches correct at once.

## Tests

`test_appnp_dropout_is_resampled_each_step`, parametrized over all three adjacency types, captures the weights actually propagated at each step through `register_propagate_forward_pre_hook` and asserts:

- **no strict nesting** — each step keeps at least one edge the previous step had dropped. This is the exact signature of the bug: with compounding, survivors are always a subset of the previous step's.
- **each step keeps roughly half the edges** at `p=0.5`, rather than `1 / 2 ** k` of them.

Seeded, so it's deterministic rather than statistical. On `master` both runnable parametrizations fail with

```
AssertionError: step 1 kept no edge that step 0 had dropped, so dropout was
applied on top of the previous step rather than resampled
```

and pass with the fix. `test_appnp_dropout_leaves_input_untouched` pins that a forward pass doesn't consume the caller's `edge_weight` — it passes before and after, and guards the restructuring.

## Verification

- `test/nn/conv/test_appnp.py`: 5 passed, 1 skipped (the `torch_sparse` parametrization — `torch-sparse` isn't installed here, so that one path is covered by CI rather than by me locally).
- `test/nn/conv/`: 268 passed, 379 skipped, no regressions.
- `FULL_TEST=1` passes, so `torch.jit.script` still compiles the rewritten loop — worth stating since the change introduces a new `Adj`-typed local inside it.
- `yapf`, `flake8`, `isort` and `ruff` clean at the pinned pre-commit versions.

`APPNP` has no other in-tree callers, so the blast radius is the layer itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NxphSQWkGcC4sgncbRU64C
