### PR TITLE
Make the number of loader workers in `glem.py` configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
+- Added a `--num_workers` option to `examples/llm/glem.py` ([#10805](https://github.com/pyg-team/pytorch_geometric/pull/10805))
 - Improved error handling in `txt2kg` multi-process execution. ([#10771](https://github.com/pyg-team/pytorch_geometric/pull/10771))
 
 ### Deprecated

--- a/examples/llm/glem.py
+++ b/examples/llm/glem.py
@@ -59,6 +59,7 @@ def main(args):
     lm_use_lora = args.lm_use_lora
     token_on_disk = args.token_on_disk
     num_em_iters = args.num_em_iters
+    num_workers = args.num_workers
     start_time = time.time()
     train_with_ext_pred = not args.train_without_ext_pred and \
         dataset_name == 'products'
@@ -153,8 +154,8 @@ def main(args):
         num_neighbors=[15, 10, 5],
         batch_size=gnn_batch_size,
         shuffle=True,
-        num_workers=12,
-        persistent_workers=True,
+        num_workers=num_workers,
+        persistent_workers=num_workers > 0,
     )
 
     # graph data loader w/ pseudo labels in M-step
@@ -164,8 +165,8 @@ def main(args):
         num_neighbors=[15, 10, 5],
         batch_size=gnn_batch_size,
         shuffle=True,
-        num_workers=12,
-        persistent_workers=True,
+        num_workers=num_workers,
+        persistent_workers=num_workers > 0,
     )
 
     # for gnn inference
@@ -174,8 +175,8 @@ def main(args):
         input_nodes=None,
         num_neighbors=[-1],
         batch_size=gnn_batch_size * 4,
-        num_workers=12,
-        persistent_workers=True,
+        num_workers=num_workers,
+        persistent_workers=num_workers > 0,
     )
     # =========================== internal function ===========================
 
@@ -405,6 +406,11 @@ if __name__ == '__main__':
                         help='number of runs')
     parser.add_argument('--num_em_iters', type=int, default=1,
                         help='number of iterations')
+    parser.add_argument(
+        '--num_workers', type=int, default=12,
+        help='Number of DataLoader workers for each of the '
+        'three GNN NeighborLoaders (36 processes in total '
+        'with the default; lower it on shared machines)')
     parser.add_argument("--dataset", type=str, default='products',
                         help='arxiv or products')
     parser.add_argument(


### PR DESCRIPTION
The three `NeighborLoader`s in `examples/llm/glem.py` hard-code `num_workers=12` with `persistent_workers=True` (36 forked sampler processes). In our CI the example hangs intermittently at the very first pretraining batch with the workers idle, and we want to run it with `--num_workers 0`. Default unchanged; persistent workers only when there are any.