### PR TITLE
Recover from the Google Drive quota page in `glem.py`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- Fixed `examples/llm/glem.py` to recover from the Google Drive quota page served instead of `giant_sagn_scr.pt`, to keep that file in `data/ogb/ext_preds/` outside the folder `ogb` deletes (an existing copy is read in place), and to raise a descriptive `RuntimeError` when the download still fails ([#10806](https://github.com/pyg-team/pytorch_geometric/pull/10806))
 - Fixed `config_store` on Python 3.14, where `typing.Union`/`typing.Optional` annotations could no longer be remapped in-place via the now read-only `__args__` attribute
 
 ### Security

--- a/examples/llm/glem.py
+++ b/examples/llm/glem.py
@@ -39,6 +39,17 @@ def get_n_params(model):
     return pp
 
 
+def is_html_page(path):
+    # What `download_url` leaves behind when Google Drive serves its quota
+    # page instead of the file.
+    try:
+        with open(path, 'rb') as f:
+            head = f.read(1024)
+    except OSError:
+        return False
+    return head.lstrip(b'\xef\xbb\xbf \t\r\n').startswith(b'<')
+
+
 def main(args):
     gpu = args.gpu
     dataset_name = args.dataset
@@ -71,11 +82,60 @@ def main(args):
     torch.cuda.empty_cache()
 
     if train_with_ext_pred:
-        ext_pred_path = download_google_url(
-            id='15sO2m7BeW7C1Upmdw3Cx1JS__6nxTAzY',
-            folder='data/ogb/ogbn_products/ext_preds',
-            filename='giant_sagn_scr.pt', log=True)
-        ext_pred = torch.load(ext_pred_path, map_location=device)
+        # Kept outside the OGB dataset folder, which `ogb` deletes and
+        # re-creates when its release file is missing or outdated.
+        ext_pred_path = osp.join(root, 'ext_preds', 'giant_sagn_scr.pt')
+        legacy_path = osp.join(root, 'ogbn_products', 'ext_preds',
+                               'giant_sagn_scr.pt')
+        if is_html_page(legacy_path):
+            # A quota page left behind by earlier versions of this example.
+            # Drop it and the emptied folders so that `ogb` does not find a
+            # dataset folder without its release file and prompt to update it.
+            try:
+                os.remove(legacy_path)
+                os.removedirs(osp.dirname(legacy_path))
+            except OSError:
+                pass
+        elif osp.isfile(legacy_path) and not osp.exists(ext_pred_path):
+            # Written there by earlier versions of this example. Read it in
+            # place: the user may share or symlink it.
+            ext_pred_path = legacy_path
+        try:
+            if is_html_page(ext_pred_path):
+                # A quota page left behind by an earlier run; `download_url`
+                # would otherwise keep it as the file and skip the download.
+                os.remove(ext_pred_path)
+            download_google_url(id='15sO2m7BeW7C1Upmdw3Cx1JS__6nxTAzY',
+                                folder=osp.dirname(ext_pred_path),
+                                filename=osp.basename(ext_pred_path), log=True)
+            ext_pred = torch.load(ext_pred_path, map_location=device)
+        except Exception as e:
+            hint = 'retry later'
+            if is_html_page(ext_pred_path):
+                # Google Drive serves an HTML quota page instead of the file
+                # once its daily download quota is exhausted, and `torch.load`
+                # then fails on it. Remove the page so the next run downloads
+                # again.
+                try:
+                    os.remove(ext_pred_path)
+                except FileNotFoundError:
+                    pass  # Another run already removed it.
+                except OSError:
+                    hint = 'delete the file and retry later'
+            elif osp.lexists(ext_pred_path) or isinstance(e, PermissionError):
+                # Anything else on disk is left alone: a valid checkpoint that
+                # failed to load for an unrelated reason (CUDA OOM, a bad
+                # `--gpu` index), a file the user placed there, or a download
+                # another run is still writing. A `PermissionError` with
+                # nothing on disk is a local problem (e.g. a read-only
+                # `root`), raised before any request is made.
+                raise
+            raise RuntimeError(
+                f"Could not download or load the external predictions "
+                f"'{ext_pred_path}' for 'ogbn-products' "
+                f"({type(e).__name__}). Google Drive may have hit its daily "
+                f"quota for this file; {hint}, place the file at that path "
+                f"manually, or run with '--train_without_ext_pred'.") from e
         ext_pseudo_labels = ext_pred.argmax(dim=-1)
         pretrain_augmented = True
 


### PR DESCRIPTION
Google Drive hands back an HTML quota page instead of `giant_sagn_scr.pt` once the file's daily quota is used up, `download_url` keeps it on disk, and every later run of `examples/llm/glem.py` then dies in `torch.load` on the same file. This deletes that file only when it really is an HTML page, re-raises anything else unchanged, and fails with a `RuntimeError` that says what to do. The external predictions also move to `data/ogb/ext_preds/` (outside the folder `ogb` deletes/re-creates), so fresh installs no longer land in ogb's interactive prompt under nohup/CI; a legacy copy is read in place and a stale page at the legacy path is cleaned up with its emptied folders.
