### PR TITLE
Make `MoleculeGPTDataset.download()` robust to PubChem errors and interrupted runs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- Fixed `MoleculeGPTDataset` crashing with `KeyError: 'Annotations'` when PubChem answers with a `PUGVIEW.ServerBusy` fault, by retrying the request with backoff ([#10804](https://github.com/pyg-team/pytorch_geometric/pull/10804))
 - Fixed `config_store` on Python 3.14, where `typing.Union`/`typing.Optional` annotations could no longer be remapped in-place via the now read-only `__args__` attribute
 
 ### Security

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
-- Fixed `MoleculeGPTDataset` crashing with `KeyError: 'Annotations'` when PubChem answers with a `PUGVIEW.ServerBusy` fault, by retrying the request with backoff ([#10804](https://github.com/pyg-team/pytorch_geometric/pull/10804))
+- Fixed `MoleculeGPTDataset.download()` crashing with `KeyError: 'Annotations'` when PubChem is busy: transient PubChem errors are now retried with backoff, Step 01 is redone after a failed run, and the download stops at PubChem's last page ([#10804](https://github.com/pyg-team/pytorch_geometric/pull/10804))
 - Fixed `config_store` on Python 3.14, where `typing.Union`/`typing.Optional` annotations could no longer be remapped in-place via the now read-only `__args__` attribute
 
 ### Security

--- a/test/datasets/test_molecule_gpt_dataset.py
+++ b/test/datasets/test_molecule_gpt_dataset.py
@@ -1,49 +1,120 @@
-import pytest
+import time
+from typing import Any, List
 
-from torch_geometric.datasets import MoleculeGPTDataset, molecule_gpt_dataset
+import pytest
+import requests
+
+from torch_geometric.datasets import MoleculeGPTDataset
+from torch_geometric.datasets.molecule_gpt_dataset import _get_pubchem_json
 from torch_geometric.testing import withPackage
+
+BUSY = {
+    'Fault': {
+        'Code': 'PUGVIEW.ServerBusy',
+        'Message': 'Too many requests or server too busy',
+    }
+}
+NOT_FOUND = {'Fault': {'Code': 'PUGVIEW.NotFound', 'Message': 'No data'}}
+PAGE = {'Annotations': {'Page': 1, 'Annotation': []}}
 
 
 class _Response:
-    def __init__(self, status_code: int, payload: dict):
+    def __init__(self, status_code: int, payload: Any):
         self.status_code = status_code
         self.ok = status_code < 400
-        self.reason = 'OK' if self.ok else 'Service Unavailable'
+        self.reason = 'OK' if self.ok else 'Error'
         self._payload = payload
 
-    def json(self) -> dict:
+    def json(self) -> Any:
+        if isinstance(self._payload, str):
+            raise ValueError('Expecting value')
         return self._payload
 
 
-def test_get_pubchem_json_retries_on_server_busy(monkeypatch):
-    fault = {
-        'Fault': {
-            'Code': 'PUGVIEW.ServerBusy',
-            'Message': 'Too many requests or server too busy',
-        }
-    }
-    page = {'Annotations': {'Page': 1, 'Annotation': []}}
-    responses = [
-        _Response(503, fault),
-        _Response(503, fault),
-        _Response(200, page)
-    ]
-    urls = []
+def _mock_pubchem(monkeypatch, responses: List[Any]):
+    calls: List[str] = []
+    sleeps: List[float] = []
 
-    def get(url):
-        urls.append(url)
-        return responses.pop(0)
+    def get(url, timeout):
+        calls.append(url)
+        response = responses.pop(0)
+        if isinstance(response, Exception):
+            raise response
+        return response
 
-    monkeypatch.setattr(molecule_gpt_dataset.requests, 'get', get)
-    monkeypatch.setattr(molecule_gpt_dataset.time, 'sleep', lambda _: None)
+    monkeypatch.setattr(requests, 'get', get)
+    monkeypatch.setattr(time, 'sleep', sleeps.append)
+    return calls, sleeps
 
-    out = molecule_gpt_dataset._get_pubchem_json('url', num_retries=2)
-    assert out == page
-    assert urls == ['url'] * 3
 
-    responses[:] = [_Response(503, fault)] * 3
-    with pytest.raises(RuntimeError, match='PUGVIEW.ServerBusy'):
-        molecule_gpt_dataset._get_pubchem_json('url', num_retries=2)
+def test_get_pubchem_json_retries_transient_errors(monkeypatch):
+    calls, sleeps = _mock_pubchem(monkeypatch, [
+        _Response(503, BUSY),
+        requests.ConnectionError('conn reset'),
+        requests.ReadTimeout('read timed out'),
+        requests.exceptions.ChunkedEncodingError('IncompleteRead'),
+        requests.exceptions.ContentDecodingError('bad gzip'),
+        _Response(502, '<html>Bad Gateway</html>'),
+        _Response(200, PAGE),
+    ])
+    out = _get_pubchem_json('url', num_retries=6, delay=1.0)
+    assert out == PAGE
+    assert calls == ['url'] * 7
+    assert sleeps == [1.0, 2.0, 4.0, 8.0, 16.0, 32.0]
+
+
+def test_get_pubchem_json_raises_after_retries(monkeypatch):
+    calls, sleeps = _mock_pubchem(monkeypatch, [_Response(503, BUSY)] * 3)
+    with pytest.raises(RuntimeError, match='PUGVIEW.ServerBusy.*3 attempts'):
+        _get_pubchem_json('url', num_retries=2)
+    assert len(calls) == 3
+    assert len(sleeps) == 2
+
+    calls, _ = _mock_pubchem(monkeypatch, [])
+    with pytest.raises(ValueError, match='non-negative'):
+        _get_pubchem_json('url', num_retries=-1)
+    assert calls == []
+
+
+@pytest.mark.parametrize('response', [
+    _Response(404, NOT_FOUND),
+    _Response(400, '<html>Bad Request</html>'),
+    _Response(200, NOT_FOUND),
+])
+def test_get_pubchem_json_fails_fast(monkeypatch, response):
+    calls, sleeps = _mock_pubchem(monkeypatch, [response])
+    match = f'HTTP {response.status_code} .*after 1 attempt$'
+    with pytest.raises(RuntimeError, match=match):
+        _get_pubchem_json('url')
+    assert len(calls) == 1
+    assert sleeps == []
+
+
+@pytest.mark.parametrize('payload', [None, {}, [1, 2, 3], '{"Annot'])
+def test_get_pubchem_json_retries_malformed_body(monkeypatch, payload):
+    # A `2xx` without a JSON object body is a truncated/garbled transfer:
+    calls, sleeps = _mock_pubchem(monkeypatch, [
+        _Response(200, payload),
+        _Response(200, PAGE),
+    ])
+    out = _get_pubchem_json('url', delay=1.0)
+    assert out == PAGE
+    assert len(calls) == 2
+    assert sleeps == [1.0]
+
+    calls, _ = _mock_pubchem(monkeypatch, [_Response(200, payload)] * 2)
+    with pytest.raises(RuntimeError, match='HTTP 200 .*malformed body.*'
+                       '2 attempts'):
+        _get_pubchem_json('url', num_retries=1)
+    assert len(calls) == 2
+
+
+@pytest.mark.parametrize('payload', [None, [1, 2], 'not json', {'Fault': 'x'}])
+def test_get_pubchem_json_non_dict_error_body(monkeypatch, payload):
+    calls, _ = _mock_pubchem(monkeypatch, [_Response(503, payload)] * 2)
+    with pytest.raises(RuntimeError, match='HTTP 503 .*2 attempts'):
+        _get_pubchem_json('url', num_retries=1)
+    assert len(calls) == 2
 
 
 @pytest.mark.dataset

--- a/test/datasets/test_molecule_gpt_dataset.py
+++ b/test/datasets/test_molecule_gpt_dataset.py
@@ -1,4 +1,7 @@
+import json
+import os
 import time
+import warnings
 from typing import Any, List
 
 import pytest
@@ -115,6 +118,123 @@ def test_get_pubchem_json_non_dict_error_body(monkeypatch, payload):
     with pytest.raises(RuntimeError, match='HTTP 503 .*2 attempts'):
         _get_pubchem_json('url', num_retries=1)
     assert len(calls) == 2
+
+
+def test_download_redoes_step_01_after_failure(monkeypatch, tmp_path):
+    dataset = MoleculeGPTDataset.__new__(MoleculeGPTDataset)
+    dataset.root = str(tmp_path)
+    dataset.total_page_num = 1
+    dataset.total_block_num = 0
+
+    # A run that dies on PubChem must not leave a raw dir that skips Step 01:
+    _mock_pubchem(monkeypatch, [_Response(503, BUSY)] * 6)
+    with pytest.raises(RuntimeError, match='PUGVIEW.ServerBusy'):
+        dataset.download()
+    assert not os.path.exists(f'{dataset.raw_dir}/CID2text.json')
+    step1_folder = f'{dataset.raw_dir}/step_01_PubChemSTM_description'
+    page_file = f'{step1_folder}/Compound_description_1.txt'
+    assert not os.path.exists(page_file)
+
+    # A page file left behind by a previous, larger run must not survive the
+    # redo next to a `CID2text.json` that does not contain it:
+    stale_file = f'{step1_folder}/Compound_description_7.txt'
+    with open(stale_file, 'w') as f:
+        f.write('7\nstale\n\n')
+
+    # U+03B3 (Greek gamma) is not encodable in cp1252, the Windows default:
+    text = 'This molecule is wet (γ-form).'
+    value = {'StringWithMarkup': [{'String': 'Water is wet (γ-form).'}]}
+    record = {
+        'LinkedRecords': {
+            'CID': [1]
+        },
+        'Name': 'Water',
+        'Data': [{
+            'Value': value
+        }],
+    }
+    page = {'Annotations': {'Page': 1, 'Annotation': [record]}}
+    calls, _ = _mock_pubchem(monkeypatch, [_Response(200, page)])
+    dataset.download()
+    assert len(calls) == 1
+    with open(f'{dataset.raw_dir}/CID2text.json') as f:
+        assert json.load(f) == {'1': [text]}
+    with open(page_file, encoding='utf-8') as f:
+        assert f.read() == f'1\n{text}\n\n'
+    assert os.listdir(step1_folder) == ['Compound_description_1.txt']
+
+
+def test_download_writes_step_01_resume_key_atomically(monkeypatch, tmp_path):
+    dataset = MoleculeGPTDataset.__new__(MoleculeGPTDataset)
+    dataset.root = str(tmp_path)
+    dataset.total_page_num = 1
+    dataset.total_block_num = 0
+
+    # A run killed while `CID2text.json` is being written (Ctrl-C, disk full)
+    # must not leave a partial file behind, since its mere existence skips
+    # Step 01 on the next call, nor the temporary file it was written to:
+    json_dump = json.dump
+
+    def dump(obj, fp, **kwargs):
+        if os.path.basename(fp.name).startswith('CID2text.json'):
+            fp.write('{"1": ["Water is w')
+            raise OSError('No space left on device')
+        json_dump(obj, fp, **kwargs)
+
+    monkeypatch.setattr(json, 'dump', dump)
+    _mock_pubchem(monkeypatch, [_Response(200, PAGE)])
+    with pytest.raises(OSError, match='No space left'):
+        dataset.download()
+    assert not os.path.exists(f'{dataset.raw_dir}/CID2text.json')
+    assert not os.path.exists(f'{dataset.raw_dir}/CID2text.json.tmp')
+
+    monkeypatch.setattr(json, 'dump', json_dump)
+    calls, _ = _mock_pubchem(monkeypatch, [_Response(200, PAGE)])
+    dataset.download()
+    assert len(calls) == 1
+    with open(f'{dataset.raw_dir}/CID2text.json') as f:
+        assert json.load(f) == {}
+    assert sorted(os.listdir(dataset.raw_dir)) == [
+        'CID2name.json',
+        'CID2name_raw.json',
+        'CID2text.json',
+        'CID2text_raw.json',
+        'step_01_PubChemSTM_description',
+    ]
+
+
+def test_download_stops_at_last_pubchem_page(monkeypatch, tmp_path):
+    dataset = MoleculeGPTDataset.__new__(MoleculeGPTDataset)
+    dataset.root = str(tmp_path)
+    dataset.total_page_num = 3
+    dataset.total_block_num = 0
+
+    # Requesting a page past `TotalPages` is a permanent PubChem HTTP 500:
+    pages = [{
+        'Annotations': {
+            'Page': i,
+            'TotalPages': 2,
+            'Annotation': []
+        }
+    } for i in (1, 2)]
+    calls, sleeps = _mock_pubchem(monkeypatch,
+                                  [_Response(200, page) for page in pages])
+    with pytest.warns(UserWarning, match="'total_page_num=3' exceeds the 2"):
+        dataset.download()
+    assert len(calls) == 2
+    assert sleeps == []
+    assert os.path.exists(f'{dataset.raw_dir}/CID2text.json')
+
+    # Under a warnings-as-errors filter the warning must not discard the
+    # pages just downloaded, so it is emitted after Step 01 is written:
+    dataset.root = str(tmp_path / 'strict')
+    calls, _ = _mock_pubchem(monkeypatch,
+                             [_Response(200, page) for page in pages])
+    with warnings.catch_warnings(), pytest.raises(UserWarning):
+        warnings.simplefilter('error')
+        dataset.download()
+    assert len(calls) == 2
+    assert os.path.exists(f'{dataset.raw_dir}/CID2text.json')
 
 
 @pytest.mark.dataset

--- a/test/datasets/test_molecule_gpt_dataset.py
+++ b/test/datasets/test_molecule_gpt_dataset.py
@@ -1,7 +1,49 @@
 import pytest
 
-from torch_geometric.datasets import MoleculeGPTDataset
+from torch_geometric.datasets import MoleculeGPTDataset, molecule_gpt_dataset
 from torch_geometric.testing import withPackage
+
+
+class _Response:
+    def __init__(self, status_code: int, payload: dict):
+        self.status_code = status_code
+        self.ok = status_code < 400
+        self.reason = 'OK' if self.ok else 'Service Unavailable'
+        self._payload = payload
+
+    def json(self) -> dict:
+        return self._payload
+
+
+def test_get_pubchem_json_retries_on_server_busy(monkeypatch):
+    fault = {
+        'Fault': {
+            'Code': 'PUGVIEW.ServerBusy',
+            'Message': 'Too many requests or server too busy',
+        }
+    }
+    page = {'Annotations': {'Page': 1, 'Annotation': []}}
+    responses = [
+        _Response(503, fault),
+        _Response(503, fault),
+        _Response(200, page)
+    ]
+    urls = []
+
+    def get(url):
+        urls.append(url)
+        return responses.pop(0)
+
+    monkeypatch.setattr(molecule_gpt_dataset.requests, 'get', get)
+    monkeypatch.setattr(molecule_gpt_dataset.time, 'sleep', lambda _: None)
+
+    out = molecule_gpt_dataset._get_pubchem_json('url', num_retries=2)
+    assert out == page
+    assert urls == ['url'] * 3
+
+    responses[:] = [_Response(503, fault)] * 3
+    with pytest.raises(RuntimeError, match='PUGVIEW.ServerBusy'):
+        molecule_gpt_dataset._get_pubchem_json('url', num_retries=2)
 
 
 @pytest.mark.dataset

--- a/torch_geometric/datasets/molecule_gpt_dataset.py
+++ b/torch_geometric/datasets/molecule_gpt_dataset.py
@@ -3,6 +3,7 @@ import json
 import multiprocessing
 import os
 import sys
+import time
 from collections import defaultdict
 from multiprocessing import Pool
 from typing import Callable, List, Optional, Tuple
@@ -16,6 +17,39 @@ from torch_geometric.data import Data, InMemoryDataset, download_url
 from torch_geometric.io import fs
 from torch_geometric.llm.models import LLM
 from torch_geometric.utils import one_hot
+
+
+def _get_pubchem_json(
+    url: str,
+    num_retries: int = 5,
+    delay: float = 5.0,
+) -> dict:
+    r"""Fetches a PubChem PUG-View JSON page.
+
+    PubChem answers with HTTP 503 and a :obj:`{"Fault": {"Code":
+    "PUGVIEW.ServerBusy", ...}}` body (instead of the requested data) whenever
+    it is rate-limited or busy, so the request is retried with exponential
+    backoff before giving up with a descriptive error.
+    """
+    for attempt in range(num_retries + 1):
+        response = requests.get(url)
+        try:
+            data = response.json()
+        except ValueError:
+            data = {}
+
+        if response.ok and 'Fault' not in data:
+            return data
+
+        if attempt < num_retries:
+            time.sleep(delay * 2**attempt)
+
+    fault = data.get('Fault', {})
+    raise RuntimeError(
+        f"PubChem request to '{url}' failed with HTTP "
+        f"{response.status_code} ({fault.get('Code', 'unknown')}: "
+        f"{fault.get('Message', response.reason)}) after "
+        f"{num_retries + 1} attempts")
 
 
 def clean_up_description(description: str) -> str:
@@ -249,8 +283,8 @@ class MoleculeGPTDataset(InMemoryDataset):
                 f_out = open(
                     f"{step1_folder}/Compound_description_{page_num}.txt", "w")
 
-                description_data = requests.get(
-                    self.description_url.format(page_num)).json()
+                description_data = _get_pubchem_json(
+                    self.description_url.format(page_num))
 
                 description_data = description_data["Annotations"]
                 assert description_data["Page"] == page_num

--- a/torch_geometric/datasets/molecule_gpt_dataset.py
+++ b/torch_geometric/datasets/molecule_gpt_dataset.py
@@ -4,6 +4,7 @@ import multiprocessing
 import os
 import sys
 import time
+import warnings
 from collections import defaultdict
 from multiprocessing import Pool
 from typing import Any, Callable, Dict, List, Optional, Tuple
@@ -260,6 +261,7 @@ class MoleculeGPTDataset(InMemoryDataset):
         force_reload (bool, optional): Whether to re-process the dataset.
             (default: :obj:`False`)
         total_page_num (int, optional): The number of pages from PubChem.
+            The download stops early at the last page PubChem serves.
             (default: :obj:`10`)
         total_block_num (int, optional): The blocks of SDF files from PubChem.
             (default: :obj:`1`)
@@ -302,8 +304,15 @@ class MoleculeGPTDataset(InMemoryDataset):
 
     def download(self) -> None:
         # Step 01. Extract description
+        # Key the guard on the final artifact rather than the folder so that
+        # an interrupted or failed run does not get skipped on the next call:
         step1_folder = f"{self.raw_dir}/step_01_PubChemSTM_description"
-        if not os.path.exists(step1_folder):
+        if not os.path.exists(f"{self.raw_dir}/CID2text.json"):
+            # Drop the per-page files of a previous, failed or larger run so
+            # that the folder only holds the pages written alongside the
+            # JSON artifacts below:
+            if os.path.exists(step1_folder):
+                fs.rm(step1_folder)
             os.makedirs(step1_folder)
             valid_CID_set = set()
             CID2name_raw, CID2name_extracted = defaultdict(list), defaultdict(
@@ -311,11 +320,9 @@ class MoleculeGPTDataset(InMemoryDataset):
             CID2text_raw, CID2text_extracted = defaultdict(list), defaultdict(
                 list)
 
-            for page_index in tqdm(range(self.total_page_num)):
-                page_num = page_index + 1
-                f_out = open(
-                    f"{step1_folder}/Compound_description_{page_num}.txt", "w")
-
+            num_pages = self.total_page_num
+            pbar = tqdm(total=num_pages)
+            for page_num in range(1, num_pages + 1):
                 description_data = _get_pubchem_json(
                     self.description_url.format(page_num))
 
@@ -324,34 +331,52 @@ class MoleculeGPTDataset(InMemoryDataset):
 
                 record_list = description_data["Annotation"]
 
-                for record in record_list:
-                    try:
-                        CID = record["LinkedRecords"]["CID"][0]
-                        if "Name" in record:
-                            name_raw = record["Name"]
-                            CID2name_raw[CID].append(name_raw)
-                        else:
-                            name_raw = None
+                # Open the page file only after the request succeeded so a
+                # failed page leaves no empty file behind, and close it on
+                # every path. Descriptions contain characters outside the
+                # Windows locale encoding (e.g. Greek letters), so pin UTF-8:
+                with open(
+                        f"{step1_folder}/Compound_description_{page_num}.txt",
+                        "w", encoding="utf-8") as f_out:
+                    for record in record_list:
+                        try:
+                            CID = record["LinkedRecords"]["CID"][0]
+                            if "Name" in record:
+                                name_raw = record["Name"]
+                                CID2name_raw[CID].append(name_raw)
+                            else:
+                                name_raw = None
 
-                        data_list = record["Data"]
-                        for data in data_list:
-                            description = data["Value"]["StringWithMarkup"][0][
-                                "String"].strip()
+                            data_list = record["Data"]
+                            for data in data_list:
+                                description = data["Value"][
+                                    "StringWithMarkup"][0]["String"].strip()
 
-                            extracted_name, extracted_description, _ = extract_name(  # noqa: E501
-                                name_raw, description)
-                            if extracted_name is not None:
-                                CID2name_extracted[CID].append(extracted_name)
+                                extracted_name, extracted_description, _ = extract_name(  # noqa: E501
+                                    name_raw, description)
+                                if extracted_name is not None:
+                                    CID2name_extracted[CID].append(
+                                        extracted_name)
 
-                            CID2text_raw[CID].append(description)
-                            CID2text_extracted[CID].append(
-                                extracted_description)
+                                CID2text_raw[CID].append(description)
+                                CID2text_extracted[CID].append(
+                                    extracted_description)
 
-                            valid_CID_set.add(CID)
-                            f_out.write(f"{CID}\n")
-                            f_out.write(f"{extracted_description}\n\n")
-                    except Exception:
-                        continue
+                                valid_CID_set.add(CID)
+                                f_out.write(f"{CID}\n")
+                                f_out.write(f"{extracted_description}\n\n")
+                        except Exception:
+                            continue
+                pbar.update()
+
+                # PubChem answers any page past `TotalPages` with a permanent
+                # HTTP 500, which `_get_pubchem_json` would retry for minutes,
+                # so stop after the last page it serves:
+                if page_num == description_data.get("TotalPages"):
+                    num_pages = page_num
+                    pbar.total = num_pages
+                    break
+            pbar.close()
 
             valid_CID_list = sorted(list(valid_CID_set))
             print(f"Total CID (with raw name) {len(CID2name_raw)}")
@@ -367,8 +392,27 @@ class MoleculeGPTDataset(InMemoryDataset):
             with open(f"{self.raw_dir}/CID2text_raw.json", "w") as f:
                 json.dump(CID2text_raw, f)
 
-            with open(f"{self.raw_dir}/CID2text.json", "w") as f:
-                json.dump(CID2text_extracted, f)
+            # `CID2text.json` is the resume key of the guard above, so write
+            # it last and atomically: a run killed while dumping it (Ctrl-C,
+            # disk full) must not leave a truncated file that skips Step 01 on
+            # the next call and then fails `json.load` in Step 03, nor a stray
+            # temporary file:
+            tmp_path = f"{self.raw_dir}/CID2text.json.tmp"
+            try:
+                with open(tmp_path, "w") as f:
+                    json.dump(CID2text_extracted, f)
+                os.replace(tmp_path, f"{self.raw_dir}/CID2text.json")
+            finally:
+                if os.path.exists(tmp_path):
+                    os.remove(tmp_path)
+
+            # Warn only once the artifacts are written so that a
+            # warnings-as-errors filter cannot discard the downloaded pages:
+            if num_pages < self.total_page_num:
+                warnings.warn(
+                    f"'total_page_num={self.total_page_num}' exceeds the "
+                    f"{num_pages} description pages PubChem serves; stopped "
+                    f"early", stacklevel=2)
 
         # Step 02. Download SDF Files
         step2_folder = f"{self.raw_dir}/step_02_PubChemSTM_SDF"

--- a/torch_geometric/datasets/molecule_gpt_dataset.py
+++ b/torch_geometric/datasets/molecule_gpt_dataset.py
@@ -6,7 +6,7 @@ import sys
 import time
 from collections import defaultdict
 from multiprocessing import Pool
-from typing import Callable, List, Optional, Tuple
+from typing import Any, Callable, Dict, List, Optional, Tuple
 
 import numpy as np
 import requests
@@ -23,33 +23,66 @@ def _get_pubchem_json(
     url: str,
     num_retries: int = 5,
     delay: float = 5.0,
-) -> dict:
+    timeout: float = 60.0,
+) -> Dict[str, Any]:
     r"""Fetches a PubChem PUG-View JSON page.
 
     PubChem answers with HTTP 503 and a :obj:`{"Fault": {"Code":
     "PUGVIEW.ServerBusy", ...}}` body (instead of the requested data) whenever
-    it is rate-limited or busy, so the request is retried with exponential
-    backoff before giving up with a descriptive error.
+    it is rate-limited or busy. Such responses, other :obj:`429`/:obj:`5xx`
+    responses, transport errors (connection, timeout, undecodable body) and
+    :obj:`2xx` responses whose body is not a JSON object (a body truncated in
+    transit) are retried with exponential backoff; anything else (or
+    exhausting the retries) raises a descriptive :class:`RuntimeError`.
     """
+    if num_retries < 0:
+        raise ValueError(f"'num_retries' must be non-negative "
+                         f"(got {num_retries})")
+    transient_errors = (
+        requests.ConnectionError,
+        requests.Timeout,
+        requests.exceptions.ChunkedEncodingError,
+        requests.exceptions.ContentDecodingError,
+    )
     for attempt in range(num_retries + 1):
-        response = requests.get(url)
         try:
-            data = response.json()
-        except ValueError:
-            data = {}
+            response = requests.get(url, timeout=timeout)
+        except transient_errors as e:
+            error, retryable = f'{type(e).__name__}: {e}', True
+        else:
+            try:
+                data = response.json()
+            except ValueError:
+                data = None
+            # A `2xx` whose body is not a JSON object was cut or garbled in
+            # transit (`urllib3<2` does not enforce `Content-Length`), so it
+            # is treated like a transport error:
+            malformed = not isinstance(data, dict) or not data
+            if malformed:
+                data = {}
+            elif response.ok and 'Fault' not in data:
+                return data
 
-        if response.ok and 'Fault' not in data:
-            return data
+            fault = data.get('Fault')
+            if not isinstance(fault, dict):
+                fault = {}
+            code = fault.get('Code', 'unknown')
+            reason = response.reason
+            if response.ok and malformed:
+                reason = 'malformed body'
+            error = (f"HTTP {response.status_code} ({code}: "
+                     f"{fault.get('Message', reason)})")
+            retryable = (response.status_code == 429
+                         or response.status_code >= 500
+                         or code == 'PUGVIEW.ServerBusy'
+                         or (response.ok and malformed))
 
-        if attempt < num_retries:
-            time.sleep(delay * 2**attempt)
+        if not retryable or attempt == num_retries:
+            break
+        time.sleep(delay * 2**attempt)
 
-    fault = data.get('Fault', {})
-    raise RuntimeError(
-        f"PubChem request to '{url}' failed with HTTP "
-        f"{response.status_code} ({fault.get('Code', 'unknown')}: "
-        f"{fault.get('Message', response.reason)}) after "
-        f"{num_retries + 1} attempts")
+    raise RuntimeError(f"PubChem request to '{url}' failed with {error} "
+                       f"after {attempt + 1} attempt{'s' if attempt else ''}")
 
 
 def clean_up_description(description: str) -> str:


### PR DESCRIPTION
PubChem answers with HTTP 503 + a `PUGVIEW.ServerBusy` fault when it's busy, which `MoleculeGPTDataset.download()` turned into `KeyError: 'Annotations'`. `_get_pubchem_json` now retries only transient errors (429/5xx/ServerBusy, transport errors, truncated 2xx bodies) with backoff and fails fast otherwise. Step 01 is also keyed on `CID2text.json` (written atomically) instead of the folder, so an interrupted run gets redone instead of skipped, and the page loop stops at PubChem's `TotalPages` instead of retrying permanent 500s. Tests cover the retry policy and the Step 01 redo; 16 passed locally.
